### PR TITLE
Introduction of the user-dir cli option.

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -40,20 +40,20 @@ Log::~Log() {
       file.close();   
 }
 
-void Log::changeDirectory(const QString defaultDir) {
+void Log::changeDirectory(const QDir defaultDir) {
    if (stream) {
       doLog(LogType_ERROR, "Cannot change logging directory after it is initialized.");
       return;
    }
    // Test default location
-   file.setFileName(defaultDir + filename);
+   file.setFileName(defaultDir.filePath(filename));
    if( file.open(QIODevice::WriteOnly | QIODevice::Truncate) ) {
       stream = new QTextStream(&file);
       return;
    }
 
    // Defaults to temporary
-   file.setFileName(QDir::tempPath() + "/" + filename);
+   file.setFileName(QDir::temp().filePath(filename));
    if( file.open(QFile::WriteOnly | QFile::Truncate) ) {
       stream = new QTextStream(&file);
       warn(QString("Log is in a temporary directory: %1").arg(file.fileName()));

--- a/src/Log.h
+++ b/src/Log.h
@@ -20,7 +20,7 @@
 #ifndef _LOG_H
 #define _LOG_H
 
-#include <QFile>
+#include <QDir>
 #include <QObject>
 #include <QMutex>
 #include <QString>
@@ -78,7 +78,7 @@ private:
 
    //! \brief Sets the default directory of the log file
    //! \param defaultDir The directory which will host the log file.
-   void changeDirectory(const QString defaultDir);
+   void changeDirectory(const QDir defaultDir);
    void doLog(const LogType lt, const QString message);
    QString getTypeName(const LogType type) const;
 };

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1944,7 +1944,7 @@ void MainWindow::saveMash()
 
 void MainWindow::openManual()
 {
-   QDesktopServices::openUrl(QUrl::fromLocalFile(Brewtarget::getDataDir()+"brewtarget-manual.html"));
+   QDesktopServices::openUrl(QUrl::fromLocalFile(Brewtarget::getDataDir().filePath("brewtarget-manual.html")));
 }
 
 // One print function to rule them all. Now we just need to make the menuing
@@ -2182,7 +2182,7 @@ void MainWindow::updateDatabase()
    // Select the db to merge with.
    otherDb = QFileDialog::getOpenFileName( this,
                                            tr("Select Database File"),
-                                           Brewtarget::getUserDataDir(),
+                                           Brewtarget::getUserDataDir().canonicalPath(),
                                            tr("Brewtarget Database (*.sqlite)") );
 
    // Merge.
@@ -2285,10 +2285,8 @@ void MainWindow::convertedMsg()
 {
 
    QMessageBox msgBox;
-   QDir dir(Brewtarget::getUserDataDir());
-
    msgBox.setText( tr("The database has been converted/upgraded."));
-   msgBox.setInformativeText( tr("The original XML files can be found in ") + Brewtarget::getUserDataDir() + "obsolete");
+   msgBox.setInformativeText( tr("The original XML files can be found in ") + Brewtarget::getUserDataDir().canonicalPath() + "obsolete");
    msgBox.exec();
 
 }

--- a/src/TimerWidget.cpp
+++ b/src/TimerWidget.cpp
@@ -158,7 +158,8 @@ void TimerWidget::retranslateUi()
 
 void TimerWidget::getSound()
 {
-   QDir soundsDir = QString("%1sounds/").arg(Brewtarget::getDataDir());
+   QDir soundsDir(Brewtarget::getDataDir().canonicalPath() + "/sounds");
+   //QDir soundsDir = QString("%1sounds/").arg(Brewtarget::getDataDir());
    QString soundFile = QFileDialog::getOpenFileName( qobject_cast<QWidget*>(this), tr("Open Sound"), soundsDir.exists() ? soundsDir.canonicalPath() : "", tr("Audio Files (*.wav *.ogg *.mp3 *.aiff)") );
 
    if( soundFile.isNull() )

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -145,15 +145,19 @@ public:
    };
 
    //! \return the data directory
-   static QString getDataDir();
+   static QDir getDataDir();
    //! \return the doc directory
-   static QString getDocDir();
+   static QDir getDocDir();
    //! \return the config directory
-   static QString getConfigDir(bool* success = 0);
+   static const QDir getConfigDir(bool* success = 0);
    //! \return user-specified directory where the database files reside.
-   static QString getUserDataDir();
-   //! \brief Blocking call that starts the application.
-   static int run();
+   static QDir getUserDataDir();
+   /*!
+    * \brief Blocking call that executes the application.
+    * \param userDirectory If !isEmpty, overwrites the current settings.
+    * \return Exit code from the application.
+    */
+   static int run(const QString &userDirectory = QString());
 
    static double toDouble(QString text, bool* ok = 0);
    static double toDouble(const BeerXMLElement* element, QString attribute, QString caller);
@@ -320,7 +324,7 @@ private:
    static QDateTime lastDbMergeRequest;
 
    //! \brief Where the user says the database files are
-   static QString userDataDir;
+   static QDir userDataDir;
 
    // Options to be edited ONLY by the OptionDialog============================
    // Whether or not to display plato instead of SG.
@@ -350,7 +354,7 @@ private:
     *
     * \returns false if anything goes awry, true if it's ok to start MainWindow
     */
-   static bool initialize();
+   static bool initialize(const QString &userDirectory = QString());
    /*!
     * \brief Run after QApplication exits to clean up shit, close database, etc.
     */
@@ -370,7 +374,7 @@ private:
     *  \brief Copies the user xml files to another directory.
     *  \returns false iff the copy is unsuccessful.
     */
-   static bool copyDataFiles(QString newPath);
+   static bool copyDataFiles(const QDir newPath);
 
    //! \brief Ensure our directories exist.
    static bool ensureDirectoriesExist();

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -130,9 +130,9 @@ bool Database::load()
    bool schemaUpdated=false;
    
    // Set file names.
-   dbFileName = (Brewtarget::getUserDataDir() + "database.sqlite");
-   dataDbFileName = (Brewtarget::getDataDir() + "default_db.sqlite");
-   dbTempBackupFileName = (Brewtarget::getUserDataDir() + "tempBackupDatabase.sqlite");
+   dbFileName = Brewtarget::getUserDataDir().filePath("database.sqlite");
+   dataDbFileName = Brewtarget::getDataDir().filePath("default_db.sqlite");
+   dbTempBackupFileName = Brewtarget::getUserDataDir().filePath("tempBackupDatabase.sqlite");
    
    // Set the files.
    dbFile.setFileName(dbFileName);
@@ -361,7 +361,7 @@ void Database::convertFromXml()
       QStringList oldFiles = QStringList() << "database.xml" << "mashs.xml" << "recipes.xml";
       for ( int i = 0; i < oldFiles.size(); ++i ) 
       {
-         QFile oldXmlFile(Brewtarget::getUserDataDir() + oldFiles[i]);
+         QFile oldXmlFile(Brewtarget::getUserDataDir().filePath(oldFiles[i]));
          // If the old file exists, import.
          if( oldXmlFile.exists() )
          {
@@ -4335,7 +4335,7 @@ bool Database::cleanupBackupDatabase()
                                      "Database Restore Failure",
                                      QString(QObject::tr("Failed to remove the temporary backup database.  "
                                                          "Navigate to '%1' and remove "
-                                                         "'tempBackupDatabase.sqlite'.")).arg(Brewtarget::getUserDataDir()));
+                                                         "'tempBackupDatabase.sqlite'.")).arg(Brewtarget::getUserDataDir().canonicalPath()));
 
                return false;
             }
