### PR TITLE
Scale on input -- item #179

### DIFF
--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -211,7 +211,7 @@ double BtLineEdit::toSI(Unit::unitDisplay oldUnit,Unit::unitScale oldScale,bool 
 
       // get the qstringToSI() from the unit system, using the found unit.
       // Force the issue in qstringToSI() unless dspScale is Unit::noScale.
-      return temp->qstringToSI(text(), works, dspScale != Unit::noScale);
+      return temp->qstringToSI(text(), works, dspScale != Unit::noScale, dspScale);
    }
    else if ( _type == STRING )
       return 0.0;

--- a/src/FermentableTableModel.cpp
+++ b/src/FermentableTableModel.cpp
@@ -592,6 +592,9 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
    else
       row = fermObs[index.row()];
 
+   Unit::unitDisplay dspUnit = displayUnit(index.column());
+   Unit::unitScale   dspScl  = displayScale(index.column());
+
    switch( index.column() )
    {
       case FERMNAMECOL:
@@ -607,13 +610,13 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
       case FERMINVENTORYCOL:
          retVal = value.canConvert(QVariant::String);
          if( retVal )
-            row->setInventoryAmount( Brewtarget::qStringToSI(value.toString(), Units::kilograms,displayUnit(FERMINVENTORYCOL)));
+            row->setInventoryAmount(Brewtarget::qStringToSI(value.toString(), Units::kilograms,dspUnit,dspScl));
          break;
       case FERMAMOUNTCOL:
          retVal = value.canConvert(QVariant::String);
          if( retVal )
          {
-            row->setAmount_kg( Brewtarget::qStringToSI(value.toString(), Units::kilograms,displayUnit(FERMAMOUNTCOL)));
+            row->setAmount_kg(Brewtarget::qStringToSI(value.toString(), Units::kilograms,dspUnit,dspScl));
             if( rowCount() > 0 )
                headerDataChanged( Qt::Vertical, 0, rowCount()-1 ); // Need to re-show header (grain percent).
          }
@@ -636,7 +639,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
       case FERMCOLORCOL:
          retVal = value.canConvert(QVariant::Double);
          if( retVal )
-            row->setColor_srm(Brewtarget::qStringToSI(value.toString(), Units::srm, displayUnit(FERMCOLORCOL)));
+            row->setColor_srm(Brewtarget::qStringToSI(value.toString(), Units::srm, dspUnit, dspScl));
          break;
       default:
          Brewtarget::logW(tr("Bad column: %1").arg(index.column()));

--- a/src/HopTableModel.cpp
+++ b/src/HopTableModel.cpp
@@ -362,6 +362,8 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
 
    row = hopObs[index.row()];
 
+   Unit::unitDisplay dspUnit = displayUnit(index.column());
+   Unit::unitScale   dspScl  = displayScale(index.column());
    switch( index.column() )
    {
       case HOPNAMECOL:
@@ -388,7 +390,7 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
       case HOPAMOUNTCOL:
          retVal = value.canConvert(QVariant::String);
          if( retVal )
-            row->setAmount_kg( Brewtarget::qStringToSI(value.toString(), Units::kilograms, displayUnit(HOPAMOUNTCOL)));
+            row->setAmount_kg( Brewtarget::qStringToSI(value.toString(), Units::kilograms, dspUnit, dspScl));
          break;
       case HOPUSECOL:
          retVal = value.canConvert(QVariant::Int);
@@ -403,7 +405,7 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
       case HOPTIMECOL:
          retVal = value.canConvert(QVariant::String);
          if( retVal )
-            row->setTime_min( Brewtarget::qStringToSI(value.toString(),Units::minutes));
+            row->setTime_min( Brewtarget::qStringToSI(value.toString(),Units::minutes,dspUnit,dspScl));
          break;
       default:
          Brewtarget::logW(QString("HopTableModel::setdata Bad column: %1").arg(index.column()));

--- a/src/MashStepTableModel.cpp
+++ b/src/MashStepTableModel.cpp
@@ -224,7 +224,6 @@ Qt::ItemFlags MashStepTableModel::flags(const QModelIndex& index ) const
 bool MashStepTableModel::setData( const QModelIndex& index, const QVariant& value, int role )
 {
    MashStep *row;
-   Unit::unitDisplay unit;
 
    if( mashObs == 0 )
       return false;
@@ -233,6 +232,9 @@ bool MashStepTableModel::setData( const QModelIndex& index, const QVariant& valu
       return false;
    else
       row = steps[index.row()];
+
+   Unit::unitDisplay dspUnit = displayUnit(index.column());
+   Unit::unitScale   dspScl  = displayScale(index.column());
 
    switch( index.column() )
    {
@@ -255,11 +257,10 @@ bool MashStepTableModel::setData( const QModelIndex& index, const QVariant& valu
       case MASHSTEPAMOUNTCOL:
          if( value.canConvert(QVariant::String) )
          {
-            unit = displayUnit(MASHSTEPAMOUNTCOL);
             if( row->type() == MashStep::Decoction )
-               row->setDecoctionAmount_l( Brewtarget::qStringToSI(value.toString(),Units::liters,unit) );
+               row->setDecoctionAmount_l( Brewtarget::qStringToSI(value.toString(),Units::liters,dspUnit,dspScl) );
             else
-               row->setInfuseAmount_l( Brewtarget::qStringToSI(value.toString(),Units::liters,unit) );
+               row->setInfuseAmount_l( Brewtarget::qStringToSI(value.toString(),Units::liters,dspUnit,dspScl) );
             return true;
          }
          else
@@ -267,8 +268,7 @@ bool MashStepTableModel::setData( const QModelIndex& index, const QVariant& valu
       case MASHSTEPTEMPCOL:
          if( value.canConvert(QVariant::String) && row->type() != MashStep::Decoction )
          {
-            unit = displayUnit(MASHSTEPTEMPCOL);
-            row->setInfuseTemp_c( Brewtarget::qStringToSI(value.toString(),Units::celsius,unit) );
+            row->setInfuseTemp_c( Brewtarget::qStringToSI(value.toString(),Units::celsius,dspUnit,dspScl) );
             return true;
          }
          else
@@ -276,9 +276,8 @@ bool MashStepTableModel::setData( const QModelIndex& index, const QVariant& valu
       case MASHSTEPTARGETTEMPCOL:
          if( value.canConvert(QVariant::String) )
          {
-            unit = displayUnit(MASHSTEPTARGETTEMPCOL);
-            row->setStepTemp_c( Brewtarget::qStringToSI(value.toString(),Units::celsius,unit) );
-            row->setEndTemp_c( Brewtarget::qStringToSI(value.toString(),Units::celsius,unit) );
+            row->setStepTemp_c( Brewtarget::qStringToSI(value.toString(),Units::celsius,dspUnit,dspScl) );
+            row->setEndTemp_c( Brewtarget::qStringToSI(value.toString(),Units::celsius,dspUnit,dspScl) );
             return true;
          }
          else
@@ -286,7 +285,7 @@ bool MashStepTableModel::setData( const QModelIndex& index, const QVariant& valu
       case MASHSTEPTIMECOL:
          if( value.canConvert(QVariant::String) )
          {
-            row->setStepTime_min( Brewtarget::qStringToSI(value.toString(),Units::minutes) );
+            row->setStepTime_min( Brewtarget::qStringToSI(value.toString(),Units::minutes,dspUnit,dspScl) );
             return true;
          }
          else

--- a/src/MiscTableModel.cpp
+++ b/src/MiscTableModel.cpp
@@ -290,7 +290,6 @@ bool MiscTableModel::setData( const QModelIndex& index, const QVariant& value, i
    Misc *row;
    int col;
    QString tmpStr;
-   Unit::unitDisplay dispUnit;
    Unit* unit;
 
    if( index.row() >= (int)miscObs.size() )
@@ -300,6 +299,9 @@ bool MiscTableModel::setData( const QModelIndex& index, const QVariant& value, i
 
    col = index.column();
    unit = row->amountIsWeight() ? (Unit*)Units::kilograms : (Unit*)Units::liters;
+
+   Unit::unitDisplay dspUnit = displayUnit(index.column());
+   Unit::unitScale   dspScl  = displayScale(index.column());
 
    switch (col )
    {
@@ -326,22 +328,18 @@ bool MiscTableModel::setData( const QModelIndex& index, const QVariant& value, i
          if( ! value.canConvert(QVariant::String) )
             return false;
 
-         row->setTime( Brewtarget::qStringToSI(value.toString(), Units::minutes) );
+         row->setTime( Brewtarget::qStringToSI(value.toString(), Units::minutes, dspUnit, dspScl) );
          break;
       case MISCINVENTORYCOL:
          if( ! value.canConvert(QVariant::String) )
             return false;
 
-         dispUnit = displayUnit(col);
-
-         row->setInventoryAmount(Brewtarget::qStringToSI(value.toString(), unit, dispUnit));
+         row->setInventoryAmount(Brewtarget::qStringToSI(value.toString(), unit, dspUnit,dspScl));
       case MISCAMOUNTCOL:
          if( ! value.canConvert(QVariant::String) )
             return false;
 
-         dispUnit = displayUnit(col);
-
-         row->setAmount( Brewtarget::qStringToSI(value.toString(), unit, dispUnit ));
+         row->setAmount( Brewtarget::qStringToSI(value.toString(), unit, dspUnit,dspScl ));
          break;
       case MISCISWEIGHT:
          if( ! value.canConvert(QVariant::Int) )

--- a/src/UnitSystem.cpp
+++ b/src/UnitSystem.cpp
@@ -43,7 +43,7 @@ UnitSystem::UnitSystem()
    amtUnit.setCaseSensitivity(Qt::CaseInsensitive);
 }
 
-double UnitSystem::qstringToSI(QString qstr, Unit* defUnit, bool force)
+double UnitSystem::qstringToSI(QString qstr, Unit* defUnit, bool force, Unit::unitScale scale)
 {
    double amt = 0.0;
    Unit* u = defUnit;
@@ -65,7 +65,14 @@ double UnitSystem::qstringToSI(QString qstr, Unit* defUnit, bool force)
    // qts, 3.6 US qts, 3.41L. If you enter 3L, you get 2.64 imperial qts,
    // 3.17 US qt. If you mean 3 US qt, you are SOL unless you mark the field
    // as US Customary.
-   found = qstringToUnit().value(unit);
+
+   if ( ! unit.isEmpty() ) {
+      found = qstringToUnit().value(unit);
+   }
+   else if ( scale != Unit::noScale ) {
+      found = scaleToUnit().value(scale);
+   }
+
    if ( ! found )
       found = Unit::getUnit(unit,false);
 

--- a/src/UnitSystem.h
+++ b/src/UnitSystem.h
@@ -60,7 +60,7 @@ public:
     * followed by a unit string) to the appropriate SI amount under this
     * UnitSystem.
     */
-   double qstringToSI(QString qstr, Unit* defUnit = 0, bool force = false);
+   double qstringToSI(QString qstr, Unit* defUnit = 0, bool force = false, Unit::unitScale scale = Unit::noScale);
 
    Unit* scaleUnit(Unit::unitScale scale);
    /*!

--- a/src/WaterTableModel.h
+++ b/src/WaterTableModel.h
@@ -32,6 +32,7 @@ class WaterItemDelegate;
 #include <QItemDelegate>
 #include <QList>
 
+#include "unit.h"
 // Forward declarations.
 class Water;
 class WaterTableWidget;
@@ -81,6 +82,12 @@ private:
    QList<Water*> waterObs;
    Recipe* recObs;
    WaterTableWidget* parentTableWidget;
+
+   void setDisplayUnit(int column, Unit::unitDisplay displayUnit);
+   void setDisplayScale(int column, Unit::unitScale displayScale);
+   QString generateName(int column) const;
+   Unit::unitDisplay displayUnit(int column) const;
+   Unit::unitScale displayScale(int column) const;
 };
 
 /*!

--- a/src/YeastTableModel.cpp
+++ b/src/YeastTableModel.cpp
@@ -325,13 +325,15 @@ Qt::ItemFlags YeastTableModel::flags(const QModelIndex& index ) const
 bool YeastTableModel::setData( const QModelIndex& index, const QVariant& value, int role )
 {
    Yeast *row;
-   Unit::unitDisplay dispUnit;
    Unit* unit;
 
    if( index.row() >= (int)yeastObs.size() || role != Qt::EditRole )
       return false;
    else
       row = yeastObs[index.row()];
+
+   Unit::unitDisplay dspUnit = displayUnit(index.column());
+   Unit::unitScale   dspScl  = displayScale(index.column());
 
    switch( index.column() )
    {
@@ -369,10 +371,9 @@ bool YeastTableModel::setData( const QModelIndex& index, const QVariant& value, 
          if( ! value.canConvert(QVariant::String) )
             return false;
 
-         dispUnit = displayUnit(YEASTAMOUNTCOL);
          unit = row->amountIsWeight() ? (Unit*)Units::kilograms : (Unit*)Units::liters;
 
-         row->setAmount(Brewtarget::qStringToSI(value.toString(),unit,dispUnit));
+         row->setAmount(Brewtarget::qStringToSI(value.toString(),unit,dspUnit,dspScl));
          break;
 
       default:

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -1217,10 +1217,10 @@ QString Brewtarget::displayThickness( double thick_lkg, bool showUnits )
       return QString("%L1").arg(num/den, fieldWidth, format, precision).arg(volUnit->getUnitName()).arg(weightUnit->getUnitName());
 }
 
-double Brewtarget::qStringToSI(QString qstr, Unit* unit, Unit::unitDisplay dispUnit, bool force)
+double Brewtarget::qStringToSI(QString qstr, Unit* unit, Unit::unitDisplay dispUnit, Unit::unitScale dispScale)
 {
    UnitSystem* temp = findUnitSystem(unit, dispUnit);
-   return temp->qstringToSI(qstr,temp->unit(),force);
+   return temp->qstringToSI(qstr,temp->unit(),false,dispScale);
 }
 
 QString Brewtarget::ibuFormulaName()

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -232,7 +232,8 @@ public:
    static QPair<double,double> displayRange(QObject *object, QString attribute, double min, double max, RangeType _type = DENSITY);
 
    //! \return SI amount for the string
-   static double qStringToSI( QString qstr, Unit* unit, Unit::unitDisplay dispUnit = Unit::noUnit, bool force = false);
+   static double qStringToSI( QString qstr, Unit* unit, 
+         Unit::unitDisplay dispUnit = Unit::noUnit, Unit::unitScale dispScale = Unit::noScale);
 
    //! \brief return the bitterness formula's name
    static QString ibuFormulaName();


### PR DESCRIPTION
Assuming I did not utterly and completely make a mess of it, this should allow
us to scale input. What I mean by that is if you specify the scale of a field
to be (for example) grams, and then type 19 into that field, brewtarget will
now interpret this as 19 grams, not 19 kg.

The unit&scale mechanisms were about 90% in place. I had to modify a few
method signatures, a few method invocations in the tables and ONE LINE in
BtLineEdit. Everything should play by the rules now. 

I should also mention I had to add the necessary code to the WaterTableModel to deal with units and scales. One day, I really want to take the time to make that stuff work.