### PR TITLE
Closes #214 -- error in equipment editor definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ ENDIF()
 #==================================Find Qt5====================================
 
 # The minimum QT5 version we need. Keep as low as necessary.
-SET(QT5_MIN_VERSION 5.3)
+SET(QT5_MIN_VERSION 5.1)
 
 # Automatically run moc on source files when necessary
 SET(CMAKE_AUTOMOC ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ ENDIF()
 #==================================Find Qt5====================================
 
 # The minimum QT5 version we need. Keep as low as necessary.
-SET(QT5_MIN_VERSION 5.1)
+SET(QT5_MIN_VERSION 5.3)
 
 # Automatically run moc on source files when necessary
 SET(CMAKE_AUTOMOC ON)

--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -248,7 +248,7 @@ void EquipmentEditor::doLayout()
                      lineEdit_topUpWater->setSizePolicy(sizePolicy2);
                      lineEdit_topUpWater->setMinimumSize(QSize(100, 0));
                      lineEdit_topUpWater->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_topUpWater->setProperty("editField", QVariant(QStringLiteral("topUpKettle_l")));
+                     lineEdit_topUpWater->setProperty("editField", QVariant(QStringLiteral("topUpWater_l")));
                   label_absorption = new QLabel(groupBox_water);
                      label_absorption->setObjectName(QStringLiteral("label_absorption"));
                   lineEdit_grainAbsorption = new BtGenericEdit(groupBox_water);


### PR DESCRIPTION
Simple fix -- make certain the edit field refers to the actual field being edited. This is kind of a hot bug.

Any chance I can talk anybody into reverting to the UI files until I can get the QML files working?