### PR TITLE
Improve recipe export (text) & add BBCode export

### DIFF
--- a/src/BrewDayScrollWidget.cpp
+++ b/src/BrewDayScrollWidget.cpp
@@ -349,28 +349,29 @@ QString BrewDayScrollWidget::buildTitleTable(bool includeImage)
             .arg(tr("Boil Volume"))
             .arg(Brewtarget::displayAmount(recObs->boilVolume_l(), "tab_recipe", "boilVolume_l", Units::liters,2))
             .arg(tr("Preboil Gravity"))
-            .arg(Brewtarget::displayAmount(recObs->boilGrav(), "tab_recipe", "og", Units::sp_grav,0));
+            .arg(Brewtarget::displayAmount(recObs->boilGrav(), "tab_recipe", "og", Units::sp_grav, 3));
 
    // fourth row: Final volume and starting gravity
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td><td class=\"right\">%3</td><td class=\"value\">%4</td></tr>")
             .arg(tr("Final Volume"))
             .arg(Brewtarget::displayAmount(recObs->finalVolume_l(), "tab_recipe", "finalVolume_l", Units::liters,2))
             .arg(tr("Starting Gravity"))
-            .arg(Brewtarget::displayAmount(recObs->og(), "tab_recipe", "og", Units::sp_grav, 0));
+            .arg(Brewtarget::displayAmount(recObs->og(), "tab_recipe", "og", Units::sp_grav, 3));
 
    // fifth row: IBU and Final gravity
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td><td class=\"right\">%3</td><td class=\"value\">%4</tr>")
             .arg(tr("IBU"))
             .arg( Brewtarget::displayAmount(recObs->IBU(),0,1))
             .arg(tr("Final Gravity"))
-            .arg(Brewtarget::displayAmount(recObs->fg(), "tab_recipe", "fg", Units::sp_grav, 0));
+            .arg(Brewtarget::displayAmount(recObs->fg(), "tab_recipe", "fg", Units::sp_grav, 3));
 
    // sixth row: ABV and estimate calories
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2%</td><td class=\"right\">%3</td><td class=\"value\">%4</tr>")
             .arg(tr("ABV"))
             .arg( Brewtarget::displayAmount(recObs->ABV_pct(),0,1) )
-            .arg(tr("Estimated calories(per 12 oz)"))
-            .arg( Brewtarget::displayAmount(recObs->calories(),0,0) );
+            .arg( Brewtarget::getVolumeUnitSystem() == SI ? tr("Estimated calories (per 33 cl)") : tr("Estimated calories (per 12 oz)"))
+            .arg( Brewtarget::displayAmount(Brewtarget::getVolumeUnitSystem() == SI ? recObs->calories33cl() : recObs->calories12oz(),0,0) );
+
    body += "</table>";
 
    return header + body;

--- a/src/BrewDayWidget.cpp
+++ b/src/BrewDayWidget.cpp
@@ -181,13 +181,13 @@ QString BrewDayWidget::buildTitleTable()
            .arg(tr("Boil Volume"))
            .arg(Brewtarget::displayAmount(recObs->boilSize_l(),Units::liters,2))
            .arg(tr("Preboil Gravity"))
-           .arg(Brewtarget::displayAmount(recObs->boilGrav(), Units::sp_grav,0));
+           .arg(Brewtarget::displayAmount(recObs->boilGrav(), Units::sp_grav, 3));
 
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td><td class=\"right\">%3</td><td class=\"value\">%4</td></tr>")
            .arg(tr("Final Volume"))
            .arg(Brewtarget::displayAmount(recObs->batchSize_l(), Units::liters,2))
            .arg(tr("Starting Gravity"))
-           .arg(Brewtarget::displayAmount(recObs->og(), Units::sp_grav, 0));
+           .arg(Brewtarget::displayAmount(recObs->og(), Units::sp_grav, 3));
 
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td><td class=\"right\">%3</td><td class=\"value\">%4</td></tr>")
            .arg(tr("Boil Time"))
