### PR TITLE
Fixes #81: Improvement/weird check box

### DIFF
--- a/src/HopTableModel.cpp
+++ b/src/HopTableModel.cpp
@@ -573,6 +573,7 @@ QWidget* HopItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewIt
       box->addItem(tr("Boil"));
       box->addItem(tr("Aroma"));
       box->addItem(tr("Dry Hop"));
+      box->setMinimumWidth(box->minimumSizeHint().width());
       box->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
       return box;
@@ -584,7 +585,7 @@ QWidget* HopItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewIt
       box->addItem(tr("Leaf"));
       box->addItem(tr("Pellet"));
       box->addItem(tr("Plug"));
-
+      box->setMinimumWidth(box->minimumSizeHint().width());
       box->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
       return box;

--- a/src/MashStepTableModel.cpp
+++ b/src/MashStepTableModel.cpp
@@ -462,6 +462,7 @@ QWidget* MashStepItemDelegate::createEditor(QWidget *parent, const QStyleOptionV
       box->addItem("Infusion");
       box->addItem("Temperature");
       box->addItem("Decoction");
+      box->setMinimumWidth(box->minimumSizeHint().width());
       box->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
       return box;

--- a/src/MiscTableModel.cpp
+++ b/src/MiscTableModel.cpp
@@ -549,6 +549,7 @@ QWidget* MiscItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
       box->addItem(tr("Herb"));
       box->addItem(tr("Flavor"));
       box->addItem(tr("Other"));
+      box->setMinimumWidth(box->minimumSizeHint().width());
       box->setSizeAdjustPolicy(QComboBox::AdjustToContents);
       return box;
    }
@@ -561,6 +562,7 @@ QWidget* MiscItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
       box->addItem(tr("Primary"));
       box->addItem(tr("Secondary"));
       box->addItem(tr("Bottling"));
+      box->setMinimumWidth(box->minimumSizeHint().width());
       box->setSizeAdjustPolicy(QComboBox::AdjustToContents);
       return box;
    }

