### PR TITLE
Issue #28 -- BtMassEdit fields are wrong

### DIFF
--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -37,7 +37,7 @@ BtLineEdit::BtLineEdit(QWidget *parent, FieldType type) :
    {
       case MASS:
          // I don't ... oh bugger
-         _units = Units::grams;
+         _units = Units::kilograms;
          break;
       case VOLUME:
          _units = Units::liters;
@@ -55,7 +55,7 @@ BtLineEdit::BtLineEdit(QWidget *parent, FieldType type) :
          _units = Units::sp_grav;
          break;
       case MIXED:
-         _units = Units::grams;
+         _units = Units::kilograms;
          break;
       case GENERIC:
       case STRING:
@@ -331,7 +331,7 @@ void BtMixedEdit::setIsWeight(bool state)
    if (state)
    {
       _type = MASS;
-      _units = Units::grams;
+      _units = Units::kilograms;
    }
    else
    {

--- a/src/SIWeightUnitSystem.cpp
+++ b/src/SIWeightUnitSystem.cpp
@@ -60,5 +60,5 @@ Unit* SIWeightUnitSystem::thicknessUnit()
    return Units::kilograms;
 }
 
-Unit* SIWeightUnitSystem::unit() { return Units::grams; };
+Unit* SIWeightUnitSystem::unit() { return Units::kilograms; };
 QString SIWeightUnitSystem::unitType() { return "SI"; }


### PR DESCRIPTION
I put everything back to using kg as the default unit for SI weight, as that
was how it is stored in the db. Not sure if it is closed, since I need to do
some more testing.