### PR TITLE
fix bug update yeast change

### DIFF
--- a/src/ScaleRecipeTool.cpp
+++ b/src/ScaleRecipeTool.cpp
@@ -40,7 +40,7 @@ ScaleRecipeTool::ScaleRecipeTool(QWidget* parent) : QDialog(parent)
 
    checkBox_batchSize->setCheckState( Qt::Checked );
    lineEdit_newEfficiency->setDisabled(true);
-   
+
    connect(&scaleGroup, SIGNAL(buttonClicked(QAbstractButton*)), this, SLOT(scaleGroupButtonPressed(QAbstractButton*)));
    connect(buttonBox, SIGNAL(accepted()), this, SLOT(scale()) );
    connect(buttonBox, SIGNAL(rejected()), this, SLOT(close()) );
@@ -73,7 +73,7 @@ void ScaleRecipeTool::show()
    // Set the batch size display to the current batch size.
    if( recObs != 0 )
       lineEdit_newBatchSize->setText(recObs);
-   
+
    setVisible(true);
 }
 
@@ -110,7 +110,10 @@ void ScaleRecipeTool::scaleByEfficiency()
       if( ferm == 0 )
          continue;
 
-      ferm->setAmount_kg(ferm->amount_kg() * ratio);
+      if( !ferm->isSugar() && !ferm->isExtract() )
+      {
+         ferm->setAmount_kg(ferm->amount_kg() * ratio);
+      }
    }
 
    Mash* mash = recObs->mash();
@@ -141,19 +144,19 @@ void ScaleRecipeTool::scaleByVolume()
 {
    if( recObs == 0 )
       return;
-   
+
    int i, size;
-   
+
    double currentBatchSize_l = recObs->batchSize_l();
    double newBatchSize_l = lineEdit_newBatchSize->toSI();
-   
+
    double ratio = newBatchSize_l / currentBatchSize_l;
-   
+
    // I think you want the equipment to be clean.
    //recObs->setEquipment(new Equipment());
    recObs->setBatchSize_l(newBatchSize_l);
    recObs->setBoilSize_l(newBatchSize_l);
-   
+
    QList<Fermentable*> ferms = recObs->fermentables();
    size = ferms.size();
    for( i = 0; i < size; ++i )
@@ -162,10 +165,10 @@ void ScaleRecipeTool::scaleByVolume()
       // NOTE: why the hell do we need this?
       if( ferm == 0 )
          continue;
-      
+
       ferm->setAmount_kg(ferm->amount_kg() * ratio);
    }
-   
+
    QList<Hop*> hops = recObs->hops();
    size = hops.size();
    for( i = 0; i < size; ++i )
@@ -174,10 +177,10 @@ void ScaleRecipeTool::scaleByVolume()
       // NOTE: why the hell do we need this?
       if( hop == 0 )
          continue;
-      
+
       hop->setAmount_kg(hop->amount_kg() * ratio);
    }
-   
+
    QList<Misc*> miscs = recObs->miscs();
    size = miscs.size();
    for( i = 0; i < size; ++i )
@@ -186,10 +189,10 @@ void ScaleRecipeTool::scaleByVolume()
       // NOTE: why the hell do we need this?
       if( misc == 0 )
          continue;
-      
+
       misc->setAmount( misc->amount() * ratio );
    }
-   
+
    QList<Water*> waters = recObs->waters();
    size = waters.size();
    for( i = 0; i < size; ++i )
@@ -198,14 +201,14 @@ void ScaleRecipeTool::scaleByVolume()
       // NOTE: why the hell do we need this?
       if( water == 0 )
          continue;
-      
+
       water->setAmount_l(water->amount_l() * ratio);
    }
-   
+
    Mash* mash = recObs->mash();
    if( mash == 0 )
       return;
-   
+
    QList<MashStep*> mashSteps = mash->mashSteps();
    size = mashSteps.size();
    for( i = 0; i < size; ++i )
@@ -214,15 +217,15 @@ void ScaleRecipeTool::scaleByVolume()
       // NOTE: why the hell do we need this?
       if( step == 0 )
          continue;
-      
+
       // Reset all these to zero so that the user
       // will know to re-run the mash wizard.
       step->setDecoctionAmount_l(0);
       step->setInfuseAmount_l(0);
    }
-   
+
    // I don't think I should scale the yeasts.
-   
+
    // Let the user know what happened.
    QMessageBox::information(this, tr("Recipe Scaled"),
              tr("The equipment and mash have been reset due to the fact that mash temperatures do not scale easily. Please re-run the mash wizard.") );

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -96,7 +96,7 @@ Database::Database()
    // Lock this here until we actually construct the first database connection.
    _threadToConnectionMutex.lock();
 
-   converted = false;   
+   converted = false;
    dirty = false;
 
    loadWasSuccessful = load();
@@ -107,7 +107,7 @@ Database::~Database()
    // If we have not explicitly unloaded, do so now and discard changes.
    if( QSqlDatabase::database( dbConName, false ).isOpen() )
       unload(false);
-   
+
    // Delete all the ingredients floating around.
    qDeleteAll(allBrewNotes);
    qDeleteAll(allEquipments);
@@ -128,21 +128,21 @@ bool Database::load()
    bool dbIsOpen;
    bool createFromScratch=false;
    bool schemaUpdated=false;
-   
+
    // Set file names.
    dbFileName = (Brewtarget::getUserDataDir() + "database.sqlite");
    dataDbFileName = (Brewtarget::getDataDir() + "default_db.sqlite");
    dbTempBackupFileName = (Brewtarget::getUserDataDir() + "tempBackupDatabase.sqlite");
-   
+
    // Set the files.
    dbFile.setFileName(dbFileName);
    dataDbFile.setFileName(dataDbFileName);
    dbTempBackupFile.setFileName(dbTempBackupFileName);
-   
+
    // Cleanup the backup database if there was a previous error.
    if( !cleanupBackupDatabase() )
       return false;
-   
+
    // If user restored the database from a backup, make the backup into the primary.
    {
       QFile newdb(QString("%1.new").arg(dbFileName));
@@ -154,12 +154,12 @@ bool Database::load()
          newdb.remove();
       }
    }
-   
+
    // If there's no dbFile, try to copy from dataDbFile.
    if( !dbFile.exists() )
    {
       Brewtarget::userDatabaseDidNotExist = true;
-      
+
       // Have to wait until db is open before creating from scratch.
       if( !dataDbFile.exists() )
          createFromScratch = true;
@@ -168,14 +168,14 @@ bool Database::load()
          dataDbFile.copy(dbFileName);
          QFile::setPermissions( dbFileName, QFile::ReadOwner | QFile::WriteOwner | QFile::ReadGroup );
       }
-      
+
       // Reset the last merge request.
       Brewtarget::lastDbMergeRequest = QDateTime::currentDateTime();
    }
 
    // Create a copy of the database to revert to if the user decides not to make changes.
    dbFile.copy(dbTempBackupFileName);
-   
+
    // Open SQLite db.
    QSqlDatabase sqldb = QSqlDatabase::addDatabase("QSQLITE");
    sqldb.setDatabaseName(dbFileName);
@@ -191,7 +191,7 @@ bool Database::load()
       // TODO: if we can't open the database, what should we do?
       return false;
    }
-   
+
    // Database is open, so can create from scratch if needed
    if(createFromScratch)
    {
@@ -199,20 +199,20 @@ bool Database::load()
       if( !success )
          Brewtarget::logE("DatabaseSchemaHelper::create() failed");
    }
-   
+
    // Associate this db with the current thread.
    _threadToConnection.insert(QThread::currentThread(), sqldb.connectionName());
    _threadToConnectionMutex.unlock();
-   
+
    // NOTE: synchronous=off reduces query time by an order of magnitude!
    QSqlQuery( "PRAGMA synchronous = off", sqlDatabase());
    QSqlQuery( "PRAGMA foreign_keys = on", sqlDatabase());
    QSqlQuery( "PRAGMA locking_mode = EXCLUSIVE", sqlDatabase());
    // Store temporary tables in memory.
    QSqlQuery( "PRAGMA temp_store = MEMORY", sqlDatabase());
-   
+
    // Update the database if need be. This has to happen before we do anything
-   // else or we dump core 
+   // else or we dump core
    bool schemaErr = false;
    schemaUpdated = updateSchema(&schemaErr);
    if( schemaErr )
@@ -224,16 +224,16 @@ bool Database::load()
       );
       return false;
    }
-   
+
    // Initialize the SELECT * query hashes.
    selectAll = Database::selectAllHash();
-   
+
    // See if there are new ingredients that we need to merge from the data-space db.
    if( dataDbFile.fileName() != dbFile.fileName()
       && ! Brewtarget::userDatabaseDidNotExist // Don't do this if we JUST copied the dataspace database.
       && QFileInfo(dataDbFile).lastModified() > Brewtarget::lastDbMergeRequest )
    {
-      
+
       if(
          QMessageBox::question(
             0,
@@ -247,11 +247,11 @@ bool Database::load()
       {
          updateDatabase(dataDbFile.fileName());
       }
-      
+
       // Update this field.
       Brewtarget::lastDbMergeRequest = QDateTime::currentDateTime();
    }
-   
+
    // Create and store all pointers.
    populateElements( allBrewNotes, Brewtarget::BREWNOTETABLE );
    populateElements( allEquipments, Brewtarget::EQUIPTABLE );
@@ -264,15 +264,16 @@ bool Database::load()
    populateElements( allStyles, Brewtarget::STYLETABLE );
    populateElements( allWaters, Brewtarget::WATERTABLE );
    populateElements( allYeasts, Brewtarget::YEASTTABLE );
-   
+
    populateElements( allRecipes, Brewtarget::RECTABLE );
-   
+
    // Connect fermentable,hop changed signals to their parent recipe.
    QHash<int,Recipe*>::iterator i;
    QList<Fermentable*>::iterator j;
    QList<Hop*>::iterator k;
-   QList<Mash*>::iterator l;
-   QList<MashStep*>::iterator m;
+   QList<Yeast*>::iterator l;
+   QList<Mash*>::iterator m;
+   QList<MashStep*>::iterator n;
 
 
    for( i = allRecipes.begin(); i != allRecipes.end(); i++ )
@@ -284,24 +285,28 @@ bool Database::load()
          connect( e, SIGNAL(changedBoilSize_l(double)), *i, SLOT(setBoilSize_l(double)));
          connect( e, SIGNAL(changedBoilTime_min(double)), *i, SLOT(setBoilTime_min(double)));
       }
-      
+
       QList<Fermentable*> tmpF = fermentables(*i);
       for( j = tmpF.begin(); j != tmpF.end(); j++ )
          connect( *j, SIGNAL(changed(QMetaProperty,QVariant)), *i, SLOT(acceptFermChange(QMetaProperty,QVariant)) );
-      
+
       QList<Hop*> tmpH = hops(*i);
-      for( k = tmpH.begin(); k != tmpH.end(); ++k )
+      for( k = tmpH.begin(); k != tmpH.end(); k++ )
          connect( *k, SIGNAL(changed(QMetaProperty,QVariant)), *i, SLOT(acceptHopChange(QMetaProperty,QVariant)) );
-      
+
+      QList<Yeast*> tmpY = yeasts(*i);
+      for( l = tmpY.begin(); l != tmpY.end(); l++)
+        connect( *l, SIGNAL(changed(QMetaProperty,QVariant)), *i, SLOT(acceptYeastChange(QMetaProperty,QVariant)) );
+
       connect( mash(*i), SIGNAL(changed(QMetaProperty,QVariant)), *i, SLOT(acceptMashChange(QMetaProperty,QVariant)) );
    }
-   
+
    QList<Mash*> tmpM = mashs();
-   for( l = tmpM.begin(); l != tmpM.end(); ++l)
+   for( m = tmpM.begin(); m != tmpM.end(); m++)
    {
-      QList<MashStep*> tmpMS = mashSteps(*l);
-      for( m=tmpMS.begin(); m != tmpMS.end(); ++m)
-         connect( *m, SIGNAL(changed(QMetaProperty,QVariant)), *l, SLOT(acceptMashStepChange(QMetaProperty,QVariant)) );
+      QList<MashStep*> tmpMS = mashSteps(*m);
+      for( n=tmpMS.begin(); n != tmpMS.end(); n++)
+         connect( *n, SIGNAL(changed(QMetaProperty,QVariant)), *m, SLOT(acceptMashStepChange(QMetaProperty,QVariant)) );
    }
 
    // The database MUST be saved if we created from scratch.
@@ -321,12 +326,12 @@ bool Database::createBlank(QString const& filename)
          Brewtarget::logW(QString("Database::createBlank(): could not open '%1'").arg(filename));
          return false;
       }
-      
+
       DatabaseSchemaHelper::create(sqldb);
-      
+
       sqldb.close();
    } // sqldb gets destroyed as it goes out of scope before removeDatabase()
-   
+
    QSqlDatabase::removeDatabase( "blank" );
    return true;
 }
