### PR TITLE
Add dynamic signal connection for yeast addition + ABV update

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1845,10 +1845,18 @@ void Database::addToRecipe( Recipe* rec, Style* s, bool noCopy )
 // Why no connect here?
 void Database::addToRecipe( Recipe* rec, Yeast* y, bool noCopy )
 {
-   addIngredientToRecipe<Yeast>( rec, y, "yeasts", "yeast_in_recipe", "yeast_id", "yeast_children", noCopy, &allYeasts );
-
+   Yeast* newYeast = addIngredientToRecipe<Yeast>( rec, y,
+                                         "yeasts",
+                                         "yeast_in_recipe",
+                                         "yeast_id",
+                                         "yeast_children",
+                                         noCopy, &allYeasts );
+   connect( newYeast, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptYeastChange(QMetaProperty,QVariant)));
    if ( ! noCopy )
+   {
       rec->recalcOgFg();
+      rec->recalcABV_pct();
+   }
 }
 
 void Database::addToRecipe( Recipe* rec, QList<Yeast*>yeasts )
@@ -1858,11 +1866,17 @@ void Database::addToRecipe( Recipe* rec, QList<Yeast*>yeasts )
 
    foreach (Yeast* yeast, yeasts )
    {
-      addIngredientToRecipe<Yeast>( rec, yeast,
-                                    "yeasts", "yeast_in_recipe",
-                                    "yeast_id", "yeast_children", false, &allYeasts );
+      Yeast* newYeast = addIngredientToRecipe<Yeast>( rec, yeast,
+                                                   "yeasts",
+                                                   "yeast_in_recipe",
+                                                   "yeast_id",
+                                                   "yeast_children",
+                                                   false, &allYeasts );
+
+      connect( newYeast, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptYeastChange(QMetaProperty,QVariant)));
    }
    rec->recalcOgFg();
+   rec->recalcABV_pct();
 }
 
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -2034,11 +2034,13 @@ void Recipe::acceptHopChange(Hop* hop)
 void Recipe::acceptYeastChange(QMetaProperty prop, QVariant val)
 {
    recalcOgFg();
+   recalcABV_pct();
 }
 
 void Recipe::acceptYeastChange(Yeast* yeast)
 {
    recalcOgFg();
+   recalcABV_pct();
 }
 
 void Recipe::acceptMashChange(QMetaProperty prop, QVariant val)


### PR DESCRIPTION
I've previously added the function to update recipe after yeast change, but it took only the yeast already in the recipe at loading. I've forgotten to add the signal connection after yeast addition. I've also added the ABV recalc for recipe update after any yeast change. I hope not forgetting anything this time.