### PR TITLE
Fixed bad static initialization of config directory

### DIFF
--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -85,7 +85,7 @@ QFile Brewtarget::pidFile;
 QDateTime Brewtarget::lastDbMergeRequest = QDateTime::fromString("1986-02-24T06:00:00", Qt::ISODate);
 
 QString Brewtarget::currentLanguage = "en";
-QDir Brewtarget::userDataDir = getConfigDir();
+QDir Brewtarget::userDataDir = QString();
 
 bool Brewtarget::checkVersion = true;
 Log Brewtarget::log(true);
@@ -388,12 +388,6 @@ const QDir Brewtarget::getConfigDir(bool *success)
    return dir.absolutePath() + "/";
 
 #elif defined(Q_OS_WIN) // Windows OS.
-   if (!qApp)
-   {  //QApplication instance doesn't exist yet
-      if (success)
-         *success = false;
-      return QString();
-   }
 
    QDir dir;
    // This is the bin/ directory.

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -388,10 +388,16 @@ const QDir Brewtarget::getConfigDir(bool *success)
    return dir.absolutePath() + "/";
 
 #elif defined(Q_OS_WIN) // Windows OS.
+   if (!qApp)
+   {  //QApplication instance doesn't exist yet
+      if (success)
+         *success = false;
+      return QString();
+   }
 
    QDir dir;
    // This is the bin/ directory.
-   dir = QDir(qApp->applicationDirPath());
+   dir = QDir(QCoreApplication::applicationDirPath());
    dir.cdUp();
    // Now we should be in the base directory (i.e. Brewtarget-2.0.0/)
 


### PR DESCRIPTION
Fixed the warning 'QCoreApplication::applicationDirPath: Please instantiate the QApplication object first' which appears on Windows builds. It also makes sure an empty QApplication pointer isn't used.