### PR TITLE
Bug #47 -- FSM weeps

### DIFF
--- a/src/BrewNoteWidget.cpp
+++ b/src/BrewNoteWidget.cpp
@@ -50,30 +50,30 @@ BrewNoteWidget::BrewNoteWidget(QWidget *parent) : QWidget(parent)
 
    // A few labels on this page need special handling, so I connect them here
    // instead of how we would normally do this.
-   connect(btLabel_projectedOg, SIGNAL(labelChanged(unitDisplay,unitScale)), this, SLOT(updateProjOg(unitDisplay,unitScale)));
-   connect(btLabel_fermentDate, SIGNAL(labelChanged(unitDisplay,unitScale)), this, SLOT(updateDateFormat(unitDisplay,unitScale)));
+   connect(btLabel_projectedOg, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), this, SLOT(updateProjOg(Unit::unitDisplay,Unit::unitScale)));
+   connect(btLabel_fermentDate, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), this, SLOT(updateDateFormat(Unit::unitDisplay,Unit::unitScale)));
 
    // I think this might work
-   updateDateFormat(noUnit, noScale);
+   updateDateFormat(Unit::noUnit, Unit::noScale);
 }
 
 // I should really do this better, but I really cannot bring myself to do
 // another UnitSystem for one input field.
-void BrewNoteWidget::updateDateFormat(unitDisplay display,unitScale scale)
+void BrewNoteWidget::updateDateFormat(Unit::unitDisplay display,Unit::unitScale scale)
 {
    QString format;
    // I need the new unit, not the old
-   unitDisplay unitDsp = (unitDisplay)Brewtarget::option("fermentDate", Brewtarget::getDateFormat(), "page_postferment", Brewtarget::UNIT).toInt();
+   Unit::unitDisplay unitDsp = (Unit::unitDisplay)Brewtarget::option("fermentDate", Brewtarget::getDateFormat(), "page_postferment", Brewtarget::UNIT).toInt();
 
    switch(unitDsp)
    {
-      case displayUS:
+      case Unit::displayUS:
          format = "MM-dd-yyyy";
          break;
-      case displayImp:
+      case Unit::displayImp:
          format = "dd-MM-yyyy";
          break;
-      case displaySI:
+      case Unit::displaySI:
       default:
          format = "yyyy-MM-dd";
    }
@@ -81,7 +81,7 @@ void BrewNoteWidget::updateDateFormat(unitDisplay display,unitScale scale)
 }
 
 
-void BrewNoteWidget::updateProjOg(unitDisplay oldUnit, unitScale oldScale)
+void BrewNoteWidget::updateProjOg(Unit::unitDisplay oldUnit, Unit::unitScale oldScale)
 {
    double low  = 0.95;
    double high = 1.05;
@@ -89,13 +89,13 @@ void BrewNoteWidget::updateProjOg(unitDisplay oldUnit, unitScale oldScale)
    int precision = 3;
 
    // I don't think we care about the old unit or scale, just the new ones
-   unitDisplay unitDsp = (unitDisplay)Brewtarget::option("projOg", noUnit, "page_preboil", Brewtarget::UNIT).toInt();
+   Unit::unitDisplay unitDsp = (Unit::unitDisplay)Brewtarget::option("projOg", Unit::noUnit, "page_preboil", Brewtarget::UNIT).toInt();
 
 
-   if ( unitDsp == noUnit )
+   if ( unitDsp == Unit::noUnit )
       unitDsp = Brewtarget::getDensityUnit();
 
-   if ( unitDsp == displayPlato )
+   if ( unitDsp == Unit::displayPlato )
       precision = 0;
 
    quant = Brewtarget::amountDisplay(bNoteObs, page_preboil, "projOg",Units::sp_grav);
@@ -294,7 +294,7 @@ void BrewNoteWidget::showChanges(QString field)
    lcdnumber_effBK->display(bNoteObs->effIntoBK_pct(),2);
 
    // Need to think about these? Maybe use the bubbles?
-   updateProjOg(noUnit,noScale); // this requires more work, but updateProj does it
+   updateProjOg(Unit::noUnit,Unit::noScale); // this requires more work, but updateProj does it
 
    lcdnumber_brewhouseEff->display(bNoteObs->brewhouseEff_pct(),2);
    lcdnumber_projABV->display(bNoteObs->projABV_pct(),2);

--- a/src/BrewNoteWidget.h
+++ b/src/BrewNoteWidget.h
@@ -66,7 +66,7 @@ public slots:
    void updateFG();
    void updateFinalVolume_l();
    void updateFermentDate(const QDateTime& datetime);
-   void updateDateFormat(unitDisplay display,unitScale scale);
+   void updateDateFormat(Unit::unitDisplay display,Unit::unitScale scale);
 
    void updateNotes();
 //   void saveAll();
@@ -74,7 +74,7 @@ public slots:
    void changed(QMetaProperty,QVariant);
    void showChanges(QString field = "");
 
-   void updateProjOg(unitDisplay oldUnit, unitScale oldScale);
+   void updateProjOg(Unit::unitDisplay oldUnit, Unit::unitScale oldScale);
 
 
 private:

--- a/src/BtLabel.cpp
+++ b/src/BtLabel.cpp
@@ -87,14 +87,14 @@ void BtLabel::initializeProperty()
 
 void BtLabel::initializeMenu()
 {
-   unitDisplay unit;
-   unitScale scale;
+   Unit::unitDisplay unit;
+   Unit::unitScale scale;
 
    if ( _menu )
       return;
 
-   unit  = (unitDisplay)Brewtarget::option(propertyName, noUnit, _section, Brewtarget::UNIT).toInt();
-   scale = (unitScale)Brewtarget::option(propertyName, noScale, _section, Brewtarget::SCALE).toInt();
+   unit  = (Unit::unitDisplay)Brewtarget::option(propertyName, Unit::noUnit, _section, Brewtarget::UNIT).toInt();
+   scale = (Unit::unitScale)Brewtarget::option(propertyName, Unit::noScale, _section, Brewtarget::SCALE).toInt();
 
    switch( whatAmI )
    {
@@ -146,8 +146,8 @@ void BtLabel::popContextMenu(const QPoint& point)
    initializeMenu();
 
    invoked = _menu->exec(widgie->mapToGlobal(point));
-   unitDisplay unit = (unitDisplay)Brewtarget::option(propertyName, noUnit, _section, Brewtarget::UNIT).toInt();
-   unitScale scale  = (unitScale)Brewtarget::option(propertyName, noUnit, _section, Brewtarget::SCALE).toInt();
+   Unit::unitDisplay unit = (Unit::unitDisplay)Brewtarget::option(propertyName, Unit::noUnit, _section, Brewtarget::UNIT).toInt();
+   Unit::unitScale scale  = (Unit::unitScale)Brewtarget::option(propertyName, Unit::noUnit, _section, Brewtarget::SCALE).toInt();
 
    if ( invoked == 0 )
       return;
@@ -158,7 +158,7 @@ void BtLabel::popContextMenu(const QPoint& point)
       Brewtarget::setOption(propertyName, invoked->data(), _section, Brewtarget::UNIT);
       // reset the scale if required
       if ( Brewtarget::hasOption(propertyName, _section, Brewtarget::SCALE) )
-         Brewtarget::setOption(propertyName, noScale, _section, Brewtarget::SCALE);
+         Brewtarget::setOption(propertyName, Unit::noScale, _section, Brewtarget::SCALE);
    }
    else
       Brewtarget::setOption(propertyName, invoked->data(), _section, Brewtarget::SCALE);
@@ -184,7 +184,7 @@ void BtLabel::popContextMenu(const QPoint& point)
    // text here.
    if ( whatAmI == COLOR )
    {
-      unitDisplay disp = (unitDisplay)invoked->data().toInt();
+      Unit::unitDisplay disp = (Unit::unitDisplay)invoked->data().toInt();
       setText( tr("Color (%1)").arg(Brewtarget::colorUnitName(disp)));
    }
 

--- a/src/BtLabel.h
+++ b/src/BtLabel.h
@@ -73,7 +73,7 @@ public slots:
 
 
 signals:
-   void labelChanged(unitDisplay oldUnit, unitScale oldScale);
+   void labelChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale);
 
 // Using protected instead of private allows me to not use the friends
 // declaration

--- a/src/BtLineEdit.h
+++ b/src/BtLineEdit.h
@@ -73,7 +73,7 @@ public:
    */
 
    BtLineEdit(QWidget* parent = 0, FieldType type = GENERIC);
-   double toSI(unitDisplay oldUnit = noUnit, unitScale oldScale = noScale, bool force = false);
+   double toSI(Unit::unitDisplay oldUnit = Unit::noUnit, Unit::unitScale oldScale = Unit::noScale, bool force = false);
    // Use this when you want to do something with the returned QString
    QString displayAmount( double amount, int precision = 3);
 
@@ -83,9 +83,13 @@ public:
    void    setText( QString amount, int precision=3 );
    void    setText( QVariant amount, int precision=3 );
 
+   // Too many places still use getDouble, which just hoses me down. We're
+   // gonna fix this.
+   double  toDouble(bool* ok);
+
 public slots:
    void lineChanged();
-   void lineChanged(unitDisplay oldUnit, unitScale oldScale);
+   void lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale);
 
 signals:
    void textModified();
@@ -94,9 +98,10 @@ protected:
    QWidget *btParent;
    QString _section, _property;
    FieldType _type;
+   Unit::unitDisplay _forceUnit;
    Unit* _units;
 
-   void initializeProperty();
+   void initializeProperties();
    void initializeSection();
 
 };

--- a/src/CelsiusTempUnitSystem.cpp
+++ b/src/CelsiusTempUnitSystem.cpp
@@ -25,15 +25,15 @@
 CelsiusTempUnitSystem::CelsiusTempUnitSystem() :
    UnitSystem()
 {
-   _type = Temp;
+   _type = Unit::Temp;
 }
 
-QMap<unitScale, Unit*> const& CelsiusTempUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& CelsiusTempUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleWithout,Units::celsius);
+      _scaleToUnit.insert(Unit::scaleWithout,Units::celsius);
    }
 
    return _scaleToUnit;
@@ -50,6 +50,6 @@ QMap<QString, Unit*> const& CelsiusTempUnitSystem::qstringToUnit()
    return _qstringToUnit;
 }
 
-Unit* CelsiusTempUnitSystem::unit() { return Units::celsius; };
+Unit* CelsiusTempUnitSystem::unit() { return Units::celsius; }
 
 QString CelsiusTempUnitSystem::unitType() { return "SI"; }

--- a/src/CelsiusTempUnitSystem.h
+++ b/src/CelsiusTempUnitSystem.h
@@ -33,7 +33,7 @@ public:
    Unit* thicknessUnit(){ return 0; }
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
    Unit* unit();
 };

--- a/src/EbcColorUnitSystem.cpp
+++ b/src/EbcColorUnitSystem.cpp
@@ -23,15 +23,15 @@
 EbcColorUnitSystem::EbcColorUnitSystem()
    : UnitSystem()
 {
-   _type = Color;
+   _type = Unit::Color;
 }
 
-QMap<unitScale, Unit*> const& EbcColorUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& EbcColorUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleWithout, Units::ebc);
+      _scaleToUnit.insert(Unit::scaleWithout, Units::ebc);
    }
 
    return _scaleToUnit;

--- a/src/EbcColorUnitSystem.h
+++ b/src/EbcColorUnitSystem.h
@@ -31,7 +31,7 @@ public:
    Unit* thicknessUnit() { return 0; }
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
    Unit* unit();
 

--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -89,17 +89,17 @@ EquipmentEditor::EquipmentEditor(QWidget* parent, bool singleEquipEditor)
    connect(checkBox_defaultEquipment, SIGNAL(stateChanged(int)), this, SLOT(updateDefaultEquipment(int)));
 
    // Labels
-   connect(label_boilSize, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_boilSize, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_batchSize, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_batchSize, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_evaporationRate, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_evaporationRate, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_topUpWater, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_topUpWater, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_boilingPoint, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_boilingPoint, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_tunVolume, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_tunVolume, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_tunWeight, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_tunWeight, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_lauterDeadspace, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_lauterDeadspace, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_trubChillerLoss, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_trubChillerLoss, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_topUpKettle, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_topUpKettle, SLOT(lineChanged(unitDisplay,unitScale)));
-   connect(label_boilTime, SIGNAL(labelChanged(unitDisplay,unitScale)), lineEdit_boilTime, SLOT(lineChanged(unitDisplay,unitScale)));
+   connect(label_boilSize, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_boilSize, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_batchSize, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_batchSize, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_evaporationRate, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_evaporationRate, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_topUpWater, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_topUpWater, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_boilingPoint, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_boilingPoint, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_tunVolume, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_tunVolume, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_tunWeight, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_tunWeight, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_lauterDeadspace, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_lauterDeadspace, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_trubChillerLoss, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_trubChillerLoss, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_topUpKettle, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_topUpKettle, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
+   connect(label_boilTime, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), lineEdit_boilTime, SLOT(lineChanged(Unit::unitDisplay,Unit::unitScale)));
 
    QMetaObject::connectSlotsByName(this);
 

--- a/src/FahrenheitTempUnitSystem.cpp
+++ b/src/FahrenheitTempUnitSystem.cpp
@@ -25,15 +25,15 @@
 FahrenheitTempUnitSystem::FahrenheitTempUnitSystem()
    : UnitSystem()
 {
-   _type = Temp;
+   _type = Unit::Temp;
 }
 
-QMap<unitScale, Unit*> const& FahrenheitTempUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& FahrenheitTempUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleWithout,Units::fahrenheit);
+      _scaleToUnit.insert(Unit::scaleWithout,Units::fahrenheit);
    }
 
    return _scaleToUnit;
@@ -50,5 +50,5 @@ QMap<QString, Unit*> const& FahrenheitTempUnitSystem::qstringToUnit()
    return _qstringToUnit;
 }
 
-Unit* FahrenheitTempUnitSystem::unit() { return Units::fahrenheit; };
+Unit* FahrenheitTempUnitSystem::unit() { return Units::fahrenheit; }
 QString FahrenheitTempUnitSystem::unitType() { return "Fahrenheit"; }

--- a/src/FahrenheitTempUnitSystem.h
+++ b/src/FahrenheitTempUnitSystem.h
@@ -33,7 +33,7 @@ public:
    Unit* thicknessUnit(){ return 0; }
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
    Unit* unit();
 };

--- a/src/FermentableTableModel.cpp
+++ b/src/FermentableTableModel.cpp
@@ -268,8 +268,8 @@ QVariant FermentableTableModel::data( const QModelIndex& index, int role ) const
 {
    Fermentable* row;
    int col = index.column();
-   unitScale scale;
-   unitDisplay unit;
+   Unit::unitScale scale;
+   Unit::unitDisplay unit;
 
    // Ensure the row is ok.
    if( index.row() >= (int)fermObs.size() )
@@ -424,19 +424,19 @@ Qt::ItemFlags FermentableTableModel::flags(const QModelIndex& index ) const
 /* --maf--
    The cell-specific work has been momentarily disabled until I can find a
    better way to implement. PLEASE DO NOT DELETE
-unitDisplay FermentableTableModel::displayUnit(const QModelIndex& index)
+Unit::unitDisplay FermentableTableModel::displayUnit(const QModelIndex& index)
 {
    Fermentable* row;
 
    if ( index.row() >= fermObs.size() )
-      return noUnit;
+      return Unit::noUnit;
 
    row = fermObs[index.row()];
 
    return row->displayUnit();
 }
 
-void FermentableTableModel::setDisplayUnit(const QModelIndex& index, unitDisplay displayUnit)
+void FermentableTableModel::setDisplayUnit(const QModelIndex& index, Unit::unitDisplay displayUnit)
 {
    Fermentable* row;
 
@@ -447,19 +447,19 @@ void FermentableTableModel::setDisplayUnit(const QModelIndex& index, unitDisplay
    row->setDisplayUnit(displayUnit);
 }
 
-unitScale FermentableTableModel::displayScale(const QModelIndex& index)
+Unit::unitScale FermentableTableModel::displayScale(const QModelIndex& index)
 {
    Fermentable* row;
 
    if ( index.row() >= fermObs.size() )
-      return noScale;
+      return Unit::noScale;
 
    row = fermObs[index.row()];
 
    return row->displayScale();
 }
 
-void FermentableTableModel::setDisplayScale(const QModelIndex& index, unitScale displayScale)
+void FermentableTableModel::setDisplayScale(const QModelIndex& index, Unit::unitScale displayScale)
 {
    Fermentable* row;
 
@@ -471,31 +471,31 @@ void FermentableTableModel::setDisplayScale(const QModelIndex& index, unitScale 
 }
 */
 
-unitDisplay FermentableTableModel::displayUnit(int column) const
+Unit::unitDisplay FermentableTableModel::displayUnit(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noUnit;
+      return Unit::noUnit;
 
-   return (unitDisplay)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::UNIT).toInt();
+   return (Unit::unitDisplay)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::UNIT).toInt();
 }
 
-unitScale FermentableTableModel::displayScale(int column) const
+Unit::unitScale FermentableTableModel::displayScale(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noScale;
+      return Unit::noScale;
 
-   return (unitScale)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::SCALE).toInt();
+   return (Unit::unitScale)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::SCALE).toInt();
 }
 
 // We need to:
 //   o clear the custom scale if set
 //   o clear any custom unit from the rows
 //      o which should have the side effect of clearing any scale
