### PR TITLE
Fixes #65: bad ingredient amount behavior in non-US locales

### DIFF
--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -222,24 +222,20 @@ const QString Fermentable::typeStringTr() const
    return typesTr.at(type());
 }
 
-double Fermentable::amount_kg()              const { return Brewtarget::toDouble(get("amount").toString(), "Fermentable::amount_kg()"); }
-double Fermentable::yield_pct()              const { return Brewtarget::toDouble(get("yield").toString(), "Fermentable::yield_pct()"); }
-double Fermentable::color_srm()              const { return Brewtarget::toDouble(get("color").toString(), "Fermentable::color_srm()"); }
-double Fermentable::coarseFineDiff_pct()     const { return Brewtarget::toDouble(get("coarse_fine_diff").toString(), "Fermentable::coarseFineDiff_pct()"); }
-double Fermentable::moisture_pct()           const { return Brewtarget::toDouble(get("moisture").toString(), "Fermentable::moisture_pct()"); }
-double Fermentable::diastaticPower_lintner() const { return Brewtarget::toDouble(get("diastatic_power").toString(), "Fermentable::diastaticPower_lintner()"); }
-double Fermentable::protein_pct()            const { return Brewtarget::toDouble(get("protein").toString(), "Fermentable::protein_pct()"); }
-double Fermentable::maxInBatch_pct()         const { return Brewtarget::toDouble(get("max_in_batch").toString(), "Fermentable::maxInBatch_pct()"); }
-double Fermentable::ibuGalPerLb()            const { return Brewtarget::toDouble(get("ibu_gal_per_lb").toString(), "Fermentable::ibuGalPerLb()"); }
+double Fermentable::amount_kg()              const { return get("amount").toDouble(); }
+double Fermentable::yield_pct()              const { return get("yield").toDouble(); }
+double Fermentable::color_srm()              const { return get("color").toDouble(); }
+double Fermentable::coarseFineDiff_pct()     const { return get("coarse_fine_diff").toDouble(); }
+double Fermentable::moisture_pct()           const { return get("moisture").toDouble(); }
+double Fermentable::diastaticPower_lintner() const { return get("diastatic_power").toDouble(); }
+double Fermentable::protein_pct()            const { return get("protein").toDouble(); }
+double Fermentable::maxInBatch_pct()         const { return get("max_in_batch").toDouble(); }
+double Fermentable::ibuGalPerLb()            const { return get("ibu_gal_per_lb").toDouble(); }
 
 // inventory must be handled separately, to my great annoyance
 double Fermentable::inventory() const 
 { 
-   QString amount = getInventory("amount").toString();
-
-   double amt = Brewtarget::toDouble( amount, "Fermentable::getInventory()");
-
-   return amt;
+   return getInventory("amount").toDouble();
 }
 
 bool Fermentable::addAfterBoil() const { return get("add_after_boil").toBool(); }

--- a/src/hop.cpp
+++ b/src/hop.cpp
@@ -295,24 +295,20 @@ const QString Hop::formString() const { return get("form").toString(); }
 const QString Hop::origin() const { return get("origin").toString(); }
 const QString Hop::substitutes() const { return get("substitutes").toString(); }
 
-double Hop::alpha_pct()          const { return Brewtarget::toDouble(get("alpha").toString(), "Hop::alpha_pct()"); }
-double Hop::amount_kg()          const { return Brewtarget::toDouble(get("amount").toString(), "Hop::amount_kg()"); }
-double Hop::time_min()           const { return Brewtarget::toDouble(get("time").toString(), "Hop::time_min()"); }
-double Hop::beta_pct()           const { return Brewtarget::toDouble(get("beta").toString(), "Hop::beta_pct()"); }
-double Hop::hsi_pct()            const { return Brewtarget::toDouble(get("hsi").toString(), "Hop::hsi_pct()"); }
-double Hop::humulene_pct()       const { return Brewtarget::toDouble(get("humulene").toString(), "Hop::humulene_pct()"); }
-double Hop::caryophyllene_pct()  const { return Brewtarget::toDouble(get("caryophyllene").toString(), "Hop::caryophyllene_pct()"); }
-double Hop::cohumulone_pct()     const { return Brewtarget::toDouble(get("cohumulone").toString(), "Hop::cohumulone_pct()"); }
-double Hop::myrcene_pct()        const { return Brewtarget::toDouble(get("myrcene").toString(), "Hop::myrcene_pct()"); }
+double Hop::alpha_pct()          const { return get("alpha").toDouble(); }
+double Hop::amount_kg()          const { return get("amount").toDouble(); }
+double Hop::time_min()           const { return get("time").toDouble(); }
+double Hop::beta_pct()           const { return get("beta").toDouble(); }
+double Hop::hsi_pct()            const { return get("hsi").toDouble(); }
+double Hop::humulene_pct()       const { return get("humulene").toDouble(); }
+double Hop::caryophyllene_pct()  const { return get("caryophyllene").toDouble(); }
+double Hop::cohumulone_pct()     const { return get("cohumulone").toDouble(); }
+double Hop::myrcene_pct()        const { return get("myrcene").toDouble(); }
 
 // inventory still must be handled separately, and I'm still annoyed.
 double Hop::inventory() const
-{ 
-   QString amount = getInventory("amount").toString();
-
-   double amt = Brewtarget::toDouble( amount, "Hop::getInventory()");
-
-   return amt;
+{
+   return getInventory("amount").toDouble();
 }
  
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -95,8 +95,8 @@ const QString Misc::useStringTr() const
    return usesTr.at(use());
 }
 
