### PR TITLE
Use vagrant for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/*
 # Kate project
 .kateproject.d/
 .idea
+
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,6 +68,6 @@ Vagrant.configure(2) do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "provision.yml"
+    ansible.playbook = "vagrant/provision.yml"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,93 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  #config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/wily64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  config.ssh.forward_x11 = true
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+   config.vm.provision "shell", inline: <<-SHELL
+     # Install Postgres 9.5
+     # Instructions lifted from https://wiki.postgresql.org/wiki/Apt#PostgreSQL_packages_for_Debian_and_Ubuntu
+     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+     sudo apt-get install wget ca-certificates
+     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+     sudo apt-get update
+     sudo apt-get upgrade
+     sudo apt-get install -y postgresql-9.5
+
+     sudo apt-get install -y build-essential
+     sudo apt-get install -y \
+        cmake \
+        qt5-default \
+        libqt5sql5-psql \
+        libqt5svg5-dev \
+        libqt5webkit5-dev \
+        libqt5multimedia5 \
+        qtmultimedia5-dev \
+        qttools5-dev \
+        qttools5-dev-tools \
+
+   SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,27 +67,7 @@ Vagrant.configure(2) do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-   config.vm.provision "shell", inline: <<-SHELL
-     # Install Postgres 9.5
-     # Instructions lifted from https://wiki.postgresql.org/wiki/Apt#PostgreSQL_packages_for_Debian_and_Ubuntu
-     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-     sudo apt-get install wget ca-certificates
-     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-     sudo apt-get update
-     sudo apt-get upgrade
-     sudo apt-get install -y postgresql-9.5
-
-     sudo apt-get install -y build-essential
-     sudo apt-get install -y \
-        cmake \
-        qt5-default \
-        libqt5sql5-psql \
-        libqt5svg5-dev \
-        libqt5webkit5-dev \
-        libqt5multimedia5 \
-        qtmultimedia5-dev \
-        qttools5-dev \
-        qttools5-dev-tools \
-
-   SHELL
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "provision.yml"
+  end
 end

--- a/dev-doc/vagrant.markdown
+++ b/dev-doc/vagrant.markdown
@@ -1,0 +1,27 @@
+Using Vagrant
+=============
+
+Vagrant allows for easily starting a VM in a known state.  This is perfect for
+development because it reduces the amount of manual configuration needed to get
+started, and helps ensure you don't introduce accidental dependencies.
+
+Requirements
+------------
+  * Install [vagrant](https://www.vagrantup.com/docs/installation/)
+  * Install [ansible](https://docs.ansible.com/ansible/intro_installation.html)
+
+
+Usage
+-----
+In the project directory, run `vagrant up`.  Vagrant will download the required
+VM image and configure it using Ansible.  The resulting VM will have Postgres
+9.5 installed with a brewtarget database & user.  A default brewtarget.conf
+which uses this Postgres database is installed for the vagrant user.
+
+Once vagrant has build the machine you can access it via `vagrant ssh`.
+Because brewtarget is a GUI application, you will probably want to have
+XForwarding back to your workstation.  A script to do this is provided as
+`vagrant/login`.
+
+The project directory will be automatically mounted at `/vagrant`.  Builds can
+be done in that directory using the normal toolchain.

--- a/provision.yml
+++ b/provision.yml
@@ -1,0 +1,57 @@
+---
+- hosts: all
+  become: true
+
+  tasks:
+    - name: Config Postgres repo
+      shell: echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+        creates=/etc/apt/sources.list.d/pgdg.list
+      tags:
+        - install
+
+    - name: Install Postgres apt key
+      apt_key:
+        url=https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        state=present
+      tags:
+        - install
+
+    - name: Install packages
+      apt:
+        name={{item}}
+        state=present
+        update_cache=yes
+      with_items:
+        - build-essential
+        - cmake
+        - qt5-default
+        - libqt5sql5-psql
+        - libqt5svg5-dev
+        - libqt5webkit5-dev
+        - libqt5multimedia5
+        - qtmultimedia5-dev
+        - qttools5-dev
+        - qttools5-dev-tools
+        - postgresql-9.5
+        - python-psycopg2
+      tags:
+        - install
+
+
+
+    - name: Create postgres user
+      become_user: postgres
+      postgresql_user:
+        name=brewtarget
+        password=brewtarget
+        role_attr_flags=NOCREATEDB,NOSUPERUSER
+      tags: dbsetup
+
+    - name: Create postgres database
+      become_user: postgres
+      postgresql_db:
+        name=brewtarget
+        owner=brewtarget
+      tags: dbsetup
+
+# vim: ft=ansible

--- a/vagrant/files/brewtarget.conf
+++ b/vagrant/files/brewtarget.conf
@@ -1,0 +1,25 @@
+[General]
+check_version=false
+color_formula=morey
+color_unit=srm
+converted=Sat Mar 19 2016
+date_format=256
+dbHostname=localhost
+dbName=brewtarget
+dbPassword=brewtarget
+dbPortnum=5432
+dbSchema=public
+dbType=1
+dbUsername=brewtarget
+firstWortHopAdjustment=1.1
+geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x2\0\0\0\0\0\0\0\0\0\x1\0\0\x6?\0\0\x3\x8f\0\0\0\0\0\0\0\x17\0\0\x6?\0\0\x3\x8f\0\0\0\0\0\0\0\0\f\x80)
+ibu_formula=tinseth
+language=en
+last_db_merge_req=2016-03-19T05:03:46
+mashHopAdjustment=0
+recipeKey=1
+temperature_scale=SI
+use_plato=false
+user_data_dir=/home/vagrant/.config/brewtarget
+volume_unit_system=SI
+weight_unit_system=SI

--- a/vagrant/login
+++ b/vagrant/login
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+SSH_CONF=`mktemp vagrant_ssh.XXXXXXX`
+
+vagrant ssh-config > ${SSH_CONF}
+ssh -X -F ${SSH_CONF} default
+
+rm ${SSH_CONF}

--- a/vagrant/provision.yml
+++ b/vagrant/provision.yml
@@ -54,4 +54,19 @@
         owner=brewtarget
       tags: dbsetup
 
+
+    - name: Create config directories
+      file:
+        state=directory
+        path=/home/vagrant/.config/brewtarget/
+        recurse=yes
+        owner=vagrant
+
+    - name: Install default config
+      copy:
+        src=brewtarget.conf
+        dest=/home/vagrant/.config/brewtarget/brewtarget.conf
+        owner=vagrant
+        mode=0644
+
 # vim: ft=ansible


### PR DESCRIPTION
I added Vagrant infrastructure to make it easier to try out the new Postgres support.  This PR includes an Ansible playbook which configures the machine with the correct version of Postgres & configures the database.

Documentation is included in dev-doc/vagrant.markdown