-void FermentableTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
+void FermentableTableModel::setDisplayUnit(int column, Unit::unitDisplay displayUnit)
 {
    // Fermentable* row; // disabled per-cell magic
    QString attribute = generateName(column);
@@ -504,19 +504,19 @@ void FermentableTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
       return;
 
    Brewtarget::setOption(attribute,displayUnit,this->objectName(),Brewtarget::UNIT);
-   Brewtarget::setOption(attribute,noScale,this->objectName(),Brewtarget::SCALE);
+   Brewtarget::setOption(attribute,Unit::noScale,this->objectName(),Brewtarget::SCALE);
 
    /* Disabled cell-specific code
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getFermentable(i);
-      row->setDisplayUnit(noUnit);
+      row->setDisplayUnit(Unit::noUnit);
    }
    */
 }
 
 // Setting the scale should clear any cell-level scaling options
-void FermentableTableModel::setDisplayScale(int column, unitScale displayScale)
+void FermentableTableModel::setDisplayScale(int column, Unit::unitScale displayScale)
 {
    // Fermentable* row; //disabled per-cell magic
 
@@ -531,7 +531,7 @@ void FermentableTableModel::setDisplayScale(int column, unitScale displayScale)
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getFermentable(i);
-      row->setDisplayScale(noScale);
+      row->setDisplayScale(Unit::noScale);
    }
    */
 }
@@ -564,8 +564,8 @@ void FermentableTableModel::contextMenu(const QPoint &point)
    QHeaderView* hView = qobject_cast<QHeaderView*>(calledBy);
 
    int selected = hView->logicalIndexAt(point);
-   unitDisplay currentUnit;
-   unitScale  currentScale;
+   Unit::unitDisplay currentUnit;
+   Unit::unitScale  currentScale;
 
    // Since we need to call setupMassMenu() two different ways, we need
    // to figure out the currentUnit and Scale here
@@ -594,9 +594,9 @@ void FermentableTableModel::contextMenu(const QPoint &point)
 
    QWidget* pMenu = invoked->parentWidget();
    if ( pMenu == menu )
-      setDisplayUnit(selected,(unitDisplay)invoked->data().toInt());
+      setDisplayUnit(selected,(Unit::unitDisplay)invoked->data().toInt());
    else
-      setDisplayScale(selected,(unitScale)invoked->data().toInt());
+      setDisplayScale(selected,(Unit::unitScale)invoked->data().toInt());
 
 }
 

--- a/src/FermentableTableModel.h
+++ b/src/FermentableTableModel.h
@@ -75,10 +75,10 @@ public:
     */
    void setInventoryEditable( bool var ) { _inventoryEditable = var; }
    
-   unitDisplay displayUnit(int column) const;
-   unitScale displayScale(int column) const;
-   void setDisplayUnit(int column, unitDisplay displayUnit);
-   void setDisplayScale(int column, unitScale displayScale);
+   Unit::unitDisplay displayUnit(int column) const;
+   Unit::unitScale displayScale(int column) const;
+   void setDisplayUnit(int column, Unit::unitDisplay displayUnit);
+   void setDisplayScale(int column, Unit::unitScale displayScale);
 
    //! \brief Reimplemented from QAbstractTableModel.
    virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;

--- a/src/HopTableModel.cpp
+++ b/src/HopTableModel.cpp
@@ -257,8 +257,8 @@ QVariant HopTableModel::data( const QModelIndex& index, int role ) const
 {
    Hop* row;
    int col = index.column();
-   unitScale scale;
-   unitDisplay unit;
+   Unit::unitScale scale;
+   Unit::unitDisplay unit;
 
    // Ensure the row is ok.
    if( index.row() >= (int)hopObs.size() )
@@ -310,7 +310,7 @@ QVariant HopTableModel::data( const QModelIndex& index, int role ) const
 
          scale = displayScale(col);
 
-         return QVariant( Brewtarget::displayAmount(row->time_min(), Units::minutes, 0, noUnit, scale) );
+         return QVariant( Brewtarget::displayAmount(row->time_min(), Units::minutes, 0, Unit::noUnit, scale) );
       case HOPFORMCOL:
         if ( role == Qt::DisplayRole )
           return QVariant( row->formStringTr() );
@@ -430,31 +430,31 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
    return retVal;
 }
 
-unitDisplay HopTableModel::displayUnit(int column) const
+Unit::unitDisplay HopTableModel::displayUnit(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noUnit;
+      return Unit::noUnit;
 
-   return (unitDisplay)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::UNIT).toInt();
+   return (Unit::unitDisplay)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::UNIT).toInt();
 }
 
-unitScale HopTableModel::displayScale(int column) const
+Unit::unitScale HopTableModel::displayScale(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noScale;
+      return Unit::noScale;
 
-   return (unitScale)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::SCALE).toInt();
+   return (Unit::unitScale)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::SCALE).toInt();
 }
 
 // We need to:
 //   o clear the custom scale if set
 //   o clear any custom unit from the rows
 //      o which should have the side effect of clearing any scale
-void HopTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
+void HopTableModel::setDisplayUnit(int column, Unit::unitDisplay displayUnit)
 {
    // Hop* row; // disabled per-cell magic
    QString attribute = generateName(column);
@@ -463,19 +463,19 @@ void HopTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
       return;
 
    Brewtarget::setOption(attribute,displayUnit,this->objectName(),Brewtarget::UNIT);
-   Brewtarget::setOption(attribute,noScale,this->objectName(),Brewtarget::SCALE);
+   Brewtarget::setOption(attribute,Unit::noScale,this->objectName(),Brewtarget::SCALE);
 
    /* Disabled cell-specific code
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getHop(i);
-      row->setDisplayUnit(noUnit);
+      row->setDisplayUnit(Unit::noUnit);
    }
    */
 }
 
 // Setting the scale should clear any cell-level scaling options
-void HopTableModel::setDisplayScale(int column, unitScale displayScale)
+void HopTableModel::setDisplayScale(int column, Unit::unitScale displayScale)
 {
    // Fermentable* row; //disabled per-cell magic
 
@@ -490,7 +490,7 @@ void HopTableModel::setDisplayScale(int column, unitScale displayScale)
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getHop(i);
-      row->setDisplayScale(noScale);
+      row->setDisplayScale(Unit::noScale);
    }
    */
 }
@@ -522,8 +522,8 @@ void HopTableModel::contextMenu(const QPoint &point)
    QHeaderView* hView = qobject_cast<QHeaderView*>(calledBy);
 
    int selected = hView->logicalIndexAt(point);
-   unitDisplay currentUnit;
-   unitScale  currentScale;
+   Unit::unitDisplay currentUnit;
+   Unit::unitScale  currentScale;
 
    // Since we need to call generateVolumeMenu() two different ways, we need
    // to figure out the currentUnit and Scale here
@@ -552,9 +552,9 @@ void HopTableModel::contextMenu(const QPoint &point)
 
    QWidget* pMenu = invoked->parentWidget();
    if ( selected != HOPTIMECOL && pMenu == menu )
-      setDisplayUnit(selected,(unitDisplay)invoked->data().toInt());
+      setDisplayUnit(selected,(Unit::unitDisplay)invoked->data().toInt());
    else
-      setDisplayScale(selected,(unitScale)invoked->data().toInt());
+      setDisplayScale(selected,(Unit::unitScale)invoked->data().toInt());
 
 }
 

--- a/src/HopTableModel.h
+++ b/src/HopTableModel.h
@@ -89,10 +89,10 @@ public:
    // Stuff for setting display units and scales -- per cell first, then by
    // column
 
-   unitDisplay displayUnit(int column) const;
-   unitScale displayScale(int column) const;
-   void setDisplayUnit(int column, unitDisplay displayUnit);
-   void setDisplayScale(int column, unitScale displayScale);
+   Unit::unitDisplay displayUnit(int column) const;
+   Unit::unitScale displayScale(int column) const;
+   void setDisplayUnit(int column, Unit::unitDisplay displayUnit);
+   void setDisplayScale(int column, Unit::unitScale displayScale);
 
 
    QString generateName(int column) const;

--- a/src/ImperialVolumeUnitSystem.cpp
+++ b/src/ImperialVolumeUnitSystem.cpp
@@ -26,20 +26,20 @@
 ImperialVolumeUnitSystem::ImperialVolumeUnitSystem()
    : UnitSystem()
 {
-   _type = Volume;
+   _type = Unit::Volume;
 }
 
-QMap<unitScale, Unit*> const& ImperialVolumeUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& ImperialVolumeUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleExtraSmall,Units::imperial_teaspoons);
-      _scaleToUnit.insert(scaleSmall,Units::imperial_tablespoons);
-      _scaleToUnit.insert(scaleMedium,Units::imperial_cups);
-      _scaleToUnit.insert(scaleLarge,Units::imperial_quarts);
-      _scaleToUnit.insert(scaleExtraLarge,Units::imperial_gallons);
-      _scaleToUnit.insert(scaleHuge,Units::imperial_barrels);
+      _scaleToUnit.insert(Unit::scaleExtraSmall,Units::imperial_teaspoons);
+      _scaleToUnit.insert(Unit::scaleSmall,Units::imperial_tablespoons);
+      _scaleToUnit.insert(Unit::scaleMedium,Units::imperial_cups);
+      _scaleToUnit.insert(Unit::scaleLarge,Units::imperial_quarts);
+      _scaleToUnit.insert(Unit::scaleExtraLarge,Units::imperial_gallons);
+      _scaleToUnit.insert(Unit::scaleHuge,Units::imperial_barrels);
    }
 
    return _scaleToUnit;
@@ -66,5 +66,5 @@ Unit* ImperialVolumeUnitSystem::thicknessUnit()
    return Units::imperial_quarts;
 }
 
-Unit* ImperialVolumeUnitSystem::unit() { return Units::imperial_gallons; };
+Unit* ImperialVolumeUnitSystem::unit() { return Units::imperial_gallons; }
 QString ImperialVolumeUnitSystem::unitType() { return "Imperial"; }

--- a/src/ImperialVolumeUnitSystem.h
+++ b/src/ImperialVolumeUnitSystem.h
@@ -33,7 +33,7 @@ public:
    Unit* thicknessUnit(); /* Inherited from UnitSystem */
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
    Unit* unit();
 };

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -408,9 +408,9 @@ MainWindow::MainWindow(QWidget* parent)
    // BWAHAHAHAHAHAHAHA. I did, I did find a better way to do it.
 
    // These are the sliders. I need to consider these harder, but small steps
-   connect(oGLabel, SIGNAL(labelChanged(unitDisplay,unitScale)), this, SLOT(redisplayLabel(unitDisplay,unitScale)));
-   connect(fGLabel, SIGNAL(labelChanged(unitDisplay,unitScale)), this, SLOT(redisplayLabel(unitDisplay,unitScale)));
-   connect(colorSRMLabel,SIGNAL(labelChanged(unitDisplay,unitScale)), this, SLOT(redisplayLabel(unitDisplay,unitScale)));
+   connect(oGLabel, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), this, SLOT(redisplayLabel(Unit::unitDisplay,Unit::unitScale)));
+   connect(fGLabel, SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), this, SLOT(redisplayLabel(Unit::unitDisplay,Unit::unitScale)));
+   connect(colorSRMLabel,SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)), this, SLOT(redisplayLabel(Unit::unitDisplay,Unit::unitScale)));
 
    connect( dialog_about->pushButton_donate, SIGNAL(clicked()), this, SLOT(openDonateLink()) );
 
@@ -751,15 +751,15 @@ void MainWindow::changed(QMetaProperty prop, QVariant value)
 
 void MainWindow::updateDensitySlider(QString attribute, RangedSlider* slider, double max)
 {
-   unitDisplay dispUnit = (unitDisplay)Brewtarget::option(attribute, noUnit, "tab_recipe", Brewtarget::UNIT).toInt();
+   Unit::unitDisplay dispUnit = (Unit::unitDisplay)Brewtarget::option(attribute, Unit::noUnit, "tab_recipe", Brewtarget::UNIT).toInt();
 
-   if ( dispUnit == noUnit )
-      dispUnit = Brewtarget::densityUnit == Brewtarget::PLATO ? displayPlato : displaySg;
+   if ( dispUnit == Unit::noUnit )
+      dispUnit = Brewtarget::densityUnit == Brewtarget::PLATO ? Unit::displayPlato : Unit::displaySg;
 
    slider->setPreferredRange(Brewtarget::displayRange(recStyle, tab_recipe, attribute, Brewtarget::DENSITY));
    slider->setRange(         Brewtarget::displayRange(tab_recipe, attribute, 1.000, max, Brewtarget::DENSITY ));
 
-   if ( dispUnit == displayPlato )
+   if ( dispUnit == Unit::displayPlato )
    {
       slider->setPrecision(1);
       slider->setTickMarks(2,5);
@@ -773,14 +773,14 @@ void MainWindow::updateDensitySlider(QString attribute, RangedSlider* slider, do
 
 void MainWindow::updateColorSlider(QString attribute, RangedSlider* slider)
 {
-   unitDisplay dispUnit = (unitDisplay)Brewtarget::option(attribute, noUnit, "tab_recipe", Brewtarget::UNIT).toInt();
+   Unit::unitDisplay dispUnit = (Unit::unitDisplay)Brewtarget::option(attribute, Unit::noUnit, "tab_recipe", Brewtarget::UNIT).toInt();
 
-   if ( dispUnit == noUnit )
-      dispUnit = Brewtarget::colorUnit == Brewtarget::SRM ? displaySrm : displayEbc;
+   if ( dispUnit == Unit::noUnit )
+      dispUnit = Brewtarget::colorUnit == Brewtarget::SRM ? Unit::displaySrm : Unit::displayEbc;
 
    slider->setPreferredRange(Brewtarget::displayRange(recStyle, tab_recipe, attribute,Brewtarget::COLOR));
    slider->setRange(Brewtarget::displayRange(tab_recipe, attribute, 1, 44, Brewtarget::COLOR) );
-   slider->setTickMarks( dispUnit == displaySrm ? 10 : 40, 2);
+   slider->setTickMarks( dispUnit == Unit::displaySrm ? 10 : 40, 2);
 
 }
 
@@ -2406,7 +2406,7 @@ void MainWindow::finishCheckingVersion()
    }
 }
 
-void MainWindow::redisplayLabel(unitDisplay oldUnit, unitScale oldScale)
+void MainWindow::redisplayLabel(Unit::unitDisplay oldUnit, Unit::unitScale oldScale)
 {
    // There is a lot of magic going on in the showChanges(). I can either
    // duplicate that magic or I can just call showChanges().

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -244,7 +244,7 @@ public slots:
    //! \brief Catches a QNetworkReply signal and gets info about any new version available.
    void finishCheckingVersion();
 
-   void redisplayLabel(unitDisplay oldUnit, unitScale oldScale);
+   void redisplayLabel(Unit::unitDisplay oldUnit, Unit::unitScale oldScale);
 
    void showEquipmentEditor();
    void showStyleEditor();

--- a/src/MashStepTableModel.cpp
+++ b/src/MashStepTableModel.cpp
@@ -131,8 +131,8 @@ int MashStepTableModel::columnCount(const QModelIndex& /*parent*/) const
 QVariant MashStepTableModel::data( const QModelIndex& index, int role ) const
 {
    MashStep* row;
-   unitDisplay unit;
-   unitScale scale;
+   Unit::unitDisplay unit;
+   Unit::unitScale scale;
    int col = index.column();
 
    if( mashObs == 0 )
@@ -169,13 +169,13 @@ QVariant MashStepTableModel::data( const QModelIndex& index, int role ) const
          unit = displayUnit(col);
          return (row->type() == MashStep::Decoction)
                 ? QVariant("---")
-                : QVariant( Brewtarget::displayAmount(row->infuseTemp_c(), Units::celsius, 3, unit, noScale) );
+                : QVariant( Brewtarget::displayAmount(row->infuseTemp_c(), Units::celsius, 3, unit, Unit::noScale) );
       case MASHSTEPTARGETTEMPCOL:
          unit = displayUnit(col);
-         return QVariant( Brewtarget::displayAmount(row->stepTemp_c(), Units::celsius,3, unit, noScale) );
+         return QVariant( Brewtarget::displayAmount(row->stepTemp_c(), Units::celsius,3, unit, Unit::noScale) );
       case MASHSTEPTIMECOL:
          scale = displayScale(col);
-         return QVariant( Brewtarget::displayAmount(row->stepTime_min(), Units::minutes,0,noUnit,scale) );
+         return QVariant( Brewtarget::displayAmount(row->stepTime_min(), Units::minutes,0,Unit::noUnit,scale) );
       default :
          Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
          return QVariant();
@@ -224,7 +224,7 @@ Qt::ItemFlags MashStepTableModel::flags(const QModelIndex& index ) const
 bool MashStepTableModel::setData( const QModelIndex& index, const QVariant& value, int role )
 {
    MashStep *row;
-   unitDisplay unit;
+   Unit::unitDisplay unit;
 
    if( mashObs == 0 )
       return false;
@@ -312,31 +312,31 @@ void MashStepTableModel::moveStepDown(int i)
    Database::instance().swapMashStepOrder( steps[i], steps[i+1] );
 }
 
-unitDisplay MashStepTableModel::displayUnit(int column) const
+Unit::unitDisplay MashStepTableModel::displayUnit(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noUnit;
+      return Unit::noUnit;
 
-   return (unitDisplay)Brewtarget::option(attribute, noUnit, this->objectName(), Brewtarget::UNIT).toInt();
+   return (Unit::unitDisplay)Brewtarget::option(attribute, Unit::noUnit, this->objectName(), Brewtarget::UNIT).toInt();
 }
 
-unitScale MashStepTableModel::displayScale(int column) const
+Unit::unitScale MashStepTableModel::displayScale(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noScale;
+      return Unit::noScale;
 
-   return (unitScale)Brewtarget::option(attribute, noScale, this->objectName(), Brewtarget::SCALE).toInt();
+   return (Unit::unitScale)Brewtarget::option(attribute, Unit::noScale, this->objectName(), Brewtarget::SCALE).toInt();
 }
 
 // We need to:
 //   o clear the custom scale if set
 //   o clear any custom unit from the rows
 //      o which should have the side effect of clearing any scale
-void MashStepTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
+void MashStepTableModel::setDisplayUnit(int column, Unit::unitDisplay displayUnit)
 {
    // MashStep* row; // disabled per-cell magic
    QString attribute = generateName(column);
@@ -345,19 +345,19 @@ void MashStepTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
       return;
 
    Brewtarget::setOption(attribute,displayUnit,this->objectName(),Brewtarget::UNIT);
-   Brewtarget::setOption(attribute,noScale,this->objectName(),Brewtarget::SCALE);
+   Brewtarget::setOption(attribute,Unit::noScale,this->objectName(),Brewtarget::SCALE);
 
    /* Disabled cell-specific code
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getMashStep(i);
-      row->setDisplayUnit(noUnit);
+      row->setDisplayUnit(Unit::noUnit);
    }
    */
 }
 
 // Setting the scale should clear any cell-level scaling options
-void MashStepTableModel::setDisplayScale(int column, unitScale displayScale)
+void MashStepTableModel::setDisplayScale(int column, Unit::unitScale displayScale)
 {
    // MashStep* row; //disabled per-cell magic
 
@@ -372,7 +372,7 @@ void MashStepTableModel::setDisplayScale(int column, unitScale displayScale)
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getMashStep(i);
-      row->setDisplayScale(noScale);
+      row->setDisplayScale(Unit::noScale);
    }
    */
 }
@@ -407,8 +407,8 @@ void MashStepTableModel::contextMenu(const QPoint &point)
    QHeaderView* hView = qobject_cast<QHeaderView*>(calledBy);
 
    int selected = hView->logicalIndexAt(point);
-   unitDisplay currentUnit;
-   unitScale  currentScale;
+   Unit::unitDisplay currentUnit;
+   Unit::unitScale  currentScale;
 
    // Since we need to call generateVolumeMenu() two different ways, we need
    // to figure out the currentUnit and Scale here
@@ -441,9 +441,9 @@ void MashStepTableModel::contextMenu(const QPoint &point)
 
    QWidget* pMenu = invoked->parentWidget();
    if ( pMenu == menu )
-      setDisplayUnit(selected,(unitDisplay)invoked->data().toInt());
+      setDisplayUnit(selected,(Unit::unitDisplay)invoked->data().toInt());
    else
-      setDisplayScale(selected,(unitScale)invoked->data().toInt());
+      setDisplayScale(selected,(Unit::unitScale)invoked->data().toInt());
 }
 
 //==========================CLASS MashStepItemDelegate===============================

--- a/src/MashStepTableModel.h
+++ b/src/MashStepTableModel.h
@@ -72,10 +72,10 @@ public:
    //! Reimplemented from QAbstractTableModel.
    virtual bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole );
 
