### PR TITLE
Break lines in the notes of the brew day html output

### DIFF
--- a/css/brewday.css
+++ b/css/brewday.css
@@ -124,3 +124,8 @@ img
    text-align:right;
 }
 
+#customNote
+{
+   display:block;
+   white-space:pre-wrap;
+}

--- a/src/BrewDayScrollWidget.cpp
+++ b/src/BrewDayScrollWidget.cpp
@@ -163,7 +163,7 @@ void BrewDayScrollWidget::print(QPrinter *mainPrinter, QPrintDialog* dialog,
 
    pDoc += tr("<h2>Notes</h2>");
    if ( recObs->notes() != "" )
-      pDoc += QString("%1").arg(recObs->notes());
+      pDoc += QString("<div id=\"customNote\">%1</div>\n").arg(recObs->notes());
 
    pDoc += "</body></html>";
 


### PR DESCRIPTION
The Brew day pdf/html output don't keep the original line breaks.

I've added a style in the css (white-space: pre-wrap) that keep them.