@@ -352,16 +357,16 @@ void Database::convertFromXml()
    {
       dir.mkdir("obsolete");
       dir.cd("obsolete");
-      
+
       QStringList oldFiles = QStringList() << "database.xml" << "mashs.xml" << "recipes.xml";
-      for ( int i = 0; i < oldFiles.size(); ++i ) 
+      for ( int i = 0; i < oldFiles.size(); ++i )
       {
          QFile oldXmlFile(Brewtarget::getUserDataDir() + oldFiles[i]);
          // If the old file exists, import.
          if( oldXmlFile.exists() )
          {
             importFromXML( oldXmlFile.fileName() );
-            
+
             // Move to obsolete/ directory.
             if( oldXmlFile.copy(dir.filePath(oldFiles[i])) )
                oldXmlFile.remove();
@@ -391,9 +396,9 @@ QSqlDatabase Database::sqlDatabase()
 {
    // Need a unique database connection for each thread.
    //http://www.linuxjournal.com/article/9602
-   
+
    QThread* t = QThread::currentThread();
-   
+
    _threadToConnectionMutex.lock();
    // If this thread already has a connection, return it.
    if( _threadToConnection.contains(t) )
@@ -404,7 +409,7 @@ QSqlDatabase Database::sqlDatabase()
    }
    // Create a unique connection name, just containing the addy of the thread.
    QString conName = QString("0x%1").arg(reinterpret_cast<uintptr_t>(t), 0, 16);
-   
+
    // Create the new connection.
    QSqlDatabase sqldb = QSqlDatabase::addDatabase("QSQLITE",conName);
    sqldb.setDatabaseName(dbFileName);
@@ -413,7 +418,7 @@ QSqlDatabase Database::sqlDatabase()
       Brewtarget::logE(QString("Could not open %1 for reading.\n%2").arg(dbFileName).arg(sqldb.lastError().text()));
       // TODO: what to do if we can't open?
    }
-   
+
    // Put new connection in the hash.
    _threadToConnection.insert(t,conName);
    _threadToConnectionMutex.unlock();
@@ -446,11 +451,11 @@ bool Database::isDirty()
 
 Database& Database::instance()
 {
-   
+
    // Not thread-safe
    //static Database dbSingleton;
    //return dbSingleton;
-   
+
    // This is not safe either. This is the double-check pattern that
    // avoids acquiring the lock unless we need to make a new instance.
    // The problem is that it's not safe. Should replace this lazy
@@ -461,42 +466,42 @@ Database& Database::instance()
    if( ! dbInstance )
    {
       mutex.lock();
-      
+
       if( ! dbInstance )
          dbInstance = new Database();
-      
+
       mutex.unlock();
    }
-   
+
    return *dbInstance;
 }
 
 void Database::dropInstance()
 {
    static QMutex mutex;
-  
+
    mutex.lock();
    delete dbInstance;
    dbInstance=0;
    mutex.unlock();
-   
+
 }
 
 bool Database::backupToDir(QString dir)
 {
    // Make sure the singleton exists.
    instance();
-   
+
    bool success = true;
    QString prefix = dir + "/";
    QString newDbFileName = prefix + "database.sqlite";
-   
+
    // Remove the files if they already exist so that
    // the copy() operation will succeed.
    QFile::remove(newDbFileName);
-   
+
    success = dbFile.copy( newDbFileName );
-   
+
    return success;
 }
 
@@ -508,15 +513,15 @@ bool Database::restoreFromFile(QString newDbFileStr)
    QString newDbFileName = prefix + "database.sqlite";
    QFile newDbFile(newDbFileName);
    */
-   
+
    QFile newDbFile(newDbFileStr);
    // Fail if we can't find file.
    if( !newDbFile.exists() )
       return false;
-   
+
    success &= newDbFile.copy(QString("%1.new").arg(dbFile.fileName()));
    QFile::setPermissions( newDbFile.fileName(), QFile::ReadOwner | QFile::WriteOwner | QFile::ReadGroup );
-   
+
    return success;
 }
 
@@ -528,8 +533,8 @@ void Database::removeIngredientFromRecipe( Recipe* rec, BeerXMLElement* ing, QSt
    q.prepare( QString("DELETE FROM `%1` WHERE `%2`='%3' AND recipe_id='%4'").arg(relTableName).arg(ingKeyName).arg(ing->_key).arg(rec->_key) );
    q.exec();
    q.finish();
- 
-   dirty = true; 
+
+   dirty = true;
    emit rec->changed( rec->metaProperty(propName), QVariant() );
 }
 
@@ -539,7 +544,7 @@ void Database::removeFromRecipe( Recipe* rec, BrewNote* b )
    sqlUpdate( Brewtarget::BREWNOTETABLE,
               "deleted=1",
               QString("id=%1").arg(b->_key) );
-   dirty = true; 
+   dirty = true;
    emit deletedBrewNoteSignal(b);
 }
 
@@ -578,11 +583,11 @@ void Database::removeFromRecipe( Recipe* rec, Water* w )
 void Database::removeFromRecipe( Recipe* rec, Instruction* ins )
 {
    removeIngredientFromRecipe( rec, ins, "instructions", "instruction_in_recipe", "instruction_id" );
-   
+
    // --maf-- Instructions just need to get whacked.
    sqlDelete( Brewtarget::INSTRUCTIONTABLE,
               QString("id=%1").arg(ins->_key) );
-   
+
    allInstructions.remove(ins->_key);
    emit changed( metaProperty("instructions"), QVariant() );
 }
@@ -595,7 +600,7 @@ void Database::removeFrom( Mash* mash, MashStep* step )
               "deleted=1",
               QString("id=%1").arg(step->_key) );
    // emit mash->changed( mash->metaProperty("mashSteps"), QVariant() );
-   dirty = true; 
+   dirty = true;
    emit mash->mashStepsChanged();
 }
 
@@ -607,7 +612,7 @@ Recipe* Database::getParentRecipe( BrewNote const* note )
    q.next();
    key = q.record().value("recipe_id").toInt();
    q.finish();
-   
+
    return allRecipes[key];
 }
 
@@ -626,8 +631,8 @@ void Database::swapMashStepOrder(MashStep* m1, MashStep* m2)
                 .arg(m1->_key).arg(m2->_key).arg(m2->_key).arg(m1->_key).arg(m1->_key).arg(m2->_key),
                 sqlDatabase());//sqldb );
    q.finish();
-  
-   dirty = true; 
+
+   dirty = true;
    emit m1->changed( m1->metaProperty("stepNumber") );
    emit m2->changed( m2->metaProperty("stepNumber") );
 }
@@ -648,8 +653,8 @@ void Database::swapInstructionOrder(Instruction* in1, Instruction* in2)
       sqlDatabase()
    );
    q.finish();
-  
-   dirty = true; 
+
+   dirty = true;
    emit in1->changed( in1->metaProperty("instructionNumber") );
    emit in2->changed( in2->metaProperty("instructionNumber") );
 }
@@ -663,7 +668,7 @@ void Database::insertInstruction(Instruction* in, int pos)
    q.next();
    parentRecipeKey = q.record().value("recipe_id").toInt();
    q.finish();
-   
+
    // Increment all instruction positions greater or equal to pos.
    q.exec(
       QString(
@@ -672,11 +677,11 @@ void Database::insertInstruction(Instruction* in, int pos)
          "WHERE recipe_id=%1 AND instruction_number>=%2"
       ).arg(parentRecipeKey).arg(pos)
    );
-   
+
    // NOTE: right here, we should be emitting changed( "instructionNumber" )
    // for each one of the rows affected above. Probably creating problems by
    // not doing so :-/
-   
+
    // Change in's position to pos.
    q.exec(
       QString(
@@ -686,8 +691,8 @@ void Database::insertInstruction(Instruction* in, int pos)
       ).arg(pos).arg(in->_key)
    );
    q.finish();
-  
-   dirty = true; 
+
+   dirty = true;
    emit in->changed( in->metaProperty("instructionNumber"), pos );
 }
 
@@ -695,9 +700,9 @@ QList<BrewNote*> Database::brewNotes(Recipe const* parent)
 {
    QList<BrewNote*> ret;
    QString filterString = QString("recipe_id = %1 AND deleted = 0").arg(parent->_key);
-   
+
    getElements(ret, filterString, Brewtarget::BREWNOTETABLE, allBrewNotes);
-   
+
    return ret;
 }
 
@@ -706,11 +711,11 @@ QList<Fermentable*> Database::fermentables(Recipe const* parent)
    QList<Fermentable*> ret;
    QString queryString = QString("SELECT fermentable_id FROM fermentable_in_recipe WHERE recipe_id = %1").arg(parent->_key);
    QSqlQuery q( queryString, sqlDatabase() );//, sqldb );
-   
+
    while( q.next() )
       ret.append(allFermentables[q.record().value("fermentable_id").toInt()]);
    q.finish();
-   
+
    return ret;
 }
 
@@ -719,11 +724,11 @@ QList<Hop*> Database::hops(Recipe const* parent)
    QList<Hop*> ret;
    QString queryString = QString("SELECT hop_id FROM hop_in_recipe WHERE recipe_id = %1").arg(parent->_key);
    QSqlQuery q( queryString, sqlDatabase() );//, sqldb );
-   
+
    while( q.next() )
       ret.append(allHops[q.record().value("hop_id").toInt()]);
    q.finish();
-   
+
    return ret;
 }
 
@@ -732,18 +737,18 @@ QList<Misc*> Database::miscs(Recipe const* parent)
    QList<Misc*> ret;
    QString queryString = QString("SELECT misc_id FROM misc_in_recipe WHERE recipe_id = %1").arg(parent->_key);
    QSqlQuery q( queryString, sqlDatabase() );//, sqldb );
-   
+
    while( q.next() )
       ret.append(allMiscs[q.record().value("misc_id").toInt()]);
    q.finish();
-   
+
    return ret;
 }
 
 Equipment* Database::equipment(Recipe const* parent)
 {
    int id = get( Brewtarget::RECTABLE, parent->key(), "equipment_id" ).toInt();
-   
+
    if( allEquipments.contains(id) )
       return allEquipments[id];
    else
@@ -753,14 +758,14 @@ Equipment* Database::equipment(Recipe const* parent)
 Style* Database::style(Recipe const* parent)
 {
    int id;
-   
+
    QString queryString = QString("SELECT style_id FROM recipe WHERE id = %1").arg(parent->_key);
    QSqlQuery q( queryString, sqlDatabase() );//, sqldb );
-   
+
    while( q.next() )
       id = q.record().value("style_id").toInt();
    q.finish();
-   
+
    if( allStyles.contains(id) )
       return allStyles[id];
    else
@@ -770,7 +775,7 @@ Style* Database::style(Recipe const* parent)
 Mash* Database::mash( Recipe const* parent )
 {
    int mashId = get( Brewtarget::RECTABLE, parent->key(), "mash_id" ).toInt();
-   
+
    if( allMashs.contains(mashId) )
       return allMashs[mashId];
    else
@@ -781,9 +786,9 @@ QList<MashStep*> Database::mashSteps(Mash const* parent)
 {
    QList<MashStep*> ret;
    QString filterString = QString("mash_id = %1 AND deleted = 0").arg(parent->_key);
-  
+
    getElements(ret, filterString, Brewtarget::MASHSTEPTABLE, allMashSteps);
-   
+
    return ret;
 }
 
@@ -793,13 +798,13 @@ QList<Instruction*> Database::instructions( Recipe const* parent )
    QString queryString = QString(
       "SELECT instruction_id FROM instruction_in_recipe WHERE recipe_id = %1 ORDER BY instruction_number ASC"
    ).arg(parent->_key);
-   
+
    QSqlQuery q( queryString, sqlDatabase() );//, sqldb );
-   
+
    while( q.next() )
       ret.append(allInstructions[q.record().value("instruction_id").toInt()]);
    q.finish();
-   
+
    return ret;
 }
 
@@ -808,11 +813,11 @@ QList<Water*> Database::waters(Recipe const* parent)
    QList<Water*> ret;
    QString queryString = QString("SELECT water_id FROM water_in_recipe WHERE recipe_id = %1").arg(parent->_key);
    QSqlQuery q( queryString, sqlDatabase() );//, sqldb );
-   
+
    while( q.next() )
       ret.append(allWaters[q.record().value("water_id").toInt()]);
    q.finish();
-   
+
    return ret;
 }
 
@@ -821,11 +826,11 @@ QList<Yeast*> Database::yeasts(Recipe const* parent)
    QList<Yeast*> ret;
    QString queryString = QString("SELECT yeast_id FROM yeast_in_recipe WHERE recipe_id = %1").arg(parent->_key);
    QSqlQuery q( queryString, sqlDatabase() );//, sqldb );
-   
+
    while( q.next() )
       ret.append(allYeasts[q.record().value("yeast_id").toInt()]);
    q.finish();
-   
+
    return ret;
 }
 
@@ -848,10 +853,10 @@ int Database::insertNewDefaultRecord( Brewtarget::DBTable table )
    else
       key = q.lastInsertId().toInt();
    q.finish();
-   
+
    //if( q.lastError().isValid() )
    //   Brewtarget::logE( QString("Database::insertNewDefaultRecord: %1").arg(q.lastError().text()) );
-  
+
    dirty = true;
    return key;
 }
@@ -859,7 +864,7 @@ int Database::insertNewDefaultRecord( Brewtarget::DBTable table )
 int Database::insertNewMashStepRecord( Mash* parent )
 {
    int key;
-   
+
    QSqlQuery q(sqlDatabase());//sqldb );
    q.setForwardOnly(true);
    q.exec( QString("INSERT INTO `%1` DEFAULT VALUES")
@@ -873,7 +878,7 @@ int Database::insertNewMashStepRecord( Mash* parent )
    else
       key = q.lastInsertId().toInt();
    q.finish();
-   
+
    // I *think* we need to set the mash_id first
    sqlUpdate( Brewtarget::MASHSTEPTABLE,
               QString("`mash_id`='%1' ").arg(parent->_key),
@@ -893,14 +898,14 @@ int Database::insertNewMashStepRecord( Mash* parent )
 BrewNote* Database::newBrewNote(BrewNote* other, bool signal)
 {
    BrewNote* tmp = copy<BrewNote>(other, true, &allBrewNotes);
-  
+
    if ( signal )
    {
       emit changed( metaProperty("brewNotes"), QVariant() );
       emit newBrewNoteSignal(tmp);
    }
 
-   dirty = true; 
+   dirty = true;
    return tmp;
 }
 
@@ -916,13 +921,13 @@ BrewNote* Database::newBrewNote(Recipe* parent, bool signal)
               QString("recipe_id=%1").arg(parent->_key),
               QString("id=%2").arg(tmp->_key) );
 
-   if ( signal ) 
+   if ( signal )
    {
       emit changed( metaProperty("brewNotes"), QVariant() );
       emit newBrewNoteSignal(tmp);
    }
-   
-   dirty = true; 
+
+   dirty = true;
    return tmp;
 }
 
@@ -933,7 +938,7 @@ Equipment* Database::newEquipment()
    tmp->_table = Brewtarget::EQUIPTABLE;
    allEquipments.insert(tmp->_key,tmp);
 
-   dirty = true; 
+   dirty = true;
    emit changed( metaProperty("equipments"), QVariant() );
    emit newEquipmentSignal(tmp);
 
@@ -943,11 +948,11 @@ Equipment* Database::newEquipment()
 Equipment* Database::newEquipment(Equipment* other)
 {
    Equipment* tmp = copy<Equipment>(other, true, &allEquipments);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("equipments"), QVariant() );
    emit newEquipmentSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -957,22 +962,22 @@ Fermentable* Database::newFermentable()
    tmp->_key = insertNewDefaultRecord(Brewtarget::FERMTABLE);
    tmp->_table = Brewtarget::FERMTABLE;
    allFermentables.insert(tmp->_key,tmp);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("fermentables"), QVariant() );
    emit newFermentableSignal(tmp);
-   
+
    return tmp;
 }
 
 Fermentable* Database::newFermentable(Fermentable* other)
 {
    Fermentable* tmp = copy<Fermentable>(other, true, &allFermentables);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("fermentables"), QVariant() );
    emit newFermentableSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -982,22 +987,22 @@ Hop* Database::newHop()
    tmp->_key = insertNewDefaultRecord(Brewtarget::HOPTABLE);
    tmp->_table = Brewtarget::HOPTABLE;
    allHops.insert(tmp->_key,tmp);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("hops"), QVariant() );
    emit newHopSignal(tmp);
