### PR TITLE
Change floating point format in beerXML to fit with the standard

### DIFF
--- a/src/BeerXMLElement.cpp
+++ b/src/BeerXMLElement.cpp
@@ -173,7 +173,7 @@ QString BeerXMLElement::text(bool val)
 
 QString BeerXMLElement::text(double val)
 {
-   return QString("%1").arg(val, 0, 'e', 5);
+   return QString("%1").arg(val, 0, 'f', 8);
 }
 
 QString BeerXMLElement::text(int val)


### PR DESCRIPTION
change the floating point format to better match beerXML v1.0

From the specification:
"- Floating Point - A floating point number, usually expressed in its simplest form with a decimal point as in "1.2", "0.004", etc...  Programs shall endeavor to store as many significant digits as possible to avoid truncating or losing small values.'

This should have no impact, but it should ensure that the exported beerXML files will be readable by every software that respects the standard.