### PR TITLE
fixes #2 - Color range wrongly updated after style change

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -895,7 +895,7 @@ void MainWindow::updateRecipeStyle()
 
       styleRangeWidget_abv->setPreferredRange(selected->abvMin_pct(), selected->abvMax_pct());
       styleRangeWidget_ibu->setPreferredRange(selected->ibuMin(), selected->ibuMax());
-      styleRangeWidget_srm->setPreferredRange(selected->colorMin_srm(), selected->colorMax_srm());
+      styleRangeWidget_srm->setPreferredRange(Brewtarget::displayRange(selected, tab_recipe, "color_srm", Brewtarget::COLOR));
    }
 }
 


### PR DESCRIPTION
The problem appears only if you configure EBC as default color unit in configuration because after changing the style, the color range was updated directly in SRM without taking care of the default unit.