### PR TITLE
Fixes #90: OG Correction Dialog auto unit conversion breaks the use case

### DIFF
--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -134,6 +134,10 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
    if ( _property.isEmpty() )
       initializeProperties();
 
+   if (text().isEmpty())
+   {
+      return;
+   }
 
    // The idea here is we need to first translate the field into a known
    // amount (aka to SI) and then into the unit we want.

--- a/src/OgAdjuster.cpp
+++ b/src/OgAdjuster.cpp
@@ -66,10 +66,11 @@ void OgAdjuster::calculate()
    double waterToAdd_l = 0.0;
 
    bool gotSG = false;
+   bool okPlato = true;
 
    // Get inputs.
    sg          = lineEdit_sg->toSI();
-   plato       = lineEdit_plato->toSI();
+   plato       = lineEdit_plato->toDouble(&okPlato);
    temp_c      = lineEdit_temp->toSI();
    hydroTemp_c = lineEdit_calTemp->toSI();
    wort_l      = lineEdit_volume->toSI();
@@ -79,7 +80,7 @@ void OgAdjuster::calculate()
 
    if( wort_l == 0 )
       return;
-   if( ! gotSG && plato == 0 )
+   if( ! gotSG && ! okPlato )
       return;
 
    if( recObs == 0 || recObs->equipment() == 0 )


### PR DESCRIPTION
Fixes OG Correction Dialog calculation from Plato

The change allows an empty LineEdit.

I also found that in the Plato conversion, the variable plato (supposed to be in P units) was in SG units (SI).