### PR TITLE
Change weird checkbox for misc amount type

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -32,6 +32,7 @@
 
 QStringList Misc::uses = QStringList() << "Boil" << "Mash" << "Primary" << "Secondary" << "Bottling";
 QStringList Misc::types = QStringList() << "Spice" << "Fining" << "Water Agent" << "Herb" << "Flavor" << "Other";
+QStringList Misc::amountTypes = QStringList() << "Weight" << "Volume";
 QHash<QString,QString> Misc::tagToProp = Misc::tagToPropHash();
 
 QHash<QString,QString> Misc::tagToPropHash()
@@ -75,7 +76,7 @@ const QString Misc::typeString() const
 
 const QString Misc::typeStringTr() const
 {
-   QStringList typesTr = QStringList() << QObject::tr("Spice") << QObject::tr("Fining") << QObject::tr("Water Agent") << QObject::tr("Herb") << QObject::tr("Flavor") << QObject::tr("Other");
+   QStringList typesTr = QStringList() << tr("Spice") << tr("Fining") << tr("Water Agent") << tr("Herb") << tr("Flavor") << tr("Other");
    return typesTr.at(type());
 }
 
@@ -91,8 +92,24 @@ const QString Misc::useString() const
 
 const QString Misc::useStringTr() const
 {
-   QStringList usesTr = QStringList() << QObject::tr("Boil") << QObject::tr("Mash") << QObject::tr("Primary") << QObject::tr("Secondary") << QObject::tr("Bottling");
+   QStringList usesTr = QStringList() << tr("Boil") << tr("Mash") << tr("Primary") << tr("Secondary") << tr("Bottling");
    return usesTr.at(use());
+}
+
+Misc::AmountType Misc::amountType() const
+{
+   return amountIsWeight() ? AmountType_Weight : AmountType_Volume;
+}
+
+const QString Misc::amountTypeString() const
+{
+   return amountTypes.at(amountType());
+}
+
+const QString Misc::amountTypeStringTr() const
+{
+   QStringList amountTypesTr = QStringList() << tr("Weight") << tr("Volume");
+   return amountTypesTr.at(amountType());
 }
 
 double Misc::amount()    const { return get("amount").toDouble(); }
@@ -123,6 +140,11 @@ void Misc::setType( Type t )
 void Misc::setUse( Use u )
 {
    set( "use", "use", uses.at(u) );
+}
+
+void Misc::setAmountType( AmountType t )
+{
+   setAmountIsWeight(t == AmountType_Weight ? true : false);
 }
 
 void Misc::setAmount( double var )

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,7 +46,9 @@ public:
    enum Type {Spice, Fining, Water_Agent, Herb, Flavor, Other}; // NOTE: BeerXML expects "Water Agent", but we can't have white space in enums :-/.
    //! \brief Where the ingredient is used.
    enum Use { Boil, Mash, Primary, Secondary, Bottling };
-   Q_ENUMS( Type Use )
+   //! \brief What is the type of amount.
+   enum AmountType { AmountType_Weight, AmountType_Volume };
+   Q_ENUMS( Type Use AmountType )
    
    virtual ~Misc() {}
    
@@ -64,6 +66,12 @@ public:
    Q_PROPERTY( QString useString READ useString /*NOTIFY changed*/ /*changedUse*/ STORED false )
    //! \brief The translated \c Use string.
    Q_PROPERTY( QString useStringTr READ useStringTr /*NOTIFY changed*/ /*changedUse*/ STORED false )
+   //! \brief The \c Amount type.
+   Q_PROPERTY( AmountType amountType READ amountType WRITE setAmountType /*NOTIFY changed*/ /*changedAmountType*/ )
+   //! \brief The \c Amount type string.
+   Q_PROPERTY( QString amountTypeString READ amountTypeString /*NOTIFY changed*/ /*changedAmountType*/ STORED false )
+   //! \brief The translated \c Use string.
+   Q_PROPERTY( QString amountTypeStringTr READ amountTypeStringTr /*NOTIFY changed*/ /*changedAmountType*/ STORED false )
    //! \brief The time used in minutes.
    Q_PROPERTY( double time READ time WRITE setTime /*NOTIFY changed*/ /*changedTime*/ )
    //! \brief The amount in either kg or L, depending on \c amountIsWeight().
@@ -81,6 +89,7 @@ public:
    void setName( const QString &var );
    void setType( Type t );
    void setUse( Use u );
+   void setAmountType( AmountType t );
    void setAmount( double var );
    void setInventoryAmount( double var );
    void setTime( double var );
@@ -96,6 +105,9 @@ public:
    Use use() const;
    const QString useString() const;
    const QString useStringTr() const;
+   AmountType amountType() const;
+   const QString amountTypeString() const;
+   const QString amountTypeStringTr() const;
    double amount() const;
    double inventory() const;
    double time() const;
@@ -127,7 +139,8 @@ private:
    
    static QStringList types;
    static QStringList uses;
-   
+   static QStringList amountTypes;
+
    static QHash<QString,QString> tagToProp;
    static QHash<QString,QString> tagToPropHash();
 };


### PR DESCRIPTION
This commit changes the checkbox used for amount type in Misc tab the same way I've changed those of fermentable tab. I missed this one when I did it.