### PR TITLE
Add missing qt5 package to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,7 @@ On Debian systems like Ubuntu, the packages for dependencies are:
 * git
 * qtbase5-dev
 * qttools5-dev
+* qttools5-dev-tools
 * qtmultimedia5-dev
 * libqt5webkit5-dev
 * libqt5sql5-sqlite


### PR DESCRIPTION
Trying to get setup on a new debian/jessie machine, needed to install
qttools5-dev-tools in order to build.