@@ -4353,7 +4353,7 @@ bool Database::cleanupBackupDatabase()
                                      QString(QObject::tr("Failed to rollback to the backup database.  "
                                                          "Navigate to '%1', remove 'database.sqlite' if it exists, "
                                                          "and rename 'tempBackupDatabase.sqlite' to "
-                                                         "'database.sqlite'.")).arg(Brewtarget::getUserDataDir()));
+                                                         "'database.sqlite'.")).arg(Brewtarget::getUserDataDir().canonicalPath()));
 
                return false;
             }
@@ -4370,7 +4370,7 @@ bool Database::cleanupBackupDatabase()
                                   QObject::tr("Database Restore Failure"),
                                   QString(QObject::tr("Failed to restore the backup database. Navigate to '%1' "
                                                       "and rename 'tempBackupDatabase.sqlite' to "
-                                                      "'database.sqlite'.").arg(Brewtarget::getUserDataDir())));
+                                                      "'database.sqlite'.").arg(Brewtarget::getUserDataDir().canonicalPath())));
 
             return false;
          }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
  * - A.J. Drobnich <aj.drobnich@gmail.com>
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
+ * - Maxime Lavigne <duguigne@gmail.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,44 +26,64 @@
 #include "brewtarget.h"
 #include "database.h"
 
