### PR TITLE
Closes #117: New ingredient can't be created into a folder

### DIFF
--- a/src/BtTreeView.cpp
+++ b/src/BtTreeView.cpp
@@ -39,6 +39,12 @@
 #include "yeast.h"
 #include "brewnote.h"
 #include "style.h"
+#include "FermentableDialog.h"
+#include "EquipmentEditor.h"
+#include "HopDialog.h"
+#include "MiscDialog.h"
+#include "StyleEditor.h"
+#include "YeastDialog.h"
 
 BtTreeView::BtTreeView(QWidget *parent, BtTreeModel::TypeMasks type) :
    QTreeView(parent)
@@ -325,12 +331,48 @@ bool BtTreeView::multiSelected()
    return hasRecipe && hasSomethingElse;
 }
 
+void BtTreeView::newIngredient() {
+
+   QString folder;
+   QModelIndexList indexes = selectionModel()->selectedRows();
+   // This is a little weird. There is an edge case where nothing is
+   // selected and you click the big blue + button.
+   if ( indexes.size() > 0 )
+      folder = folderName(indexes.at(0));
+
+   switch(_type) {
+      case BtTreeModel::EQUIPMASK:
+         qobject_cast<EquipmentEditor*>(_editor)->newEquipment(folder);
+         break;
+      case BtTreeModel::FERMENTMASK:
+         qobject_cast<FermentableDialog*>(_editor)->newFermentable(folder);
+         break;
+      case BtTreeModel::HOPMASK:
+         qobject_cast<HopDialog*>(_editor)->newHop(folder);
+         break;
+      case BtTreeModel::MISCMASK:
+         qobject_cast<MiscDialog*>(_editor)->newMisc(folder);
+         break;
+      case BtTreeModel::STYLEMASK:
+         qobject_cast<StyleEditor*>(_editor)->newStyle(folder);
+         break;
+      case BtTreeModel::YEASTMASK:
+         qobject_cast<YeastDialog*>(_editor)->newYeast(folder);
+         break;
+      default:
+         Brewtarget::logW(QString("BtTreeView::setupContextMenu unrecognized mask %1").arg(_type));
+   }
+
+}
+
 void BtTreeView::setupContextMenu(QWidget* top, QWidget* editor)
 {
    QMenu*_newMenu = new QMenu(this);
 
    _contextMenu = new QMenu(this);
    subMenu = new QMenu(this);
+
+   _editor = editor;
 
    _newMenu->setTitle(tr("New"));
    _contextMenu->addMenu(_newMenu);
@@ -351,19 +393,19 @@ void BtTreeView::setupContextMenu(QWidget* top, QWidget* editor)
 
          break;
       case BtTreeModel::EQUIPMASK:
-         _newMenu->addAction(tr("Equipment"), editor, SLOT(newEquipment()));
+         _newMenu->addAction(tr("Equipment"), this, SLOT(newIngredient()));
          break;
       case BtTreeModel::FERMENTMASK:
-         _newMenu->addAction(tr("Fermentable"), editor, SLOT(newFermentable()));
+         _newMenu->addAction(tr("Fermentable"), this, SLOT(newIngredient()));
          break;
       case BtTreeModel::HOPMASK:
-         _newMenu->addAction(tr("Hop"), editor, SLOT(newHop()));
+         _newMenu->addAction(tr("Hop"), this, SLOT(newIngredient()));
          break;
       case BtTreeModel::MISCMASK:
-         _newMenu->addAction(tr("Misc"), editor, SLOT(newMisc()));
+         _newMenu->addAction(tr("Misc"), this, SLOT(newIngredient()));
          break;
       case BtTreeModel::STYLEMASK:
-         _newMenu->addAction(tr("Style"), editor, SLOT(newStyle()));
+         _newMenu->addAction(tr("Style"), editor, SLOT(newIngredient()));
          break;
       case BtTreeModel::YEASTMASK:
          _newMenu->addAction(tr("Yeast"), editor, SLOT(newYeast()));

--- a/src/BtTreeView.cpp
+++ b/src/BtTreeView.cpp
@@ -405,10 +405,10 @@ void BtTreeView::setupContextMenu(QWidget* top, QWidget* editor)
          _newMenu->addAction(tr("Misc"), this, SLOT(newIngredient()));
          break;
       case BtTreeModel::STYLEMASK:
-         _newMenu->addAction(tr("Style"), editor, SLOT(newIngredient()));
+         _newMenu->addAction(tr("Style"), this, SLOT(newIngredient()));
          break;
       case BtTreeModel::YEASTMASK:
-         _newMenu->addAction(tr("Yeast"), editor, SLOT(newYeast()));
+         _newMenu->addAction(tr("Yeast"), this, SLOT(newIngredient()));
          break;
       default:
          Brewtarget::logW(QString("BtTreeView::setupContextMenu unrecognized mask %1").arg(_type));

--- a/src/BtTreeView.h
+++ b/src/BtTreeView.h
@@ -128,6 +128,9 @@ public:
    friend class YeastTreeView;
    friend class StyleTreeView;
 
+public slots:
+   void newIngredient();
+
 private slots:
    void expandFolder(BtTreeModel::TypeMasks kindaThing, QModelIndex fIdx);
 
@@ -137,6 +140,7 @@ private:
    BtTreeModel::TypeMasks _type;
    QMenu* _contextMenu, *subMenu;
    QPoint dragStart;
+   QWidget* _editor;
 
    bool doubleClick;
 

--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -638,6 +638,11 @@ void EquipmentEditor::save()
 
 void EquipmentEditor::newEquipment()
 {
+   newEquipment(QString());
+}
+
+void EquipmentEditor::newEquipment(QString folder)
+{
    QString name = QInputDialog::getText(this, tr("Equipment name"),
                                           tr("Equipment name:"));
    if( name.isEmpty() )
@@ -645,6 +650,9 @@ void EquipmentEditor::newEquipment()
 
    Equipment* e = Database::instance().newEquipment();
    e->setName( name );
+
+   if ( ! folder.isEmpty() )
+      e->setFolder(folder);
 
    setEquipment(e);
    show();

--- a/src/EquipmentEditor.h
+++ b/src/EquipmentEditor.h
@@ -38,6 +38,7 @@
 #include <QLineEdit>
 #include <QTextEdit>
 
+#include "BtLabel.h"
 // Forward declarations
 class BtGenericEdit;
 class BtMassEdit;
@@ -138,6 +139,7 @@ public:
    //! Edit the given equipment.
    void setEquipment( Equipment* e );
    
+   void newEquipment(QString folder);
 
 public slots:
    //! Save the changes to the equipment.

--- a/src/FermentableDialog.cpp
+++ b/src/FermentableDialog.cpp
@@ -206,7 +206,7 @@ void FermentableDialog::addFermentable(const QModelIndex& index)
    Database::instance().addToRecipe( mainWindow->currentRecipe(), ferm );
 }
 
-void FermentableDialog::newFermentable()
+void FermentableDialog::newFermentable(QString folder)
 {
    QString name = QInputDialog::getText(this, tr("Fermentable name"),
                                           tr("Fermentable name:"));
@@ -215,8 +215,15 @@ void FermentableDialog::newFermentable()
    
    Fermentable* ferm = Database::instance().newFermentable();
    ferm->setName(name);
+   if ( ! folder.isEmpty() )
+      ferm->setFolder(folder);
+
    fermEdit->setFermentable(ferm);
    fermEdit->show();
+}
+
+void FermentableDialog::newFermentable() {
+   newFermentable(QString());
 }
 
 void FermentableDialog::filterFermentables(QString searchExpression)

--- a/src/FermentableDialog.h
+++ b/src/FermentableDialog.h
@@ -63,6 +63,7 @@ public:
    QPushButton *pushButton_remove;
    //! @}
 
+   void newFermentable(QString folder);
 public slots:
    /*! If \b index is the default, will add the selected fermentable to list.
     *  Otherwise, will add the fermentable at the specified index.
@@ -70,9 +71,10 @@ public slots:
    void addFermentable(const QModelIndex& index = QModelIndex());
    void removeFermentable();
    void editSelected();
-   void newFermentable();
+
    void filterFermentables(QString searchExpression);
    //void changed(QMetaProperty,QVariant);
+   void newFermentable();
 
 protected:
 

--- a/src/HopDialog.cpp
+++ b/src/HopDialog.cpp
@@ -206,6 +206,10 @@ void HopDialog::editSelected()
 
 void HopDialog::newHop()
 {
+   newHop(QString());
+}
+void HopDialog::newHop(QString folder) 
+{
    QString name = QInputDialog::getText(this, tr("Hop name"),
                                           tr("Hop name:"));
    if( name.isEmpty() )
@@ -213,6 +217,9 @@ void HopDialog::newHop()
 
    Hop* hop = Database::instance().newHop();
    hop->setName(name);
+   if ( ! folder.isEmpty() )
+      hop->setFolder(folder);
+
    hopEditor->setHop(hop);
    hopEditor->show();
 }

--- a/src/HopDialog.h
+++ b/src/HopDialog.h
@@ -63,6 +63,8 @@ public:
    QLineEdit *qLineEdit_searchBox;
    //! @}
 
+   void newHop(QString folder);
+
 public slots:
    //! Add selected hop to current recipe.
    void addHop(const QModelIndex& = QModelIndex());

--- a/src/MiscDialog.cpp
+++ b/src/MiscDialog.cpp
@@ -202,6 +202,11 @@ void MiscDialog::editSelected()
 
 void MiscDialog::newMisc()
 {
+   newMisc(QString());
+}
+
+void MiscDialog::newMisc(QString folder) 
+{
    QString name = QInputDialog::getText(this, tr("Misc name"),
                                               tr("Misc name:"));
    if(name.isEmpty())
@@ -209,6 +214,9 @@ void MiscDialog::newMisc()
 
    Misc* m = Database::instance().newMisc();
    m->setName(name);
+   if ( ! folder.isEmpty() ) 
+      m->setFolder(folder);
+
    miscEdit->setMisc(m);
    miscEdit->show();
 }

--- a/src/MiscDialog.h
+++ b/src/MiscDialog.h
@@ -63,6 +63,7 @@ public:
    QPushButton *pushButton_remove;
    //! @}
 
+   void newMisc(QString folder);
 public slots:
    //! Add the selected misc to the current recipe.
    void addMisc(const QModelIndex& = QModelIndex());

--- a/src/StyleEditor.cpp
+++ b/src/StyleEditor.cpp
@@ -125,6 +125,11 @@ void StyleEditor::save()
 
 void StyleEditor::newStyle()
 {
+   newStyle(QString());
+}
+
+void StyleEditor::newStyle(QString folder)
+{
    QString name = QInputDialog::getText(this, tr("Style name"),
                                           tr("Style name:"));
    if( name.isEmpty() )
@@ -132,6 +137,8 @@ void StyleEditor::newStyle()
 
    Style *s = Database::instance().newStyle();
    s->setName( name );
+   if ( ! folder.isEmpty() ) 
+      s->setFolder(folder);
 
    setStyle(s);
    show();

--- a/src/StyleEditor.h
+++ b/src/StyleEditor.h
@@ -49,6 +49,8 @@ public:
    virtual ~StyleEditor() {}
    void setStyle( Style* s );
 
+   void newStyle(QString folder);
+
 public slots:
    void save();
    void newStyle();

--- a/src/YeastDialog.cpp
+++ b/src/YeastDialog.cpp
@@ -207,6 +207,11 @@ void YeastDialog::editSelected()
 
 void YeastDialog::newYeast()
 {
+   newYeast(QString());
+}
+
+void YeastDialog::newYeast(QString folder)
+{
    QString name = QInputDialog::getText(this, tr("Yeast name"),
                                               tr("Yeast name:"));
    if( name.isEmpty() )
@@ -214,6 +219,9 @@ void YeastDialog::newYeast()
 
    Yeast* y = Database::instance().newYeast();
    y->setName(name);
+   if ( ! folder.isEmpty() )
+      y->setFolder(folder);
+
    yeastEditor->setYeast(y);
    yeastEditor->show();
    y->setDisplay(true);

--- a/src/YeastDialog.h
+++ b/src/YeastDialog.h
@@ -64,6 +64,7 @@ public:
    QPushButton *pushButton_remove;
    //! @}
 
+   void newYeast(QString folder);
 public slots:
    void addYeast(const QModelIndex& = QModelIndex());
    void removeYeast();


### PR DESCRIPTION
It wasn't so much a bug as an intentional design choice. The problem I avoided
solving was that the tree didn't know which editor to call.

I fixed that by modifying the signal to call a BtTreeView slot, which figured
out the folder and called the proper editor. It required me adding a new
method to all of the editors, and modifying the signal slightly.