-   
+
    return tmp;
 }
 
 Hop* Database::newHop(Hop* other)
 {
    Hop* tmp = copy<Hop>(other, true, &allHops);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("hops"), QVariant() );
    emit newHopSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -1008,15 +1013,15 @@ Instruction* Database::newInstruction(Recipe* rec)
    tmp->_key = insertNewDefaultRecord(Brewtarget::INSTRUCTIONTABLE);
    tmp->_table = Brewtarget::INSTRUCTIONTABLE;
    allInstructions.insert(tmp->_key,tmp);
-   
+
    // Database's instructions have changed.
 
-   dirty = true; 
+   dirty = true;
    emit changed( metaProperty("instructions"), QVariant() );
-   
+
    // Add without copying to "instruction_in_recipe"
    addIngredientToRecipe<Instruction>( rec, tmp, "instructions", "instruction_in_recipe", "instruction_id", "instruction_children", true, 0, false );
-   
+
    return tmp;
 }
 
@@ -1028,7 +1033,7 @@ int Database::instructionNumber(Instruction const* in)
       ).arg(in->_key),
       sqlDatabase()
    );
-   
+
    if( q.next() )
       return q.record().value("instruction_number").toInt();
    else
@@ -1042,11 +1047,11 @@ Mash* Database::newMash()
    tmp->_table = Brewtarget::MASHTABLE;
 
    allMashs.insert(tmp->_key,tmp);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("mashs"), QVariant() );
    emit newMashSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -1056,13 +1061,13 @@ Mash* Database::newMash(Recipe* parent)
    tmp->_key = insertNewDefaultRecord(Brewtarget::MASHTABLE);
    tmp->_table = Brewtarget::MASHTABLE;
    allMashs.insert(tmp->_key,tmp);
-   
+
    // Connect tmp to parent, removing any existing mash in parent.
    sqlUpdate( Brewtarget::RECTABLE,
               QString("mash_id=%1").arg(tmp->_key),
               QString("id=%1").arg(parent->_key) );
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("mashs"), QVariant() );
    emit newMashSignal(tmp);
 
@@ -1083,11 +1088,11 @@ Mash* Database::newMash(Mash* other, bool displace)
                  QString("mash_id=%1").arg(tmp->_key),
                  QString("mash_id=%1").arg(other->_key) );
    }
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("mashs"), QVariant() );
    emit newMashSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -1103,7 +1108,7 @@ MashStep* Database::newMashStep(Mash* mash)
    allMashSteps.insert(tmp->_key,tmp);
    connect( tmp, SIGNAL(changed(QMetaProperty,QVariant)), mash, SLOT(acceptMashStepChange(QMetaProperty,QVariant)) );
 
-   dirty = true; 
+   dirty = true;
    emit changed( metaProperty("mashs"), QVariant() );
    emit mash->mashStepsChanged();
    return tmp;
@@ -1115,22 +1120,22 @@ Misc* Database::newMisc()
    tmp->_key = insertNewDefaultRecord(Brewtarget::MISCTABLE);
    tmp->_table = Brewtarget::MISCTABLE;
    allMiscs.insert(tmp->_key,tmp);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("miscs"), QVariant() );
    emit newMiscSignal(tmp);
-   
+
    return tmp;
 }
 
 Misc* Database::newMisc(Misc* other)
 {
    Misc* tmp = copy<Misc>(other, true, &allMiscs);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("miscs"), QVariant() );
    emit newMiscSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -1140,48 +1145,48 @@ Recipe* Database::newRecipe(bool addMash)
    tmp->_key = insertNewDefaultRecord(Brewtarget::RECTABLE);
    tmp->_table = Brewtarget::RECTABLE;
    allRecipes.insert(tmp->_key,tmp);
-   
+
    // Now, need to create a new mash for the recipe.
    if ( addMash )
       newMash( tmp );
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("recipes"), QVariant() );
    emit newRecipeSignal(tmp);
-   
+
    return tmp;
 }
 
 Recipe* Database::newRecipe(Recipe* other)
 {
    Recipe* tmp = copy<Recipe>(other, true, &allRecipes);
-   
+
    // Copy fermentables
    foreach( Fermentable* a, other->fermentables() )
       addToRecipe( tmp, a );
-   
+
    // Copy hops
    foreach( Hop* a, other->hops() )
       addToRecipe( tmp, a );
-   
+
    // Copy miscs
    foreach( Misc* a, other->miscs() )
       addToRecipe( tmp, a );
-   
+
    // Copy yeasts
    foreach( Yeast* a, other->yeasts() )
       addToRecipe( tmp, a );
-   
+
    // Copy style/mash/equipment
    // Style or equipment might be non-existent but these methods handle that.
    addToRecipe( tmp, other->equipment() );
    addToRecipe( tmp, other->mash() );
    addToRecipe( tmp, other->style() );
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("recipes"), QVariant() );
    emit newRecipeSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -1191,21 +1196,21 @@ Style* Database::newStyle()
    tmp->_key = insertNewDefaultRecord(Brewtarget::STYLETABLE);
    tmp->_table = Brewtarget::STYLETABLE;
    allStyles.insert(tmp->_key,tmp);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("styles"), QVariant() );
    emit newStyleSignal(tmp);
-   
+
    return tmp;
 }
 
 Style* Database::newStyle(Style* other)
 {
    Style* tmp = copy<Style>(other, true, &allStyles);
-   
+
    emit changed( metaProperty("styles"), QVariant() );
    emit newStyleSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -1215,11 +1220,11 @@ Water* Database::newWater()
    tmp->_key = insertNewDefaultRecord(Brewtarget::WATERTABLE);
    tmp->_table = Brewtarget::WATERTABLE;
    allWaters.insert(tmp->_key,tmp);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("waters"), QVariant() );
    emit newWaterSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -1229,22 +1234,22 @@ Yeast* Database::newYeast()
    tmp->_key = insertNewDefaultRecord(Brewtarget::YEASTTABLE);
    tmp->_table = Brewtarget::YEASTTABLE;
    allYeasts.insert(tmp->_key,tmp);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("yeasts"), QVariant() );
    emit newYeastSignal(tmp);
-   
+
    return tmp;
 }
 
 Yeast* Database::newYeast(Yeast* other)
 {
    Yeast* tmp = copy<Yeast>(other, true, &allYeasts);
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("yeasts"), QVariant() );
    emit newYeastSignal(tmp);
-   
+
    return tmp;
 }
 
@@ -1263,8 +1268,8 @@ void Database::deleteRecord( Brewtarget::DBTable table, BeerXMLElement* object )
                          true);
    // For now, immediately execute the command.
    command->redo();
-   dirty = true; 
-   
+   dirty = true;
+
    // Push the command on the undo stack.
    //commandStack.push(command);
 }
@@ -1277,19 +1282,19 @@ void Database::duplicateMashSteps(Mash *oldMash, Mash *newMash)
    {
       // Copy the old mash step.
       MashStep* newStep = copy<MashStep>(*ms,true,&allMashSteps);
-      
+
       // Put it in the new mash.
       sqlUpdate(
          Brewtarget::MASHSTEPTABLE,
          QString("mash_id='%1'").arg(newMash->key()),
          QString("id='%1'").arg(newStep->key())
       );
-      
+
       // Make the new mash pay attention to the new step.
-      connect( newStep, SIGNAL(changed(QMetaProperty,QVariant)), newMash, SLOT(acceptMashStepChange(QMetaProperty,QVariant)) );          
+      connect( newStep, SIGNAL(changed(QMetaProperty,QVariant)), newMash, SLOT(acceptMashStepChange(QMetaProperty,QVariant)) );
    }
-   
-   dirty = true; 
+
+   dirty = true;
    emit changed( metaProperty("mashs"), QVariant() );
    emit newMash->mashStepsChanged();
 }
@@ -1298,7 +1303,7 @@ void Database::duplicateMashSteps(Mash *oldMash, Mash *newMash)
 void Database::remove(Equipment* equip)
 {
    deleteRecord(Brewtarget::EQUIPTABLE,equip);
-   
+
    emit changed( metaProperty("equipments"), QVariant() );
    emit deletedEquipmentSignal(equip);
 }
@@ -1322,7 +1327,7 @@ void Database::remove(QList<Equipment*> equip)
 void Database::remove(Fermentable* ferm)
 {
    deleteRecord(Brewtarget::FERMTABLE,ferm);
-   
+
    emit changed( metaProperty("fermentables"), QVariant());
    emit deletedFermentableSignal(ferm);
 }
@@ -1337,17 +1342,17 @@ void Database::remove(QList<Fermentable*> ferm)
    {
       deleteRecord(Brewtarget::FERMTABLE,*it);
       emit deletedFermentableSignal(*it);
-      
+
       it++;
    }
-   
+
    emit changed( metaProperty("fermentables"), QVariant());
 }
 
 void Database::remove(Hop* hop)
 {
    deleteRecord(Brewtarget::HOPTABLE,hop);
-   
+
    emit changed( metaProperty("hops"), QVariant() );
    emit deletedHopSignal(hop);
 }
@@ -1362,7 +1367,7 @@ void Database::remove(QList<Hop*> hop)
    {
       deleteRecord(Brewtarget::HOPTABLE,*it);
       emit deletedHopSignal(*it);
-      
+
       it++;
    }
 
@@ -1372,7 +1377,7 @@ void Database::remove(QList<Hop*> hop)
 void Database::remove(Mash* mash)
 {
    deleteRecord(Brewtarget::MASHTABLE,mash);
-   
+
    emit changed( metaProperty("mashs"), QVariant() );
    emit deletedMashSignal(mash);
 }
@@ -1409,7 +1414,7 @@ void Database::remove(QList<Mash*> mash)
 void Database::remove(MashStep* mashStep)
 {
    deleteRecord(Brewtarget::MASHSTEPTABLE,mashStep);
-   
+
    emit changed( metaProperty("mashSteps"), QVariant() );
 }
 
@@ -1430,7 +1435,7 @@ void Database::remove(QList<MashStep*> mashStep)
 void Database::remove(Misc* misc)
 {
    deleteRecord(Brewtarget::MISCTABLE,misc);
-   
+
    emit changed( metaProperty("miscs"), QVariant());
    emit deletedMiscSignal(misc);
 }
@@ -1453,7 +1458,7 @@ void Database::remove(QList<Misc*> misc)
 void Database::remove(Recipe* rec)
 {
    deleteRecord(Brewtarget::RECTABLE,rec);
-   
+
    emit changed( metaProperty("recipes"), QVariant() );
    emit deletedRecipeSignal(rec);
 }
@@ -1476,7 +1481,7 @@ void Database::remove(QList<Recipe*> rec)
 void Database::remove(Style* style)
 {
    deleteRecord(Brewtarget::STYLETABLE,style);
-   
+
    emit changed( metaProperty("styles"), QVariant() );
    emit deletedStyleSignal(style);
 }
@@ -1499,7 +1504,7 @@ void Database::remove(QList<Style*> style)
 void Database::remove(Water* water)
 {
    deleteRecord(Brewtarget::WATERTABLE,water);
-   
+
    emit changed( metaProperty("waters"), QVariant());
    emit deletedWaterSignal(water);
 }
@@ -1522,7 +1527,7 @@ void Database::remove(QList<Water*> water)
 void Database::remove(Yeast* yeast)
 {
    deleteRecord(Brewtarget::YEASTTABLE,yeast);
-   
+
    emit changed( metaProperty("yeasts"), QVariant());
    emit deletedYeastSignal(yeast);
 }
@@ -1546,7 +1551,7 @@ QString Database::getDbFileName()
 {
    // Ensure instance exists.
    instance();
-   
+
    return dbFileName;
 }
 
@@ -1562,17 +1567,17 @@ void Database::updateEntry( Brewtarget::DBTable table, int key, const char* col_
                                notify);
 
    command->redo();
-   dirty = true; 
+   dirty = true;
 }
 
 // Inventory functions ========================================================
 
-//This links ingredients with the same name. 
+//This links ingredients with the same name.
 //The first displayed ingredient in the database is assumed to be the parent.
 //TODO: make the child_id column UNIQUE in the database
 void Database::populateChildTablesByName(Brewtarget::DBTable table){
    Brewtarget::logW( "Populating Children Ingredient Links" );
-      
+
    QString queryString = QString(
       "SELECT DISTINCT name FROM %1"
    ).arg(tableNames[table]);
@@ -1597,7 +1602,7 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table){
          QSqlQuery insertq( queryString, sqlDatabase() );
       }
    }
-   
+
 }
 // populate ingredient tables
 void Database::populateChildTablesByName(){
@@ -1613,7 +1618,7 @@ int Database::getParentID(Brewtarget::DBTable table, int childKey){
    QString queryString = QString(
       "SELECT parent_id FROM %1 WHERE child_id = %2 LIMIT 1"
    ).arg(tableNames[tableToChildTable[table]]).arg(childKey);
-   
+
    QSqlQuery q( queryString, sqlDatabase() );
    q.first();
    ret = q.record().value("parent_id").toInt();
@@ -1645,12 +1650,12 @@ Brewtarget::DBTable Database::getInventoryTable(Brewtarget::DBTable table){
 //create a new inventory row
 void Database::newInventory(Brewtarget::DBTable invForTable, int invForID){
    QString invTable = tableNames[tableToInventoryTable[invForTable]];
-   
+
    QString queryString = QString(
       "INSERT OR REPLACE INTO %1 (%2_id) VALUES (%3)"
    ).arg(invTable).arg(tableNames[invForTable]).arg(getParentID(invForTable, invForID));
    QSqlQuery q( queryString, sqlDatabase() );
-   
+
 }
 
 // Add to recipe ==============================================================
@@ -1660,22 +1665,22 @@ void Database::addToRecipe( Recipe* rec, Equipment* e, bool noCopy )
 
    if( e == 0 )
       return;
-  
+
    // Make a copy of equipment.
    if ( ! noCopy )
       newEquip = copy<Equipment>(e,false,&allEquipments);
    else
       newEquip = e;
 
-   
-   dirty = true; 
+
+   dirty = true;
    // Update equipment_id
    sqlUpdate(Brewtarget::RECTABLE,
              QString("`equipment_id`='%1'").arg(newEquip->key()),
              QString("id='%1'").arg(rec->_key));
 
    newEquip->setDisplay(false);
-   
+
    // NOTE: need to disconnect the recipe's old equipment?
    connect( newEquip, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptEquipChange(QMetaProperty,QVariant)) );
    // NOTE: If we don't reconnect these signals, bad things happen when
@@ -1702,7 +1707,7 @@ void Database::addToRecipe( Recipe* rec, Fermentable* ferm, bool noCopy )
    connect( newFerm, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptFermChange(QMetaProperty,QVariant)) );
    // recalcAll is very expensive. When doing a massive import, don't do it
    // with every fermentable. Let it happen once
-   if (! noCopy ) 
+   if (! noCopy )
       rec->recalcAll();
 }
 