@@ -198,8 +198,8 @@ QString BrewDayWidget::buildTitleTable()
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td><td class=\"right\">%3</td><td class=\"value\">%4</tr>")
            .arg(tr("Predicted Efficiency"))
            .arg(Brewtarget::displayAmount(recObs->efficiency_pct(),0,0))
-           .arg(tr("Estimated calories (per 12 oz)"))
-           .arg(Brewtarget::displayAmount(recObs->calories(),0,0));
+           .arg(Brewtarget::getVolumeUnitSystem() == SI ? tr("Estimated calories (per 33 cl)") : tr("Estimated calories (per 12 oz)"))
+           .arg(Brewtarget::displayAmount(Brewtarget::getVolumeUnitSystem() == SI ? recObs->calories33cl() : recObs->calories12oz(),0,0));
 
    body += "</table>";
 

--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -147,10 +147,10 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
       case VOLUME:
       case TEMPERATURE:
       case TIME:
+      case DENSITY:
          val = toSI(oldUnit,oldScale,force);
          amt = displayAmount(val,3);
          break;
-      case DENSITY:
       case COLOR:
          val = toSI(oldUnit,oldScale,force);
          amt = displayAmount(val,0);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -400,6 +400,7 @@ MainWindow::MainWindow(QWidget* parent)
    connect( actionRecipePrint, SIGNAL(triggered()), this, SLOT(print()));
    connect( actionRecipePreview, SIGNAL(triggered()), this, SLOT(print()));
    connect( actionRecipeHTML, SIGNAL(triggered()), this, SLOT(print()));
+   connect( actionRecipeBBCode, SIGNAL(triggered()), this, SLOT(print()));
    connect( actionBrewdayPrint, SIGNAL(triggered()), this, SLOT(print()));
    connect( actionBrewdayPreview, SIGNAL(triggered()), this, SLOT(print()));
    connect( actionBrewdayHTML, SIGNAL(triggered()), this, SLOT(print()));
@@ -849,21 +850,7 @@ void MainWindow::showChanges(QMetaProperty* prop)
 
    ibuGuSlider->setValue(recipeObs->IBU()/((recipeObs->og()-1)*1000));
 
-   // Do some work for the calories per ??
-   // The hard part is that we store it as calories per 12oz. The adjust
-   // roughly converts between 12 oz and 33cL
-   double adjust;
-   if ( Brewtarget::volumeUnitSystem == SI ) 
-   {
-      adjust = 3.3/3.55;
-      label_caloriesper->setText(tr("calories/33cL"));
-   }
-   else
-   {
-      adjust = 1;
-      label_caloriesper->setText(tr("calories/12oz"));
-   }
-   label_calories->setText( QString("%1").arg(recipeObs->calories() * adjust,0,'f',0) );
+   label_calories->setText( QString("%1").arg( Brewtarget::getVolumeUnitSystem() == SI ? recipeObs->calories33cl() : recipeObs->calories12oz(),0,'f',0) );
 
    // See if we need to change the mash in the table.
    if( (updateAll && recipeObs->mash()) ||
@@ -1997,6 +1984,10 @@ void MainWindow::print()
       selection == actionRecipeHTML ? recipeFormatter->print(printer, 0, RecipeFormatter::HTML, outfile) :
                                       brewDayScrollWidget->print(printer, 0, BrewDayScrollWidget::HTML, outfile);
       delete outfile;
+   }
+   else if ( selection == actionRecipeBBCode )
+   {
+      QApplication::clipboard()->setText(recipeFormatter->getBBCodeFormat());
    }
 }
 

--- a/src/RecipeFormatter.h
+++ b/src/RecipeFormatter.h
@@ -67,9 +67,11 @@ public:
    //! Get the maximum number of characters in a list of strings.
    unsigned int getMaxLength( QStringList* list );
    //! Prepend a string with spaces until its final length is the given length.
-   QString padToLength( QString str, unsigned int length );
+   QString padToLength( const QString &str, unsigned int length );
    //! Same as \b padToLength but with multiple strings.
