### PR TITLE
Closes #223 Changing IBU formula or mash/fwh percentages, nothing happens

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -884,10 +884,16 @@ void MainWindow::showChanges(QMetaProperty* prop)
 
    // See if we need to change the mash in the table.
    if( (updateAll && recipeObs->mash()) ||
-       (propName == "mash" &&
-       recipeObs->mash()) )
+       (propName == "mash" && recipeObs->mash()) )
    {
       mashStepTableModel->setMash(recipeObs->mash());
+   }
+
+   // Not sure about this, but I am annoyed that modifying the hop usage
+   // modifiers isn't automatically updating my display
+   if ( updateAll ) {
+     recipeObs->acceptHopChange( recipeObs->metaProperty("hops"), QVariant());
+     hopTableProxy->invalidate();
    }
 }
 


### PR DESCRIPTION
Right now, if you modify the hop usage percentages or the IBU formula, you
have to restart brewtarget. This was surprisingly annoying to me, so I fixed
it.