@@ -1759,7 +1764,7 @@ void Database::addToRecipe( Recipe* rec, QList<Hop*>hops )
 void Database::addToRecipe( Recipe* rec, Mash* m, bool noCopy )
 {
    Mash* newMash;
-  
+
    // Make a copy of mash.
    // Making a copy of the mash isn't enough. We need a copy of the mashsteps
    // too.
@@ -1770,14 +1775,14 @@ void Database::addToRecipe( Recipe* rec, Mash* m, bool noCopy )
    }
    else
       newMash = m;
-   
+
    // Update mash_id
    sqlUpdate(Brewtarget::RECTABLE,
              QString("`mash_id`='%1'").arg(newMash->key()),
              QString("id='%1'").arg(rec->_key));
-   
+
    // Emit a changed signal.
-   dirty = true; 
+   dirty = true;
    connect( newMash, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptMashChange(QMetaProperty,QVariant)));
    emit rec->changed( rec->metaProperty("mash"), BeerXMLElement::qVariantFromPtr(newMash) );
    // And let the recipe recalc all?
@@ -1788,7 +1793,7 @@ void Database::addToRecipe( Recipe* rec, Mash* m, bool noCopy )
 void Database::addToRecipe( Recipe* rec, Misc* m, bool noCopy )
 {
    addIngredientToRecipe<Misc>( rec, m, "miscs", "misc_in_recipe", "misc_id", "misc_children", noCopy, &allMiscs );
-   if (! noCopy ) 
+   if (! noCopy )
       rec->recalcAll();
 }
 
@@ -1810,7 +1815,7 @@ void Database::addToRecipe( Recipe* rec, QList<Misc*>miscs )
 void Database::addToRecipe( Recipe* rec, Water* w, bool noCopy )
 {
    addIngredientToRecipe<Water>( rec, w, "waters", "water_in_recipe", "water_id", "water_children", noCopy, &allWaters );
-   if (! noCopy ) 
+   if (! noCopy )
       rec->recalcAll();
 }
 
@@ -1820,19 +1825,19 @@ void Database::addToRecipe( Recipe* rec, Style* s, bool noCopy )
 
    if ( s == 0 )
       return;
-   
+
    if ( ! noCopy )
       newStyle = copy<Style>(s,false,&allStyles);
-   else 
+   else
       newStyle = s;
-   
+
    sqlUpdate(Brewtarget::RECTABLE,
              QString("`style_id`='%1'").arg(newStyle->key()),
              QString("id='%1'").arg(rec->_key));
 
    newStyle->setDisplay(false);
-   dirty = true; 
-   
+   dirty = true;
+
    // Emit a changed signal.
    emit rec->changed( rec->metaProperty("style"), BeerXMLElement::qVariantFromPtr(newStyle) );
 }
@@ -1872,7 +1877,7 @@ void Database::sqlUpdate( Brewtarget::DBTable table, QString const& setClause, Q
    if( q.lastError().isValid() )
       Brewtarget::logE( QString("Database::sqlUpdate(): %1").arg(q.lastError().text()) );
    q.finish();
-   dirty = true; 
+   dirty = true;
 }
 
 void Database::sqlDelete( Brewtarget::DBTable table, QString const& whereClause )
@@ -1882,29 +1887,29 @@ void Database::sqlDelete( Brewtarget::DBTable table, QString const& whereClause 
                 .arg(whereClause),
                 sqlDatabase());
    q.finish();
-   dirty = true; 
+   dirty = true;
 }
 
 QHash<Brewtarget::DBTable,QSqlQuery> Database::selectAllHash()
 {
    QHash<Brewtarget::DBTable,QSqlQuery> ret;
    QHash<Brewtarget::DBTable,QString> names = Database::tableNamesHash();
-   
+
    foreach( Brewtarget::DBTable table, names.keys() )
    {
       QSqlQuery q(sqlDatabase());
       q.prepare( QString("SELECT * FROM `%1` WHERE `id`=:id").arg(names[table]) );
-      
+
       ret[table] = q;
    }
-   
+
    return ret;
 }
 
 QHash<Brewtarget::DBTable,QString> Database::tableNamesHash()
 {
    QHash<Brewtarget::DBTable,QString> tmp;
-   
+
    tmp[ Brewtarget::BREWNOTETABLE ] = "brewnote";
    tmp[ Brewtarget::EQUIPTABLE ] = "equipment";
    tmp[ Brewtarget::FERMTABLE ] = "fermentable";
@@ -1917,7 +1922,7 @@ QHash<Brewtarget::DBTable,QString> Database::tableNamesHash()
    tmp[ Brewtarget::STYLETABLE ] = "style";
    tmp[ Brewtarget::WATERTABLE ] = "water";
    tmp[ Brewtarget::YEASTTABLE ] = "yeast";
-   
+
    //inventory tables
    tmp[ Brewtarget::FERMINVTABLE ] = "fermentable_in_inventory";
    tmp[ Brewtarget::HOPINVTABLE ] = "hop_in_inventory";
@@ -1928,14 +1933,14 @@ QHash<Brewtarget::DBTable,QString> Database::tableNamesHash()
    tmp[ Brewtarget::HOPCHILDTABLE ] = "hop_children";
    tmp[ Brewtarget::MISCCHILDTABLE ] = "misc_children";
    tmp[ Brewtarget::YEASTCHILDTABLE ] = "yeast_children";
-   
+
    return tmp;
 }
 
 QHash<QString,Brewtarget::DBTable> Database::classNameToTableHash()
 {
    QHash<QString,Brewtarget::DBTable> tmp;
-   
+
    tmp["BrewNote"] = Brewtarget::BREWNOTETABLE;
    tmp["Equipment"] = Brewtarget::EQUIPTABLE;
    tmp["Fermentable"] = Brewtarget::FERMTABLE;
@@ -1948,31 +1953,31 @@ QHash<QString,Brewtarget::DBTable> Database::classNameToTableHash()
    tmp["Style"] = Brewtarget::STYLETABLE;
    tmp["Water"] = Brewtarget::WATERTABLE;
    tmp["Yeast"] = Brewtarget::YEASTTABLE;
-   
+
    return tmp;
 }
 
 QHash<Brewtarget::DBTable,Brewtarget::DBTable> Database::tableToChildTableHash()
 {
    QHash<Brewtarget::DBTable,Brewtarget::DBTable> tmp;
-   
+
    tmp[Brewtarget::FERMTABLE] = Brewtarget::FERMCHILDTABLE;
    tmp[Brewtarget::HOPTABLE] = Brewtarget::HOPCHILDTABLE;
    tmp[Brewtarget::MISCTABLE] = Brewtarget::MISCCHILDTABLE;
    tmp[Brewtarget::YEASTTABLE] = Brewtarget::YEASTCHILDTABLE;
-   
+
    return tmp;
 }
 
 QHash<Brewtarget::DBTable,Brewtarget::DBTable> Database::tableToInventoryTableHash()
 {
    QHash<Brewtarget::DBTable,Brewtarget::DBTable> tmp;
-   
+
    tmp[Brewtarget::FERMTABLE] = Brewtarget::FERMINVTABLE;
    tmp[Brewtarget::HOPTABLE] = Brewtarget::HOPINVTABLE;
    tmp[Brewtarget::MISCTABLE] = Brewtarget::MISCINVTABLE;
    tmp[Brewtarget::YEASTTABLE] = Brewtarget::YEASTINVTABLE;
-   
+
    return tmp;
 }
 
@@ -2060,7 +2065,7 @@ bool Database::updateSchema(bool* err)
    int currentVersion = DatabaseSchemaHelper::currentVersion( sqlDatabase() );
    int newVersion = DatabaseSchemaHelper::dbVersion;
    bool doUpdate = currentVersion < newVersion;
-   
+
    if( doUpdate )
    {
       bool success = DatabaseSchemaHelper::migrate( currentVersion, newVersion, sqlDatabase() );
@@ -2073,19 +2078,19 @@ bool Database::updateSchema(bool* err)
       }
       dirty = true;
    }
-   
+
    //populate ingredient links
    int repopChild = 0;
    QSqlQuery popchildq( "SELECT repopulateChildrenOnNextStart FROM settings WHERE id=1", sqlDatabase() );
    if( popchildq.next() )
       repopChild = popchildq.record().value("repopulateChildrenOnNextStart").toInt();
-   
+
    if(repopChild == 1){
       populateChildTablesByName();
       QSqlQuery popchildq( "UPDATE settings SET repopulateChildrenOnNextStart = 0", sqlDatabase() );
-   
+
    }
-   
+
    if( err )
       *err = false;
    return doUpdate;
@@ -2103,7 +2108,7 @@ bool Database::importFromXML(const QString& filename)
    QStringList tags = QStringList() << "EQUIPMENT" << "FERMENTABLE" << "HOP" << "MISC" << "STYLE" << "YEAST" << "WATER" << "MASHS";
    inFile.setFileName(filename);
    bool ret = true;
-   
+
    if( ! inFile.open(QIODevice::ReadOnly) )
    {
       Brewtarget::logW(QString("Database::importFromXML: Could not open %1 for reading.").arg(filename));
@@ -2130,7 +2135,7 @@ bool Database::importFromXML(const QString& filename)
          list = xmlDoc.elementsByTagName(tag);
          count = list.size();
 
-         if ( count > 0 ) 
+         if ( count > 0 )
          {
             // Tell how many there were in the status bar.
             //statusBar()->showMessage( tr("Found %1 %2.").arg(count).arg(tag.toLower()), 5000 );
@@ -2389,59 +2394,59 @@ void Database::toXml( Equipment* a, QDomDocument& doc, QDomNode& parent )
    QDomElement equipNode;
    QDomElement tmpNode;
    QDomText tmpText;
-   
+
    equipNode = doc.createElement("EQUIPMENT");
-   
+
    tmpNode = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("VERSION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->version()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("BOIL_SIZE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->boilSize_l()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("BATCH_SIZE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->batchSize_l()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TUN_VOLUME");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tunVolume_l()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TUN_WEIGHT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tunWeight_kg()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TUN_SPECIFIC_HEAT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tunSpecificHeat_calGC()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TOP_UP_WATER");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->topUpWater_l()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TRUB_CHILLER_LOSS");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->trubChillerLoss_l()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("EVAP_RATE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->evapRate_pctHr()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("REAL_EVAP_RATE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->evapRate_lHr()));
    tmpNode.appendChild(tmpText);
@@ -2451,27 +2456,27 @@ void Database::toXml( Equipment* a, QDomDocument& doc, QDomNode& parent )
    tmpText = doc.createTextNode(BeerXMLElement::text(a->boilTime_min()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("CALC_BOIL_VOLUME");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->calcBoilVolume()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("LAUTER_DEADSPACE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->lauterDeadspace_l()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TOP_UP_KETTLE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->topUpKettle_l()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("HOP_UTILIZATION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->hopUtilization_pct()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("NOTES");
    tmpText = doc.createTextNode(a->notes());
    tmpNode.appendChild(tmpText);
@@ -2482,7 +2487,7 @@ void Database::toXml( Equipment* a, QDomDocument& doc, QDomNode& parent )
    tmpText = doc.createTextNode(BeerXMLElement::text(a->grainAbsorption_LKg()));
    tmpNode.appendChild(tmpText);
    equipNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("BOILING_POINT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->boilingPoint_c()));
    tmpNode.appendChild(tmpText);
@@ -2495,99 +2500,99 @@ void Database::toXml( Fermentable* a, QDomDocument& doc, QDomNode& parent )
    QDomElement fermNode;
    QDomElement tmpNode;
    QDomText tmpText;
-   
+
    fermNode = doc.createElement("FERMENTABLE");
-   
+
    tmpNode = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("VERSION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->version()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TYPE");
    tmpText = doc.createTextNode(Fermentable::types.at(a->type()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("AMOUNT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->amount_kg()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("YIELD");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->yield_pct()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("COLOR");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->color_srm()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("ADD_AFTER_BOIL");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->addAfterBoil()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("ORIGIN");
    tmpText = doc.createTextNode(a->origin());
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("SUPPLIER");
    tmpText = doc.createTextNode(a->supplier());
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("NOTES");
    tmpText = doc.createTextNode(a->notes());
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("COARSE_FINE_DIFF");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->coarseFineDiff_pct()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("MOISTURE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->moisture_pct()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("DIASTATIC_POWER");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->diastaticPower_lintner()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("PROTEIN");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->protein_pct()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("MAX_IN_BATCH");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->maxInBatch_pct()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("RECOMMEND_MASH");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->recommendMash()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("IS_MASHED");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->isMashed()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("IBU_GAL_PER_LB");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->ibuGalPerLb()));
    tmpNode.appendChild(tmpText);
    fermNode.appendChild(tmpNode);
-   
+
    parent.appendChild(fermNode);
 }
 
@@ -2596,94 +2601,94 @@ void Database::toXml( Hop* a, QDomDocument& doc, QDomNode& parent )
    QDomElement hopNode;
    QDomElement tmpNode;
    QDomText tmpText;
-   
+
    hopNode = doc.createElement("HOP");
-   
+
    tmpNode = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("VERSION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->version()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("ALPHA");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->alpha_pct()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("AMOUNT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->amount_kg()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("USE");
    tmpText = doc.createTextNode(a->useString());
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TIME");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->time_min()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("NOTES");
    tmpText = doc.createTextNode(a->notes());
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TYPE");
    tmpText = doc.createTextNode(a->typeString());
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("FORM");
    tmpText = doc.createTextNode(a->formString());
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("BETA");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->beta_pct()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("HSI");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->hsi_pct()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("ORIGIN");
    tmpText = doc.createTextNode(a->origin());
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("SUBSTITUTES");
    tmpText = doc.createTextNode(a->substitutes());
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("HUMULENE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->humulene_pct()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("CARYOPHYLLENE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->caryophyllene_pct()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("COHUMULONE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->cohumulone_pct()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("MYRCENE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->myrcene_pct()));
    tmpNode.appendChild(tmpText);
    hopNode.appendChild(tmpNode);
-   
+
    parent.appendChild(hopNode);
 }
 
@@ -2692,29 +2697,29 @@ void Database::toXml( Instruction* a, QDomDocument& doc, QDomNode& parent )
    QDomElement insNode;
    QDomElement tmpNode;
    QDomText tmpText;
-   
+
    insNode = doc.createElement("INSTRUCTION");
-   
+
    tmpNode = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpNode.appendChild(tmpText);
    insNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("DIRECTIONS");
    tmpText = doc.createTextNode(a->directions());
    tmpNode.appendChild(tmpText);
    insNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("HAS_TIMER");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->hasTimer()));
    tmpNode.appendChild(tmpText);
    insNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TIMER_VALUE");
    tmpText = doc.createTextNode(a->timerValue());
    tmpNode.appendChild(tmpText);
    insNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("COMPLETED");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->completed()));
    tmpNode.appendChild(tmpText);
@@ -2733,68 +2738,68 @@ void Database::toXml( Mash* a, QDomDocument& doc, QDomNode& parent )
    QDomElement mashNode;
    QDomElement tmpNode;
    QDomText tmpText;
-   
+
    int i, size;
-   
+
    mashNode = doc.createElement("MASH");
-   
+
    tmpNode = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("VERSION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->version()));
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("GRAIN_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->grainTemp_c()));
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("MASH_STEPS");
    QList<MashStep*> mashSteps = a->mashSteps();
    size = mashSteps.size();
    for( i = 0; i < size; ++i )
       toXml( mashSteps[i], doc, tmpNode);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("NOTES");
    tmpText = doc.createTextNode(a->notes());
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TUN_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tunTemp_c()));
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("SPARGE_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->spargeTemp_c()));
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("PH");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->ph()));
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TUN_WEIGHT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tunWeight_kg()));
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TUN_SPECIFIC_HEAT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tunSpecificHeat_calGC()));
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("EQUIP_ADJUST");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->equipAdjust()));
    tmpNode.appendChild(tmpText);
    mashNode.appendChild(tmpNode);
