### PR TITLE
Fixes wrong field display.

### DIFF
--- a/src/OgAdjuster.cpp
+++ b/src/OgAdjuster.cpp
@@ -95,7 +95,7 @@ void OgAdjuster::calculate()
       sg_20C = sg_15C * Algorithms::getWaterDensity_kgL(15)/Algorithms::getWaterDensity_kgL(20);
 
       plato = Algorithms::SG_20C20C_toPlato( sg_20C );
-      lineEdit_plato->setText(plato);
+      lineEdit_plato->setText( sg_20C ); //Event if the display is in Plato, we must send it in default unit
    }
    else
    {

--- a/src/PitchDialog.cpp
+++ b/src/PitchDialog.cpp
@@ -130,7 +130,7 @@ void PitchDialog::calculate()
 
    lineEdit_cells->setText(cells/1e9, 1);
    lineEdit_starterVol->setText(starterVol_l);
-   lineEdit_yeast->setText(dry_g);
+   lineEdit_yeast->setText(dry_g/1000); //Needs to be converted into default unit (kg)
    lineEdit_vials->setText(vials,0);
 }
 

--- a/src/PrimingDialog.cpp
+++ b/src/PrimingDialog.cpp
@@ -91,6 +91,8 @@ void PrimingDialog::calculate()
    }
    else
       sugar_g = 0;
-   
-   lineEdit_output->setText( sugar_g );
+
+   //The amount have to be set in default unit to BtLineEdit.
+   //We should find a better solution, but until it is not, we must do it this way.
+   lineEdit_output->setText( sugar_g/1000 );
 }

--- a/src/RefractoDialog.cpp
+++ b/src/RefractoDialog.cpp
@@ -97,7 +97,9 @@ void RefractoDialog::calculate()
 
    lineEdit_og->setText(og);
    lineEdit_sg->setText(sg);
-   lineEdit_re->setText(re);
+   //Even if the real extract if display in Plato, it must be given in system unit.
+   //Conversion is made by BtLineEdit
+   lineEdit_re->setText(Algorithms::PlatoToSG_20C20C(re));
    lineEdit_abv->setText(abv);
    lineEdit_abw->setText(abw);
 }

--- a/ui/ogAdjuster.ui
+++ b/ui/ogAdjuster.ui
@@ -257,6 +257,9 @@
               <property name="editField" stdset="0">
                <string notr="true">plato</string>
               </property>
+              <property name="forcedUnit" stdset="0">
+               <string notr="true">displayPlato</string>
+              </property>
              </widget>
             </item>
            </layout>


### PR DESCRIPTION
BtLineEdit includes all the display unit management inside, all value to display must be passed to setText() in the default sytem unit. It is BtLineEdit who takes care of displaying the value in the right unit. Doing this way is ok, but we may find a better way of handling. You could create a class BtValue which would contains its value is default unit, and have all necessary methods to return the value in another unit. This is an idea, but I don't know if it is a good one.

It's really frustrating that every fixes regarding BtLineEdit seams to break something else every time.