### PR TITLE
Closes #209 -- UI complains about missing widget

### DIFF
--- a/ui/mashWizard.ui
+++ b/ui/mashWizard.ui
@@ -132,7 +132,6 @@
   </layout>
   <zorder>buttonBox</zorder>
   <zorder>label_batches</zorder>
-  <zorder>verticalLayoutWidget</zorder>
  </widget>
  <tabstops>
   <tabstop>lineEdit_mashThickness</tabstop>


### PR DESCRIPTION
That was odd. Apparently, deleting widgets in designer can sometimes leave
behind zorder tags. According to those same sources, the only way to fix the
problem is to open the ui file with a text editor and remove the tag.

So I did and fixed it.