-   
+
    parent.appendChild(mashNode);
 }
 
@@ -2803,59 +2808,59 @@ void Database::toXml( MashStep* a, QDomDocument& doc, QDomNode& parent )
    QDomElement mashStepNode;
    QDomElement tmpNode;
    QDomText tmpText;
-   
+
    mashStepNode = doc.createElement("MASH_STEP");
-   
+
    tmpNode = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("VERSION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->version()));
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TYPE");
    tmpText = doc.createTextNode(a->typeString());
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("INFUSE_AMOUNT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->infuseAmount_l()));
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("STEP_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->stepTemp_c()));
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("STEP_TIME");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->stepTime_min()));
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("RAMP_TIME");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->rampTime_min()));
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("END_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->endTemp_c()));
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("INFUSE_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->infuseTemp_c()));
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("DECOCTION_AMOUNT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->decoctionAmount_l()));
    tmpNode.appendChild(tmpText);
    mashStepNode.appendChild(tmpNode);
-   
+
    parent.appendChild(mashStepNode);
 }
 
@@ -2864,54 +2869,54 @@ void Database::toXml( Misc* a, QDomDocument& doc, QDomNode& parent )
    QDomElement miscNode;
    QDomElement tmpNode;
    QDomText tmpText;
-   
+
    miscNode = doc.createElement("MISC");
-   
+
    tmpNode = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("VERSION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->version()));
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TYPE");
    tmpText = doc.createTextNode(a->typeString());
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("USE");
    tmpText = doc.createTextNode(a->useString());
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TIME");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->time()));
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("AMOUNT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->amount()));
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("AMOUNT_IS_WEIGHT");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->amountIsWeight()));
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("USE_FOR");
    tmpText = doc.createTextNode(a->useFor());
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("NOTES");
    tmpText = doc.createTextNode(a->notes());
    tmpNode.appendChild(tmpText);
    miscNode.appendChild(tmpNode);
-   
+
    parent.appendChild(miscNode);
 }
 
@@ -2920,55 +2925,55 @@ void Database::toXml( Recipe* a, QDomDocument& doc, QDomNode& parent )
    QDomElement recipeNode;
    QDomElement tmpNode;
    QDomText tmpText;
-   
+
    int i;
-   
+
    recipeNode = doc.createElement("RECIPE");
-   
+
    tmpNode = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("VERSION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->version()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TYPE");
    tmpText = doc.createTextNode(a->type());
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    Style* style = a->style();
    if( style != 0 )
       toXml( style, doc, recipeNode);
-   
+
    tmpNode = doc.createElement("BREWER");
    tmpText = doc.createTextNode(a->brewer());
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("BATCH_SIZE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->batchSize_l()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("BOIL_SIZE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->boilSize_l()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("BOIL_TIME");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->boilTime_min()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("EFFICIENCY");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->efficiency_pct()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("HOPS");
    QList<Hop*> hops = a->hops();
    for( i = 0; i < hops.size(); ++i )
@@ -2980,29 +2985,29 @@ void Database::toXml( Recipe* a, QDomDocument& doc, QDomNode& parent )
    for( i = 0; i < ferms.size(); ++i )
       toXml( ferms[i], doc, tmpNode);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("MISCS");
    QList<Misc*> miscs = a->miscs();
    for( i = 0; i < miscs.size(); ++i )
       toXml( miscs[i], doc, tmpNode);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("YEASTS");
    QList<Yeast*> yeasts = a->yeasts();
    for( i = 0; i < yeasts.size(); ++i )
       toXml( yeasts[i], doc, tmpNode);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("WATERS");
    QList<Water*> waters = a->waters();
    for( i = 0; i < waters.size(); ++i )
       toXml( waters[i], doc, tmpNode);
    recipeNode.appendChild(tmpNode);
-   
+
    Mash* mash = a->mash();
    if( mash != 0 )
       toXml( mash, doc, recipeNode);
-   
+
    tmpNode = doc.createElement("INSTRUCTIONS");
    QList<Instruction*> instructions = a->instructions();
    for( i = 0; i < instructions.size(); ++i )
@@ -3019,116 +3024,116 @@ void Database::toXml( Recipe* a, QDomDocument& doc, QDomNode& parent )
    tmpText = doc.createTextNode(a->asstBrewer());
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    Equipment* equip = a->equipment();
    if( equip )
       toXml( equip, doc, recipeNode);
-   
+
    tmpNode = doc.createElement("NOTES");
    tmpText = doc.createTextNode(a->notes());
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TASTE_NOTES");
    tmpText = doc.createTextNode(a->tasteNotes());
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TASTE_RATING");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tasteRating()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("OG");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->og()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("FG");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->fg()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("FERMENTATION_STAGES");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->fermentationStages()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("PRIMARY_AGE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->primaryAge_days()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("PRIMARY_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->primaryTemp_c()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("SECONDARY_AGE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->secondaryAge_days()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("SECONDARY_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->secondaryTemp_c()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TERTIARY_AGE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tertiaryAge_days()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("TERTIARY_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->tertiaryTemp_c()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("AGE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->age_days()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("AGE_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->ageTemp_c()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("DATE");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->date()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("CARBONATION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->carbonation_vols()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("FORCED_CARBONATION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->forcedCarbonation()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("PRIMING_SUGAR_NAME");
    tmpText = doc.createTextNode(a->primingSugarName());
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("CARBONATION_TEMP");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->carbonationTemp_c()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("PRIMING_SUGAR_EQUIV");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->primingSugarEquiv()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    tmpNode = doc.createElement("KEG_PRIMING_FACTOR");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->kegPrimingFactor()));
    tmpNode.appendChild(tmpText);
    recipeNode.appendChild(tmpNode);
-   
+
    parent.appendChild(recipeNode);
 }
 
@@ -3331,12 +3336,12 @@ void Database::toXml( Yeast* a, QDomDocument& doc, QDomNode& parent )
    QDomText tmpText;
 
    yeastNode = doc.createElement("YEAST");
-   
+
    tmpElement = doc.createElement("NAME");
    tmpText = doc.createTextNode(a->name());
    tmpElement.appendChild(tmpText);
    yeastNode.appendChild(tmpElement);
-   
+
    tmpElement = doc.createElement("VERSION");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->version()));
    tmpElement.appendChild(tmpText);
@@ -3440,14 +3445,14 @@ void Database::fromXml(BeerXMLElement* element, QHash<QString,QString> const& xm
          Brewtarget::logW( QString("Node at line %1 is not an element.").arg(textNode.lineNumber()) );
          continue;
       }
-      
+
       child = node.firstChild();
       if( child.isNull() || ! child.isText() )
          continue;
-      
+
       xmlTag = node.nodeName();
       textNode = child.toText();
-       
+
       if( xmlTagsToProperties.contains(xmlTag) )
       {
          switch( element->metaProperty(xmlTagsToProperties[xmlTag]).type() )
@@ -3491,12 +3496,12 @@ void Database::fromXml(BeerXMLElement* element, QHash<QString,QString> const& xm
       }
    }
 
-   dirty = true; 
+   dirty = true;
 }
 
 BrewNote* Database::brewNoteFromXml( QDomNode const& node, Recipe* parent )
 {
-   BrewNote* ret = newBrewNote(parent);  
+   BrewNote* ret = newBrewNote(parent);
 
    // Need to tell the brewnote not to perform the calculations
    ret->setLoading(true);
@@ -3510,8 +3515,8 @@ Equipment* Database::equipmentFromXml( QDomNode const& node, Recipe* parent )
 {
    // When loading from XML, we need to delay the signals until after
    // everything is done. This should significantly speed up the load times
-   blockSignals(true); 
-   
+   blockSignals(true);
+
    Equipment* ret;
    QList<Equipment*> matchingEquips;
    QDomNode n;
@@ -3523,9 +3528,9 @@ Equipment* Database::equipmentFromXml( QDomNode const& node, Recipe* parent )
       // Check to see if there is a hop already in the DB with the same name.
       n = node.firstChildElement("NAME");
       QString name = n.firstChild().toText().nodeValue();
-      
+
       getElements<Equipment>( matchingEquips, QString("name='%1'").arg(name), Brewtarget::EQUIPTABLE, allEquipments );
-      
+
       if( matchingEquips.length() > 0 )
       {
          createdNew = false;
@@ -3536,7 +3541,7 @@ Equipment* Database::equipmentFromXml( QDomNode const& node, Recipe* parent )
    }
    else
       ret = newEquipment();
-   
+
    fromXml( ret, Equipment::tagToProp, node );
 
    // If we are importing one of our beerXML files, the utilization is always
@@ -3556,7 +3561,7 @@ Equipment* Database::equipmentFromXml( QDomNode const& node, Recipe* parent )
       emit changed( metaProperty("equipments"), QVariant() );
       emit newEquipmentSignal(ret);
    }
-   
+
    return ret;
 }
 