-   void padAllToMaxLength( QStringList* list );
+   void padAllToMaxLength( QStringList* list, unsigned int padding=2 );
+   //! Return the text wrapped with the given length
+   QString wrapText( const QString &text, int wrapLength );
    
    //! Send a printable version to the printer.
    void print(QPrinter *mainPrinter, QPrintDialog* dialog, int action = PRINT, QFile* outFile=0);
@@ -81,15 +83,23 @@ public slots:
 private:
    QString getTextSeparator();
 
-   QString buildTitleTable();
-   QString buildFermentableTable();
-   QString buildHopsTable();
-   QString buildYeastTable();
-   QString buildMashTable();
-   QString buildMiscTable();
-   QString buildNotes();
-   QString buildInstructionTable();
-   QString buildBrewNotes();
+   QString buildStatTableHtml();
+   QString buildStatTableTxt();
+   QString buildFermentableTableHtml();
+   QString buildFermentableTableTxt();
+   QString buildHopsTableHtml();
+   QString buildHopsTableTxt();
+   QString buildYeastTableHtml();
+   QString buildYeastTableTxt();
+   QString buildMashTableHtml();
+   QString buildMashTableTxt();
+   QString buildMiscTableHtml();
+   QString buildMiscTableTxt();
+   QString buildNotesHtml();
+   QString buildInstructionTableHtml();
+   QString buildInstructionTableTxt();
+   QString buildBrewNotesHtml();
+   QString buildBrewNotesTxt();
    QString getCSS();
 
    QList<Hop*> sortHopsByTime(Recipe* rec);

--- a/src/UnitSystem.cpp
+++ b/src/UnitSystem.cpp
@@ -86,8 +86,13 @@ double UnitSystem::qstringToSI(QString qstr, Unit* defUnit, bool force)
    return u->toSI(amt);
 }
 
-QString UnitSystem::displayAmount( double amount, Unit* units, Unit::unitScale scale )
+QString UnitSystem::displayAmount( double amount, Unit* units, int precision, Unit::unitScale scale )
 {
+   // If the precision is not specified, we take the default one
+   if( precision < 0)
+   {
+      precision = this->precision;
+   }
 
    // Special cases. Make sure the unit isn't null and that we're
    // dealing with volume.

--- a/src/UnitSystem.h
+++ b/src/UnitSystem.h
@@ -46,7 +46,7 @@ public:
     * 'amount' of type 'units' in this UnitSystem. This string should also
     * be recognized by qstringToSI()
     */
-   QString displayAmount( double amount, Unit* units, Unit::unitScale scale = Unit::noScale );
+   QString displayAmount( double amount, Unit* units, int precision = -1, Unit::unitScale scale = Unit::noScale );
 
    /*!
     * amountDisplay() should return the double representing the appropriate

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -1139,7 +1139,7 @@ QString Brewtarget::displayAmount( double amount, Unit* units, int precision, Un
    if ( temp == 0 )
       ret = QString("%L1 %2").arg(SIAmount, fieldWidth, format, precision).arg(SIUnitName);
 
-   ret = temp->displayAmount( amount, units, displayScale );
+   ret = temp->displayAmount( amount, units, precision, displayScale );
 
    return ret;
 }

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -253,6 +253,8 @@ public:
    static Unit::unitDisplay getDensityUnit();
    //! \return the date format
    static Unit::unitDisplay getDateFormat();
+   //! \return the volume system
+   static iUnitSystem getVolumeUnitSystem();
 
    //! \brief Read options from file. This is deprecated, but we need it
    // around for the conversion
@@ -389,8 +391,6 @@ private:
 
    //! \return the weight system
    static iUnitSystem getWeightUnitSystem();
-   //! \return the volume system
-   static iUnitSystem getVolumeUnitSystem();
    //! \return the temperature scale
    static TempScale getTemperatureScale();
    //! \return the color units

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -694,7 +694,7 @@ void Recipe::generateInstructions()
    addPreinstructions(miscSteps(Misc::Primary));
 
    str = tr("Let ferment until FG is %1.")
-         .arg(Brewtarget::displayAmount(fg(), "tab_recipe", "fg", Units::sp_grav));
+         .arg(Brewtarget::displayAmount(fg(), "tab_recipe", "fg", Units::sp_grav, 3));
    ins = Database::instance().newInstruction(this);
    ins->setName(tr("Ferment"));
    ins->setDirections(str);
@@ -1189,11 +1189,18 @@ double Recipe::boilGrav()
    return _boilGrav;
 }
 
-double Recipe::calories()
+double Recipe::calories12oz()
 {
    if( _uninitializedCalcs )
       recalcAll();
    return _calories;
+}
+
+double Recipe::calories33cl()
+{
+   if( _uninitializedCalcs )
+      recalcAll();
+   return _calories*3.3/3.55;
 }
 
 double Recipe::wortFromMash_l()

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -164,7 +164,7 @@ public:
    //! \brief The calculated final volume into the primary in liters.
    Q_PROPERTY( double finalVolume_l READ finalVolume_l /*WRITE*/ /*NOTIFY changed*/ /*changedEstimateFinalVolume_l*/ STORED false)
    //! \brief The calculated Calories per 12 oz. (kcal).
