### PR TITLE
Closes #220 - incorrect mash temperature

### DIFF
--- a/src/HopTableModel.cpp
+++ b/src/HopTableModel.cpp
@@ -295,7 +295,7 @@ QVariant HopTableModel::data( const QModelIndex& index, int role ) const
 
          scale = displayScale(col);
 
-         return QVariant( Brewtarget::displayAmount(row->time_min(), Units::minutes, 0, Unit::noUnit, scale) );
+         return QVariant( Brewtarget::displayAmount(row->time_min(), Units::minutes, 3, Unit::noUnit, scale) );
       case HOPFORMCOL:
         if ( role == Qt::DisplayRole )
           return QVariant( row->formStringTr() );

--- a/src/MashStepTableModel.cpp
+++ b/src/MashStepTableModel.cpp
@@ -175,7 +175,7 @@ QVariant MashStepTableModel::data( const QModelIndex& index, int role ) const
          return QVariant( Brewtarget::displayAmount(row->stepTemp_c(), Units::celsius,3, unit, Unit::noScale) );
       case MASHSTEPTIMECOL:
          scale = displayScale(col);
-         return QVariant( Brewtarget::displayAmount(row->stepTime_min(), Units::minutes,0,Unit::noUnit,scale) );
+         return QVariant( Brewtarget::displayAmount(row->stepTime_min(), Units::minutes,3,Unit::noUnit,scale) );
       default :
          Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
          return QVariant();

--- a/src/MiscTableModel.cpp
+++ b/src/MiscTableModel.cpp
@@ -215,7 +215,7 @@ QVariant MiscTableModel::data( const QModelIndex& index, int role ) const
 
          scale = displayScale(MISCTIMECOL);
 
-         return QVariant( Brewtarget::displayAmount(row->time(), Units::minutes, 0, Unit::noUnit, scale) );
+         return QVariant( Brewtarget::displayAmount(row->time(), Units::minutes, 3, Unit::noUnit, scale) );
       case MISCINVENTORYCOL:
          if( role != Qt::DisplayRole )
             return QVariant();


### PR DESCRIPTION
Just noticed the bug is not well named. Anyway. I missed three places where
time data was being shown with a precision of 0. This worked before I decided
time should be decimal. This patch corrects those three places, and the bug
goes back to 2.3.1 so I'm retro'ing it.