@@ -3566,7 +3571,7 @@ Fermentable* Database::fermentableFromXml( QDomNode const& node, Recipe* parent 
    Fermentable* ret;
    bool createdNew = true;
    blockSignals(true);
-   
+
    // If we are just importing a hop by itself, need to do some dupe-checking.
    if( parent == 0 )
    {
@@ -3575,7 +3580,7 @@ Fermentable* Database::fermentableFromXml( QDomNode const& node, Recipe* parent 
       QString name = n.firstChild().toText().nodeValue();
       QList<Fermentable*> matchingFerms;
       getElements<Fermentable>( matchingFerms, QString("name='%1'").arg(name), Brewtarget::FERMTABLE, allFermentables );
-      
+
       if( matchingFerms.length() > 0 )
       {
          createdNew = false;
@@ -3586,10 +3591,10 @@ Fermentable* Database::fermentableFromXml( QDomNode const& node, Recipe* parent 
    }
    else
       ret = newFermentable();
-   
+
    fromXml( ret, Fermentable::tagToProp, node );
 
-   
+
    // Handle enums separately.
    n = node.firstChildElement("TYPE");
    if ( n.firstChild().isNull() )
@@ -3670,7 +3675,7 @@ Hop* Database::hopFromXml( QDomNode const& node, Recipe* parent )
    QDomNode n;
    Hop* ret;
    bool createdNew = true;
-   blockSignals(true); 
+   blockSignals(true);
 
    // If we are just importing a hop by itself, need to do some dupe-checking.
    if( parent == 0 )
@@ -3680,7 +3685,7 @@ Hop* Database::hopFromXml( QDomNode const& node, Recipe* parent )
       QString name = n.firstChild().toText().nodeValue();
       QList<Hop*> matchingHops;
       getElements<Hop>( matchingHops, QString("name='%1'").arg(name), Brewtarget::HOPTABLE, allHops );
-      
+
       if( matchingHops.length() > 0 )
       {
          createdNew = false;
@@ -3691,9 +3696,9 @@ Hop* Database::hopFromXml( QDomNode const& node, Recipe* parent )
    }
    else
       ret = newHop();
-   
+
    fromXml( ret, Hop::tagToProp, node );
-  
+
    // Handle enums separately.
    n = node.firstChildElement("USE");
    if ( n.firstChild().isNull() )
@@ -3743,12 +3748,12 @@ Hop* Database::hopFromXml( QDomNode const& node, Recipe* parent )
 Instruction* Database::instructionFromXml( QDomNode const& node, Recipe* parent )
 {
 
-   blockSignals(true); 
+   blockSignals(true);
    Instruction* ret = newInstruction(parent);
-   
+
    fromXml( ret, Instruction::tagToProp, node );
 
-   blockSignals(false); 
+   blockSignals(false);
    emit changed( metaProperty("instructions"), QVariant() );
    return ret;
 }
@@ -3757,33 +3762,33 @@ Mash* Database::mashFromXml( QDomNode const& node, Recipe* parent )
 {
    QDomNode n;
 
-   blockSignals(true); 
+   blockSignals(true);
    Mash* ret;
 
    // Mashes are weird. We need to know if this is a duplicate, but we need to
-   // make a copy of it anyway. 
+   // make a copy of it anyway.
    n = node.firstChildElement("NAME");
    QString name = n.firstChild().toText().nodeValue();
-   
+
    if( parent )
       ret = newMash(parent);
    else
       ret = newMash();
-  
-   // If the mash has a name 
+
+   // If the mash has a name
    if ( ! name.isEmpty() )
    {
       QList<Mash*> matchingMash;
       getElements<Mash>( matchingMash, QString("name='%1'").arg(name), Brewtarget::MASHTABLE, allMashs );
-     
-      // If there are no other matches in the database 
+
+      // If there are no other matches in the database
       if( matchingMash.isEmpty() )
          ret->setDisplay(true);
    }
    // First, get all the standard properties.
    fromXml( ret, Mash::tagToProp, node );
 
-   // Now, get the individual mash steps. 
+   // Now, get the individual mash steps.
    n = node.firstChildElement("MASH_STEPS");
    if( n.isNull() )
       return ret;
@@ -3796,7 +3801,7 @@ Mash* Database::mashFromXml( QDomNode const& node, Recipe* parent )
          ret->invalidate();
    }
 
-   blockSignals(false); 
+   blockSignals(false);
 
    emit changed( metaProperty("mashs"), QVariant() );
    emit newMashSignal(ret);
@@ -3812,22 +3817,22 @@ MashStep* Database::mashStepFromXml( QDomNode const& node, Mash* parent )
    bool blocked = signalsBlocked();
 
    if (! blocked )
-      blockSignals(true); 
+      blockSignals(true);
 
    MashStep* ret = newMashStep(parent);
    // I am only doing this on mashsteps because they cause all sorts of
    // expensive recalculations to happen
    ret->blockSignals(true);
-  
+
    fromXml(ret,MashStep::tagToProp,node);
-   
+
    // Handle enums separately.
    n = node.firstChildElement("TYPE");
    if ( n.firstChild().isNull() )
       ret->invalidate();
    else {
       //Try to make sure incoming format matches
-      //e.g. convert INFUSION to Infusion 
+      //e.g. convert INFUSION to Infusion
       str = n.firstChild().toText().nodeValue();
       str = str.toLower();
       str[0] = str.at(0).toTitleCase();
@@ -3837,11 +3842,11 @@ MashStep* Database::mashStepFromXml( QDomNode const& node, Mash* parent )
                        )
                     ) );
    }
-  
+
    ret->blockSignals(false);
    if (! blocked )
    {
-      blockSignals(false); 
+      blockSignals(false);
       emit changed( metaProperty("mashs"), QVariant() );
       emit parent->mashStepsChanged();
    }
@@ -3905,9 +3910,9 @@ Misc* Database::miscFromXml( QDomNode const& node, Recipe* parent )
 {
    QDomNode n;
    bool createdNew = true;
-   blockSignals(true); 
+   blockSignals(true);
    Misc* ret;
-   
+
    // If we are just importing a misc by itself, need to do some dupe-checking.
    if( parent == 0 )
    {
@@ -3916,7 +3921,7 @@ Misc* Database::miscFromXml( QDomNode const& node, Recipe* parent )
       QString name = n.firstChild().toText().nodeValue();
       QList<Misc*> matchingMiscs;
       getElements<Misc>( matchingMiscs, QString("name='%1'").arg(name), Brewtarget::MISCTABLE, allMiscs );
-      
+
       if( matchingMiscs.length() > 0 )
       {
          createdNew = false;
@@ -3927,9 +3932,9 @@ Misc* Database::miscFromXml( QDomNode const& node, Recipe* parent )
    }
    else
       ret = newMisc();
-   
+
    fromXml( ret, Misc::tagToProp, node );
-   
+
    // Handle enums separately.
    n = node.firstChildElement("TYPE");
    // Assuming these return anything is a bad idea. So far, several other brewing programs are not generating
@@ -3944,7 +3949,7 @@ Misc* Database::miscFromXml( QDomNode const& node, Recipe* parent )
       ret->invalidate();
    else
       ret->setUse(static_cast<Misc::Use>(getQualifiedMiscUseIndex(n.firstChild().toText().nodeValue(), ret)));
-   
+
    if ( ! ret->isValid() )
    {
       QString name = ret->name();
@@ -3981,24 +3986,24 @@ Recipe* Database::recipeFromXml( QDomNode const& node )
 
    // Don't create a new mash -- we do that later
    Recipe* ret = newRecipe(false);
- 
+
    // Get standard properties.
    fromXml( ret, Recipe::tagToProp, node);
-   
+
    // Get style. Note: styleFromXml requires the entire node, not just the
    // firstchild of the node.
    n = node.firstChildElement("STYLE");
    styleFromXml(n, ret);
    if ( ! ret->style()->isValid())
       ret->invalidate();
-   
+
    // Get equipment. equipmentFromXml requires the entire node, not just the
    // first child
    n = node.firstChildElement("EQUIPMENT");
    equipmentFromXml(n, ret);
    if ( !ret->equipment()->isValid() )
       ret->invalidate();
-   
+
    // Get hops.
    n = node.firstChildElement("HOPS");
    for( n = n.firstChild(); !n.isNull(); n = n.nextSibling() )
@@ -4007,7 +4012,7 @@ Recipe* Database::recipeFromXml( QDomNode const& node )
       if ( ! temp->isValid() )
          ret->invalidate();
    }
-   
+
    // Get ferms.
    n = node.firstChildElement("FERMENTABLES");
    for( n = n.firstChild(); !n.isNull(); n = n.nextSibling() )
@@ -4016,7 +4021,7 @@ Recipe* Database::recipeFromXml( QDomNode const& node )
       if ( ! temp->isValid() )
          ret->invalidate();
    }
-   
+
    // get mashes. There is only one mash per recipe, so this needs the entire
    // node.
    n = node.firstChildElement("MASH");
@@ -4032,7 +4037,7 @@ Recipe* Database::recipeFromXml( QDomNode const& node )
       if (! temp->isValid())
          ret->invalidate();
    }
-   
+
    // Get yeasts.
    n = node.firstChildElement("YEASTS");
    for( n = n.firstChild(); !n.isNull(); n = n.nextSibling() )
@@ -4041,7 +4046,7 @@ Recipe* Database::recipeFromXml( QDomNode const& node )
       if ( !temp->isValid() )
          ret->invalidate();
    }
-   
+
    // Get waters. Odd. Waters don't invalidate.
    n = node.firstChildElement("WATERS");
    for( n = n.firstChild(); !n.isNull(); n = n.nextSibling() )
@@ -4074,7 +4079,7 @@ Style* Database::styleFromXml( QDomNode const& node, Recipe* parent )
 {
    QDomNode n;
    bool createdNew = true;
-   blockSignals(true); 
+   blockSignals(true);
    Style* ret;
    QString name;
    QList<Style*> matching;
@@ -4086,7 +4091,7 @@ Style* Database::styleFromXml( QDomNode const& node, Recipe* parent )
       n = node.firstChildElement("NAME");
       name = n.firstChild().toText().nodeValue();
       getElements<Style>( matching, QString("name='%1'").arg(name), Brewtarget::STYLETABLE, allStyles );
-      
+
       if( matching.length() > 0 )
       {
          createdNew = false;
@@ -4097,7 +4102,7 @@ Style* Database::styleFromXml( QDomNode const& node, Recipe* parent )
    }
    else
       ret = newStyle();
-   
+
    fromXml( ret, Style::tagToProp, node );
 
    // Handle enums separately.
@@ -4139,11 +4144,11 @@ Style* Database::styleFromXml( QDomNode const& node, Recipe* parent )
 
 Water* Database::waterFromXml( QDomNode const& node, Recipe* parent )
 {
-   blockSignals(true); 
+   blockSignals(true);
    bool createdNew = true;
    Water* ret;
    QDomNode n;
-   
+
    // If we are just importing a style by itself, need to do some dupe-checking.
    if( parent == 0 )
    {
@@ -4152,7 +4157,7 @@ Water* Database::waterFromXml( QDomNode const& node, Recipe* parent )
       QString name = n.firstChild().toText().nodeValue();
       QList<Water*> matching;
       getElements<Water>( matching, QString("name='%1'").arg(name), Brewtarget::WATERTABLE, allWaters );
-      
+
       if( matching.length() > 0 )
       {
          createdNew = false;
@@ -4163,7 +4168,7 @@ Water* Database::waterFromXml( QDomNode const& node, Recipe* parent )
    }
    else
       ret = newWater();
-   
+
    fromXml( ret, Water::tagToProp, node );
    if( parent )
       addToRecipe( parent, ret, true );
@@ -4174,7 +4179,7 @@ Water* Database::waterFromXml( QDomNode const& node, Recipe* parent )
       emit changed( metaProperty("waters"), QVariant() );
       emit newWaterSignal(ret);
    }
-   
+
    return ret;
 }
 
@@ -4186,7 +4191,7 @@ Yeast* Database::yeastFromXml( QDomNode const& node, Recipe* parent )
    Yeast* ret;
    QString name;
    QList<Yeast*> matching;
-   
+
    // If we are just importing a yeast by itself, need to do some dupe-checking.
    if( parent == 0 )
    {
@@ -4194,7 +4199,7 @@ Yeast* Database::yeastFromXml( QDomNode const& node, Recipe* parent )
       n = node.firstChildElement("NAME");
       name = n.firstChild().toText().nodeValue();
       getElements<Yeast>( matching, QString("name='%1'").arg(name), Brewtarget::YEASTTABLE, allYeasts );
-      
+
       if( matching.length() > 0 )
       {
          createdNew = false;
@@ -4205,7 +4210,7 @@ Yeast* Database::yeastFromXml( QDomNode const& node, Recipe* parent )
    }
    else
       ret = newYeast();
-   
+
    fromXml( ret, Yeast::tagToProp, node );
 
    // Handle enums separately.
@@ -4263,14 +4268,14 @@ Yeast* Database::yeastFromXml( QDomNode const& node, Recipe* parent )
 
    if( parent )
       addToRecipe( parent, ret, true );
-   
+
    blockSignals(false);
    if( createdNew )
    {
       emit changed( metaProperty("yeasts"), QVariant() );
       emit newYeastSignal(ret);
    }
-   
+
    return ret;
 }
 
@@ -4300,7 +4305,7 @@ bool Database::cleanupBackupDatabase()
          QPushButton *restoreButton = messageBox.addButton(QObject::tr("Restore"), QMessageBox::AcceptRole);
          messageBox.addButton(QObject::tr("Rollback"), QMessageBox::RejectRole);
          messageBox.setDefaultButton(restoreButton);
-         
+
          // Display the message box.
          messageBox.exec();
 
@@ -4366,12 +4371,12 @@ bool Database::cleanupBackupDatabase()
 QList<TableParams> Database::makeTableParams()
 {
    typedef BeerXMLElement* (Database::*NewIngFunc)(void);
-   
+
    QList<TableParams> ret;
    TableParams tmp;
-   
+
    //=============================Equipment====================================
-   
+
    tmp.tableName = "equipment";
    tmp.propName = QStringList() <<
       "name" << "boil_size" << "batch_size" << "tun_volume" << "tun_weight" <<
@@ -4382,10 +4387,10 @@ QList<TableParams> Database::makeTableParams()
    tmp.newElement =
       (NewIngFunc) (Equipment*(Database::*)(void))
       &Database::newEquipment;
-   
+
    ret.append(tmp);
    //==============================Fermentables================================
-   
+
    tmp.tableName = "fermentable";
    tmp.propName = QStringList() <<
       "name" << "ftype" << "amount" << "yield" << "color" <<
@@ -4396,7 +4401,7 @@ QList<TableParams> Database::makeTableParams()
       (NewIngFunc)
       (Fermentable*(Database::*)(void))
       &Database::newFermentable;
-   
+
    //==============================Hops=============================
    tmp.tableName = "hop";
    tmp.propName = QStringList() <<
@@ -4409,11 +4414,11 @@ QList<TableParams> Database::makeTableParams()
       (NewIngFunc)
       (Hop*(Database::*)(void))
       &Database::newHop;
-   
+
    ret.append(tmp);
-   
+
    //==================================Miscs===================================
-   
+
    tmp.tableName = "misc";
    tmp.propName = QStringList() <<
       "name" << "mtype" << "use" << "time" << "amount" << "amount_is_weight" <<
@@ -4422,10 +4427,10 @@ QList<TableParams> Database::makeTableParams()
       (NewIngFunc)
       (Misc*(Database::*)(void))
       &Database::newMisc;
-   
+
    ret.append(tmp);
    //==================================Styles==================================
-   
+
    tmp.tableName = "style";
    tmp.propName = QStringList() <<
       "name" << "s_type" << "category" << "category_number" <<
@@ -4437,11 +4442,11 @@ QList<TableParams> Database::makeTableParams()
       (NewIngFunc)
       (Style*(Database::*)(void))
       &Database::newStyle;
-   
+
    ret.append(tmp);
-   
+
    //==================================Yeasts==================================
-   
+
    tmp.tableName = "yeast";
    tmp.propName = QStringList() <<
       "name" << "ytype" << "form" << "amount" << "amount_is_weight" <<
@@ -4452,11 +4457,11 @@ QList<TableParams> Database::makeTableParams()
       (NewIngFunc)
       (Yeast*(Database::*)(void))
       &Database::newYeast;
-   
+
    ret.append(tmp);
-   
+
    //===================================Waters=================================
-   
+
    tmp.tableName = "water";
    tmp.propName = QStringList() <<
       "name" << "amount" << "calcium" << "bicarbonate" << "sulfate" <<
@@ -4465,9 +4470,9 @@ QList<TableParams> Database::makeTableParams()
       (NewIngFunc)
       (Water*(Database::*)(void))
       &Database::newWater;
-   
+
    ret.append(tmp);
-   
+
    return ret;
 }
 
@@ -4478,7 +4483,7 @@ void Database::updateDatabase(QString const& filename)
 
    QVariant btid, newid, oldid;
    QVariant zero(0);
-   
+
    QList<QVariant> propVal;
    QStringList varAndHolder;
 
@@ -4493,18 +4498,18 @@ void Database::updateDatabase(QString const& filename)
                             QString(QObject::tr("Failed to open the database '%1'.").arg(filename)));
       return;
    }
-   
+
    // This is the basic gist...
    // For each (id, hop_id) in newSqldb.bt_hop...
-   
+
    // Call this newRecord
    // SELECT * FROM newSqldb.hop WHERE id=<hop_id>
-   
+
    // UPDATE hop SET name=:name, alpha=:alpha,... WHERE id=(SELECT hop_id FROM bt_hop WHERE id=:bt_id)
-   
+
    // Bind :bt_id from <id>
    // Bind :name, :alpha, ..., from newRecord.
-   
+
    // Execute.
 
    foreach( TableParams tp, tableParams)
@@ -4512,10 +4517,10 @@ void Database::updateDatabase(QString const& filename)
       QSqlQuery qNewBtIng(
          QString("SELECT * FROM bt_%1").arg(tp.tableName),
          newSqldb );
-                  
+
       QSqlQuery qNewIng( newSqldb );
       qNewIng.prepare(QString("SELECT * FROM %1 WHERE id=:id").arg(tp.tableName));
-      
+
       // Construct the big update query.
       QSqlQuery qUpdateOldIng( sqlDatabase() );
       QString updateString = QString("UPDATE %1 SET ").arg(tp.tableName);
@@ -4527,28 +4532,28 @@ void Database::updateDatabase(QString const& filename)
       updateString.append(", `deleted`=:zero WHERE `id`=:id");
       qUpdateOldIng.prepare(updateString);
       qUpdateOldIng.bindValue( ":zero", zero );