-   Q_PROPERTY( double calories READ calories /*WRITE*/ /*NOTIFY changed*/ /*changedEstimateCalories*/ STORED false)
+   Q_PROPERTY( double calories READ calories12oz /*WRITE*/ /*NOTIFY changed*/ /*changedEstimateCalories*/ STORED false)
    //! \brief The amount of grains in the mash in kg.
    Q_PROPERTY( double grainsInMash_kg READ grainsInMash_kg /*WRITE*/ /*NOTIFY changed*/ /*changedGrainsInMash_kg*/ STORED false)
    //! \brief The total amount of grains in the recipe in kg.
@@ -272,7 +272,8 @@ public:
    double boilVolume_l();
    double postBoilVolume_l();
    double finalVolume_l();
-   double calories();
+   double calories12oz();
+   double calories33cl();
    double grainsInMash_kg();
    double grains_kg();
    QList<double> IBUs();

--- a/ui/mainWindow.ui
+++ b/ui/mainWindow.ui
@@ -233,8 +233,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>561</width>
-           <height>371</height>
+           <width>635</width>
+           <height>499</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1096,8 +1096,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>561</width>
-           <height>371</height>
+           <width>648</width>
+           <height>296</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1649,7 +1649,7 @@
      <x>0</x>
      <y>0</y>
      <width>1050</width>
-     <height>15</height>
+     <height>27</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuAbout">
@@ -1680,6 +1680,7 @@
      <addaction name="actionRecipePreview"/>
      <addaction name="actionRecipePrint"/>
      <addaction name="actionRecipeHTML"/>
+     <addaction name="actionRecipeBBCode"/>
     </widget>
     <widget class="QMenu" name="menuDatabase">
      <property name="title">
@@ -2189,6 +2190,15 @@
   <action name="actionStrikeWater_Calculator">
    <property name="text">
     <string>Strike Water Calculator</string>
+   </property>
+  </action>
+  <action name="actionRecipeBBCode">
+   <property name="icon">
+    <iconset resource="../brewtarget.qrc">
+     <normaloff>:/images/clipboard.svg</normaloff>:/images/clipboard.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Export to &amp;BBCode</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
I changed almost all the behavior of the getTextFormat function in order to make it smaller and easier to maintain. I split this function in order to reuse all sub-function for BBCode extraction.
I change many thing to use the same unit and scales as in the main interface (it seems more logical).
Doing this I found a bug on the displayAmount function which was trashing the precision parameter in some cases.
I think that it can still be improved, but it is quite OK now.
I didn't give an implementation for the BBCode function as it would be considered as a new feature (even if I'd really like to see it included into 2.2.0), but it will be very easy to write know, as it will be base on the text format extract.
One other thing I did, is to clean the calories management. Before that it was sometime per 33cl and other times per 35cl.

@Brewtarget/developers : Please review and give me some feedbacks