-   unitDisplay displayUnit(int column) const;
-   unitScale displayScale(int column) const;
-   void setDisplayUnit(int column, unitDisplay displayUnit);
-   void setDisplayScale(int column, unitScale displayScale);
+   Unit::unitDisplay displayUnit(int column) const;
+   Unit::unitScale displayScale(int column) const;
+   void setDisplayUnit(int column, Unit::unitDisplay displayUnit);
+   void setDisplayScale(int column, Unit::unitScale displayScale);
    QString generateName(int column) const;
 
 public slots:

--- a/src/MiscTableModel.cpp
+++ b/src/MiscTableModel.cpp
@@ -191,8 +191,8 @@ int MiscTableModel::columnCount(const QModelIndex& /*parent*/) const
 QVariant MiscTableModel::data( const QModelIndex& index, int role ) const
 {
    Misc* row;
-   unitDisplay unit;
-   unitScale scale;
+   Unit::unitDisplay unit;
+   Unit::unitScale scale;
 
    // Ensure the row is ok.
    if( index.row() >= (int)miscObs.size() )
@@ -231,19 +231,19 @@ QVariant MiscTableModel::data( const QModelIndex& index, int role ) const
 
          scale = displayScale(MISCTIMECOL);
 
-         return QVariant( Brewtarget::displayAmount(row->time(), Units::minutes, 0, noUnit, scale) );
+         return QVariant( Brewtarget::displayAmount(row->time(), Units::minutes, 0, Unit::noUnit, scale) );
       case MISCINVENTORYCOL:
          if( role != Qt::DisplayRole )
             return QVariant();
 
          unit = displayUnit(index.column());
-         return QVariant( Brewtarget::displayAmount(row->inventory(), row->amountIsWeight()? (Unit*)Units::kilograms : (Unit*)Units::liters, 3, unit, noScale ) );
+         return QVariant( Brewtarget::displayAmount(row->inventory(), row->amountIsWeight()? (Unit*)Units::kilograms : (Unit*)Units::liters, 3, unit, Unit::noScale ) );
       case MISCAMOUNTCOL:
          if( role != Qt::DisplayRole )
             return QVariant();
 
          unit = displayUnit(index.column());
-         return QVariant( Brewtarget::displayAmount(row->amount(), row->amountIsWeight()? (Unit*)Units::kilograms : (Unit*)Units::liters, 3, unit, noScale ) );
+         return QVariant( Brewtarget::displayAmount(row->amount(), row->amountIsWeight()? (Unit*)Units::kilograms : (Unit*)Units::liters, 3, unit, Unit::noScale ) );
 
       case MISCISWEIGHT:
          if ( role == Qt::CheckStateRole )
@@ -308,7 +308,7 @@ bool MiscTableModel::setData( const QModelIndex& index, const QVariant& value, i
    Misc *row;
    int col;
    QString tmpStr;
-   unitDisplay dispUnit;
+   Unit::unitDisplay dispUnit;
    Unit* unit;
 
    if( index.row() >= (int)miscObs.size() )
@@ -419,31 +419,31 @@ Misc* MiscTableModel::getMisc(unsigned int i)
    return miscObs[i];
 }
 
-unitDisplay MiscTableModel::displayUnit(int column) const
+Unit::unitDisplay MiscTableModel::displayUnit(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noUnit;
+      return Unit::noUnit;
 
-   return (unitDisplay)Brewtarget::option(attribute, noUnit, this->objectName(), Brewtarget::UNIT).toInt();
+   return (Unit::unitDisplay)Brewtarget::option(attribute, Unit::noUnit, this->objectName(), Brewtarget::UNIT).toInt();
 }
 
-unitScale MiscTableModel::displayScale(int column) const
+Unit::unitScale MiscTableModel::displayScale(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noScale;
+      return Unit::noScale;
 
-   return (unitScale)Brewtarget::option(attribute, noScale, this->objectName(), Brewtarget::SCALE).toInt();
+   return (Unit::unitScale)Brewtarget::option(attribute, Unit::noScale, this->objectName(), Brewtarget::SCALE).toInt();
 }
 
 // We need to:
 //   o clear the custom scale if set
 //   o clear any custom unit from the rows
 //      o which should have the side effect of clearing any scale
-void MiscTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
+void MiscTableModel::setDisplayUnit(int column, Unit::unitDisplay displayUnit)
 {
    // Misc* row; // disabled per-cell magic
    QString attribute = generateName(column);
@@ -452,19 +452,19 @@ void MiscTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
       return;
 
    Brewtarget::setOption(attribute,displayUnit,this->objectName(),Brewtarget::UNIT);
-   Brewtarget::setOption(attribute,noScale,this->objectName(),Brewtarget::SCALE);
+   Brewtarget::setOption(attribute,Unit::noScale,this->objectName(),Brewtarget::SCALE);
 
    /* Disabled cell-specific code
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getMisc(i);
-      row->setDisplayUnit(noUnit);
+      row->setDisplayUnit(Unit::noUnit);
    }
    */
 }
 
 // Setting the scale should clear any cell-level scaling options
-void MiscTableModel::setDisplayScale(int column, unitScale displayScale)
+void MiscTableModel::setDisplayScale(int column, Unit::unitScale displayScale)
 {
    // Misc* row; //disabled per-cell magic
 
@@ -479,7 +479,7 @@ void MiscTableModel::setDisplayScale(int column, unitScale displayScale)
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getMisc(i);
-      row->setDisplayScale(noScale);
+      row->setDisplayScale(Unit::noScale);
    }
    */
 }
@@ -511,8 +511,8 @@ void MiscTableModel::contextMenu(const QPoint &point)
    QHeaderView* hView = qobject_cast<QHeaderView*>(calledBy);
 
    int selected = hView->logicalIndexAt(point);
-   unitDisplay currentUnit;
-   unitScale  currentScale;
+   Unit::unitDisplay currentUnit;
+   Unit::unitScale  currentScale;
 
    // Since we need to call generateVolumeMenu() two different ways, we need
    // to figure out the currentUnit and Scale here
@@ -541,9 +541,9 @@ void MiscTableModel::contextMenu(const QPoint &point)
       return;
 
    if ( selected == MISCTIMECOL )
-      setDisplayScale(selected,(unitScale)invoked->data().toInt());
+      setDisplayScale(selected,(Unit::unitScale)invoked->data().toInt());
    else
-      setDisplayUnit(selected,(unitDisplay)invoked->data().toInt());
+      setDisplayUnit(selected,(Unit::unitDisplay)invoked->data().toInt());
 }
 
 //======================CLASS MiscItemDelegate===========================

--- a/src/MiscTableModel.h
+++ b/src/MiscTableModel.h
@@ -90,10 +90,10 @@ public:
    //! \brief Reimplemented from QAbstractTableModel
    virtual bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole );
 
-   unitDisplay displayUnit(int column) const;
-   unitScale displayScale(int column) const;
-   void setDisplayUnit(int column, unitDisplay displayUnit);
-   void setDisplayScale(int column, unitScale displayScale);
+   Unit::unitDisplay displayUnit(int column) const;
+   Unit::unitScale displayScale(int column) const;
+   void setDisplayUnit(int column, Unit::unitDisplay displayUnit);
+   void setDisplayScale(int column, Unit::unitScale displayScale);
    QString generateName(int column) const;
 
 public slots:

--- a/src/OptionDialog.cpp
+++ b/src/OptionDialog.cpp
@@ -228,79 +228,79 @@ void OptionDialog::saveAndClose()
    if( button == radioButton_sg )
    {
       Brewtarget::densityUnit = Brewtarget::SG;
-      Brewtarget::thingToUnitSystem.insert(Density, UnitSystems::sgDensityUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Density, UnitSystems::sgDensityUnitSystem());
    }
    else
    {
       Brewtarget::densityUnit = Brewtarget::PLATO;
-      Brewtarget::thingToUnitSystem.insert(Density, UnitSystems::platoDensityUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Density, UnitSystems::platoDensityUnitSystem());
    }
 
    button = weightGroup->checkedButton();
    if( button == weight_imperial )
    {
       weightUnitSystem = Imperial;
-      Brewtarget::thingToUnitSystem.insert(Mass, UnitSystems::usWeightUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Mass, UnitSystems::usWeightUnitSystem());
    }
    else if( button == weight_us)
    {
       weightUnitSystem = USCustomary;
-      Brewtarget::thingToUnitSystem.insert(Mass, UnitSystems::usWeightUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Mass, UnitSystems::usWeightUnitSystem());
    }
    else
    {
       weightUnitSystem = SI;
-      Brewtarget::thingToUnitSystem.insert(Mass, UnitSystems::siWeightUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Mass, UnitSystems::siWeightUnitSystem());
    }
 
    button = volumeGroup->checkedButton();
    if( button == volume_imperial )
    {
       volumeUnitSystem = Imperial;
-      Brewtarget::thingToUnitSystem.insert(Volume,UnitSystems::imperialVolumeUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Volume,UnitSystems::imperialVolumeUnitSystem());
    }
    else if( button == volume_us )
    {
       volumeUnitSystem = USCustomary;
-      Brewtarget::thingToUnitSystem.insert(Volume,UnitSystems::usVolumeUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Volume,UnitSystems::usVolumeUnitSystem());
    }
    else
    {
       volumeUnitSystem = SI;
-      Brewtarget::thingToUnitSystem.insert(Volume,UnitSystems::siVolumeUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Volume,UnitSystems::siVolumeUnitSystem());
    }
 
    button = tempGroup->checkedButton();
    if( button == fahrenheit )
    {
       temperatureScale = Fahrenheit;
-      Brewtarget::thingToUnitSystem.insert(Temp,UnitSystems::fahrenheitTempUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Temp,UnitSystems::fahrenheitTempUnitSystem());
    }
    else
    {
       temperatureScale = Celsius;
-      Brewtarget::thingToUnitSystem.insert(Temp,UnitSystems::celsiusTempUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Temp,UnitSystems::celsiusTempUnitSystem());
    }
    
    button = colorUnitGroup->checkedButton();
    if( button == radioButton_ebc )
    {
-      Brewtarget::thingToUnitSystem.insert(Color,UnitSystems::ebcColorUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Color,UnitSystems::ebcColorUnitSystem());
       colorUnit = Brewtarget::EBC;
    }
    else
    {
-      Brewtarget::thingToUnitSystem.insert(Color,UnitSystems::srmColorUnitSystem());
+      Brewtarget::thingToUnitSystem.insert(Unit::Color,UnitSystems::srmColorUnitSystem());
       colorUnit = Brewtarget::SRM;
    }
 
    button = dateFormatGroup->checkedButton();
    if ( button == radioButton_usDate )
-      Brewtarget::dateFormat = displayUS;
+      Brewtarget::dateFormat = Unit::displayUS;
    else if ( button == radioButton_euDate )
-      Brewtarget::dateFormat = displayImp;
+      Brewtarget::dateFormat = Unit::displayImp;
    else
-      Brewtarget::dateFormat = displaySI;
+      Brewtarget::dateFormat = Unit::displaySI;
 
    Brewtarget::ibuFormula = iformula;
    Brewtarget::colorFormula = cformula;
@@ -450,13 +450,13 @@ void OptionDialog::showChanges()
 
    switch(Brewtarget::dateFormat)
    {
-      case displayImp:
+      case Unit::displayImp:
          radioButton_euDate->setChecked(true);
          break;
-      case displayUS:
+      case Unit::displayUS:
          radioButton_usDate->setChecked(true);
          break;
-      case displaySI:
+      case Unit::displaySI:
       default:
          radioButton_isoDate->setChecked(true);
    }

--- a/src/PitchDialog.cpp
+++ b/src/PitchDialog.cpp
@@ -45,8 +45,8 @@ PitchDialog::PitchDialog(QWidget* parent) : QDialog(parent)
    connect( checkBox_CalculateViability, SIGNAL(stateChanged(int)), this, SLOT(toggleViabilityFromDate(int)));
 
    // Dates are a little more cranky
-   connect(label_productionDate,SIGNAL(labelChanged(unitDisplay,unitScale)),this,SLOT(updateProductionDate(unitDisplay,unitScale)));
-   updateProductionDate(noUnit,noScale);
+   connect(label_productionDate,SIGNAL(labelChanged(Unit::unitDisplay,Unit::unitScale)),this,SLOT(updateProductionDate(Unit::unitDisplay,Unit::unitScale)));
+   updateProductionDate(Unit::noUnit,Unit::noScale);
    updateShownPitchRate(0);
 }
 
@@ -54,21 +54,21 @@ PitchDialog::~PitchDialog()
 {
 }
 
-void PitchDialog::updateProductionDate(unitDisplay dsp, unitScale scl)
+void PitchDialog::updateProductionDate(Unit::unitDisplay dsp, Unit::unitScale scl)
 {
    QString format;
    // I need the new unit, not the old
-   unitDisplay unitDsp = (unitDisplay)Brewtarget::option("productionDate", Brewtarget::getDateFormat(), "pitchRateCalc", Brewtarget::UNIT).toInt();
+   Unit::unitDisplay unitDsp = (Unit::unitDisplay)Brewtarget::option("productionDate", Brewtarget::getDateFormat(), "pitchRateCalc", Brewtarget::UNIT).toInt();
 
    switch(unitDsp)
    {
-      case displayUS:
+      case Unit::displayUS:
          format = "MM-dd-yyyy";
          break;
-      case displayImp:
+      case Unit::displayImp:
          format = "dd-MM-yyyy";
          break;
-      case displaySI:
+      case Unit::displaySI:
       default:
          format = "yyyy-MM-dd";
    }

--- a/src/PitchDialog.h
+++ b/src/PitchDialog.h
@@ -52,7 +52,7 @@ public slots:
    void toggleViabilityFromDate(int state);
    void updateViabilityFromDate(QDate date);
 
-   void updateProductionDate(unitDisplay dsp, unitScale scl);
+   void updateProductionDate(Unit::unitDisplay dsp, Unit::unitScale scl);
 
 private:
 

--- a/src/PlatoDensityUnitSystem.cpp
+++ b/src/PlatoDensityUnitSystem.cpp
@@ -23,15 +23,15 @@
 PlatoDensityUnitSystem::PlatoDensityUnitSystem()
    : UnitSystem()
 {
-   _type = Density;
+   _type = Unit::Density;
 }
 
-QMap<unitScale, Unit*> const& PlatoDensityUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& PlatoDensityUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleWithout, Units::plato);
+      _scaleToUnit.insert(Unit::scaleWithout, Units::plato);
    }
 
    return _scaleToUnit;