-      
+
       QSqlQuery qOldBtIng( sqlDatabase() );
       qOldBtIng.prepare(
          QString("SELECT * FROM bt_%1 WHERE `id`=:btid").arg(tp.tableName) );
-      
+
       QSqlQuery qOldBtIngInsert( sqlDatabase() );
       qOldBtIngInsert.prepare(
          QString("INSERT INTO bt_%1 `id`=:id `%2_id`=:%3_id")
             .arg(tp.tableName)
             .arg(tp.tableName)
             .arg(tp.tableName) );
-      
+
       // Resize propVal appropriately for current table.
       propVal.clear();
       foreach( QString pn, tp.propName )
          propVal.append(QVariant());
-      
+
       while( qNewBtIng.next() )
       {
          btid = qNewBtIng.record().value("id");
          newid = qNewBtIng.record().value(QString("%1_id").arg(tp.tableName));
-         
+
          qNewIng.bindValue(":id", newid);
          qNewIng.exec();
          if( !qNewIng.next() )
@@ -4556,7 +4561,7 @@ void Database::updateDatabase(QString const& filename)
             Brewtarget::logE(QString("Oops. %1").arg(qNewIng.lastError().text()));
             return;
          }
-         
+
          QList<QVariant>::iterator it = propVal.begin();
          foreach( QString pn, tp.propName )
          {
@@ -4568,23 +4573,23 @@ void Database::updateDatabase(QString const& filename)
                *it );
             ++it;
          }
-         
+
          // Done retrieving new ingredient data.
          qNewIng.finish();
-         
+
          // Find the bt_<ingredient> record in the local table.
          qOldBtIng.bindValue( ":btid", btid );
          qOldBtIng.exec();
-         
+
          // If the btid exists in the old bt_hop table, do an update.
          if( qOldBtIng.next() )
          {
             oldid = qOldBtIng.record().value(
                QString("%1_id").arg(tp.tableName) );
             qOldBtIng.finish();
-            
+
             qUpdateOldIng.bindValue( ":id", oldid );
-            
+
             qUpdateOldIng.exec();
             if( qUpdateOldIng.lastError().isValid() )
             {
@@ -4608,7 +4613,7 @@ void Database::updateDatabase(QString const& filename)
                   QString("Database::updateDatabase(): %1")
                   .arg(qUpdateOldIng.lastError().text()) );
             }
-            
+
             // Insert an entry into our bt_<ingredient> table.
             qOldBtIngInsert.bindValue( ":id", btid );
             qOldBtIngInsert.bindValue( QString(":%1_id").arg(tp.tableName), oldid );

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -2031,6 +2031,16 @@ void Recipe::acceptHopChange(Hop* hop)
    recalcIBU();
 }
 
+void Recipe::acceptYeastChange(QMetaProperty prop, QVariant val)
+{
+   recalcOgFg();
+}
+
+void Recipe::acceptYeastChange(Yeast* yeast)
+{
+   recalcOgFg();
+}
+
 void Recipe::acceptMashChange(QMetaProperty prop, QVariant val)
 {
    Mash* mashSend = qobject_cast<Mash*>(sender());

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -129,12 +129,12 @@ Recipe::Recipe()
      _fg(1.000),
      _uninitializedCalcs(true)
 {
-   setObjectName("Recipe"); 
+   setObjectName("Recipe");
 }
 
 Recipe::Recipe( Recipe const& other ) : BeerXMLElement(other)
 {
-   setObjectName("Recipe"); 
+   setObjectName("Recipe");
 }
 
 void Recipe::removeInstruction(Instruction* ins)
@@ -147,7 +147,7 @@ void Recipe::swapInstructions( Instruction* ins1, Instruction* ins2 )
    QList<Instruction*> ins = instructions();
    if( !(ins.contains(ins1) && ins.contains(ins2)) )
       return;
-   
+
    Database::instance().swapInstructionOrder(ins1, ins2);
 }
 
@@ -198,7 +198,7 @@ Instruction* Recipe::mashWaterIns(unsigned int size)
 
    if( mash() == 0 )
       return 0;
-   
+
    ins = Database::instance().newInstruction(this);
    ins->setName(tr("Heat water"));
    str = tr("Bring ");
@@ -221,7 +221,7 @@ QVector<PreInstruction> Recipe::mashInstructions(double timeRemaining, double to
 
    if( mash() == 0 )
       return preins;
-   
+
    QList<MashStep*> msteps = mash()->mashSteps();
    for( i = 0; i < size; ++i )
    {
@@ -613,13 +613,13 @@ void Recipe::generateInstructions()
 
    // First wort hopping
    firstWortHopsIns();
-    
+
    // Need to top up the kettle before boil?
    topOffIns();
 
    // Boil instructions
-   preinstructions.clear();   
-   
+   preinstructions.clear();
+
    // Find boil time.
    if( equipment() != 0 )
       timeRemaining = equipment()->boilTime_min();
@@ -630,17 +630,17 @@ void Recipe::generateInstructions()
                                         tr("You did not configure an equipment (which you really should), so tell me the boil time.")),
                                         Units::minutes);
    }
-   
+
    str = tr("Bring the wort to a boil and hold for %1.").arg(Brewtarget::displayAmount( timeRemaining, "tab_recipe", "boilTime_min", Units::minutes));
    ins = Database::instance().newInstruction(this);
    ins->setName(tr("Start boil"));
    ins->setInterval(timeRemaining);
    ins->setDirections(str);
-   
+
    /*** Get fermentables unless we haven't added yet ***/
    if ( hasBoilFermentable() )
       preinstructions.push_back(boilFermentablesPre(timeRemaining));
-   
+
    // add the intructions for including Extracts to wort
    if ( hasBoilExtract() )
       preinstructions.push_back(addExtracts(timeRemaining-1));
@@ -665,7 +665,7 @@ void Recipe::generateInstructions()
    preinstructions.clear();
    preinstructions += hopSteps(Hop::UseAroma);
    addPreinstructions(preinstructions);
-   
+
    // Fermentation instructions
    preinstructions.clear();
 
@@ -674,7 +674,7 @@ void Recipe::generateInstructions()
 
    /*** post boil ***/
    postboilIns();
-   
+
    /*** Primary yeast ***/
    str = tr("Cool wort and pitch ");
    QList<Yeast*> ylist = yeasts();
@@ -766,7 +766,7 @@ QString Recipe::nextAddToBoil(double& time)
          foundSomething = true;
       }
    }
-   
+
    time = foundSomething ? max : -1.0;
    return ret;
 }
@@ -840,7 +840,7 @@ void Recipe::setBatchSize_l( double var )
    }
 
    set( "batchSize_l", "batch_size", tmp );
-   
+
    // NOTE: this is bad, but we have to call recalcAll(), because the estimated
    // boil/batch volumes depend on the target volumes when there are no mash
    // steps to actually provide an estimate for the volumes.
@@ -861,7 +861,7 @@ void Recipe::setBoilSize_l( double var )
    }
 
    set( "boilSize_l", "boil_size", tmp );
-   
+
    // NOTE: this is bad, but we have to call recalcAll(), because the estimated
    // boil/batch volumes depend on the target volumes when there are no mash
    // steps to actually provide an estimate for the volumes.
@@ -1124,7 +1124,7 @@ void Recipe::setPrimingSugarEquiv( double var )
 void Recipe::setKegPrimingFactor( double var )
 {
    double tmp;
-   
+
    if( var < 0.0 )
    {
       Brewtarget::logW( QString("Recipe: keg priming factor < 0: %1").arg(var) );
@@ -1374,7 +1374,7 @@ double Recipe::batchSizeNoLosses_l()
    Equipment* e = equipment();
    if( e )
       ret += e->trubChillerLoss_l();
-   
+
    return ret;
 }
 
@@ -1390,7 +1390,7 @@ void Recipe::recalcAll()
    // Someone has already called this function back in the call stack, so return to avoid recursion.
    if( !_recalcMutex.tryLock() )
       return;
-   
+
    // Times are in seconds, and are cumulative.
    recalcGrainsInMash_kg(); // 0.01
    recalcGrains_kg(); // 0.03
@@ -1402,9 +1402,9 @@ void Recipe::recalcAll()
    recalcBoilGrav(); // 0.14
    recalcIBU(); // 0.15
    recalcCalories();
-   
+
    _uninitializedCalcs = false;
-   
+
    _recalcMutex.unlock();
 }
 
@@ -1416,8 +1416,8 @@ void Recipe::recalcABV_pct()
    // The multiplicative factor actually varies from
    // 125 for weak beers to 135 for strong beers.
    ret = 130*(_og_fermentable - _fg_fermentable);
-  
-   if ( ret != _ABV_pct ) 
+
+   if ( ret != _ABV_pct )
    {
       _ABV_pct = ret;
       emit changed( metaProperty("ABV_pct"), _ABV_pct );
@@ -1440,8 +1440,8 @@ void Recipe::recalcColor_srm()
    }
 
    ret = ColorMethods::mcuToSrm(mcu);
- 
-   if ( _color_srm != ret ) 
+
+   if ( _color_srm != ret )
    {
       _color_srm = ret;
       emit changed( metaProperty("color_srm"), _color_srm );
@@ -1454,7 +1454,7 @@ void Recipe::recalcIBU()
    unsigned int i;
    double ibus = 0.0;
    double tmp = 0.0;
-   
+
    // Bitterness due to hops...
    _ibus.clear();
    QList<Hop*> hhops = hops();
@@ -1475,7 +1475,7 @@ void Recipe::recalcIBU()
               (ferms[i]->amount_kg() / batchSize_l()) / 8.34538;
    }
 
-   if ( ibus != _IBU ) 
+   if ( ibus != _IBU )
    {
       _IBU = ibus;
       emit changed( metaProperty("IBU"), _IBU );
@@ -1497,7 +1497,7 @@ void Recipe::recalcVolumeEstimates()
       _wortFromMash_l = 0.0;
    else
    {
-   
+
       waterAdded_l = mash()->totalMashWater_l();
       if( equipment() != 0 )
          absorption_lKg = equipment()->grainAbsorption_LKg();
@@ -1506,14 +1506,14 @@ void Recipe::recalcVolumeEstimates()
 
       tmp_wfm = (waterAdded_l - absorption_lKg * _grainsInMash_kg);
    }
-   
+
    // boilVolume_l ==============================
-   
+
    if( equipment() != 0 )
       tmp = tmp_wfm - equipment()->lauterDeadspace_l() + equipment()->topUpKettle_l();
    else
       tmp = tmp_wfm;
-   
+
    // Need to account for extract/sugar volume also.
    QList<Fermentable*> ferms = fermentables();
    foreach( Fermentable* f, ferms )
@@ -1526,14 +1526,14 @@ void Recipe::recalcVolumeEstimates()
       else if( type == Fermentable::Dry_Extract )
          tmp += f->amount_kg() / PhysicalConstants::dryExtractDensity_kgL;
    }
-   
+
    if( tmp <= 0.0 )
       tmp = boilSize_l(); // Give up.
- 
+
    tmp_bv = tmp;
-   
+
    // finalVolume_l ==============================
-   
+
    // NOTE: the following figure is not based on the other volume estimates
    // since we want to show og,fg,ibus,etc. as if the collected wort is correct.
    _finalVolumeNoLosses_l = batchSizeNoLosses_l();
@@ -1547,7 +1547,7 @@ void Recipe::recalcVolumeEstimates()
       _finalVolume_l = tmp_bv - 4.0; // This is just shooting in the dark. Can't do much without an equipment.
       //_finalVolumeNoLosses_l = _finalVolume_l;
    }
-   
+
    // postBoilVolume_l ===========================
 
    if( equipment() != 0 )
@@ -1566,7 +1566,7 @@ void Recipe::recalcVolumeEstimates()
       _boilVolume_l = tmp_bv;
       emit changed( metaProperty("boilVolume_l"), _boilVolume_l );
    }
