### PR TITLE
Closes #206 - core while populating child tables

### DIFF
--- a/src/OptionDialog.h
+++ b/src/OptionDialog.h
@@ -76,7 +76,7 @@ private:
       NOCHANGE,
       NEEDSTEST,
       TESTFAILED,
-      TESTPASSED,
+      TESTPASSED
    };
 
    testStates status;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -310,14 +310,16 @@ bool Database::load()
          }
    }
 
-   // With the db open, we can get all our hashes. This has to happen before
-   // updateSchema
-   Database::tableNames = tableNamesHash();
-   Database::classNameToTable = classNameToTableHash();
    // Update the database if need be. This has to happen before we do anything
    // else or we dump core
    bool schemaErr = false;
    schemaUpdated = updateSchema(&schemaErr);
+
+   // Since updateSchema could add new tables, we have to wait until this
+   // point to populate the tables. 
+   Database::tableNames = tableNamesHash();
+   Database::classNameToTable = classNameToTableHash();
+
    if( schemaErr )
    {
          QMessageBox::critical(
@@ -327,7 +329,6 @@ bool Database::load()
          );
          return false;
    }
-
 
    // Initialize the SELECT * query hashes.
    selectAll = Database::selectAllHash();
@@ -1737,7 +1738,15 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table){
 }
 // populate ingredient tables
 void Database::populateChildTablesByName(){
+
    try {
+      // I really dislike this. It counts as spooky action at a distance, but
+      // the populateChildTablesByName methods need these hashes populated
+      // early and there is no easy way to untangle them. Yes, this results in
+      // the work being done twice. Such is life.
+      Database::tableNames = tableNamesHash();
+      Database::classNameToTable = classNameToTableHash();
+
       populateChildTablesByName(Brewtarget::FERMTABLE);
       populateChildTablesByName(Brewtarget::HOPTABLE);
       populateChildTablesByName(Brewtarget::MISCTABLE);

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -43,8 +43,8 @@ bool operator==(Fermentable &f1, Fermentable &f2);
 class Fermentable : public BeerXMLElement
 {
    Q_OBJECT
-   Q_CLASSINFO("signal", "fermentables");
-   Q_CLASSINFO("prefix", "fermentable");
+   Q_CLASSINFO("signal", "fermentables")
+   Q_CLASSINFO("prefix", "fermentable")
 
    friend class Brewtarget;
    friend class Database;

--- a/src/hop.h
+++ b/src/hop.h
@@ -42,8 +42,8 @@ bool operator==( Hop &h1, Hop &h2 );
 class Hop : public BeerXMLElement
 {
    Q_OBJECT
-   Q_CLASSINFO("signal", "hops");
-   Q_CLASSINFO("prefix", "hop");
+   Q_CLASSINFO("signal", "hops")
+   Q_CLASSINFO("prefix", "hop")
    
    friend class Database;
 public:

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -38,8 +38,8 @@
 class Instruction : public BeerXMLElement
 {
    Q_OBJECT
-   Q_CLASSINFO("signal", "instructions");
-   Q_CLASSINFO("prefix", "instruction");
+   Q_CLASSINFO("signal", "instructions")
+   Q_CLASSINFO("prefix", "instruction")
    friend class Database;
 public:
    

--- a/src/misc.h
+++ b/src/misc.h
@@ -38,8 +38,8 @@ class Misc;
 class Misc : public BeerXMLElement
 {
    Q_OBJECT
-   Q_CLASSINFO("signal", "miscs");
-   Q_CLASSINFO("prefix", "misc");
+   Q_CLASSINFO("signal", "miscs")
+   Q_CLASSINFO("prefix", "misc")
    
    friend class Database;
 public:

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -65,8 +65,8 @@ bool operator==(Recipe &r1, Recipe &r2 );
 class Recipe : public BeerXMLElement
 {
    Q_OBJECT
-   Q_CLASSINFO("signal", "recipes");
-   Q_CLASSINFO("prefix", "recipe");
+   Q_CLASSINFO("signal", "recipes")
+   Q_CLASSINFO("prefix", "recipe")
    
    friend class Database;
 public:

--- a/src/water.h
+++ b/src/water.h
@@ -39,8 +39,8 @@ bool operator==(Water &w1, Water &w2);
 class Water : public BeerXMLElement
 {
    Q_OBJECT
-   Q_CLASSINFO("signal", "waters");
-   Q_CLASSINFO("prefix", "water");
+   Q_CLASSINFO("signal", "waters")
+   Q_CLASSINFO("prefix", "water")
    
    friend class Database;
 public:

--- a/src/yeast.h
+++ b/src/yeast.h
@@ -41,8 +41,8 @@ bool operator==(Yeast &y1, Yeast &y2);
 class Yeast : public BeerXMLElement
 {
    Q_OBJECT
-   Q_CLASSINFO("signal", "yeasts");
-   Q_CLASSINFO("prefix", "yeast");
+   Q_CLASSINFO("signal", "yeasts")
+   Q_CLASSINFO("prefix", "yeast")
    
    friend class Database;
 public:


### PR DESCRIPTION
populateChildrenTables() requires the tableName hash to be populated, but
the hash can't be populated until after DatabaseSchemaHelper::migrate is
called. With the way the methods are written now, this leads to a chicken-egg
sort of problem.

I solved the problem by simply have populateChildrenTables() prepopulate the
hash. On the one time we need to call that method, the hash will get
initialized twice. I could maybe fix that, but it seemed an awful lot of work
for something that should happen once. In a broader question, shouldn't the
populateChildrenTables be part of the migrate code?

The changes to the header files are simply cleaning some compiler warnings.