### PR TITLE
Make running instance check less Linux specific

### DIFF
--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -396,6 +396,14 @@ private:
     */
    static void cleanup();
 
+
+   /*!
+    * \brief Checks if another instance is already running.
+    *
+    * Currently only works on Unix systems.
+    */
+   static bool instanceRunning();
+
    /*!
     *  \brief Helper to get option values from XML.
     *


### PR DESCRIPTION
Someday I'd like to get Brewtarget to build on BSD.  This is one very tiny step towards that goal.

This does change the behavior slightly in that the single-instance restriction is only enforced if the user is using SQLite.  I don't think there is any harm in allowing multiple instances to run against Postgres. (Although I may doubt the usefulness)