### PR TITLE
Closes #211 - Crash recreating brewday instructions.

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -699,16 +699,17 @@ void Database::removeIngredientFromRecipe( Recipe* rec, BeerXMLElement* ing )
       q.setForwardOnly(true);
 
       if ( ! q.exec(deleteFromInRecipe) )
-         throw QString("failed to delete in recipe.");
+         throw QString("failed to delete in_recipe.");
 
-      if ( ! q.exec( deleteFromChildren ) )
+      // I don't really like this, but I can't think of a better solution. Of
+      // all the ingredients, instructions don't have a _children table. Given
+      // that it is only one table, I will try the easy way first
+      if ( tableName != "instruction" && ! q.exec( deleteFromChildren ) )
          throw QString("failed to delete children.");
 
       if ( ! q.exec( deleteIngredient ) )
          throw QString("failed to delete ingredient.");
 
-      if ( qobject_cast<Instruction*>(ing) ) 
-         sqlDelete( Brewtarget::INSTRUCTIONTABLE,QString("id=%1").arg(ing->_key));
    }
    catch ( QString e ) {
       Brewtarget::logE(QString("%1 %2 %3 %4")

--- a/src/database.h
+++ b/src/database.h
@@ -724,7 +724,6 @@ private:
             // Any ingredient part of a recipe shouldn't be visible, unless otherwise requested.
             // Not sure I like this. It's a long call stack just to end up back
             // here
-            qDebug() << Q_FUNC_INFO << "Bet its here";
             ing->setDisplay(! doNotDisplay );
          }
          else


### PR DESCRIPTION
The easy part is the problem defintion. In one of my multiple refactorings,
the removeIngredientFromRecipe method attempted to remove a line from
instruction_children, and that table doesn't exist.

I thrashed around a little, but it is one exception for just one class and I
didn't feel a more generic solution was required. This is, admittedly, a
little hackish and I will likely come to regret it later.

The change to database.h is removing a qDebug() line that I swear I have
removed at least three times already.