### PR TITLE
Fixes #184 All ageing times in Extras tab are scaled to days.

### DIFF
--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -90,6 +90,22 @@ void BtLineEdit::initializeProperties()
    {
       _forceUnit = Unit::noUnit;
    }
+
+   unitName = property("forcedScale");
+   _property = property("editField").toString();
+
+   if ( unitName.isValid() )
+   {
+      const QMetaObject &mo = Unit::staticMetaObject;
+      int index = mo.indexOfEnumerator("unitScale");
+      QMetaEnum unitEnum = mo.enumerator(index);
+      _forceScale = (Unit::unitScale)unitEnum.keyToValue(unitName.toString().toStdString().c_str());
+   }
+
+   else
+   {
+      _forceScale = Unit::noScale;
+   }
 }
 
 void BtLineEdit::initializeSection()
@@ -195,7 +211,11 @@ double BtLineEdit::toSI(Unit::unitDisplay oldUnit,Unit::unitScale oldScale,bool 
       else
          dspUnit   = (Unit::unitDisplay)Brewtarget::option(_property, Unit::noUnit, _section, Brewtarget::UNIT).toInt();
 
-      dspScale  = (Unit::unitScale)Brewtarget::option(_property, Unit::noUnit, _section, Brewtarget::SCALE).toInt();
+      // If the display scale is forced, use this scale as the default one.
+      if( _forceScale != Unit::noScale )
+         dspScale = _forceScale;
+      else
+         dspScale  = (Unit::unitScale)Brewtarget::option(_property, Unit::noUnit, _section, Brewtarget::SCALE).toInt();
    }
 
    // Find the unit system containing dspUnit

--- a/src/BtLineEdit.h
+++ b/src/BtLineEdit.h
@@ -99,6 +99,7 @@ protected:
    QString _section, _property;
    FieldType _type;
    Unit::unitDisplay _forceUnit;
+   Unit::unitScale _forceScale;
    Unit* _units;
 
    void initializeProperties();

--- a/ui/recipeExtrasWidget.ui
+++ b/ui/recipeExtrasWidget.ui
@@ -169,6 +169,9 @@
            <property name="editField" stdset="0">
             <string notr="true">primaryAge_days</string>
            </property>
+           <property name="forcedScale" stdset="0">
+            <string notr="true">scaleLarge</string>
+           </property>
           </widget>
          </item>
          <item row="4" column="0">
@@ -244,6 +247,9 @@
            </property>
            <property name="editField" stdset="0">
             <string notr="true">secondaryAge_days</string>
+           </property>
+           <property name="forcedScale" stdset="0">
+            <string notr="true">scaleLarge</string>
            </property>
           </widget>
          </item>
@@ -321,6 +327,9 @@
            <property name="editField" stdset="0">
             <string notr="true">tertiaryAge_days</string>
            </property>
+           <property name="forcedScale" stdset="0">
+            <string notr="true">scaleLarge</string>
+           </property>
           </widget>
          </item>
          <item row="8" column="0">
@@ -396,6 +405,9 @@
            </property>
            <property name="editField" stdset="0">
             <string notr="true">age</string>
+           </property>
+           <property name="forcedScale" stdset="0">
+            <string notr="true">scaleLarge</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
It makes no sense to have these in any other scale by default. Users
can just enter the number of days without specifying units to set
ageing in days.