-   
+
    if ( tmp_fv != _finalVolume_l )
    {
       _finalVolume_l = tmp_fv;
@@ -1585,18 +1585,18 @@ void Recipe::recalcGrainsInMash_kg()
    unsigned int i, size;
    double ret = 0.0;
    Fermentable* ferm;
-   
+
    QList<Fermentable*> ferms = fermentables();
    size = ferms.size();
    for( i = 0; i < size; ++i )
    {
       ferm = ferms[i];
-      
+
       if( ferm->type() == Fermentable::Grain && ferm->isMashed() )
          ret += ferm->amount_kg();
    }
 
-   if ( ret != _grainsInMash_kg ) 
+   if ( ret != _grainsInMash_kg )
    {
       _grainsInMash_kg = ret;
       emit changed( metaProperty("grainsInMash_kg"), _grainsInMash_kg );
@@ -1613,7 +1613,7 @@ void Recipe::recalcGrains_kg()
    for( i = 0; i < size; ++i )
       ret += ferms[i]->amount_kg();
 
-   if ( ret != _grains_kg ) 
+   if ( ret != _grains_kg )
    {
       _grains_kg = ret;
       emit changed( metaProperty("grains_kg"), _grains_kg );
@@ -1649,7 +1649,7 @@ void Recipe::recalcCalories()
    // Alcohol by weight?
    abw = (startPlato-RE)/(2.0665 - (0.010665 * startPlato));
 
-   // The final results of this formular are calories per 100 ml. 
+   // The final results of this formular are calories per 100 ml.
    // The 3.55 puts it in terms of 12 oz. I really should have stored it
    // without that adjust.
    tmp = ((6.9*abw) + 4.0 * (RE-0.1)) * ffg * 3.55;
@@ -1660,7 +1660,7 @@ void Recipe::recalcCalories()
    if ( tmp < 0 )
       tmp = 0;
 
-   if ( tmp != _calories ) 
+   if ( tmp != _calories )
    {
       _calories = tmp;
       emit changed( metaProperty("calories"), _calories );
@@ -1683,7 +1683,7 @@ QHash<QString,double> Recipe::calcTotalPoints()
 
    QList<Fermentable*> ferms = fermentables();
    QHash<QString,double> ret;
-   
+
    for( i = 0; static_cast<int>(i) < ferms.size(); ++i )
    {
       ferm = ferms[i];
@@ -1706,8 +1706,8 @@ QHash<QString,double> Recipe::calcTotalPoints()
          if (ferm->addAfterBoil())
             lateAddition_kg += ferm->equivSucrose_kg();
       }
-   }   
-   
+   }
+
    ret.insert("sugar_kg", sugar_kg);
    ret.insert("nonFermetableSugars_kg", nonFermetableSugars_kg);
    ret.insert("sugar_kg_ignoreEfficiency", sugar_kg_ignoreEfficiency);
@@ -1730,15 +1730,15 @@ void Recipe::recalcBoilGrav()
    sugars = calcTotalPoints();
    sugar_kg = sugars.value("sugar_kg");
    sugar_kg_ignoreEfficiency = sugars.value("sugar_kg_ignoreEfficiency");
-   lateAddition_kg = sugars.value("ateAddition_kg");
+   lateAddition_kg = sugars.value("lateAddition_kg");
    lateAddition_kg_ignoreEff = sugars.value("lateAddition_kg_ignoreEff");
-   
+
    // Since the efficiency refers to how much sugar we get into the fermenter,
    // we need to adjust for that here.
    sugar_kg = (efficiency_pct()/100.0 * (sugar_kg - lateAddition_kg) + sugar_kg_ignoreEfficiency - lateAddition_kg_ignoreEff);
 
    ret = Algorithms::PlatoToSG_20C20C( Algorithms::getPlato(sugar_kg, boilSize_l()) );
- 
+
    if ( ret != _boilGrav )
    {
       _boilGrav = ret;
@@ -1761,7 +1761,7 @@ void Recipe::recalcOgFg()
    double tmp_og, tmp_fg, tmp_pnts, tmp_ferm_pnts;
    Yeast* yeast;
    QHash<QString,double> sugars;
-  
+
    _og_fermentable = _fg_fermentable = 0.0;
 
    // The first time through really has to get the _og and _fg from the
@@ -1783,7 +1783,7 @@ void Recipe::recalcOgFg()
    // We might lose some sugar in the form of Trub/Chiller loss and lauter deadspace.
    if( equipment() != 0 )
    {
-      
+
       kettleWort_l = (_wortFromMash_l - equipment()->lauterDeadspace_l()) + equipment()->topUpKettle_l();
       postBoilWort_l = equipment()->wortEndOfBoil_l(kettleWort_l);
       ratio = (postBoilWort_l - equipment()->trubChillerLoss_l()) / postBoilWort_l;
@@ -1810,7 +1810,7 @@ void Recipe::recalcOgFg()
       ferm_kg = sugar_kg - nonFermetableSugars_kg;
       plato = Algorithms::getPlato( ferm_kg, _finalVolumeNoLosses_l);
       _og_fermentable = Algorithms::PlatoToSG_20C20C( plato );
-      plato = Algorithms::getPlato( nonFermetableSugars_kg, _finalVolumeNoLosses_l); 
+      plato = Algorithms::getPlato( nonFermetableSugars_kg, _finalVolumeNoLosses_l);
       tmp_ferm_pnts = ((Algorithms::PlatoToSG_20C20C( plato ))-1)*1000.0;
    }
    else
@@ -1830,7 +1830,7 @@ void Recipe::recalcOgFg()
    }
    if( yeasties.size() > 0 && attenuation_pct <= 0.0 ) // This means we have yeast, but they neglected to provide attenuation percentages.
       attenuation_pct = 75.0; // 75% is an average attenuation.
-   
+
    if ( nonFermetableSugars_kg != 0.0 )
    {
       tmp_ferm_pnts = (tmp_pnts-tmp_ferm_pnts) * (1.0 - attenuation_pct/100.0);
@@ -1844,8 +1844,8 @@ void Recipe::recalcOgFg()
       tmp_fg =  1 + tmp_pnts/1000.0;
       _fg_fermentable = tmp_fg;
    }
-   
-   if ( _og != tmp_og ) 
+
+   if ( _og != tmp_og )
    {
       _og     = tmp_og;
       // NOTE: We don't want to do this on the first load of the recipe. The
@@ -1859,7 +1859,7 @@ void Recipe::recalcOgFg()
       emit changed( metaProperty("points"), (_og-1.0)*1e3 );
    }
 
-   if ( tmp_fg != _fg ) 
+   if ( tmp_fg != _fg )
    {
       _fg     = tmp_fg;
       set( "fg", "fg", _fg, false );
@@ -1875,10 +1875,10 @@ double Recipe::ibuFromHop(Hop const* hop)
    double ibus = 0.0;
    double fwhAdjust = Brewtarget::toDouble(Brewtarget::option("firstWortHopAdjustment", 1.1).toString(), "Recipe::ibmFromHop()");
    double mashHopAdjust = Brewtarget::toDouble(Brewtarget::option("mashHopAdjustment", 0).toString(), "Recipe::ibmFromHop()");
-   
+
    if( hop == 0 )
       return 0.0;
-   
+
    double AArating = hop->alpha_pct()/100.0;
    double grams = hop->amount_kg()*1000.0;
    double minutes = hop->time_min();
@@ -1892,13 +1892,13 @@ double Recipe::ibuFromHop(Hop const* hop)
    // (http://homebrew.stackexchange.com/questions/7343/does-wort-gravity-affect-hop-utilization),
    // it seems more appropriate to just use the OG directly, since it is the total
    // amount of break material that truly affects the IBUs.
-   
+
    if( equip )
    {
       hopUtilization = equip->hopUtilization_pct() / 100.0;
       boilTime = equip->boilTime_min();
    }
-   
+
    if( hop->use() == Hop::Boil)
       ibus = IbuMethods::getIbus( AArating, grams, _finalVolumeNoLosses_l, _og, minutes );
    else if( hop->use() == Hop::First_Wort )
@@ -1912,7 +1912,7 @@ double Recipe::ibuFromHop(Hop const* hop)
    else if( hop->form() == Hop::Plug )
       ibus *= 0.92;
 
-   // Adjust for hop utilization. 
+   // Adjust for hop utilization.
    ibus *= hopUtilization;
 
    return ibus;
@@ -1923,11 +1923,11 @@ bool Recipe::isValidType( const QString &str )
    static const QString types[] = {"Extract", "Partial Mash", "All Grain"};
    static const unsigned int size = 3;
    unsigned int i;
-   
+
    for( i = 0; i < size; ++i )
       if( str == types[i] )
          return true;
-   
+
    return false;
 }
 
@@ -1965,7 +1965,7 @@ QList<QString> Recipe::getReagents(QList<Hop*> hops, bool firstWort)
 
    for( int i = 0; i < hops.size(); ++i )
    {
-      if( firstWort && 
+      if( firstWort &&
          (hops[i]->use() == Hop::First_Wort) )
       {
          tmp = QString("%1 %2,")
@@ -1987,13 +1987,13 @@ QList<QString> Recipe::getReagents( QList<MashStep*> msteps )
       if( msteps[i]->type() != MashStep::Infusion )
          continue;
 
-      if ( i+1 < msteps.size() ) 
+      if ( i+1 < msteps.size() )
       {
          tmp = tr("%1 water to %2, ")
                 .arg(Brewtarget::displayAmount(msteps[i]->infuseAmount_l(), "mashStepTableModel", "infuseAmount_l", Units::liters))
                 .arg(Brewtarget::displayAmount(msteps[i]->infuseTemp_c(),"mashStepTableModel", "infuseTemp_c",  Units::celsius));
       }
-      else 
+      else
       {
          tmp = tr("%1 water to %2 ")
                 .arg(Brewtarget::displayAmount(msteps[i]->infuseAmount_l(), "mashStepTableModel", "infuseAmount_l", Units::liters))
@@ -2026,7 +2026,7 @@ void Recipe::acceptHopChange(QMetaProperty prop, QVariant val)
    recalcIBU();
 }
 
-void Recipe::acceptHopChange(Hop* hop) 
+void Recipe::acceptHopChange(Hop* hop)
 {
    recalcIBU();
 }
@@ -2037,7 +2037,7 @@ void Recipe::acceptMashChange(QMetaProperty prop, QVariant val)
 
    if ( mashSend == 0 )
       return;
-   
+
    recalcAll();
 }
 

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -65,7 +65,7 @@ bool operator==(Recipe &r1, Recipe &r2 );
 class Recipe : public BeerXMLElement
 {
    Q_OBJECT
-   
+
    friend class Database;
 public:
 
@@ -74,11 +74,11 @@ public:
    friend bool operator<(Recipe &r1, Recipe &r2 );
    friend bool operator==(Recipe &r1, Recipe &r2 );
    friend class RecipeFormatter;
-   
+
    // NOTE: move to database?
    //! \brief Retains only the name, but sets everything else to defaults.
    void clear();
-   
+
    //! \brief The name.
    Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The type (lager, ale, etc.).
@@ -133,13 +133,13 @@ public:
    Q_PROPERTY( double primingSugarEquiv READ primingSugarEquiv WRITE setPrimingSugarEquiv /*NOTIFY changed*/ /*changedPrimingSugarEquiv*/ )
    //! \brief The factor required to convert the amount of sugar required for bottles to keg (usually about 0.5).
    Q_PROPERTY( double kegPrimingFactor READ kegPrimingFactor WRITE setKegPrimingFactor /*NOTIFY changed*/ /*changedKegPrimingFactor*/ )
-  
+
    // Calculated stored properties.
    //! \brief The calculated OG.
    Q_PROPERTY( double og READ og WRITE setOg /*NOTIFY changed*/ /*changedOg*/ )
    //! \brief The calculated FG.
    Q_PROPERTY( double fg READ fg WRITE setFg /*NOTIFY changed*/ /*changedFg*/ )
-   
+
    // Calculated unstored properties. These need to listen for changes to
    // the uncalculated properties they depend on, and re-emit changed()
    // when appropriate.
@@ -171,7 +171,7 @@ public:
    Q_PROPERTY( double grains_kg READ grains_kg /*WRITE*/ /*NOTIFY changed*/ /*changedGrains_kg*/ STORED false)
    //! \brief The beer color as a displayable QColor.
    Q_PROPERTY( QColor SRMColor READ SRMColor /*WRITE*/ /*NOTIFY changed*/ STORED false )
-   
+
    // Relational properties.
    //! \brief The mash.
    Q_PROPERTY( Mash* mash READ mash /*WRITE*/ /*NOTIFY changed*/ STORED false)
@@ -195,7 +195,7 @@ public:
    Q_PROPERTY( QList<Yeast*> yeasts READ yeasts /*WRITE*/ /*NOTIFY changed*/ STORED false )
    //! \brief The waters.
    Q_PROPERTY( QList<Water*> waters READ waters /*WRITE*/ /*NOTIFY changed*/ STORED false )
-   
+
    // Relational setters.
    // NOTE: do these add/remove methods belong here? Should they only exist in Database?
    void addHop( Hop *var );
@@ -260,7 +260,7 @@ public:
    double carbonationTemp_c() const;
    double primingSugarEquiv() const;
    double kegPrimingFactor() const;
-   
+
    // Calculated getters.
    double points();
    double ABV_pct();
@@ -276,7 +276,7 @@ public:
    double grainsInMash_kg();
    double grains_kg();
    QList<double> IBUs();
-   
+
    // Relational getters
    QList<Hop*> hops() const;
    QList<Instruction*> instructions() const;
@@ -285,11 +285,11 @@ public:
    QList<Yeast*> yeasts() const;
    QList<Water*> waters() const;
    QList<BrewNote*> brewNotes() const;
-   
+
    Mash* mash() const;
    Equipment* equipment() const;
    Style* style() const;
-   
+
    // Other junk.
    QVector<PreInstruction> mashInstructions(double timeRemaining, double totalWaterAdded_l, unsigned int size);
    QVector<PreInstruction> mashSteps();
@@ -300,7 +300,7 @@ public:
    bool hasBoilExtract();
    bool isFermentableSugar(Fermentable*);
    PreInstruction addExtracts(double timeRemaining);
-   
+
    // Helpers
    //! \brief Get the ibus from a given \c hop.
    double ibuFromHop(Hop const* hop);
@@ -308,19 +308,21 @@ public:
    QList<QString> getReagents( QList<MashStep*> msteps );
    QList<QString> getReagents( QList<Hop*> hops, bool firstWort = false );
    QHash<QString,double> calcTotalPoints();
-   
+
 signals:
    //! \brief Emitted when \c name() changes.
    void changedName(const QString&);
-   
+
 public slots:
    void acceptEquipChange(QMetaProperty prop, QVariant val);
    void acceptFermChange(QMetaProperty prop, QVariant val);
    void acceptHopChange(QMetaProperty prop, QVariant val);
+   void acceptYeastChange(QMetaProperty prop, QVariant val);
    void acceptMashChange(QMetaProperty prop, QVariant val);
 
    void acceptFermChange(Fermentable* ferm);
    void acceptHopChange(Hop* hop);
+   void acceptYeastChange(Yeast* yeast);
    void acceptMashChange(Mash* mash);
 
    // Setters
@@ -353,12 +355,12 @@ public slots:
    void setCarbonationTemp_c( double var );
    void setPrimingSugarEquiv( double var );
    void setKegPrimingFactor( double var );
-   
+
 private:
-   
+
    Recipe();
    Recipe(Recipe const& other);
-   
+
    // Calculated properties.
    double _ABV_pct;
    double _color_srm;
@@ -375,25 +377,25 @@ private:
    double _grainsInMash_kg;
    double _grains_kg;
    QColor _SRMColor;
-   
+
    // Calculated, but stored...BeerXML is weird sometimes.
    double _og;
    double _fg;
    double _og_fermentable;
    double _fg_fermentable;
-   
+
    // True when constructed, indicates whether recalcAll has been called.
    bool _uninitializedCalcs;
    QMutex _uninitializedCalcsMutex;
    QMutex _recalcMutex;
-   
+
    // Batch size without losses.
    double batchSizeNoLosses_l();
-   
+
    // Some recalculators for calculated properties.
-   
+
    /* Recalculates all the calculated properties.
-    * 
+    *
     * WARNING: this call took 0.15s in rev 916!
     */
    void recalcAll();
@@ -417,7 +419,7 @@ private:
    Q_INVOKABLE void recalcCalories();
    // Emits changed(og), changed(fg). Depends on: _wortFromMash_l, _finalVolume_l
    Q_INVOKABLE void recalcOgFg();
-   
+
    // Adds instructions to the recipe.
    Instruction* postboilFermentablesIns();
    Instruction* postboilIns();
@@ -425,11 +427,11 @@ private:
    Instruction* mashWaterIns(unsigned int size);
    Instruction* firstWortHopsIns();
    Instruction* topOffIns();
-   
+
    //void setDefaults();
    void addPreinstructions( QVector<PreInstruction> preins );
    bool isValidType( const QString &str );
-   
+
    static QHash<QString,QString> tagToProp;
    static QHash<QString,QString> tagToPropHash();
 };


### PR DESCRIPTION
If you edit one of the yeast you've already added to the recipe the changes are not taken into account directly.
Now, when you make a change in the yeast properties, the recipe is updated (only the OG&FG because these are the only fields impacted).