### PR TITLE
Fixes #221 - Can't add mash step in dev

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1047,73 +1047,6 @@ QList<Yeast*> Database::yeasts(Recipe const* parent)
 
 // Named constructors =========================================================
 
-int Database::insertNewDefaultRecord( Brewtarget::DBTable table )
-{
-   int key;
-   QString insert = QString("INSERT INTO %1 DEFAULT VALUES").arg(tableNames[table]);
-   QSqlQuery q(sqlDatabase());
-
-   try {
-      if ( ! q.exec(insert) )
-         throw QString("could not insert a record into");
-   }
-   catch ( QString e ) {
-      Brewtarget::logE(QString("%1 %2 %3 %4")
-                           .arg(Q_FUNC_INFO)
-                           .arg(e)
-                           .arg(q.lastQuery())
-                           .arg(q.lastError().text()));
-      q.finish();
-      throw;
-   }
-
-   key = q.lastInsertId().toInt();
-   q.finish();
-
-   makeDirty();
-   return key;
-}
-
-// If we are doing triggers for instructions, why aren't we doing triggers for
-// mash steps?
-
-int Database::insertNewMashStepRecord( Mash* parent )
-{
-   int key;
-   QString coalesce = QString( "step_number = (SELECT COALESCE(MAX(step_number)+1,0) FROM %1 WHERE deleted=%2 AND mash_id=%3 )")
-                        .arg(tableNames[Brewtarget::MASHSTEPTABLE])
-                        .arg(Brewtarget::dbFalse())
-                        .arg(parent->_key);
-
-   sqlDatabase().transaction();
-
-   QSqlQuery q(sqlDatabase());
-   q.setForwardOnly(true);
-
-   try {
-      key = insertNewDefaultRecord(Brewtarget::MASHSTEPTABLE);
-      if ( key == -42 )
-         throw QString("invalid key");
-
-      // I *think* we need to set the mash_id first
-      sqlUpdate( Brewtarget::MASHSTEPTABLE, QString("mash_id=%1 ").arg(parent->_key), QString("id=%1").arg(key) );
-
-      // Just sets the step number within the mash to the next available number.
-      // we need coalesce here instead of isnull. coalesce is SQL standard, so
-      // should be more widely supported than isnull
-      sqlUpdate( Brewtarget::MASHSTEPTABLE, coalesce, QString("id=%1").arg(key) );
-   }
-   catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
-      sqlDatabase().rollback();
-      throw;
-   }
-
-   sqlDatabase().commit();
-   makeDirty();
-   return key;
-}
-
 BrewNote* Database::newBrewNote(BrewNote* other, bool signal)
 {
    BrewNote* tmp = copy<BrewNote>(other, true, &allBrewNotes);
@@ -1132,20 +1065,13 @@ BrewNote* Database::newBrewNote(BrewNote* other, bool signal)
 
 BrewNote* Database::newBrewNote(Recipe* parent, bool signal)
 {
-   BrewNote* tmp = new BrewNote();
-   int key;
+   BrewNote* tmp;
 
    sqlDatabase().transaction();
 
    try {
-      key = insertNewDefaultRecord(Brewtarget::BREWNOTETABLE);
-      if ( key == -42 )
-         throw QString("could not insert new brewnote");
+      tmp = newIngredient(&allBrewNotes);
 
-      tmp->_key = key;
-      tmp->_table = Brewtarget::BREWNOTETABLE;
-
-      allBrewNotes.insert(tmp->_key,tmp);
       sqlUpdate( Brewtarget::BREWNOTETABLE,
                QString("recipe_id=%1").arg(parent->_key),
                QString("id=%2").arg(tmp->_key) );
@@ -1243,13 +1169,9 @@ Instruction* Database::newInstruction(Recipe* rec)
    try {
       tmp = newIngredient(&allInstructions);
 
-      if ( ! tmp )
-         throw QString("Could not create new instruction");
       // Add without copying to "instruction_in_recipe". We already have a
       // transaction open, so tell addIng to not worry about it
-         tmp = addIngredientToRecipe<Instruction>(rec,tmp,true,0,false,false);
-         if ( ! tmp )
-            throw QString("Could not add instruction to recipe");
+      tmp = addIngredientToRecipe(rec,tmp,true,0,false,false);
    }
    catch ( QString e ) {
       Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
@@ -1278,23 +1200,6 @@ int Database::instructionNumber(Instruction const* in)
       return q.record().value("instruction_number").toInt();
    else
       return 0;
-}
-
-// TODO: Fix these -- I would like to see if there is a reasonable way to
-// collapse these three methods into one
-Mash* Database::newMash()
-{
-   Mash* tmp = new Mash();
-   tmp->_key = insertNewDefaultRecord(Brewtarget::MASHTABLE);
-   tmp->_table = Brewtarget::MASHTABLE;
-
-   allMashs.insert(tmp->_key,tmp);
-
-   makeDirty();
-   emit changed( metaProperty("mashs"), QVariant() );
-   emit newMashSignal(tmp);
-
-   return tmp;
 }
 
 Mash* Database::newMash(Mash* other, bool displace)
@@ -1351,9 +1256,6 @@ Mash* Database::newMash(Recipe* parent, bool transact)
    try {
       tmp = newIngredient(&allMashs);
 
-      if ( ! tmp )
-         throw QString("Could not create new mash");
-
       // Connect tmp to parent, removing any existing mash in parent.
       sqlUpdate( Brewtarget::RECTABLE,
                  QString("mash_id=%1").arg(tmp->_key),
@@ -1377,20 +1279,39 @@ Mash* Database::newMash(Recipe* parent, bool transact)
    return tmp;
 }
 
+// If we are doing triggers for instructions, why aren't we doing triggers for
+// mash steps?
 MashStep* Database::newMashStep(Mash* mash, bool connected)
 {
    // TODO: encapsulate in QUndoCommand.
    // NOTE: we have unique(mash_id,step_number) constraints on this table,
    // so may have to pay special attention when creating the new record.
    MashStep* tmp;
+   QString coalesce = QString( "step_number = (SELECT COALESCE(MAX(step_number)+1,0) FROM %1 WHERE deleted=%2 AND mash_id=%3 )")
+                        .arg(tableNames[Brewtarget::MASHSTEPTABLE])
+                        .arg(Brewtarget::dbFalse())
+                        .arg(mash->_key);
 
    sqlDatabase().transaction();
 
+   QSqlQuery q(sqlDatabase());
+   q.setForwardOnly(true);
+
+   // mashsteps are weird, because we have to do the linking between step and
+   // mash
    try {
       tmp = newIngredient(&allMashSteps);
 
-      if ( !tmp )
-         throw QString("Could not create new mashstep");
+      // I *think* we need to set the mash_id first
+      sqlUpdate( Brewtarget::MASHSTEPTABLE, 
+                 QString("mash_id=%1 ").arg(mash->_key),
+                 QString("id=%1").arg(tmp->_key)
+               );
+
+      // Just sets the step number within the mash to the next available number.
+      // we need coalesce here instead of isnull. coalesce is SQL standard, so
+      // should be more widely supported than isnull
+      sqlUpdate( Brewtarget::MASHSTEPTABLE, coalesce, QString("id=%1").arg(tmp->_key) );
    }
    catch (QString e) {
       Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
@@ -1398,12 +1319,11 @@ MashStep* Database::newMashStep(Mash* mash, bool connected)
       throw;
    }
 
-   allMashSteps.insert(tmp->_key,tmp);
+   sqlDatabase().commit();
 
    if ( connected ) 
       connect( tmp, SIGNAL(changed(QMetaProperty,QVariant)), mash, SLOT(acceptMashStepChange(QMetaProperty,QVariant)) );
 
-   sqlDatabase().commit();
    makeDirty();
    emit changed( metaProperty("mashs"), QVariant() );
    emit mash->mashStepsChanged();
@@ -1442,11 +1362,7 @@ Recipe* Database::newRecipe()
    try {
       tmp = newIngredient(&allRecipes);
 
-      if ( ! tmp )
-         throw QString("Could not create new recipe");
-
-      if( ! newMash(tmp,false) )
-         throw QString("Could not create new mash");
+      newMash(tmp,false);
    }
    catch (QString e ) {
       Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
@@ -1462,8 +1378,9 @@ Recipe* Database::newRecipe()
    return tmp;
 }
 
-// TODO: Oh my. This ... the entire thing should be transacted. But there is
-// no way to tell each of the addTo* to not transact and ... oh my.
+// TODO: Oh my. This the entire thing should be transacted. It took some work
+// to get all the addToRecipe methods to play nice.
+// 
 Recipe* Database::newRecipe(Recipe* other)
 {
    Recipe* tmp;
@@ -1504,21 +1421,21 @@ Style* Database::newStyle(Style* other)
 {
    Style* tmp;
 
-   if ( other )
-      tmp = copy(other, true, &allStyles);
-   else
-      tmp = newIngredient(&allStyles);
+   try {
+      if ( other )
+         tmp = copy(other, true, &allStyles);
+      else
+         tmp = newIngredient(&allStyles);
+   }
+   catch (QString e) {
+      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      sqlDatabase().rollback();
+      throw;
+   }
 
-   if ( tmp ) {
-      makeDirty();
-      emit changed( metaProperty("styles"), QVariant() );
-      emit newStyleSignal(tmp);
-   }
-   else {
-      Brewtarget::logE( QString("%1 could not %2 hop")
-            .arg(Q_FUNC_INFO)
-            .arg( other ? "copy" : "create"));
-   }
+   makeDirty();
+   emit changed( metaProperty("styles"), QVariant() );
+   emit newStyleSignal(tmp);
 
    return tmp;
 }
@@ -1527,22 +1444,21 @@ Water* Database::newWater(Water* other)
 {
    Water* tmp;
 
-   if ( other )
-      tmp = copy(other,true,&allWaters);
-   else
-      tmp = newIngredient(&allWaters);
-
-
-   if ( tmp ) {
-      makeDirty();
-      emit changed( metaProperty("waters"), QVariant() );
-      emit newWaterSignal(tmp);
+   try {
+      if ( other )
+         tmp = copy(other,true,&allWaters);
+      else
+         tmp = newIngredient(&allWaters);
    }
-   else {
-      Brewtarget::logE( QString("%1 could not %2 hop")
-            .arg(Q_FUNC_INFO)
-            .arg( other ? "copy" : "create"));
+   catch (QString e) {
+      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      sqlDatabase().rollback();
+      throw;
    }
+
+   makeDirty();
+   emit changed( metaProperty("waters"), QVariant() );
+   emit newWaterSignal(tmp);
 
    return tmp;
 }
@@ -1551,22 +1467,22 @@ Yeast* Database::newYeast(Yeast* other)
 {
    Yeast* tmp;
 
-   if (other)
-      tmp = copy(other, true, &allYeasts);
-   else
-      tmp = newIngredient(&allYeasts);
+   try {
+      if (other)
+         tmp = copy(other, true, &allYeasts);
+      else
+         tmp = newIngredient(&allYeasts);
+   }
+   catch (QString e) {
+      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      sqlDatabase().rollback();
+      throw;
+   }
 
 
-   if ( tmp ) {
-      makeDirty();
-      emit changed( metaProperty("yeasts"), QVariant() );
-      emit newYeastSignal(tmp);
-   }
-   else {
-      Brewtarget::logE( QString("%1 could not %2 hop")
-            .arg(Q_FUNC_INFO)
-            .arg( other ? "copy" : "create"));
-   }
+   makeDirty();
+   emit changed( metaProperty("yeasts"), QVariant() );
+   emit newYeastSignal(tmp);
 
    return tmp;
 }
@@ -1579,7 +1495,7 @@ void Database::deleteRecord( Brewtarget::DBTable table, BeerXMLElement* object )
 
    try {
       updateEntry( table, object->_key, "deleted", Brewtarget::dbTrue(),
-                   object->metaObject()->property(ndx), object, false, false);
+                   object->metaObject()->property(ndx), object, true);
    }
    catch (QString e) {
       Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e) );
@@ -1669,6 +1585,10 @@ void Database::updateEntry( Brewtarget::DBTable table, int key, const char* col_
 
    if ( transact )
       sqlDatabase().commit();
+
+   if ( notify )
+      emit object->changed(prop,value);
+
    makeDirty();
 
 }
@@ -1681,9 +1601,7 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table){
    Brewtarget::logW( "Populating Children Ingredient Links" );
 
    try {
-      QString queryString = QString(
-         "SELECT DISTINCT name FROM %1"
-      ).arg(tableNames[table]);
+      QString queryString = QString("SELECT DISTINCT name FROM %1").arg(tableNames[table]);
 
       QSqlQuery nameq( queryString, sqlDatabase() );
 
@@ -2138,7 +2056,7 @@ void Database::addToRecipe( Recipe* rec, QList<Yeast*>yeasts, bool transact )
    try {
       foreach (Yeast* yeast, yeasts )
       {
-         Yeast* newYeast = addIngredientToRecipe<Yeast>( rec, yeast, false, &allYeasts,true,false );
+         Yeast* newYeast = addIngredientToRecipe( rec, yeast, false, &allYeasts,true,false );
          connect( newYeast, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptYeastChange(QMetaProperty,QVariant)));
       }
    }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1171,7 +1171,7 @@ Instruction* Database::newInstruction(Recipe* rec)
 
       // Add without copying to "instruction_in_recipe". We already have a
       // transaction open, so tell addIng to not worry about it
-      tmp = addIngredientToRecipe(rec,tmp,true,0,false,false);
+      tmp = addIngredientToRecipe<Instruction>(rec,tmp,true,0,false,false);
    }
    catch ( QString e ) {
       Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));

--- a/src/database.h
+++ b/src/database.h
@@ -150,10 +150,18 @@ public:
       T* tmp = new T();
       // To quote the talking heads, my god what have I done?
       Brewtarget::DBTable table = classNameToTable[ tmp->metaObject()->className() ];
+      QString insert = QString("INSERT INTO %1 DEFAULT VALUES").arg(tableNames[table]);
+
+      QSqlQuery q(sqlDatabase());
+
+      q.setForwardOnly(true);
+
       try {
-         key = insertNewDefaultRecord(table);
-         if ( key == -42 )
-            throw QString("could not create default %1").arg(tmp->metaObject()->className());
+         if ( ! q.exec(insert) )
+            throw QString("could not insert a record into");
+
+         key = q.lastInsertId().toInt();
+         q.finish();
       }
       catch (QString e) {
          Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
@@ -174,8 +182,7 @@ public:
 
    MashStep* newMashStep(Mash* parent, bool connected = true);
 
-   Mash* newMash();
-   Mash* newMash(Mash* other, bool displace = true);
+   Mash* newMash(Mash* other = 0, bool displace = true);
    Mash* newMash(Recipe* parent, bool transaction = true);
 
    Recipe* newRecipe();
@@ -259,10 +266,8 @@ public:
    // of ingredients in rec.
    void removeIngredientFromRecipe( Recipe* rec, BeerXMLElement* ing );
 
-   // Two odd balls I can't resolve quite yet. But I will.
+   // An odd ball I can't resolve quite yet. But I will.
    // This one isn't even needed. remove does it
-   // void removeFromRecipe( Recipe* rec, BrewNote* b );
-   // 
    void removeFromRecipe( Recipe* rec, Instruction* ins );
 
    //! Remove \b step from \b mash.
@@ -636,16 +641,6 @@ private:
    {
       return metaObject()->property(metaObject()->indexOfProperty(name));
    }
-
-   /*! Make a new row in the \b table.
-    *  \returns key of new row.
-    *  Only works if all the fields in the table have default values.
-    */
-   int insertNewDefaultRecord( Brewtarget::DBTable table );
-
-   /*! Insert a new row in \b mashstep, where \b parent is the parent mash.
-    */
-   int insertNewMashStepRecord( Mash* parent );
 
    //! Mark the \b object in \b table as deleted.
    void deleteRecord( Brewtarget::DBTable table, BeerXMLElement* object );


### PR DESCRIPTION
Two problems, and a few cleanups.

The first problem was that newMashStep() wasn't calling insertNewMashStep(),
so the extra two steps to connect the mashstep to its mash weren't being done.
In fixing this, I was able to remove both insertNewDefaultIngredient and
insertNewDefaultMash. Nice little bonus there.

The second problem was I had missed a signal when I removed the SetterCommand
class. Basically, it never signaled anything had changed. I added the signal
back in, and things are happy again. I've tested by mucking around in the
mashstep editor and playing with the hops.

In the process, I found a few methods that hadn't been updated to use the hot
new try-catch process or were doing it wrong. I cleaned those up.