--- a/src/YeastTableModel.cpp
+++ b/src/YeastTableModel.cpp
@@ -519,6 +519,7 @@ QWidget* YeastItemDelegate::createEditor(QWidget *parent, const QStyleOptionView
       box->addItem(tr("Wheat"));
       box->addItem(tr("Wine"));
       box->addItem(tr("Champagne"));
+      box->setMinimumWidth(box->minimumSizeHint().width());
       box->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
       return box;
@@ -531,7 +532,8 @@ QWidget* YeastItemDelegate::createEditor(QWidget *parent, const QStyleOptionView
       box->addItem(tr("Dry"));
       box->addItem(tr("Slant"));
       box->addItem(tr("Culture"));
-
+      box->setMinimumWidth(box->minimumSizeHint().width());
+      box->setSizeAdjustPolicy(QComboBox::AdjustToContents);
       return box;
    }
    else

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -212,6 +212,30 @@ void Fermentable::setDefaults()
 // Get
 const QString Fermentable::name() const { return get("name").toString(); }
 const Fermentable::Type Fermentable::type() const { return static_cast<Fermentable::Type>(types.indexOf(get("ftype").toString())); }
+const Fermentable::AdditionMethod Fermentable::additionMethod() const
+{
+   Fermentable::AdditionMethod additionMethod;
+   if(isMashed())
+      additionMethod = Fermentable::Mashed;
+   else
+   {
+      if(type() == Fermentable::Grain)
+         additionMethod = Fermentable::Steeped;
+      else
+         additionMethod = Fermentable::Not_Mashed;
+   }
+   return additionMethod;
+}
+const Fermentable::AdditionTime Fermentable::additionTime() const
+{
+   Fermentable::AdditionTime additionTime;
+   if(addAfterBoil())
+      additionTime = Fermentable::Late;
+   else
+      additionTime = Fermentable::Normal;
+
+   return additionTime;
+}
 const QString Fermentable::typeString() const
 {
    return types.at(type());
@@ -220,6 +244,34 @@ const QString Fermentable::typeStringTr() const
 {
    static QStringList typesTr = QStringList () << QObject::tr("Grain") << QObject::tr("Sugar") << QObject::tr("Extract") << QObject::tr("Dry Extract") << QObject::tr("Adjunct");
    return typesTr.at(type());
+}
+
+const QString Fermentable::additionMethodStringTr() const
+{
+    QString retString;
+
+    if(isMashed())
+       retString = tr("Mashed");
+    else
+    {
+       if(type() == Fermentable::Grain)
+          retString = tr("Steeped");
+       else
+          retString = tr("Not mashed");
+    }
+    return retString;
+}
+
+const QString Fermentable::additionTimeStringTr() const
+{
+    QString retString;
+
+    if(addAfterBoil())
+       retString = tr("Late");
+    else
+       retString = tr("Normal");
+
+    return retString;
 }
 
 double Fermentable::amount_kg()              const { return get("amount").toDouble(); }
@@ -271,9 +323,26 @@ void Fermentable::setName( const QString& str )
    set("name", "name", str);
    emit changedName(str);
 }
+
 void Fermentable::setType( Type t )
 {
    set("type", "ftype", types.at(t));
+}
+
+void Fermentable::setAdditionMethod( Fermentable::AdditionMethod m )
+{
+   if( m == Fermentable::Mashed )
+      setIsMashed(true);
+   else
+      setIsMashed(false);
+}
+
+void Fermentable::setAdditionTime( Fermentable::AdditionTime t )
+{
+   if( t == Fermentable::Late )
+      setAddAfterBoil(true);
+   else
+      setAddAfterBoil(false);
 }
 
 void Fermentable::setAmount_kg( double num )

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -49,8 +49,12 @@ public:
 
    //! \brief The type of Fermentable.
    enum Type {Grain, Sugar, Extract, Dry_Extract, Adjunct}; // NOTE: BeerXML expects a space for "Dry_Extract". We're screwed.
-   Q_ENUMS( TYPE )
-   
+   //! \brief The addition method.
+   enum AdditionMethod {Mashed, Steeped, Not_Mashed};
+   //! \brief The addition time.
+   enum AdditionTime {Normal, Late};
+   Q_ENUMS( Type AdditionMethod AdditionTime )
+
    virtual ~Fermentable() {}
    
    //! \brief The name.
@@ -61,6 +65,14 @@ public:
    Q_PROPERTY( QString typeString            READ typeString             /*WRITE*/                       /*NOTIFY changed*/ /*changedTypeString*/             STORED false )
    //! \brief The translated \c Type string.
    Q_PROPERTY( QString typeStringTr          READ typeStringTr           /*WRITE*/                       /*NOTIFY changed*/ /*changedTypeStringTr*/           STORED false )
+   //! \brief The \c addition method.
+   Q_PROPERTY( AdditionMethod additionMethod READ additionMethod         WRITE setAdditionMethod         /*NOTIFY changed*/ /*changedAdditionMethod*/         STORED false )
+   //! \brief The translated \c Method string.
+   Q_PROPERTY( QString additionMethodStringTr READ additionMethodStringTr /*WRITE*/                      /*NOTIFY changed*/ /*changedAdditionMethodStringTr*/ STORED false )
+   //! \brief The \c addition time.
+   Q_PROPERTY( AdditionTime additionTime     READ additionTime           WRITE setAdditionTime           /*NOTIFY changed*/ /*changedAdditionTime*/           STORED false )
+   //! \brief The translated \c Addition string.
+   Q_PROPERTY( QString additionTimeStringTr  READ additionTimeStringTr   /*WRITE*/                       /*NOTIFY changed*/ /*changedAdditionTimeStringTr*/   STORED false )
    //! \brief The amount in kg.
    Q_PROPERTY( double amount_kg              READ amount_kg              WRITE setAmount_kg              /*NOTIFY changed*/ /*changedAmount_kg*/ )
    //! \brief The amount in inventory in kg.
@@ -105,6 +117,12 @@ public:
    const QString typeString() const;
    //! Returns a translated type string.
    const QString typeStringTr() const;
+   const AdditionMethod additionMethod() const;
+   //! Returns a translated addition method string.
+   const QString additionMethodStringTr() const;
+   const AdditionTime additionTime() const;
+   //! Returns a translated addition time string.
+   const QString additionTimeStringTr() const;
    double amount_kg() const;
    double inventory() const;
    double yield_pct() const;
@@ -131,6 +149,8 @@ public:
 
    void setName( const QString& str );
    void setType( Type t );
+   void setAdditionMethod( AdditionMethod m );
+   void setAdditionTime( AdditionTime t );
    void setAmount_kg( double num );
    void setInventoryAmount( double num );
    void setYield_pct( double num );


### PR DESCRIPTION
This is a first approach in order to change the weird checkbox used for Mashed option.
This commit aims to improve display avoiding manual resizing.
I need to find a way to hide one of the two parameters "Steeped" or "Not Mashed" regarding the fermentable type.

This branch fixes the bug #81 