--- a/src/PlatoDensityUnitSystem.h
+++ b/src/PlatoDensityUnitSystem.h
@@ -31,7 +31,7 @@ public:
    Unit* thicknessUnit() { return 0; }
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
    Unit* unit();
 

--- a/src/RefractoDialog.cpp
+++ b/src/RefractoDialog.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <QString>
+#include <QDebug>
 #include "RefractoDialog.h"
 #include "Algorithms.h"
 #include "brewtarget.h"
@@ -42,9 +43,9 @@ void RefractoDialog::calculate()
    bool haveOP = true;
    bool haveOG = true;
 
-   double originalPlato = Brewtarget::toDouble(lineEdit_op->text(),      &haveOP);
-   double inputOG       = Brewtarget::toDouble(lineEdit_inputOG->text(), &haveOG);
-   double currentPlato  = Brewtarget::toDouble(lineEdit_cp->text(),      &haveCP);
+   double originalPlato = lineEdit_op->toDouble(&haveOP);
+   double inputOG       = lineEdit_inputOG->toDouble(&haveOG);
+   double currentPlato  = lineEdit_cp->toDouble(&haveCP);
    double ri = 0;
    double og = 0;
    double sg = 0;
@@ -55,8 +56,12 @@ void RefractoDialog::calculate()
    clearOutputFields();
 
    // Abort if we don't have the current plato.
-   if( ! haveCP )
+   // I really dislike just doing nothing as the user is POUNDING on the
+   // calculate button, waiting for something to happen. Maybe we should
+   // provide some ... oh ... feedback that they are doing something wrong?
+   if( ! haveCP ) {
       return;
+   }
 
    ri = Algorithms::refractiveIndex(currentPlato);
    lineEdit_ri->setText(Brewtarget::displayAmount(ri));
@@ -71,8 +76,10 @@ void RefractoDialog::calculate()
       originalPlato = Algorithms::SG_20C20C_toPlato( inputOG );
       lineEdit_op->setText(originalPlato);
    }
-   else if( (!haveOP) && (!haveOG) )
+   else if( (!haveOP) && (!haveOG) ) {
+      qDebug() << Q_FUNC_INFO << "no plato or og";
       return; // Can't do much if we don't have OG or OP.
+   }
 
    og = Algorithms::PlatoToSG_20C20C( originalPlato );
    if( originalPlato != currentPlato )

--- a/src/SIVolumeUnitSystem.cpp
+++ b/src/SIVolumeUnitSystem.cpp
@@ -25,7 +25,7 @@
 SIVolumeUnitSystem::SIVolumeUnitSystem()
    : UnitSystem()
 {
-   _type = Volume;
+   _type = Unit::Volume;
 }
 
 Unit* SIVolumeUnitSystem::thicknessUnit()
@@ -33,13 +33,13 @@ Unit* SIVolumeUnitSystem::thicknessUnit()
    return Units::liters;
 }
 
-QMap<unitScale, Unit*> const& SIVolumeUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& SIVolumeUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleExtraSmall, Units::milliliters);
-      _scaleToUnit.insert(scaleSmall, Units::liters);
+      _scaleToUnit.insert(Unit::scaleExtraSmall, Units::milliliters);
+      _scaleToUnit.insert(Unit::scaleSmall, Units::liters);
    }
 
    return _scaleToUnit;
@@ -57,5 +57,5 @@ QMap<QString, Unit*> const& SIVolumeUnitSystem::qstringToUnit()
    return _qstringToUnit;
 }
 
-Unit* SIVolumeUnitSystem::unit() { return Units::liters; };
+Unit* SIVolumeUnitSystem::unit() { return Units::liters; }
 QString SIVolumeUnitSystem::unitType() { return "SI"; }

--- a/src/SIVolumeUnitSystem.h
+++ b/src/SIVolumeUnitSystem.h
@@ -33,7 +33,7 @@ public:
    Unit* thicknessUnit(); /* Inherited from UnitSystem */
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
    Unit* unit();
 };

--- a/src/SIWeightUnitSystem.cpp
+++ b/src/SIWeightUnitSystem.cpp
@@ -26,17 +26,17 @@
 SIWeightUnitSystem::SIWeightUnitSystem()
    : UnitSystem()
 {
-   _type = Mass;
+   _type = Unit::Mass;
 }
 
-QMap<unitScale, Unit*> const& SIWeightUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& SIWeightUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleExtraSmall,Units::milligrams);
-      _scaleToUnit.insert(scaleSmall, Units::grams);
-      _scaleToUnit.insert(scaleMedium, Units::kilograms);
+      _scaleToUnit.insert(Unit::scaleExtraSmall,Units::milligrams);
+      _scaleToUnit.insert(Unit::scaleSmall, Units::grams);
+      _scaleToUnit.insert(Unit::scaleMedium, Units::kilograms);
    }
 
    return _scaleToUnit;
@@ -60,5 +60,5 @@ Unit* SIWeightUnitSystem::thicknessUnit()
    return Units::kilograms;
 }
 
-Unit* SIWeightUnitSystem::unit() { return Units::grams; };
+Unit* SIWeightUnitSystem::unit() { return Units::grams; }
 QString SIWeightUnitSystem::unitType() { return "SI"; }

--- a/src/SIWeightUnitSystem.h
+++ b/src/SIWeightUnitSystem.h
@@ -34,7 +34,7 @@ public:
    Unit* thicknessUnit(); /* Inherited from UnitSystem */
    QString unitType(); 
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
    Unit* unit();
 };

--- a/src/SgDensityUnitSystem.cpp
+++ b/src/SgDensityUnitSystem.cpp
@@ -23,15 +23,15 @@
 SgDensityUnitSystem::SgDensityUnitSystem()
    : UnitSystem()
 {
-   _type = Density;
+   _type = Unit::Density;
 }
 
-QMap<unitScale, Unit*> const& SgDensityUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& SgDensityUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleWithout,Units::sp_grav);
+      _scaleToUnit.insert(Unit::scaleWithout,Units::sp_grav);
    }
 
    return _scaleToUnit;

--- a/src/SgDensityUnitSystem.h
+++ b/src/SgDensityUnitSystem.h
@@ -31,7 +31,7 @@ public:
    Unit* thicknessUnit(){ return 0; }
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
    Unit* unit();
 

--- a/src/SrmColorUnitSystem.cpp
+++ b/src/SrmColorUnitSystem.cpp
@@ -22,15 +22,15 @@
 SrmColorUnitSystem::SrmColorUnitSystem()
    : UnitSystem()
 {
-   _type = Color;
+   _type = Unit::Color;
 }
 
-QMap<unitScale, Unit*> const& SrmColorUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& SrmColorUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleWithout,Units::srm);
+      _scaleToUnit.insert(Unit::scaleWithout,Units::srm);
    }
 
    return _scaleToUnit;

--- a/src/SrmColorUnitSystem.h
+++ b/src/SrmColorUnitSystem.h
@@ -32,7 +32,7 @@ public:
    SrmColorUnitSystem();
    Unit* thicknessUnit(){ return 0; }
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
 
    QString unitType();

--- a/src/TimeUnitSystem.cpp
+++ b/src/TimeUnitSystem.cpp
@@ -25,18 +25,18 @@
 
 TimeUnitSystem::TimeUnitSystem()
 {
-   _type = Time;
+   _type = Unit::Time;
 }
 
-QMap<unitScale, Unit*> const& TimeUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& TimeUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleExtraSmall,Units::seconds);
-      _scaleToUnit.insert(scaleSmall,Units::minutes);
-      _scaleToUnit.insert(scaleMedium,Units::hours);
-      _scaleToUnit.insert(scaleLarge,Units::days);
+      _scaleToUnit.insert(Unit::scaleExtraSmall,Units::seconds);
+      _scaleToUnit.insert(Unit::scaleSmall,Units::minutes);
+      _scaleToUnit.insert(Unit::scaleMedium,Units::hours);
+      _scaleToUnit.insert(Unit::scaleLarge,Units::days);
    }
 
    return _scaleToUnit;
@@ -56,5 +56,5 @@ QMap<QString, Unit*> const& TimeUnitSystem::qstringToUnit()
    return _qstringToUnit;
 }
 
-Unit* TimeUnitSystem::unit() { return Units::minutes; };
+Unit* TimeUnitSystem::unit() { return Units::minutes; }
 QString TimeUnitSystem::unitType() { return "entropy"; }

--- a/src/TimeUnitSystem.h
+++ b/src/TimeUnitSystem.h
@@ -33,7 +33,7 @@ public:
    Unit* thicknessUnit(){ return 0; }
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
 
    Unit* unit();

--- a/src/USVolumeUnitSystem.cpp
+++ b/src/USVolumeUnitSystem.cpp
@@ -25,20 +25,20 @@
 
 USVolumeUnitSystem::USVolumeUnitSystem()
 {
-   _type = Volume;
+   _type = Unit::Volume;
 }
 
-QMap<unitScale, Unit*> const& USVolumeUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& USVolumeUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleExtraSmall,Units::us_teaspoons);
-      _scaleToUnit.insert(scaleSmall,Units::us_tablespoons);
-      _scaleToUnit.insert(scaleMedium,Units::us_cups);
-      _scaleToUnit.insert(scaleLarge,Units::us_quarts);
-      _scaleToUnit.insert(scaleExtraLarge,Units::us_gallons);
-      _scaleToUnit.insert(scaleHuge,Units::us_barrels);
+      _scaleToUnit.insert(Unit::scaleExtraSmall,Units::us_teaspoons);
+      _scaleToUnit.insert(Unit::scaleSmall,Units::us_tablespoons);
+      _scaleToUnit.insert(Unit::scaleMedium,Units::us_cups);
+      _scaleToUnit.insert(Unit::scaleLarge,Units::us_quarts);
+      _scaleToUnit.insert(Unit::scaleExtraLarge,Units::us_gallons);
+      _scaleToUnit.insert(Unit::scaleHuge,Units::us_barrels);
    }
 
    return _scaleToUnit;
@@ -65,6 +65,6 @@ Unit* USVolumeUnitSystem::thicknessUnit()
    return Units::us_quarts;
 }
 
-Unit* USVolumeUnitSystem::unit() { return Units::us_gallons; };
+Unit* USVolumeUnitSystem::unit() { return Units::us_gallons; }
 
 QString USVolumeUnitSystem::unitType() { return "USCustomary"; }

--- a/src/USVolumeUnitSystem.h
+++ b/src/USVolumeUnitSystem.h
@@ -33,7 +33,7 @@ public:
    Unit* thicknessUnit(); /* Inherited from UnitSystem */
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
 
    Unit* unit();

--- a/src/USWeightUnitSystem.cpp
+++ b/src/USWeightUnitSystem.cpp
@@ -26,16 +26,16 @@
 
 USWeightUnitSystem::USWeightUnitSystem()
 {
-   _type = Mass;
+   _type = Unit::Mass;
 }
 
-QMap<unitScale, Unit*> const& USWeightUnitSystem::scaleToUnit()
+QMap<Unit::unitScale, Unit*> const& USWeightUnitSystem::scaleToUnit()
 {
-   static QMap<unitScale, Unit*> _scaleToUnit;
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
    if( _scaleToUnit.empty() )
    {
-      _scaleToUnit.insert(scaleExtraSmall,Units::ounces);
-      _scaleToUnit.insert(scaleSmall,Units::pounds);
+      _scaleToUnit.insert(Unit::scaleExtraSmall,Units::ounces);
+      _scaleToUnit.insert(Unit::scaleSmall,Units::pounds);
    }
 
    return _scaleToUnit;
@@ -58,5 +58,5 @@ Unit* USWeightUnitSystem::thicknessUnit()
    return Units::pounds;
 }
 
-Unit* USWeightUnitSystem::unit() { return Units::pounds; };
+Unit* USWeightUnitSystem::unit() { return Units::pounds; }
 QString USWeightUnitSystem::unitType() { return "USCustomary"; }

--- a/src/USWeightUnitSystem.h
+++ b/src/USWeightUnitSystem.h
@@ -31,7 +31,7 @@ public:
    Unit* thicknessUnit(); /* Inherited from UnitSystem */
    QString unitType();
 
-   QMap<unitScale, Unit*> const& scaleToUnit();
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
    QMap<QString, Unit*> const& qstringToUnit();
 
    Unit* unit();

--- a/src/UnitSystem.cpp
+++ b/src/UnitSystem.cpp
@@ -86,7 +86,7 @@ double UnitSystem::qstringToSI(QString qstr, Unit* defUnit, bool force)
    return u->toSI(amt);
 }
 
-QString UnitSystem::displayAmount( double amount, Unit* units, unitScale scale )
+QString UnitSystem::displayAmount( double amount, Unit* units, Unit::unitScale scale )
 {
 
    // Special cases. Make sure the unit isn't null and that we're
@@ -101,8 +101,8 @@ QString UnitSystem::displayAmount( double amount, Unit* units, unitScale scale )
    Unit* last = 0;
 
    // Don't loop if the 'without' key is defined
-   if ( scaleToUnit().contains(scaleWithout) )
-      scale = scaleWithout;
+   if ( scaleToUnit().contains(Unit::scaleWithout) )
+      scale = Unit::scaleWithout;
 
    // If a specific scale is provided, just use that and don't loop.
    if ( scaleToUnit().contains(scale) )
@@ -114,7 +114,7 @@ QString UnitSystem::displayAmount( double amount, Unit* units, unitScale scale )
    // scaleToUnit() is a QMap which means we loop in the  order in which the
    // items were inserted. Order counts, and this map has to be
    // created from smallest to largest scale (e.g., mg, g, kg).
-   QMap<unitScale, Unit*>::const_iterator it;
+   QMap<Unit::unitScale, Unit*>::const_iterator it;
    for( it = scaleToUnit().begin(); it != scaleToUnit().end(); ++it)
    {
       Unit* bob = it.value();
@@ -139,7 +139,7 @@ QString UnitSystem::displayAmount( double amount, Unit* units, unitScale scale )
 
 }
 
-double UnitSystem::amountDisplay( double amount, Unit* units, unitScale scale )
+double UnitSystem::amountDisplay( double amount, Unit* units, Unit::unitScale scale )
 {
    // Special cases. Make sure the unit isn't null and that we're
    // dealing with volume.
@@ -151,8 +151,8 @@ double UnitSystem::amountDisplay( double amount, Unit* units, unitScale scale )
    Unit* last = 0;
 
    // Short circuit if the 'without' key is defined
-   if ( scaleToUnit().contains(scaleWithout) )
-      scale = scaleWithout;
+   if ( scaleToUnit().contains(Unit::scaleWithout) )
+      scale = Unit::scaleWithout;
 
    if ( scaleToUnit().contains(scale) )
    {
@@ -160,7 +160,7 @@ double UnitSystem::amountDisplay( double amount, Unit* units, unitScale scale )
       return bob->fromSI(SIAmount);
    }
 
-   QMap<unitScale, Unit*>::const_iterator it;
+   QMap<Unit::unitScale, Unit*>::const_iterator it;
    for( it = scaleToUnit().begin(); it != scaleToUnit().end(); ++it)
    {
       Unit* bob = it.value();
@@ -179,4 +179,4 @@ double UnitSystem::amountDisplay( double amount, Unit* units, unitScale scale )
 
 }
 
-Unit* UnitSystem::scaleUnit(unitScale scale) { return scaleToUnit().contains(scale) ?  scaleToUnit().value(scale) : 0; }
+Unit* UnitSystem::scaleUnit(Unit::unitScale scale) { return scaleToUnit().contains(scale) ?  scaleToUnit().value(scale) : 0; }

--- a/src/UnitSystem.h
+++ b/src/UnitSystem.h
@@ -46,14 +46,14 @@ public:
     * 'amount' of type 'units' in this UnitSystem. This string should also
     * be recognized by qstringToSI()
     */
-   QString displayAmount( double amount, Unit* units, unitScale scale = noScale );
+   QString displayAmount( double amount, Unit* units, Unit::unitScale scale = Unit::noScale );
 
    /*!
     * amountDisplay() should return the double representing the appropriate
     * unit and scale. Similar in nature to displayAmount(), but just returning
     * raw doubles.
     */
-   double amountDisplay( double amount, Unit* units, unitScale scale = noScale );
+   double amountDisplay( double amount, Unit* units, Unit::unitScale scale = Unit::noScale );
 
    /*!
     * qstringToSI() should convert 'qstr' (consisting of a decimal amount,
@@ -62,7 +62,7 @@ public:
     */
    double qstringToSI(QString qstr, Unit* defUnit = 0, bool force = false);
 
-   Unit* scaleUnit(unitScale scale);
+   Unit* scaleUnit(Unit::unitScale scale);
    /*!
     * Returns the unit associated with thickness. If this unit system is
     * US weight, it would return lb. If it were US volume, it would return
@@ -72,13 +72,13 @@ public:
    virtual Unit* unit() = 0;
 
    /*!
-    * \brief Map from a \c unitScale to a concrete \c Unit
+    * \brief Map from a \c Unit::unitScale to a concrete \c Unit
     *
     * \note The implementing subclass is required to create
     *    the map such that the units are inserted from smallest
     *    to largest.
     */
-   virtual QMap<unitScale, Unit*> const& scaleToUnit() = 0;
+   virtual QMap<Unit::unitScale, Unit*> const& scaleToUnit() = 0;
 
    //! \brief Map from SI abbreviation to a concrete \c Unit
    virtual QMap<QString, Unit*> const& qstringToUnit() = 0;
@@ -91,7 +91,7 @@ protected:
    static const char format;
    static const int precision;
 
-   UnitType _type;
+   Unit::UnitType _type;
    QRegExp amtUnit;
 };
 

--- a/src/YeastTableModel.cpp
+++ b/src/YeastTableModel.cpp
@@ -226,7 +226,7 @@ int YeastTableModel::columnCount(const QModelIndex& /*parent*/) const
 QVariant YeastTableModel::data( const QModelIndex& index, int role ) const
 {
    Yeast* row;
-   unitDisplay unit;
+   Unit::unitDisplay unit;
 
    // Ensure the row is ok.
    if( index.row() >= (int)yeastObs.size() )
@@ -283,7 +283,7 @@ QVariant YeastTableModel::data( const QModelIndex& index, int role ) const
                                                       row->amountIsWeight() ? (Unit*)Units::kilograms : (Unit*)Units::liters,
                                                       3,
                                                       unit,
-                                                      noScale
+                                                      Unit::noScale
                                                    )
                         );
 