-void importFromXml(const QString & optionValue);
-void createBlankDb(const QString & optionValue);
+void importFromXml(const QString & filename);
+void createBlankDb(const QString & filename);
 
 int main(int argc, char **argv)
 {  
    QApplication app(argc, argv);
    app.setOrganizationName("brewtarget");
+
+   // Allows a different set of QTSettings while in debug mode.
+   // Settings changed whilst debugging will not interfere with other installed instance of BT.
+#ifdef QT_DEBUG
+   app.setApplicationName("brewtarget-debug");
+#else
    app.setApplicationName("brewtarget");
+#endif
+
    app.setApplicationVersion(VERSIONSTRING);
 
    QCommandLineParser parser;
    parser.addHelpOption();
    parser.addVersionOption();
 
-   const QCommandLineOption importFromXmlOption("from-xml", "Imports DB from XML", "file");
-   const QCommandLineOption createBlankDBOption("create-blank", "Creates a blank DB", "file");
+   const QCommandLineOption importFromXmlOption("from-xml", "Imports DB from XML in <file>", "file");
+   const QCommandLineOption createBlankDBOption("create-blank", "Creates an empty database in <file>", "file");
+   /*!
+    * \brief Forces the application to a specific user directory.
+    *
+    * If this directory exists, it will replace the user directory taken
+    * from QSettings.
+    */
+   const QCommandLineOption userDirectoryOption("user-dir", "Overwrite the directory used by the application with <directory>", "directory", QString());
 
    parser.addOption(importFromXmlOption);
    parser.addOption(createBlankDBOption);
+   parser.addOption(userDirectoryOption);
 
    parser.process(app);
 
    if (parser.isSet(importFromXmlOption)) importFromXml(parser.value(importFromXmlOption));
    if (parser.isSet(createBlankDBOption)) createBlankDb(parser.value(createBlankDBOption));
    
-   return Brewtarget::run();
+   return Brewtarget::run(parser.value(userDirectoryOption));
 }
 
-void importFromXml(const QString & optionValue) {
-    Database::instance().importFromXML(optionValue);
+/*!
+ * \brief Imports the content of an xml file to the database.
+ *
+ * Use at your own risk.
+ */
+void importFromXml(const QString & filename) {
+    Database::instance().importFromXML(filename);
     Database::dropInstance();
-    // If you know enough to run --from-xml, I am going to assume you know
-    // enough to do it right
     Brewtarget::setOption("converted", QDate().currentDate().toString());
     exit(0);
 }
 
-void createBlankDb(const QString & optionValue) {
-    Database::createBlank(optionValue);
+//! \brief Creates a blank database using the given filename.
+void createBlankDb(const QString & filename) {
+    Database::createBlank(filename);
     exit(0);
 }


### PR DESCRIPTION
This commit introduces the possibility of running brewtarget on a custom
database folder which will not impact your normal usage of the
Application.

This is intended for people with multiple version of Brewtarget and for
people helping test and debug the application.

  * Modification to the settings made while debugging the application no
    longuer interfere with normal settings.
  * Introduction of the --user-dir cli option which allows the caller to
    point to a directory containg the DB. This option will not store
    itself in the settings. Meaning running brewtarget again without param
    will revert to the known user data directory.
  * There were a lot of "file and directory arithmetics" implicated in
    this modification. Things like adding slash, double slash, backward
    slash, ... at the end of paths, and between path element. I stored the
    user data dir as a QDir instead of a QString to eliminate all these
    potential errors. It meant changing calls in a few file.