### PR TITLE
Add compilation flag to disable QtMultimedia.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ OPTION( DO_RELEASE_BUILD
 OPTION( NO_MESSING_WITH_FLAGS
         "On means do not add any build flags whatsoever. May override other options."
         OFF )
+OPTION( NO_QTMULTIMEDIA
+        "On means QtMultimedia won't be linked to the final binary and related functionalities will be disabled."
+        OFF )
 
 # Do this right off the bat
 ENABLE_TESTING()
@@ -41,6 +44,10 @@ IF( NOT ${NO_MESSING_WITH_FLAGS} )
       SET( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -pipe" )
       SET( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pipe" )
    ENDIF()
+ENDIF()
+
+IF( ${NO_QTMULTIMEDIA} )
+   ADD_DEFINITIONS( -DNO_QTMULTIMEDIA )
 ENDIF()
 
 IF( ${DO_RELEASE_BUILD} )
@@ -114,8 +121,10 @@ INCLUDE_DIRECTORIES(${Qt5WebKitWidgets_INCLUDE_DIRS})
 FIND_PACKAGE(Qt5Xml REQUIRED)
 INCLUDE_DIRECTORIES(${Qt5Xml_INCLUDE_DIRS})
 
+IF( NOT ${NO_QTMULTIMEDIA} )
 FIND_PACKAGE(Qt5Multimedia REQUIRED)
 INCLUDE_DIRECTORIES(${Qt5Multimedia_INCLUDE_DIRS})
+ENDIF()
 
 FIND_PACKAGE(Qt5Test REQUIRED)
 INCLUDE_DIRECTORIES(${Qt5Test_INCLUDE_DIRS})
@@ -341,8 +350,9 @@ SET( brewtarget_MAC_ICNS "${ROOTDIR}/mac/BrewtargetIcon.icns" )
 #==========================Find dlls for Win32=================================
 
 IF( WIN32 )
-
+   IF( NOT ${NO_QTMULTIMEDIA} )
    FIND_PACKAGE(Qt5MultimediaWidgets REQUIRED)
+   ENDIF()
    FIND_PACKAGE(Qt5OpenGL REQUIRED)
    FIND_PACKAGE(Qt5Sensors REQUIRED)
    FIND_PACKAGE(Qt5Quick REQUIRED)
@@ -350,8 +360,10 @@ IF( WIN32 )
 
    GET_TARGET_PROPERTY(QtCore_location Qt5::Core LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtGui_location Qt5::Gui LOCATION_${CMAKE_BUILD_TYPE})
+   IF( NOT ${NO_QTMULTIMEDIA} )
    GET_TARGET_PROPERTY(QtMultimedia_location Qt5::Multimedia LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtMultimediaWidgets_location Qt5::MultimediaWidgets LOCATION_${CMAKE_BUILD_TYPE})
+   ENDIF()
    GET_TARGET_PROPERTY(QtNetwork_location Qt5::Network LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtOpenGL_location Qt5::OpenGL LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtPositioning_location Qt5::Positioning LOCATION_${CMAKE_BUILD_TYPE})
@@ -386,14 +398,19 @@ IF( WIN32 )
         ${QtXml_location}
         ${QtWebKit_location}
         ${QtGui_location}
-        ${QtMultimedia_location}
-        ${QtMultimediaWidgets_location}
         ${QtWebKitWidgets_location}
         ${QtOpenGL_location}
         ${QtSensors_location}
         ${QtQuick_location}
         ${QtPositioning_location}
    )
+   IF( NOT ${NO_QTMULTIMEDIA})
+      SET( Qt_DLLs,
+        ${Qt_DLLs}
+        ${QtMultimedia_location}
+        ${QtMultimediaWidgets_location}
+   )
+   ENDIF()
    IF (${Qt5Core_VERSION_STRING} VERSION_GREATER "5.3.0")
       FIND_PACKAGE(Qt5WebChannel REQUIRED)
       GET_TARGET_PROPERTY(QtWebChannel_location Qt5::WebChannel LOCATION_${CMAKE_BUILD_TYPE})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -378,9 +378,9 @@ IF( WIN32 AND MINGW )
    SET_TARGET_PROPERTIES( ${brewtarget_EXECUTABLE} PROPERTIES LINK_FLAGS "-Wl,-enable-stdcall-fixup -Wl,-enable-auto-import -Wl,-enable-runtime-pseudo-reloc -mthreads -Wl,-subsystem,windows")
 ENDIF()
 
-QT5_USE_MODULES( ${brewtarget_EXECUTABLE}
+SET( QT5_USE_MODULES_LIST
+   ${brewtarget_EXECUTABLE}
    Widgets
-   Multimedia
    Network
    PrintSupport
    Qml
@@ -388,7 +388,13 @@ QT5_USE_MODULES( ${brewtarget_EXECUTABLE}
    Xml
    WebKit
    WebKitWidgets
-)
+   )
+
+IF( NOT ${NO_QTMULTIMEDIA})
+SET( QT5_USE_MODULES_LIST ${QT5_USE_MODULES_LIST} Multimedia)
+ENDIF()
+
+QT5_USE_MODULES( ${QT5_USE_MODULES_LIST})
 
 #=================================Tests========================================
 
@@ -400,10 +406,9 @@ ADD_EXECUTABLE(
    $<TARGET_OBJECTS:btobjlib>
 )
 
-QT5_USE_MODULES(
+SET( QT5_USE_MODULES_LIST
    brewtarget_tests
    Widgets
-   Multimedia
    Network
    PrintSupport
    Qml
@@ -412,7 +417,13 @@ QT5_USE_MODULES(
    WebKit
    WebKitWidgets
    Test
-)
+   )
+
+IF( NOT ${NO_QTMULTIMEDIA})
+SET( QT5_USE_MODULES_LIST ${QT5_USE_MODULES_LIST} Multimedia)
+ENDIF()
+
+QT5_USE_MODULES(${QT5_USE_MODULES_LIST})
 
 ADD_TEST(
    NAME pstdintTest

--- a/src/TimerWidget.cpp
+++ b/src/TimerWidget.cpp
@@ -43,8 +43,10 @@ TimerWidget::TimerWidget(QWidget* parent)
      flashTimer(new QTimer(this)),
      paletteOld(),
      paletteNew(),
+#ifndef NO_QTMULTIMEDIA
      mediaPlayer(new QMediaPlayer(this)),
      playlist(new QMediaPlaylist(mediaPlayer)),
+#endif
      oldColors(true)
 {
    doLayout();
@@ -53,9 +55,11 @@ TimerWidget::TimerWidget(QWidget* parent)
    timer->setInterval(1000);
    flashTimer->setInterval(500);
 
+#ifndef NO_QTMULTIMEDIA
    playlist->setPlaybackMode(QMediaPlaylist::Loop);
    mediaPlayer->setVolume(100);
    mediaPlayer->setPlaylist(playlist);
+#endif
 
    paletteOld = lcdNumber->palette();
    paletteNew = QPalette(paletteOld);
@@ -75,8 +79,10 @@ TimerWidget::TimerWidget(QWidget* parent)
 
 TimerWidget::~TimerWidget()
 {
+#ifndef NO_QTMULTIMEDIA
    mediaPlayer->stop();
    playlist->clear();
+#endif
 }
 
 void TimerWidget::doLayout()
@@ -160,13 +166,13 @@ void TimerWidget::getSound()
       Brewtarget::logW("Null sound file.");
       return;
    }
-
+#ifndef NO_QTMULTIMEDIA
    if( !playlist->clear() )
       Brewtarget::logW(playlist->errorString());
    if( !playlist->addMedia(QUrl::fromLocalFile(soundFile)) )
       Brewtarget::logW(playlist->errorString());
    playlist->setCurrentIndex(0);
-
+#endif
    // Indicate a sound is loaded
    pushButton_sound->setCheckable(true);
    pushButton_sound->setChecked(true);
@@ -191,7 +197,9 @@ void TimerWidget::flash()
 
 void TimerWidget::setTimer()
 {
+#ifndef NO_QTMULTIMEDIA
    mediaPlayer->stop();
+#endif
    stopFlashing();
 
    setTimer(lineEdit->text());
@@ -210,7 +218,9 @@ void TimerWidget::endTimer()
    timer->stop();
    flashTimer->start();
 
+#ifndef NO_QTMULTIMEDIA
    mediaPlayer->play();
+#endif
 }
 
 void TimerWidget::setTimer(QString text)
@@ -280,7 +290,9 @@ void TimerWidget::startStop()
    else
    {
       timer->stop();
+#ifndef NO_QTMULTIMEDIA
       mediaPlayer->stop();
+#endif
       stopFlashing();
       pushButton_startStop->setText(tr("Start"));
       start = true;

--- a/src/TimerWidget.h
+++ b/src/TimerWidget.h
@@ -26,8 +26,10 @@
 #include <QTimer>
 #include <QString>
 #include <QPalette>
+#ifndef NO_QTMULTIMEDIA
 #include <QMediaPlayer>
 #include <QMediaPlaylist>
+#endif
 #include <QPushButton>
 #include <QLineEdit>
 #include <QLCDNumber>
@@ -95,8 +97,10 @@ private:
    QTimer* timer;
    QTimer* flashTimer;
    QPalette paletteOld, paletteNew;
+#ifndef NO_QTMULTIMEDIA
    QMediaPlayer* mediaPlayer;
    QMediaPlaylist* playlist;
+#endif
    bool oldColors;
 };
 


### PR DESCRIPTION
This allow to compile and execute Brewtarget without QtMultimedia.
It may allows developers to develop and test on the platforms that have a conflict on the Gstreamer version linked with QtMultimedia and QtWebKit.
The only drawback is that the timer can't play any sound.

This is a temporary fix for the bug #9 