@@ -340,7 +340,7 @@ Qt::ItemFlags YeastTableModel::flags(const QModelIndex& index ) const
 bool YeastTableModel::setData( const QModelIndex& index, const QVariant& value, int role )
 {
    Yeast *row;
-   unitDisplay dispUnit;
+   Unit::unitDisplay dispUnit;
    Unit* unit;
 
    if( index.row() >= (int)yeastObs.size() || role != Qt::EditRole )
@@ -402,31 +402,31 @@ Yeast* YeastTableModel::getYeast(unsigned int i)
    return yeastObs[i];
 }
 
-unitDisplay YeastTableModel::displayUnit(int column) const
+Unit::unitDisplay YeastTableModel::displayUnit(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noUnit;
+      return Unit::noUnit;
 
-   return (unitDisplay)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::UNIT).toInt();
+   return (Unit::unitDisplay)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::UNIT).toInt();
 }
 
-unitScale YeastTableModel::displayScale(int column) const
+Unit::unitScale YeastTableModel::displayScale(int column) const
 {
    QString attribute = generateName(column);
 
    if ( attribute.isEmpty() )
-      return noScale;
+      return Unit::noScale;
 
-   return (unitScale)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::SCALE).toInt();
+   return (Unit::unitScale)Brewtarget::option(attribute, QVariant(-1), this->objectName(), Brewtarget::SCALE).toInt();
 }
 
 // We need to:
 //   o clear the custom scale if set
 //   o clear any custom unit from the rows
 //      o which should have the side effect of clearing any scale
-void YeastTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
+void YeastTableModel::setDisplayUnit(int column, Unit::unitDisplay displayUnit)
 {
    // Yeast* row; // disabled per-cell magic
    QString attribute = generateName(column);
@@ -435,19 +435,19 @@ void YeastTableModel::setDisplayUnit(int column, unitDisplay displayUnit)
       return;
 
    Brewtarget::setOption(attribute,displayUnit,this->objectName(),Brewtarget::UNIT);
-   Brewtarget::setOption(attribute,noScale,this->objectName(),Brewtarget::SCALE);
+   Brewtarget::setOption(attribute,Unit::noScale,this->objectName(),Brewtarget::SCALE);
 
    /* Disabled cell-specific code
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getYeast(i);
-      row->setDisplayUnit(noUnit);
+      row->setDisplayUnit(Unit::noUnit);
    }
    */
 }
 
 // Setting the scale should clear any cell-level scaling options
-void YeastTableModel::setDisplayScale(int column, unitScale displayScale)
+void YeastTableModel::setDisplayScale(int column, Unit::unitScale displayScale)
 {
    // Yeast* row; //disabled per-cell magic
 
@@ -462,7 +462,7 @@ void YeastTableModel::setDisplayScale(int column, unitScale displayScale)
    for (int i = 0; i < rowCount(); ++i )
    {
       row = getYeast(i);
-      row->setDisplayScale(noScale);
+      row->setDisplayScale(Unit::noScale);
    }
    */
 }
@@ -488,8 +488,8 @@ void YeastTableModel::contextMenu(const QPoint &point)
    QHeaderView* hView = qobject_cast<QHeaderView*>(calledBy);
 
    int selected = hView->logicalIndexAt(point);
-   unitDisplay currentUnit;
-   unitScale  currentScale;
+   Unit::unitDisplay currentUnit;
+   Unit::unitScale  currentScale;
 
    currentUnit  = displayUnit(selected);
    currentScale = displayScale(selected);
@@ -510,7 +510,7 @@ void YeastTableModel::contextMenu(const QPoint &point)
    if ( invoked == 0 )
       return;
 
-   setDisplayUnit(selected,(unitDisplay)invoked->data().toInt());
+   setDisplayUnit(selected,(Unit::unitDisplay)invoked->data().toInt());
 }
 
 

--- a/src/YeastTableModel.h
+++ b/src/YeastTableModel.h
@@ -88,10 +88,10 @@ public:
    //! \brief Reimplemented from QAbstractTableModel.
    virtual bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole );
 
-   unitDisplay displayUnit(int column) const;
-   unitScale displayScale(int column) const;
-   void setDisplayUnit(int column, unitDisplay displayUnit);
-   void setDisplayScale(int column, unitScale displayScale);
+   Unit::unitDisplay displayUnit(int column) const;
+   Unit::unitScale displayScale(int column) const;
+   void setDisplayUnit(int column, Unit::unitDisplay displayUnit);
+   void setDisplayScale(int column, Unit::unitScale displayScale);
    QString generateName(int column) const;
 
 public slots:

--- a/src/brewnote.cpp
+++ b/src/brewnote.cpp
@@ -346,10 +346,10 @@ QString BrewNote::brewDate_short()  const
   QString format;
   switch (Brewtarget::getDateFormat())
   {
-     case displayUS:
+     case Unit::displayUS:
         format = "MM-dd-yyyy";
         break;
-     case displayImp:
+     case Unit::displayImp:
         format = "dd-MM-yyyy";
         break;
      default:

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -95,7 +95,7 @@ iUnitSystem Brewtarget::weightUnitSystem = SI;
 iUnitSystem Brewtarget::volumeUnitSystem = SI;
 
 TempScale Brewtarget::tempScale = Celsius;
-unitDisplay Brewtarget::dateFormat = displaySI;
+Unit::unitDisplay Brewtarget::dateFormat = Unit::displaySI;
 
 Brewtarget::ColorType Brewtarget::colorFormula = Brewtarget::MOREY;
 Brewtarget::IbuType Brewtarget::ibuFormula = Brewtarget::TINSETH;
@@ -266,25 +266,25 @@ iUnitSystem Brewtarget::getVolumeUnitSystem()
    return volumeUnitSystem;
 }
 
-unitDisplay Brewtarget::getColorUnit()
+Unit::unitDisplay Brewtarget::getColorUnit()
 {
    if ( colorUnit == Brewtarget::SRM )
-      return displaySrm;
+      return Unit::displaySrm;
 
-   return displayEbc;
+   return Unit::displayEbc;
 }
 
-unitDisplay Brewtarget::getDateFormat()
+Unit::unitDisplay Brewtarget::getDateFormat()
 {
    return dateFormat;
 }
 
-unitDisplay Brewtarget::getDensityUnit()
+Unit::unitDisplay Brewtarget::getDensityUnit()
 {
    if ( densityUnit == Brewtarget::SG )
-      return displaySg;
+      return Unit::displaySg;
 
-   return displayPlato;
+   return Unit::displayPlato;
 }
 
 TempScale Brewtarget::getTemperatureScale()
@@ -640,17 +640,17 @@ void Brewtarget::convertPersistentOptions()
       if( text == "Imperial" )
       {
          weightUnitSystem = Imperial;
-         thingToUnitSystem.insert(Mass,UnitSystems::usWeightUnitSystem());
+         thingToUnitSystem.insert(Unit::Mass,UnitSystems::usWeightUnitSystem());
       }
       else if (text == "USCustomary")
       {
          weightUnitSystem = USCustomary;
-         thingToUnitSystem.insert(Mass,UnitSystems::usWeightUnitSystem());
+         thingToUnitSystem.insert(Unit::Mass,UnitSystems::usWeightUnitSystem());
       }
       else
       {
          weightUnitSystem = SI;
-         thingToUnitSystem.insert(Mass,UnitSystems::siWeightUnitSystem());
+         thingToUnitSystem.insert(Unit::Mass,UnitSystems::siWeightUnitSystem());
       }
    }
 
@@ -661,17 +661,17 @@ void Brewtarget::convertPersistentOptions()
       if( text == "Imperial" )
       {
          volumeUnitSystem = Imperial;
-         thingToUnitSystem.insert(Volume,UnitSystems::imperialVolumeUnitSystem());
+         thingToUnitSystem.insert(Unit::Volume,UnitSystems::imperialVolumeUnitSystem());
       }
       else if (text == "USCustomary")
       {
          volumeUnitSystem = USCustomary;
-         thingToUnitSystem.insert(Volume,UnitSystems::usVolumeUnitSystem());
+         thingToUnitSystem.insert(Unit::Volume,UnitSystems::usVolumeUnitSystem());
       }
       else
       {
          volumeUnitSystem = SI;
-         thingToUnitSystem.insert(Volume,UnitSystems::siVolumeUnitSystem());
+         thingToUnitSystem.insert(Unit::Volume,UnitSystems::siVolumeUnitSystem());
       }
    }
 
@@ -682,18 +682,18 @@ void Brewtarget::convertPersistentOptions()
       if( text == "Fahrenheit" )
       {
          tempScale = Fahrenheit;
-         thingToUnitSystem.insert(Temp,UnitSystems::fahrenheitTempUnitSystem());
+         thingToUnitSystem.insert(Unit::Temp,UnitSystems::fahrenheitTempUnitSystem());
       }
       else
       {
          tempScale = Celsius;
-         thingToUnitSystem.insert(Temp,UnitSystems::celsiusTempUnitSystem());
+         thingToUnitSystem.insert(Unit::Temp,UnitSystems::celsiusTempUnitSystem());
       }
    }
 
    //======================Time======================
    // Set the one and only time system.
-   thingToUnitSystem.insert(Time,UnitSystems::timeUnitSystem());
+   thingToUnitSystem.insert(Unit::Time,UnitSystems::timeUnitSystem());
 
    //===================IBU===================
    text = getOptionValue(*optionsDoc, "ibu_formula", &hasOption);
@@ -732,12 +732,12 @@ void Brewtarget::convertPersistentOptions()
       if( text == "true" )
       {
          densityUnit = PLATO;
-         thingToUnitSystem.insert(Density,UnitSystems::platoDensityUnitSystem());
+         thingToUnitSystem.insert(Unit::Density,UnitSystems::platoDensityUnitSystem());
       }
       else if( text == "false" )
       {
          densityUnit = SG;
-         thingToUnitSystem.insert(Density,UnitSystems::sgDensityUnitSystem());
+         thingToUnitSystem.insert(Unit::Density,UnitSystems::sgDensityUnitSystem());
       }
       else
       {
@@ -752,12 +752,12 @@ void Brewtarget::convertPersistentOptions()
       if( text == "srm" )
       {
          colorUnit = SRM;
-         thingToUnitSystem.insert(Color,UnitSystems::srmColorUnitSystem());
+         thingToUnitSystem.insert(Unit::Color,UnitSystems::srmColorUnitSystem());
       }
       else if( text == "ebc" )
       {
          colorUnit = EBC;
-         thingToUnitSystem.insert(Color,UnitSystems::ebcColorUnitSystem());
+         thingToUnitSystem.insert(Unit::Color,UnitSystems::ebcColorUnitSystem());
       }
       else
          Brewtarget::logW(QString("Bad color_unit type: %1").arg(text));
@@ -835,17 +835,17 @@ void Brewtarget::readSystemOptions()
    if( text == "Imperial" )
    {
       weightUnitSystem = Imperial;
-      thingToUnitSystem.insert(Mass,UnitSystems::usWeightUnitSystem());
+      thingToUnitSystem.insert(Unit::Mass,UnitSystems::usWeightUnitSystem());
    }
    else if (text == "USCustomary")
    {
       weightUnitSystem = USCustomary;
-      thingToUnitSystem.insert(Mass,UnitSystems::usWeightUnitSystem());
+      thingToUnitSystem.insert(Unit::Mass,UnitSystems::usWeightUnitSystem());
    }
    else
    {
       weightUnitSystem = SI;
-      thingToUnitSystem.insert(Mass,UnitSystems::siWeightUnitSystem());
+      thingToUnitSystem.insert(Unit::Mass,UnitSystems::siWeightUnitSystem());
    }
 
    //===========================Volume=======================
@@ -853,17 +853,17 @@ void Brewtarget::readSystemOptions()
    if( text == "Imperial" )
    {
       volumeUnitSystem = Imperial;
-      thingToUnitSystem.insert(Volume,UnitSystems::imperialVolumeUnitSystem());
+      thingToUnitSystem.insert(Unit::Volume,UnitSystems::imperialVolumeUnitSystem());
    }
    else if (text == "USCustomary")
    {
       volumeUnitSystem = USCustomary;
-      thingToUnitSystem.insert(Volume,UnitSystems::usVolumeUnitSystem());
+      thingToUnitSystem.insert(Unit::Volume,UnitSystems::usVolumeUnitSystem());
    }
    else
    {
       volumeUnitSystem = SI;
-      thingToUnitSystem.insert(Volume,UnitSystems::siVolumeUnitSystem());
+      thingToUnitSystem.insert(Unit::Volume,UnitSystems::siVolumeUnitSystem());
    }
 
    //=======================Temp======================
@@ -871,17 +871,17 @@ void Brewtarget::readSystemOptions()
    if( text == "Fahrenheit" )
    {
       tempScale = Fahrenheit;
-      thingToUnitSystem.insert(Temp,UnitSystems::fahrenheitTempUnitSystem());
+      thingToUnitSystem.insert(Unit::Temp,UnitSystems::fahrenheitTempUnitSystem());
    }
    else
    {
       tempScale = Celsius;
-      thingToUnitSystem.insert(Temp,UnitSystems::celsiusTempUnitSystem());
+      thingToUnitSystem.insert(Unit::Temp,UnitSystems::celsiusTempUnitSystem());
    }
 
    //======================Time======================
    // Set the one and only time system.
-   thingToUnitSystem.insert(Time,UnitSystems::timeUnitSystem());
+   thingToUnitSystem.insert(Unit::Time,UnitSystems::timeUnitSystem());
 
    //===================IBU===================
    text = option("ibu_formula", "tinseth").toString();
@@ -912,12 +912,12 @@ void Brewtarget::readSystemOptions()
    if ( option("use_plato", false).toBool() )
    {
       densityUnit = PLATO;
-      thingToUnitSystem.insert(Density,UnitSystems::platoDensityUnitSystem());
+      thingToUnitSystem.insert(Unit::Density,UnitSystems::platoDensityUnitSystem());
    }
    else
    {
       densityUnit = SG;
-      thingToUnitSystem.insert(Density,UnitSystems::sgDensityUnitSystem());
+      thingToUnitSystem.insert(Unit::Density,UnitSystems::sgDensityUnitSystem());
    }
 
    //=======================Color unit===================
@@ -925,18 +925,18 @@ void Brewtarget::readSystemOptions()
    if( text == "srm" )
    {
       colorUnit = SRM;
-      thingToUnitSystem.insert(Color,UnitSystems::srmColorUnitSystem());
+      thingToUnitSystem.insert(Unit::Color,UnitSystems::srmColorUnitSystem());
    }
    else if( text == "ebc" )
    {
       colorUnit = EBC;
-      thingToUnitSystem.insert(Color,UnitSystems::ebcColorUnitSystem());
+      thingToUnitSystem.insert(Unit::Color,UnitSystems::ebcColorUnitSystem());
    }
    else
       Brewtarget::logW(QString("Bad color_unit type: %1").arg(text));
 
    //=======================Date format===================
-   dateFormat = (unitDisplay)option("date_format",displaySI).toInt();
+   dateFormat = (Unit::unitDisplay)option("date_format",Unit::displaySI).toInt();
 }
 
 void Brewtarget::saveSystemOptions()