-double Misc::amount()    const { return Brewtarget::toDouble(get("amount").toString(), "Misc::amount()"); }
-double Misc::time()      const { return Brewtarget::toDouble(get("time").toString(), "Misc::time()"); }
+double Misc::amount()    const { return get("amount").toDouble(); }
+double Misc::time()      const { return get("time").toDouble(); }
 
 bool Misc::amountIsWeight() const { return get("amount_is_weight").toBool(); }
 
@@ -105,11 +105,7 @@ QString Misc::notes() const { return get("notes").toString(); }
 
 double Misc::inventory() const 
 { 
-   QString amount = getInventory("amount").toString();
-
-   double amt = Brewtarget::toDouble( amount, "Misc::getInventory" ); 
-
-   return amt;
+   return getInventory("amount").toDouble();
 }
 
 //============================"SET" METHODS=====================================

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -254,18 +254,18 @@ QString Style::examples() const { return get("examples").toString(); }
 const Style::Type Style::type() const { return static_cast<Style::Type>(types.indexOf(get("s_type").toString())); }
 const QString Style::typeString() const { return types.at(type()); }
 
-double Style::ogMin()        const { return Brewtarget::toDouble(get("og_min").toString(), "Style::ogMin()"); }
-double Style::ogMax()        const { return Brewtarget::toDouble(get("og_max").toString(), "Style::ogMax()"); }
-double Style::fgMin()        const { return Brewtarget::toDouble(get("fg_min").toString(), "Style::fgMin()"); }
-double Style::fgMax()        const { return Brewtarget::toDouble(get("fg_max").toString(), "Style::fgMax()"); }
-double Style::ibuMin()       const { return Brewtarget::toDouble(get("ibu_min").toString(), "Style::ibuMin()"); }
-double Style::ibuMax()       const { return Brewtarget::toDouble(get("ibu_max").toString(), "Style::ibuMax()"); }
-double Style::colorMin_srm() const { return Brewtarget::toDouble(get("color_min").toString(), "Style::colorMin_srm()"); }
-double Style::colorMax_srm() const { return Brewtarget::toDouble(get("color_max").toString(), "Style::colorMax_srm()"); }
-double Style::carbMin_vol()  const { return Brewtarget::toDouble(get("carb_min").toString(), "Style::carbMin_vol()"); }
-double Style::carbMax_vol()  const { return Brewtarget::toDouble(get("carb_max").toString(), "Style::carbMax_vol()"); }
-double Style::abvMin_pct()   const { return Brewtarget::toDouble(get("abv_min").toString(), "Style::abvMin_pct()"); }
-double Style::abvMax_pct()   const { return Brewtarget::toDouble(get("abv_max").toString(), "Style::abvMax_pct()"); }
+double Style::ogMin()        const { return get("og_min").toDouble(); }
+double Style::ogMax()        const { return get("og_max").toDouble(); }
+double Style::fgMin()        const { return get("fg_min").toDouble(); }
+double Style::fgMax()        const { return get("fg_max").toDouble(); }
+double Style::ibuMin()       const { return get("ibu_min").toDouble(); }
+double Style::ibuMax()       const { return get("ibu_max").toDouble(); }
+double Style::colorMin_srm() const { return get("color_min").toDouble(); }
+double Style::colorMax_srm() const { return get("color_max").toDouble(); }
+double Style::carbMin_vol()  const { return get("carb_min").toDouble(); }
+double Style::carbMax_vol()  const { return get("carb_max").toDouble(); }
+double Style::abvMin_pct()   const { return get("abv_min").toDouble(); }
+double Style::abvMax_pct()   const { return get("abv_max").toDouble(); }
 
 bool Style::isValidType( const QString &str ) { return types.contains( str ); }
 

--- a/src/yeast.cpp
+++ b/src/yeast.cpp
@@ -86,10 +86,10 @@ const QString Yeast::typeString() const { return types.at(type()); }
 const QString Yeast::formString() const { return forms.at(form()); }
 const QString Yeast::flocculationString() const { return flocculations.at(flocculation()); }
 
-double Yeast::amount() const { return Brewtarget::toDouble(get("amount").toString(), "Yeast::amount()"); }
-double Yeast::minTemperature_c() const { return Brewtarget::toDouble(get("min_temperature").toString(), "Yeast::minTemperature_c()"); }
-double Yeast::maxTemperature_c() const { return Brewtarget::toDouble(get("max_temperature").toString(), "Yeast::maxTemperature_c()"); }
-double Yeast::attenuation_pct() const { return Brewtarget::toDouble(get("attenuation").toString(), "Yeast::attenuation_pct()"); }
+double Yeast::amount() const { return get("amount").toDouble(); }
+double Yeast::minTemperature_c() const { return get("min_temperature").toDouble(); }
+double Yeast::maxTemperature_c() const { return get("max_temperature").toDouble(); }
+double Yeast::attenuation_pct() const { return get("attenuation").toDouble(); }
 
 int Yeast::inventory() const { return getInventory("quanta").toInt(); }
 int Yeast::timesCultured() const { return get("times_cultured").toInt(); }


### PR DESCRIPTION
The problem was that simple double properties of the ingredients
were being passed through the localization procedures in the
Brewtarget class when they should not have been.