### PR TITLE
Check for Visual Studio in pstdint.h

### DIFF
--- a/src/pstdint.h
+++ b/src/pstdint.h
@@ -193,7 +193,11 @@
  *  do nothing else.  On the Mac OS X version of gcc this is _STDINT_H_.
  */
 
-#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined (__UINT_FAST64_TYPE__)) )) && !defined (_PSTDINT_H_INCLUDED)
+#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) \
+      || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) \
+      || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined (__UINT_FAST64_TYPE__)) ) \
+      || (defined(_MSC_VER) && (_MSC_VER>=1700 || defined(_STDINT))) \
+    ) && !defined (_PSTDINT_H_INCLUDED)
 #include <stdint.h>
 #define _PSTDINT_H_INCLUDED
 # ifndef PRINTF_INT64_MODIFIER


### PR DESCRIPTION
I've modified pstdint.h to check for VS2012 and up which have their own version of stdint.h, similarly to what's already being done for GCC. Without this change VS2015 report redefinition errors and the build fails.