@@ -947,9 +947,9 @@ void Brewtarget::saveSystemOptions()
    setOption("last_db_merge_req", lastDbMergeRequest.toString(Qt::ISODate));
    setOption("language", getCurrentLanguage());
    setOption("user_data_dir", userDataDir);
-   setOption("weight_unit_system", thingToUnitSystem.value(Mass)->unitType());
-   setOption("volume_unit_system",thingToUnitSystem.value(Volume)->unitType());
-   setOption("temperature_scale", thingToUnitSystem.value(Temp)->unitType());
+   setOption("weight_unit_system", thingToUnitSystem.value(Unit::Mass)->unitType());
+   setOption("volume_unit_system",thingToUnitSystem.value(Unit::Volume)->unitType());
+   setOption("temperature_scale", thingToUnitSystem.value(Unit::Temp)->unitType());
    setOption("use_plato", densityUnit == PLATO);
    setOption("date_format", dateFormat);
 
@@ -992,28 +992,28 @@ void Brewtarget::saveSystemOptions()
 void Brewtarget::loadMap()
 {
    // ==== mass ====
-   thingToUnitSystem.insert(Mass | displaySI, UnitSystems::siWeightUnitSystem() );
-   thingToUnitSystem.insert(Mass | displayUS, UnitSystems::usWeightUnitSystem() );
-   thingToUnitSystem.insert(Mass | displayImp,UnitSystems::usWeightUnitSystem() );
+   thingToUnitSystem.insert(Unit::Mass | Unit::displaySI, UnitSystems::siWeightUnitSystem() );
+   thingToUnitSystem.insert(Unit::Mass | Unit::displayUS, UnitSystems::usWeightUnitSystem() );
+   thingToUnitSystem.insert(Unit::Mass | Unit::displayImp,UnitSystems::usWeightUnitSystem() );
 
    // ==== volume ====
-   thingToUnitSystem.insert(Volume | displaySI, UnitSystems::siVolumeUnitSystem() );
-   thingToUnitSystem.insert(Volume | displayUS, UnitSystems::usVolumeUnitSystem() );
-   thingToUnitSystem.insert(Volume | displayImp,UnitSystems::imperialVolumeUnitSystem() );
+   thingToUnitSystem.insert(Unit::Volume | Unit::displaySI, UnitSystems::siVolumeUnitSystem() );
+   thingToUnitSystem.insert(Unit::Volume | Unit::displayUS, UnitSystems::usVolumeUnitSystem() );
+   thingToUnitSystem.insert(Unit::Volume | Unit::displayImp,UnitSystems::imperialVolumeUnitSystem() );
 
    // ==== time is empty ==== (this zen moment was free)
 
    // ==== temp ====
-   thingToUnitSystem.insert(Temp | displaySI,UnitSystems::celsiusTempUnitSystem() );
-   thingToUnitSystem.insert(Temp | displayUS,UnitSystems::fahrenheitTempUnitSystem() );
+   thingToUnitSystem.insert(Unit::Temp | Unit::displaySI,UnitSystems::celsiusTempUnitSystem() );
+   thingToUnitSystem.insert(Unit::Temp | Unit::displayUS,UnitSystems::fahrenheitTempUnitSystem() );
 
    // ==== color ====
-   thingToUnitSystem.insert(Color | displaySrm,UnitSystems::srmColorUnitSystem() );
-   thingToUnitSystem.insert(Color | displayEbc,UnitSystems::ebcColorUnitSystem() );
+   thingToUnitSystem.insert(Unit::Color | Unit::displaySrm,UnitSystems::srmColorUnitSystem() );
+   thingToUnitSystem.insert(Unit::Color | Unit::displayEbc,UnitSystems::ebcColorUnitSystem() );
 
    // ==== density ====
-   thingToUnitSystem.insert(Density | displaySg,   UnitSystems::sgDensityUnitSystem() );
-   thingToUnitSystem.insert(Density | displayPlato,UnitSystems::platoDensityUnitSystem() );
+   thingToUnitSystem.insert(Unit::Density | Unit::displaySg,   UnitSystems::sgDensityUnitSystem() );
+   thingToUnitSystem.insert(Unit::Density | Unit::displayPlato,UnitSystems::platoDensityUnitSystem() );
 }
 
 void Brewtarget::log(LogType lt, QString message)
@@ -1108,7 +1108,7 @@ double Brewtarget::toDouble(QString text, QString caller)
 
 // Displays "amount" of units "units" in the proper format.
 // If "units" is null, just return the amount.
