### PR TITLE
Closes #195 again .. again?

### DIFF
--- a/src/BtTreeModel.cpp
+++ b/src/BtTreeModel.cpp
@@ -989,7 +989,7 @@ bool BtTreeModel::renameFolder(BtFolder* victim, QString newName)
    QPair<QString,BtTreeItem*> f;
    QList<QPair<QString, BtTreeItem*> > folders;
    // This space is important       ^
-   int i;
+   int i, kids,src;
 
    if ( ! ndx.isValid() )
       return false;
@@ -1011,10 +1011,17 @@ bool BtTreeModel::renameFolder(BtFolder* victim, QString newName)
       targetPath = f.first;
       BtTreeItem* target = f.second;
 
+      // As we move things, childCount changes. This makes sure we loop
+      // through all of the kids
+      kids = target->childCount();
+      src = 0;
       // Ok. We have a start and an index.
-      for (i=0; i < target->childCount(); ++i)
+      for (i=0; i < kids; ++i)
       {
-         BtTreeItem* next = target->child(i);
+         // This looks weird and it is. As we move children out, the 0 items
+         // changes to the next child. In the case of a folder, though, we
+         // don't move it, so we need to get the item beyond that.
+         BtTreeItem* next = target->child(src);
          // If a folder, push it onto the folders stack for latter processing
          if ( next->type() == BtTreeItem::FOLDER ) 
          {
@@ -1022,6 +1029,7 @@ bool BtTreeModel::renameFolder(BtFolder* victim, QString newName)
             newTarget.first = targetPath % "/" % next->name();
             newTarget.second = next;
             folders.append(newTarget);
+            src++;
          }
          else // Leafnode
             next->thing()->setFolder(targetPath);


### PR DESCRIPTION
The rebase generated way too many collisions. It was faster to create a new
branch.

Moving folders used childCount() as the test condition in a for loop. Because
I moved the children into the new folder, childCount() got decremented by one.
This resulted in the loop counter getting incremented, the test condition
getting decremented and me moving only about half the children.

The fix is a bit more involved, since I don't move folders. I capture the
starting childCount at the start and use that for the test condition, and I
only take the first non-folder child through the whole operation. The only
tricky part is that I don't move folders, so I have to increment a counter to
indicate where the first non-folder item is.