### PR TITLE
issue:#39 - Can not export recipe.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2071,7 +2071,6 @@ void MainWindow::copySelected()
 
 QFile* MainWindow::openForWrite( QString filterStr, QString defaultSuff)
 {
-   const char* filename;
    QFile* outFile = new QFile();
 
    fileSaver->setNameFilter( filterStr );
@@ -2079,7 +2078,7 @@ QFile* MainWindow::openForWrite( QString filterStr, QString defaultSuff)
 
    if( fileSaver->exec() )
    {
-      filename = fileSaver->selectedFiles()[0].toLatin1();
+      QString filename = fileSaver->selectedFiles()[0];
       outFile->setFileName(filename);
 
       if( ! outFile->open(QIODevice::WriteOnly | QIODevice::Truncate) )


### PR DESCRIPTION
Fixing issue https://github.com/Brewtarget/brewtarget/issues/39 : Not unnecessarily converting the QString filename before feeding it to a QFile.