-QString Brewtarget::displayAmount( double amount, Unit* units, int precision, unitDisplay displayUnits, unitScale displayScale)
+QString Brewtarget::displayAmount( double amount, Unit* units, int precision, Unit::unitDisplay displayUnits, Unit::unitScale displayScale)
 {
    int fieldWidth = 0;
    char format = 'f';
@@ -1142,8 +1142,8 @@ QString Brewtarget::displayAmount(BeerXMLElement* element, QObject* object, QStr
    double amount = 0.0;
    QString value;
    bool ok = false;
-   unitScale dispScale;
-   unitDisplay dispUnit;
+   Unit::unitScale dispScale;
+   Unit::unitDisplay dispUnit;
 
    if ( element->property(attribute.toLatin1().constData()).canConvert(QVariant::Double) )
    {
@@ -1153,8 +1153,8 @@ QString Brewtarget::displayAmount(BeerXMLElement* element, QObject* object, QStr
       if ( ! ok )
          logW( QString("Brewtarget::displayAmount(BeerXMLElement*,QObject*,QString,Unit*,int) could not convert %1 to double").arg(value));
       // Get the display units and scale
-      dispUnit  = (unitDisplay)option(attribute, noUnit,  object->objectName(), UNIT).toInt();
-      dispScale = (unitScale)option(  attribute, noScale, object->objectName(), SCALE).toInt();
+      dispUnit  = (Unit::unitDisplay)option(attribute, Unit::noUnit,  object->objectName(), UNIT).toInt();
+      dispScale = (Unit::unitScale)option(  attribute, Unit::noScale, object->objectName(), SCALE).toInt();
 
       return displayAmount(amount, units, precision, dispUnit, dispScale);
    }
@@ -1165,18 +1165,18 @@ QString Brewtarget::displayAmount(BeerXMLElement* element, QObject* object, QStr
 
 QString Brewtarget::displayAmount(double amt, QString section, QString attribute, Unit* units, int precision )
 {
-   unitScale dispScale;
-   unitDisplay dispUnit;
+   Unit::unitScale dispScale;
+   Unit::unitDisplay dispUnit;
 
    // Get the display units and scale
-   dispUnit  = (unitDisplay)Brewtarget::option(attribute, noUnit,  section, UNIT).toInt();
-   dispScale = (unitScale)Brewtarget::option(  attribute, noScale, section, SCALE).toInt();
+   dispUnit  = (Unit::unitDisplay)Brewtarget::option(attribute, Unit::noUnit,  section, UNIT).toInt();
+   dispScale = (Unit::unitScale)Brewtarget::option(  attribute, Unit::noScale, section, SCALE).toInt();
 
    return displayAmount(amt, units, precision, dispUnit, dispScale);
 
 }
 
-double Brewtarget::amountDisplay( double amount, Unit* units, int precision, unitDisplay displayUnits, unitScale displayScale)
+double Brewtarget::amountDisplay( double amount, Unit* units, int precision, Unit::unitDisplay displayUnits, Unit::unitScale displayScale)
 {
    UnitSystem* temp;
 
@@ -1208,8 +1208,8 @@ double Brewtarget::amountDisplay(BeerXMLElement* element, QObject* object, QStri
    double amount = 0.0;
    QString value;
    bool ok = false;
-   unitScale dispScale;
-   unitDisplay dispUnit;
+   Unit::unitScale dispScale;
+   Unit::unitDisplay dispUnit;
 
    if ( element->property(attribute.toLatin1().constData()).canConvert(QVariant::Double) )
    {
@@ -1219,8 +1219,8 @@ double Brewtarget::amountDisplay(BeerXMLElement* element, QObject* object, QStri
       if ( ! ok )
          logW( QString("Brewtarget::amountDisplay(BeerXMLElement*,QObject*,QString,Unit*,int) could not convert %1 to double").arg(value));
       // Get the display units and scale
-      dispUnit  = (unitDisplay)option(attribute, noUnit,  object->objectName(), UNIT).toInt();
-      dispScale = (unitScale)option(  attribute, noScale, object->objectName(), SCALE).toInt();
+      dispUnit  = (Unit::unitDisplay)option(attribute, Unit::noUnit,  object->objectName(), UNIT).toInt();
+      dispScale = (Unit::unitScale)option(  attribute, Unit::noScale, object->objectName(), SCALE).toInt();
 
       return amountDisplay(amount, units, precision, dispUnit, dispScale);
    }
@@ -1228,7 +1228,7 @@ double Brewtarget::amountDisplay(BeerXMLElement* element, QObject* object, QStri
       return -1.0;
 }
 
-UnitSystem* Brewtarget::findUnitSystem(Unit* unit, unitDisplay display)
+UnitSystem* Brewtarget::findUnitSystem(Unit* unit, Unit::unitDisplay display)
 {
    if ( ! unit )
       return 0;
@@ -1237,7 +1237,7 @@ UnitSystem* Brewtarget::findUnitSystem(Unit* unit, unitDisplay display)
 
    // noUnit means get the default UnitSystem. Through little planning on my
    // part, it happens that is equivalent to just the unitType
-   if ( display != noUnit )
+   if ( display != Unit::noUnit )
       key |= display;
 
    if ( thingToUnitSystem.contains( key ) )
@@ -1248,8 +1248,8 @@ UnitSystem* Brewtarget::findUnitSystem(Unit* unit, unitDisplay display)
 
 void Brewtarget::getThicknessUnits( Unit** volumeUnit, Unit** weightUnit )
 {
-   *volumeUnit = thingToUnitSystem.value(Volume | displayDef)->thicknessUnit();
-   *weightUnit = thingToUnitSystem.value(Mass   | displayDef)->thicknessUnit();
+   *volumeUnit = thingToUnitSystem.value(Unit::Volume | Unit::displayDef)->thicknessUnit();
+   *weightUnit = thingToUnitSystem.value(Unit::Mass   | Unit::displayDef)->thicknessUnit();
 }
 
 QString Brewtarget::displayThickness( double thick_lkg, bool showUnits )
@@ -1258,8 +1258,8 @@ QString Brewtarget::displayThickness( double thick_lkg, bool showUnits )
    char format = 'f';
    int precision = 2;
 
-   Unit* volUnit    = thingToUnitSystem.value(Volume | displayDef)->thicknessUnit();
-   Unit* weightUnit = thingToUnitSystem.value(Mass   | displayDef)->thicknessUnit();
+   Unit* volUnit    = thingToUnitSystem.value(Unit::Volume | Unit::displayDef)->thicknessUnit();
+   Unit* weightUnit = thingToUnitSystem.value(Unit::Mass   | Unit::displayDef)->thicknessUnit();
 
    double num = volUnit->fromSI(thick_lkg);
    double den = weightUnit->fromSI(1.0);
@@ -1270,7 +1270,7 @@ QString Brewtarget::displayThickness( double thick_lkg, bool showUnits )
       return QString("%L1").arg(num/den, fieldWidth, format, precision).arg(volUnit->getUnitName()).arg(weightUnit->getUnitName());
 }
 
-double Brewtarget::qStringToSI(QString qstr, Unit* unit, unitDisplay dispUnit, bool force)
+double Brewtarget::qStringToSI(QString qstr, Unit* unit, Unit::unitDisplay dispUnit, bool force)
 {
    UnitSystem* temp = findUnitSystem(unit, dispUnit);
    return temp->qstringToSI(qstr,temp->unit(),force);
@@ -1303,12 +1303,12 @@ QString Brewtarget::colorFormulaName()
    return tr("Unknown");
 }
 
-QString Brewtarget::colorUnitName(unitDisplay display)
+QString Brewtarget::colorUnitName(Unit::unitDisplay display)
 {
-   if ( display == noUnit )
+   if ( display == Unit::noUnit )
       display = getColorUnit();
 
-   if ( display == displaySrm )
+   if ( display == Unit::displaySrm )
       return QString("SRM");
    else
       return QString("EBC");
@@ -1354,9 +1354,9 @@ QPair<double,double> Brewtarget::displayRange(BeerXMLElement* element, QObject *
 QPair<double,double> Brewtarget::displayRange(QObject *object, QString attribute, double min, double max, RangeType _type)
 {
    QPair<double,double> range;
-   unitDisplay displayUnit;
+   Unit::unitDisplay displayUnit;
 
-   displayUnit = (unitDisplay)option(attribute, noUnit, object->objectName(), UNIT).toInt();
+   displayUnit = (Unit::unitDisplay)option(attribute, Unit::noUnit, object->objectName(), UNIT).toInt();
 
    if ( _type == DENSITY )
    {
@@ -1435,52 +1435,52 @@ QString Brewtarget::generateName(QString attribute, const QString section, iUnit
 // putting them here.
 // I use a QActionGroup to make sure only one button is ever selected at once.
 // It allows me to cache the menus later and speeds the response time up.
-QMenu* Brewtarget::setupColorMenu(QWidget* parent, unitDisplay unit)
+QMenu* Brewtarget::setupColorMenu(QWidget* parent, Unit::unitDisplay unit)
 {
    QMenu* menu = new QMenu(parent);
    QActionGroup* qgrp = new QActionGroup(parent);
 
-   generateAction(menu, tr("Default"), noUnit, unit, qgrp);
-   generateAction(menu, tr("EBC"), displayEbc, unit, qgrp);
-   generateAction(menu, tr("SRM"), displaySrm, unit, qgrp);
+   generateAction(menu, tr("Default"), Unit::noUnit, unit, qgrp);
+   generateAction(menu, tr("EBC"), Unit::displayEbc, unit, qgrp);
+   generateAction(menu, tr("SRM"), Unit::displaySrm, unit, qgrp);
 
    return menu;
 }
 
-QMenu* Brewtarget::setupDateMenu(QWidget* parent, unitDisplay unit)
+QMenu* Brewtarget::setupDateMenu(QWidget* parent, Unit::unitDisplay unit)
 {
    QMenu* menu = new QMenu(parent);
    QActionGroup* qgrp = new QActionGroup(parent);
 
-   generateAction(menu, tr("Default"),    noUnit,     unit, qgrp);
-   generateAction(menu, tr("YYYY-mm-dd"), displaySI,  unit, qgrp);
-   generateAction(menu, tr("dd-mm-YYYY"), displayImp, unit, qgrp);
-   generateAction(menu, tr("mm-dd-YYYY"), displayUS,  unit, qgrp);
+   generateAction(menu, tr("Default"),    Unit::noUnit,     unit, qgrp);
+   generateAction(menu, tr("YYYY-mm-dd"), Unit::displaySI,  unit, qgrp);
+   generateAction(menu, tr("dd-mm-YYYY"), Unit::displayImp, unit, qgrp);
+   generateAction(menu, tr("mm-dd-YYYY"), Unit::displayUS,  unit, qgrp);
 
    return menu;
 }
 
-QMenu* Brewtarget::setupDensityMenu(QWidget* parent, unitDisplay unit)
+QMenu* Brewtarget::setupDensityMenu(QWidget* parent, Unit::unitDisplay unit)
 {
    QMenu* menu = new QMenu(parent);
    QActionGroup* qgrp = new QActionGroup(parent);
 
-   generateAction(menu, tr("Default"), noUnit, unit, qgrp);
-   generateAction(menu, tr("Plato"), displayPlato, unit, qgrp);
-   generateAction(menu, tr("Specific Gravity"), displaySg, unit, qgrp);
+   generateAction(menu, tr("Default"), Unit::noUnit, unit, qgrp);
+   generateAction(menu, tr("Plato"), Unit::displayPlato, unit, qgrp);
+   generateAction(menu, tr("Specific Gravity"), Unit::displaySg, unit, qgrp);
 
    return menu;
 }
 
-QMenu* Brewtarget::setupMassMenu(QWidget* parent, unitDisplay unit, unitScale scale, bool generateScale)
+QMenu* Brewtarget::setupMassMenu(QWidget* parent, Unit::unitDisplay unit, Unit::unitScale scale, bool generateScale)
 {
    QMenu* menu = new QMenu(parent);
    QMenu* sMenu;
    QActionGroup* qgrp = new QActionGroup(parent);
 
-   generateAction(menu, tr("Default"), noUnit, unit, qgrp);
-   generateAction(menu, tr("SI"), displaySI, unit, qgrp);
-   generateAction(menu, tr("US Customary"), displayUS, unit, qgrp);
+   generateAction(menu, tr("Default"), Unit::noUnit, unit, qgrp);
+   generateAction(menu, tr("SI"), Unit::displaySI, unit, qgrp);
+   generateAction(menu, tr("US Customary"), Unit::displayUS, unit, qgrp);
 
    // Some places can't do scale -- like yeast tables and misc tables because
    // they can be mixed. It doesn't stop the unit selection from working, but
@@ -1488,28 +1488,28 @@ QMenu* Brewtarget::setupMassMenu(QWidget* parent, unitDisplay unit, unitScale sc
    if ( generateScale == false )
       return menu;
 
-   if ( unit == noUnit )
+   if ( unit == Unit::noUnit )
    {
-      if ( thingToUnitSystem.value(Mass) == UnitSystems::usWeightUnitSystem() )
-         unit = displayUS;
+      if ( thingToUnitSystem.value(Unit::Mass) == UnitSystems::usWeightUnitSystem() )
+         unit = Unit::displayUS;
       else
-         unit = displaySI;
+         unit = Unit::displaySI;
    }
 
    sMenu = new QMenu(menu);
    QActionGroup* qsgrp = new QActionGroup(menu);
    switch(unit)
    {
-      case displaySI:
-         generateAction(sMenu, tr("Default"), noScale, scale,qsgrp);
-         generateAction(sMenu, tr("Milligrams"), scaleExtraSmall, scale,qsgrp);
-         generateAction(sMenu, tr("Grams"), scaleSmall, scale,qsgrp);
-         generateAction(sMenu, tr("Kilograms"), scaleMedium, scale,qsgrp);
+      case Unit::displaySI:
+         generateAction(sMenu, tr("Default"), Unit::noScale, scale,qsgrp);
+         generateAction(sMenu, tr("Milligrams"), Unit::scaleExtraSmall, scale,qsgrp);
+         generateAction(sMenu, tr("Grams"), Unit::scaleSmall, scale,qsgrp);
+         generateAction(sMenu, tr("Kilograms"), Unit::scaleMedium, scale,qsgrp);
          break;
       default:
-         generateAction(sMenu, tr("Default"), noScale, scale,qsgrp);
-         generateAction(sMenu, tr("Ounces"), scaleExtraSmall, scale,qsgrp);
-         generateAction(sMenu, tr("Pounds"), scaleSmall, scale,qsgrp);
+         generateAction(sMenu, tr("Default"), Unit::noScale, scale,qsgrp);
+         generateAction(sMenu, tr("Ounces"), Unit::scaleExtraSmall, scale,qsgrp);
+         generateAction(sMenu, tr("Pounds"), Unit::scaleSmall, scale,qsgrp);
          break;
    }
    sMenu->setTitle("Scale");
@@ -1518,30 +1518,30 @@ QMenu* Brewtarget::setupMassMenu(QWidget* parent, unitDisplay unit, unitScale sc
    return menu;
 }
 
-QMenu* Brewtarget::setupTemperatureMenu(QWidget* parent, unitDisplay unit)
+QMenu* Brewtarget::setupTemperatureMenu(QWidget* parent, Unit::unitDisplay unit)
 {
    QMenu* menu = new QMenu(parent);
    QActionGroup* qgrp = new QActionGroup(parent);
 
-   generateAction(menu, tr("Default"), noUnit, unit, qgrp);
-   generateAction(menu, tr("Celsius"), displaySI, unit, qgrp);
-   generateAction(menu, tr("Fahrenheit"), displayUS, unit, qgrp);
+   generateAction(menu, tr("Default"), Unit::noUnit, unit, qgrp);
+   generateAction(menu, tr("Celsius"), Unit::displaySI, unit, qgrp);
+   generateAction(menu, tr("Fahrenheit"), Unit::displayUS, unit, qgrp);
 
    return menu;
 }
 
 // Time menus only have scale
-QMenu* Brewtarget::setupTimeMenu(QWidget* parent, unitScale scale)
+QMenu* Brewtarget::setupTimeMenu(QWidget* parent, Unit::unitScale scale)
 {
    QMenu* menu = new QMenu(parent);
    QMenu* sMenu = new QMenu(menu);
    QActionGroup* qgrp = new QActionGroup(parent);
 
-   generateAction(sMenu, tr("Default"), noScale, scale, qgrp);
-   generateAction(sMenu, tr("Seconds"), scaleExtraSmall, scale, qgrp);
-   generateAction(sMenu, tr("Minutes"), scaleSmall, scale, qgrp);
-   generateAction(sMenu, tr("Hours"),   scaleMedium, scale, qgrp);
-   generateAction(sMenu, tr("Days"),    scaleLarge, scale, qgrp);
+   generateAction(sMenu, tr("Default"), Unit::noScale, scale, qgrp);
+   generateAction(sMenu, tr("Seconds"), Unit::scaleExtraSmall, scale, qgrp);
+   generateAction(sMenu, tr("Minutes"), Unit::scaleSmall, scale, qgrp);
+   generateAction(sMenu, tr("Hours"),   Unit::scaleMedium, scale, qgrp);
+   generateAction(sMenu, tr("Days"),    Unit::scaleLarge, scale, qgrp);
 
    sMenu->setTitle("Scale");
    menu->addMenu(sMenu);
@@ -1549,28 +1549,28 @@ QMenu* Brewtarget::setupTimeMenu(QWidget* parent, unitScale scale)
    return menu;
 }
 
-QMenu* Brewtarget::setupVolumeMenu(QWidget* parent, unitDisplay unit, unitScale scale, bool generateScale)
+QMenu* Brewtarget::setupVolumeMenu(QWidget* parent, Unit::unitDisplay unit, Unit::unitScale scale, bool generateScale)
 {
    QMenu* menu = new QMenu(parent);
    QActionGroup* qgrp = new QActionGroup(parent);
    QMenu* sMenu;
 
-   generateAction(menu, tr("Default"), noUnit, unit, qgrp);
-   generateAction(menu, tr("SI"), displaySI, unit, qgrp);
-   generateAction(menu, tr("US Customary"), displayUS, unit, qgrp);
-   generateAction(menu, tr("British Imperial"), displayImp, unit, qgrp);
+   generateAction(menu, tr("Default"), Unit::noUnit, unit, qgrp);
+   generateAction(menu, tr("SI"), Unit::displaySI, unit, qgrp);
+   generateAction(menu, tr("US Customary"), Unit::displayUS, unit, qgrp);
+   generateAction(menu, tr("British Imperial"), Unit::displayImp, unit, qgrp);
 
    if ( generateScale == false )
       return menu;
 
-   if ( unit == noUnit )
+   if ( unit == Unit::noUnit )
    {
-      if ( thingToUnitSystem.value(Volume) == UnitSystems::usVolumeUnitSystem() )
-         unit = displayUS;
-      else if ( thingToUnitSystem.value(Volume) == UnitSystems::imperialVolumeUnitSystem() )
-         unit = displayImp;
+      if ( thingToUnitSystem.value(Unit::Volume) == UnitSystems::usVolumeUnitSystem() )
+         unit = Unit::displayUS;
+      else if ( thingToUnitSystem.value(Unit::Volume) == UnitSystems::imperialVolumeUnitSystem() )
+         unit = Unit::displayImp;
       else
-         unit = displaySI;
+         unit = Unit::displaySI;
    }
 
 
@@ -1578,20 +1578,20 @@ QMenu* Brewtarget::setupVolumeMenu(QWidget* parent, unitDisplay unit, unitScale 
    QActionGroup* qsgrp = new QActionGroup(menu);
    switch(unit)
    {
-      case displaySI:
-         generateAction(sMenu, tr("Default"), noScale, scale,qsgrp);
-         generateAction(sMenu, tr("MilliLiters"), scaleExtraSmall, scale,qsgrp);
-         generateAction(sMenu, tr("Liters"), scaleSmall, scale,qsgrp);
+      case Unit::displaySI:
+         generateAction(sMenu, tr("Default"), Unit::noScale, scale,qsgrp);
+         generateAction(sMenu, tr("MilliLiters"), Unit::scaleExtraSmall, scale,qsgrp);
+         generateAction(sMenu, tr("Liters"), Unit::scaleSmall, scale,qsgrp);
          break;
         // I can cheat because Imperial and US use the same names
       default:
-         generateAction(sMenu, tr("Default"), noScale, scale,qsgrp);
-         generateAction(sMenu, tr("Teaspoons"), scaleExtraSmall, scale,qsgrp);
-         generateAction(sMenu, tr("Tablespoons"), scaleSmall, scale,qsgrp);
-         generateAction(sMenu, tr("Cups"), scaleMedium, scale,qsgrp);
-         generateAction(sMenu, tr("Quarts"), scaleLarge, scale,qsgrp);
-         generateAction(sMenu, tr("Gallons"), scaleExtraLarge, scale,qsgrp);
-         generateAction(sMenu, tr("Barrels"), scaleHuge, scale,qsgrp);
+         generateAction(sMenu, tr("Default"), Unit::noScale, scale,qsgrp);
+         generateAction(sMenu, tr("Teaspoons"), Unit::scaleExtraSmall, scale,qsgrp);
+         generateAction(sMenu, tr("Tablespoons"), Unit::scaleSmall, scale,qsgrp);
+         generateAction(sMenu, tr("Cups"), Unit::scaleMedium, scale,qsgrp);
+         generateAction(sMenu, tr("Quarts"), Unit::scaleLarge, scale,qsgrp);
+         generateAction(sMenu, tr("Gallons"), Unit::scaleExtraLarge, scale,qsgrp);
+         generateAction(sMenu, tr("Barrels"), Unit::scaleHuge, scale,qsgrp);
          break;
    }
    sMenu->setTitle("Scale");

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -179,10 +179,10 @@ public:
     *  \param units the units that \c amount is in
     *  \param precision how many decimal places
     *  \param unitDisplay which unit system to use, defaulting to "noUnit" which means use the system default
-    *  \param unitScale which scale to use, defaulting to noScale which means use the largest scale that generates a value > 1
+    *  \param Unit::Unit::unitScale which scale to use, defaulting to Unit::Unit::noScale which means use the largest scale that generates a value > 1
     */
    static QString displayAmount( double amount, Unit* units=0, int precision=3,
-                                 unitDisplay displayUnit = noUnit, unitScale displayScale = noScale );
+                                 Unit::unitDisplay displayUnit = Unit::noUnit, Unit::Unit::unitScale displayScale = Unit::Unit::noScale );
    /*!
     * \brief Displays an amount in the appropriate units.
     *
@@ -213,7 +213,7 @@ public:
     *  \param precision how many decimal places
     */
    static double amountDisplay( double amount, Unit* units=0, int precision=3,
-                                 unitDisplay displayUnit = noUnit, unitScale displayScale = noScale );
+                                 Unit::unitDisplay displayUnit = Unit::noUnit, Unit::Unit::unitScale displayScale = Unit::Unit::noScale );
    /*!
     * \brief Displays an amount in the appropriate units.
     *
@@ -234,7 +234,7 @@ public:
    static QPair<double,double> displayRange(QObject *object, QString attribute, double min, double max, RangeType _type = DENSITY);
 
    //! \return SI amount for the string
-   static double qStringToSI( QString qstr, Unit* unit, unitDisplay dispUnit = noUnit, bool force = false);
+   static double qStringToSI( QString qstr, Unit* unit, Unit::unitDisplay dispUnit = Unit::noUnit, bool force = false);
 
    //! \brief return the bitterness formula's name
    static QString ibuFormulaName();
@@ -242,17 +242,17 @@ public:
    static QString colorFormulaName();
 
    // One method to rule them all, and in darkness bind them
-   static UnitSystem* findUnitSystem(Unit* unit, unitDisplay display);
-   static QString colorUnitName(unitDisplay display);
+   static UnitSystem* findUnitSystem(Unit* unit, Unit::unitDisplay display);
+   static QString colorUnitName(Unit::unitDisplay display);
 
    //! \return true iff the string has a valid unit substring at the end.
    static bool hasUnits(QString qstr);
 
    // You do know I will have to kill these too?
    //! \return the density units
-   static unitDisplay getDensityUnit();
+   static Unit::unitDisplay getDensityUnit();
    //! \return the date format
-   static unitDisplay getDateFormat();
+   static Unit::unitDisplay getDateFormat();
 
    //! \brief Read options from file. This is deprecated, but we need it
    // around for the conversion
@@ -291,13 +291,13 @@ public:
    static QString generateName(QString attribute, const QString section, iUnitOps ops);
 
    // Grr. Shortcuts never, ever pay  off
-   static QMenu* setupColorMenu(QWidget* parent, unitDisplay unit);
-   static QMenu* setupDateMenu(QWidget* parent, unitDisplay unit);
-   static QMenu* setupDensityMenu(QWidget* parent, unitDisplay unit);
-   static QMenu* setupMassMenu(QWidget* parent, unitDisplay unit, unitScale scale = noScale, bool generateScale = true);
-   static QMenu* setupTemperatureMenu(QWidget* parent, unitDisplay unit);
-   static QMenu* setupVolumeMenu(QWidget* parent, unitDisplay unit, unitScale scale = noScale, bool generateScale = true);
-   static QMenu* setupTimeMenu(QWidget* parent, unitScale scale);
+   static QMenu* setupColorMenu(QWidget* parent, Unit::unitDisplay unit);
+   static QMenu* setupDateMenu(QWidget* parent, Unit::unitDisplay unit);
+   static QMenu* setupDensityMenu(QWidget* parent, Unit::unitDisplay unit);
+   static QMenu* setupMassMenu(QWidget* parent, Unit::unitDisplay unit, Unit::Unit::unitScale scale = Unit::Unit::noScale, bool generateScale = true);
+   static QMenu* setupTemperatureMenu(QWidget* parent, Unit::unitDisplay unit);
+   static QMenu* setupVolumeMenu(QWidget* parent, Unit::unitDisplay unit, Unit::Unit::unitScale scale = Unit::Unit::noScale, bool generateScale = true);
+   static QMenu* setupTimeMenu(QWidget* parent, Unit::Unit::unitScale scale);
    static void generateAction(QMenu* menu, QString text, QVariant data, QVariant currentVal, QActionGroup* qgrp = 0);
 
    //! \return the main window.
@@ -342,7 +342,7 @@ private:
    static ColorUnitType colorUnit;
    static DensityUnitType densityUnit;
    static IbuType ibuFormula;
-   static unitDisplay dateFormat;
+   static Unit::unitDisplay dateFormat;
    //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
    /*!
@@ -394,7 +394,7 @@ private:
    //! \return the temperature scale
    static TempScale getTemperatureScale();
    //! \return the color units
-   static unitDisplay getColorUnit();
+   static Unit::unitDisplay getColorUnit();
 };
 
 Q_DECLARE_METATYPE( Brewtarget::DBTable )

--- a/src/unit.h
+++ b/src/unit.h
@@ -59,17 +59,6 @@ class SgUnit;
 #include <QMultiMap>
 #include <QRegExp>
 
-enum UnitType
-{
-   Mass     = 0x100000,
-   Volume   = 0x200000,
-   Time     = 0x300000,
-   Temp     = 0x400000,
-   Color    = 0x500000,
-   Density  = 0x600000,
-   None     = 0x000000
-};
-
 enum iUnitSystem
 {
     SI = 0,
@@ -86,33 +75,6 @@ enum TempScale
     Kelvin
 };
 
-// DO NOT change noscale's value. Lots of assumptions are made based on this
-// value, both in the code and (more importantly) in the database.
-enum unitScale
-{
-   noScale = -1,
-   scaleExtraSmall = 0,
-   scaleSmall = 1,
-   scaleMedium = 2,
-   scaleLarge = 3,
-   scaleExtraLarge = 4,
-   scaleHuge = 5,
-   scaleWithout=1000
-};
-
-enum unitDisplay
-{
-   noUnit       = -1,
-   displayDef   = 0x000,
-   displaySI    = 0x100,
-   displayUS    = 0x101,
-   displayImp   = 0x102,
-   displaySrm   = 0x200,
-   displayEbc   = 0x201,
-   displaySg    = 0x300,
-   displayPlato = 0x301
-};
-
 // TODO: implement ppm, percent, diastatic power, ibuGalPerLb,
 
 /*!
@@ -124,11 +86,50 @@ enum unitDisplay
 class Unit : public QObject
 {
    Q_OBJECT
+
    Q_ENUMS(unitDisplay)
    Q_ENUMS(unitScale)
    Q_ENUMS(UnitType)
 
    public:
+      // Did you know you need these to be *INSIDE* the class definition for
+      // Qt to see them?
+      enum unitDisplay
+      {
+         noUnit       = -1,
+         displayDef   = 0x000,
+         displaySI    = 0x100,
+         displayUS    = 0x101,
+         displayImp   = 0x102,
+         displaySrm   = 0x200,
+         displayEbc   = 0x201,
+         displaySg    = 0x300,
+         displayPlato = 0x301
+      };
+
+      enum unitScale
+      {
+         noScale = -1,
+         scaleExtraSmall = 0,
+         scaleSmall = 1,
+         scaleMedium = 2,
+         scaleLarge = 3,
+         scaleExtraLarge = 4,
+         scaleHuge = 5,
+         scaleWithout=1000
+      };
+
+      enum UnitType
+      {
+         Mass     = 0x100000,
+         Volume   = 0x200000,
+         Time     = 0x300000,
+         Temp     = 0x400000,
+         Color    = 0x500000,
+         Density  = 0x600000,
+         None     = 0x000000
+      };
+
       virtual ~Unit() {}
       virtual double toSI( double amt ) const =0;// { return amt; }
       virtual double fromSI( double amt ) const =0;// { return amt; }
@@ -137,13 +138,14 @@ class Unit : public QObject
       const QString getUnitName() const { return unitName; }
       const QString getSIUnitName() const { return SIUnitName; }
 
-      const UnitType getUnitType() const { return _type; };
+      const Unit::UnitType getUnitType() const { return _type; };
       const int getUnitOrTempSystem() const { return _unitSystem; };
 
       const double boundary() const { return 1.0; };
 
       static Unit* getUnit(QString& name, bool matchCurrentSystem = true);
       static QString convert(QString qstr, QString toUnit);
+
 
    protected:
       UnitType _type;
@@ -158,7 +160,6 @@ class Unit : public QObject
       static void setupMap();
       static QString unitFromString(QString qstr);
       static double valueFromString(QString qstr);
-
 
 };
 

--- a/ui/brewNoteWidget.ui
+++ b/ui/brewNoteWidget.ui
@@ -747,7 +747,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -755,7 +755,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -768,7 +768,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -776,7 +776,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -784,7 +784,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -792,7 +792,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -812,9 +812,9 @@
  <connections>
   <connection>
    <sender>btLabel_Sg</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_SG</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>70</x>
@@ -828,9 +828,9 @@
   </connection>
   <connection>
    <sender>btLabel_volIntoBk</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_volIntoBK</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>58</x>
@@ -844,9 +844,9 @@
   </connection>
   <connection>
    <sender>btLabel_strikeTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_strikeTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>48</x>
@@ -860,9 +860,9 @@
   </connection>
   <connection>
    <sender>btLabel_mashFinTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_mashFinTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>51</x>
@@ -876,9 +876,9 @@
   </connection>
   <connection>
    <sender>btLabel_Og</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_OG</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>125</x>
@@ -892,9 +892,9 @@
   </connection>
   <connection>
    <sender>btLabel_postBoilVol</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_postBoilVol</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>92</x>
@@ -908,9 +908,9 @@
   </connection>
   <connection>
    <sender>btLabel_volIntoFerm</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_volIntoFerm</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>76</x>
@@ -924,9 +924,9 @@
   </connection>
   <connection>
    <sender>btLabel_pitchTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_pitchTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>105</x>
@@ -940,9 +940,9 @@
   </connection>
   <connection>
    <sender>btLabel_postFermentFg</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_FG</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>50</x>
@@ -956,9 +956,9 @@
   </connection>
   <connection>
    <sender>btLabel_finalVolume</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_finalVol</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>38</x>

--- a/ui/fermentableEditor.ui
+++ b/ui/fermentableEditor.ui
@@ -739,7 +739,7 @@
    <slots>
     <signal>textModified()</signal>
     <slot>lineChanged()</slot>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -747,7 +747,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -755,7 +755,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
     <slot>popContextMenu(QPoint)</slot>
    </slots>
   </customwidget>
@@ -764,7 +764,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
  </customwidgets>
@@ -825,9 +825,9 @@
   </connection>
   <connection>
    <sender>label_amount</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>65</x>
@@ -841,9 +841,9 @@
   </connection>
   <connection>
    <sender>label_inventory</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_inventory</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>66</x>
@@ -857,9 +857,9 @@
   </connection>
   <connection>
    <sender>label_color</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_color</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>67</x>

--- a/ui/hopEditor.ui
+++ b/ui/hopEditor.ui
@@ -872,7 +872,7 @@
    <slots>
     <signal>textModified()</signal>
     <slot>lineChanged()</slot>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -880,7 +880,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -888,7 +888,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -896,7 +896,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
     <slot>popContextMenu(QPoint)</slot>
    </slots>
   </customwidget>
@@ -937,9 +937,9 @@
   </connection>
   <connection>
    <sender>label_amount</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>87</x>
@@ -953,9 +953,9 @@
   </connection>
   <connection>
    <sender>label_time</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_time</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>66</x>
@@ -969,9 +969,9 @@
   </connection>
   <connection>
    <sender>label_inventory</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_inventory</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>50</x>

--- a/ui/mainWindow.ui
+++ b/ui/mainWindow.ui
@@ -2198,7 +2198,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -2206,7 +2206,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -2214,7 +2214,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -2222,7 +2222,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -2230,7 +2230,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -2238,7 +2238,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -2391,9 +2391,9 @@
  <connections>
   <connection>
    <sender>label_targetBatchSize</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_batchSize</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>536</x>
@@ -2407,9 +2407,9 @@
   </connection>
   <connection>
    <sender>label_targetBoilSize</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_boilSize</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>536</x>
@@ -2423,9 +2423,9 @@
   </connection>
   <connection>
    <sender>label_calcBatchSize</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_calcBatchSize</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>536</x>
@@ -2439,9 +2439,9 @@
   </connection>
   <connection>
    <sender>label_calcBoilSize</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_calcBoilSize</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>536</x>
@@ -2455,9 +2455,9 @@
   </connection>
   <connection>
    <sender>label_boilSg</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_boilSg</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>536</x>
@@ -2471,9 +2471,9 @@
   </connection>
   <connection>
    <sender>label_boiltime</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_boilTime</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>455</x>

--- a/ui/mashDesigner.ui
+++ b/ui/mashDesigner.ui
@@ -503,7 +503,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -511,7 +511,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -519,7 +519,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -527,7 +527,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
  </customwidgets>
@@ -546,9 +546,9 @@
  <connections>
   <connection>
    <sender>label_targetTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_temp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>39</x>
@@ -562,9 +562,9 @@
   </connection>
   <connection>
    <sender>label_stepTime</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_time</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>56</x>

--- a/ui/mashEditor.ui
+++ b/ui/mashEditor.ui
@@ -443,7 +443,7 @@
    <slots>
     <signal>textModified()</signal>
     <slot>lineChanged()</slot>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -451,7 +451,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
     <slot>popContextMenu(QPoint)</slot>
    </slots>
   </customwidget>
@@ -460,7 +460,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -468,7 +468,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
  </customwidgets>
@@ -508,9 +508,9 @@
   </connection>
   <connection>
    <sender>label_grainTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_grainTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>87</x>
@@ -524,9 +524,9 @@
   </connection>
   <connection>
    <sender>label_spargeTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_spargeTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>87</x>
@@ -540,9 +540,9 @@
   </connection>
   <connection>
    <sender>label_tunTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_tunTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>326</x>
@@ -556,9 +556,9 @@
   </connection>
   <connection>
    <sender>label_tunMass</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_tunMass</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>326</x>

--- a/ui/mashStepEditor.ui
+++ b/ui/mashStepEditor.ui
@@ -487,7 +487,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -495,7 +495,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -503,7 +503,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -511,7 +511,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -519,7 +519,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -527,7 +527,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
  </customwidgets>
@@ -567,9 +567,9 @@
   </connection>
   <connection>
    <sender>label_stepTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_stepTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>29</x>
@@ -583,9 +583,9 @@
   </connection>
   <connection>
    <sender>label_infuseAmount</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_infuseAmount</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>53</x>
@@ -599,9 +599,9 @@
   </connection>
   <connection>
    <sender>label_infuseTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_infuseTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>40</x>
@@ -615,9 +615,9 @@
   </connection>
   <connection>
    <sender>label_decoctionAmount</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_decoctionAmount</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>310</x>
@@ -631,9 +631,9 @@
   </connection>
   <connection>
    <sender>label_endTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_endTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>310</x>
@@ -647,9 +647,9 @@
   </connection>
   <connection>
    <sender>label_stepTime</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_stepTime</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>282</x>
@@ -663,9 +663,9 @@
   </connection>
   <connection>
    <sender>label_rampTime</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_rampTime</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>301</x>

--- a/ui/miscEditor.ui
+++ b/ui/miscEditor.ui
@@ -466,7 +466,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -474,7 +474,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -482,7 +482,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -490,7 +490,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
     <slot>setIsWeight(bool)</slot>
    </slots>
   </customwidget>
@@ -531,9 +531,9 @@
   </connection>
   <connection>
    <sender>label_time</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_time</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>
@@ -547,9 +547,9 @@
   </connection>
   <connection>
    <sender>label_amount</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>69</x>
@@ -563,9 +563,9 @@
   </connection>
   <connection>
    <sender>label_inventory</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_inventory</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>108</x>

--- a/ui/namedMashEditor.ui
+++ b/ui/namedMashEditor.ui
@@ -612,7 +612,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -620,7 +620,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -628,7 +628,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
     <slot>popContextMenu(QPoint)</slot>
    </slots>
   </customwidget>
@@ -639,7 +639,7 @@
    <slots>
     <signal>textModified()</signal>
     <slot>lineChanged()</slot>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -659,9 +659,9 @@
  <connections>
   <connection>
    <sender>label_grainTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_grainTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>90</x>
@@ -675,9 +675,9 @@
   </connection>
   <connection>
    <sender>label_spargeTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_spargeTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>53</x>
@@ -691,9 +691,9 @@
   </connection>
   <connection>
    <sender>label_tunTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_tunTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>437</x>
@@ -707,9 +707,9 @@
   </connection>
   <connection>
    <sender>label_tunMass</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_tunMass</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>387</x>

--- a/ui/ogAdjuster.ui
+++ b/ui/ogAdjuster.ui
@@ -572,7 +572,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -580,7 +580,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -588,7 +588,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -596,7 +596,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -604,7 +604,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
  </customwidgets>
@@ -612,9 +612,9 @@
  <connections>
   <connection>
    <sender>label_temp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_temp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>30</x>
@@ -628,9 +628,9 @@
   </connection>
   <connection>
    <sender>label_calTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_calTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>55</x>
@@ -644,9 +644,9 @@
   </connection>
   <connection>
    <sender>label_batchsize</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_batchSize</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>411</x>
@@ -660,9 +660,9 @@
   </connection>
   <connection>
    <sender>label_add</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_add</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>411</x>
@@ -676,9 +676,9 @@
   </connection>
   <connection>
    <sender>label_volume</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_volume</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>174</x>

--- a/ui/pitchDialog.ui
+++ b/ui/pitchDialog.ui
@@ -452,7 +452,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -460,7 +460,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -468,7 +468,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -476,7 +476,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -489,7 +489,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
     <slot>popContextMenu(QPoint)</slot>
    </slots>
   </customwidget>
@@ -500,7 +500,7 @@
    <slots>
     <signal>textModified()</signal>
     <slot>lineChanged()</slot>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -527,9 +527,9 @@
  <connections>
   <connection>
    <sender>label_vol</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_vol</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>178</x>
@@ -543,9 +543,9 @@
   </connection>
   <connection>
    <sender>label_og</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_OG</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>203</x>
@@ -559,9 +559,9 @@
   </connection>
   <connection>
    <sender>label_starterVol</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_starterVol</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>464</x>
@@ -575,9 +575,9 @@
   </connection>
   <connection>
    <sender>label_yeast</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_yeast</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>478</x>

--- a/ui/primingDialog.ui
+++ b/ui/primingDialog.ui
@@ -258,7 +258,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -266,7 +266,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -274,7 +274,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -282,7 +282,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -290,7 +290,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
     <slot>popContextMenu(QPoint)</slot>
    </slots>
   </customwidget>
@@ -301,7 +301,7 @@
    <slots>
     <signal>textModified()</signal>
     <slot>lineChanged()</slot>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -325,9 +325,9 @@
  <connections>
   <connection>
    <sender>label_beerVol</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_beerVol</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>68</x>
@@ -341,9 +341,9 @@
   </connection>
   <connection>
    <sender>label_temp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_temp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>80</x>
@@ -357,9 +357,9 @@
   </connection>
   <connection>
    <sender>label_output</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_output</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>258</x>

--- a/ui/recipeExtrasWidget.ui
+++ b/ui/recipeExtrasWidget.ui
@@ -575,7 +575,7 @@
    <extends>QLineEdit</extends>
    <header location="global">BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -583,7 +583,7 @@
    <extends>QLabel</extends>
    <header location="global">BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -591,7 +591,7 @@
    <extends>QLabel</extends>
    <header location="global">BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -599,7 +599,7 @@
    <extends>QLineEdit</extends>
    <header location="global">BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -636,9 +636,9 @@
  <connections>
   <connection>
    <sender>label_ageTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_ageTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>92</x>
@@ -652,9 +652,9 @@
   </connection>
   <connection>
    <sender>label_secTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_secTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>96</x>
@@ -668,9 +668,9 @@
   </connection>
   <connection>
    <sender>label_tertTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_tertTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>101</x>
@@ -684,9 +684,9 @@
   </connection>
   <connection>
    <sender>label_primaryTemp</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_primaryTemp</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>55</x>
@@ -700,9 +700,9 @@
   </connection>
   <connection>
    <sender>label_secAge</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_secAge</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>90</x>
@@ -716,9 +716,9 @@
   </connection>
   <connection>
    <sender>label_tertAge</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_tertAge</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>103</x>
@@ -732,9 +732,9 @@
   </connection>
   <connection>
    <sender>label_age</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_age</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>107</x>
@@ -748,9 +748,9 @@
   </connection>
   <connection>
    <sender>label_primaryAge</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_primaryAge</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>93</x>

--- a/ui/refractoDialog.ui
+++ b/ui/refractoDialog.ui
@@ -57,6 +57,9 @@
             <property name="editField" stdset="0">
              <string notr="true">origPlato</string>
             </property>
+            <property name="forcedUnit" stdset="0">
+             <string notr="true">displayPlato</string>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -88,6 +91,9 @@
             </property>
             <property name="editField" stdset="0">
              <string notr="true">inputOG</string>
+            </property>
+            <property name="forcedUnit" stdset="0">
+             <string>displaySg</string>
             </property>
            </widget>
           </item>
@@ -131,6 +137,9 @@
             </property>
             <property name="editField" stdset="0">
              <string notr="true">curP</string>
+            </property>
+            <property name="forcedUnit" stdset="0">
+             <string>displayPlato</string>
             </property>
            </widget>
           </item>
@@ -229,6 +238,9 @@
         <property name="readOnly">
          <bool>true</bool>
         </property>
+        <property name="forcedUnit" stdset="0">
+         <string>displaySg</string>
+        </property>
        </widget>
       </item>
       <item row="5" column="0">
@@ -326,6 +338,9 @@
         <property name="readOnly">
          <bool>true</bool>
         </property>
+        <property name="forcedUnit" stdset="0">
+         <string>displayPlato</string>
+        </property>
        </widget>
       </item>
       <item row="2" column="0">
@@ -355,6 +370,9 @@
         <property name="readOnly">
          <bool>true</bool>
         </property>
+        <property name="forcedUnit" stdset="0">
+         <string>displaySg</string>
+        </property>
        </widget>
       </item>
      </layout>
@@ -368,7 +386,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>

--- a/ui/scaleRecipeTool.ui
+++ b/ui/scaleRecipeTool.ui
@@ -158,7 +158,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -166,7 +166,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>

--- a/ui/strikeWaterDialog.ui
+++ b/ui/strikeWaterDialog.ui
@@ -441,7 +441,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -449,7 +449,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -459,7 +459,7 @@
    <slots>
     <signal>textModified()</signal>
     <slot>lineChanged()</slot>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -467,7 +467,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
     <slot>popContextMenu(QPoint)</slot>
    </slots>
   </customwidget>
@@ -476,7 +476,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -484,7 +484,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
  </customwidgets>

--- a/ui/styleEditor.ui
+++ b/ui/styleEditor.ui
@@ -947,7 +947,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -955,7 +955,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -968,7 +968,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -976,7 +976,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
  </customwidgets>
@@ -986,9 +986,9 @@
  <connections>
   <connection>
    <sender>label_og</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_ogMin</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>43</x>
@@ -1002,9 +1002,9 @@
   </connection>
   <connection>
    <sender>label_og</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_ogMax</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>43</x>
@@ -1018,9 +1018,9 @@
   </connection>
   <connection>
    <sender>label_fg</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_fgMin</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>43</x>
@@ -1034,9 +1034,9 @@
   </connection>
   <connection>
    <sender>label_fg</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_fgMax</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>43</x>
@@ -1050,9 +1050,9 @@
   </connection>
   <connection>
    <sender>label_color</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_colorMin</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>43</x>
@@ -1066,9 +1066,9 @@
   </connection>
   <connection>
    <sender>label_color</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_colorMax</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>43</x>

--- a/ui/yeastEditor.ui
+++ b/ui/yeastEditor.ui
@@ -715,7 +715,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -723,7 +723,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -736,7 +736,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(unitDisplay,unitScale)</signal>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -744,7 +744,7 @@
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
-    <slot>lineChanged(unitDisplay,unitScale)</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
     <slot>setIsWeight(bool)</slot>
    </slots>
   </customwidget>
@@ -785,9 +785,9 @@
   </connection>
   <connection>
    <sender>label_amount</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>48</x>
@@ -801,9 +801,9 @@
   </connection>
   <connection>
    <sender>label_minTemperature</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_minTemperature</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>46</x>
@@ -817,9 +817,9 @@
   </connection>
   <connection>
    <sender>label_maxTemperature</sender>
-   <signal>labelChanged(unitDisplay,unitScale)</signal>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_maxTemperature</receiver>
-   <slot>lineChanged(unitDisplay,unitScale)</slot>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>46</x>


### PR DESCRIPTION
Who knew that for the Q_ENUM to do its job, the enum had to be
declared inside the class definition? And without that, I couldn't do what I
wanted. So I did.

To move it inside the class means I needed full references
(Unit::unitDisplay, Unit::unitScale and Unit::unitType) everywhere they are
used. You know, I had wondered why that was the case. Anyway, that was about
60 files. Then I had to redo all of the signal/slot stuff. 10 more ui files
for that.

I know I keep promising not to do this. I wouldn't believe my promises any
more :)

Anyway. Bug 47 is almost done. I just need to update a few more files.