### PR TITLE
Travis CI for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,8 @@ before_install:
   - brew update
 install:
   - brew install cmake
+  - brew install qt5
+script:
+  - ./configure -v
+  - cd build
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ before_install:
   - brew update
 install:
   - brew install qt5
-script:
-  - ./configure -v
+before_script:
+  - mkdir build
   - cd build
-  - make
+  - cmake ..
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - travis-osx
 before_install:
+  - export PATH=/usr/local/opt/qt5/bin:$PATH
   - brew update
 install:
   - brew install qt5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c++
+branches:
+  only:
+    - travis-osx
+before_install:
+  - brew update
+install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
 before_install:
   - brew update
 install:
-  - brew install cmake
   - brew install qt5
 script:
   - ./configure -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: c++
-os:
-  - osx
+os: osx
 branches:
   only:
     - travis-osx
 before_install:
   - brew update
-install: true
+install:
+  - brew install cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: c++
+os:
+  - osx
 branches:
   only:
     - travis-osx

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/xor-gate/brewtarget.svg?branch=travis-osx)](https://travis-ci.org/xor-gate/brewtarget)
+
 # Brewtarget
 
 Brewtarget is free open-source brewing software, and a beer recipe creation


### PR DESCRIPTION
Hi guys,

I gave it a shot to integrate brewtarget with Travis CI (Continues Integration) because the current mac build is a little outdated. This is just initial and very handy for people who don't own a mac (happily I do).

This can also be expanded for linux builds (I dont know about windows e.g MinGW builds).

Kind regards,
Jerry