### PR TITLE
A pleasing rework of BtLineEdit

### DIFF
--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -27,41 +27,11 @@
 #include <QSettings>
 #include <QDebug>
 
-BtLineEdit::BtLineEdit(QWidget *parent, FieldType type) :
+BtLineEdit::BtLineEdit(QWidget *parent, Unit::UnitType type) :
    QLineEdit(parent)
 {
    btParent = parent;
    _type = type;
-
-   switch( _type )
-   {
-      case MASS:
-         // I don't ... oh bugger
-         _units = Units::kilograms;
-         break;
-      case VOLUME:
-         _units = Units::liters;
-         break;
-      case TEMPERATURE:
-         _units = Units::celsius;
-         break;
-      case TIME:
-         _units = Units::minutes;
-         break;
-      case COLOR:
-         _units = Units::srm;
-         break;
-      case DENSITY:
-         _units = Units::sp_grav;
-         break;
-      case MIXED:
-         _units = Units::kilograms;
-         break;
-      case GENERIC:
-      case STRING:
-         _units = 0;
-         break;
-   }
 
    connect(this,SIGNAL(editingFinished()),this,SLOT(lineChanged()));
 }
@@ -69,43 +39,6 @@ BtLineEdit::BtLineEdit(QWidget *parent, FieldType type) :
 void BtLineEdit::lineChanged()
 {
    lineChanged(Unit::noUnit,Unit::noScale);
-}
-
-// Dynamic properties need to be evaluated late, so we do it this way
-void BtLineEdit::initializeProperties()
-{
-   QVariant unitName = property("forcedUnit");
-   _property = property("editField").toString();
-
-
-   if ( unitName.isValid() ) 
-   {
-      const QMetaObject &mo = Unit::staticMetaObject;
-      int index = mo.indexOfEnumerator("unitDisplay");
-      QMetaEnum unitEnum = mo.enumerator(index);
-
-      _forceUnit = (Unit::unitDisplay)unitEnum.keyToValue(unitName.toString().toStdString().c_str());
-   }
-   else 
-   {
-      _forceUnit = Unit::noUnit;
-   }
-
-   unitName = property("forcedScale");
-   _property = property("editField").toString();
-
-   if ( unitName.isValid() )
-   {
-      const QMetaObject &mo = Unit::staticMetaObject;
-      int index = mo.indexOfEnumerator("unitScale");
-      QMetaEnum unitEnum = mo.enumerator(index);
-      _forceScale = (Unit::unitScale)unitEnum.keyToValue(unitName.toString().toStdString().c_str());
-   }
-
-   else
-   {
-      _forceScale = Unit::noScale;
-   }
 }
 
 void BtLineEdit::initializeSection()
@@ -147,9 +80,6 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
    if ( _section.isEmpty() )
       initializeSection();
 
-   if ( _property.isEmpty() )
-      initializeProperties();
-
    if (text().isEmpty())
    {
       return;
@@ -159,26 +89,26 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
    // amount (aka to SI) and then into the unit we want.
    switch( _type )
    {
-      case MASS:
-      case VOLUME:
-      case TEMPERATURE:
-      case TIME:
-      case DENSITY:
+      case Unit::Mass:
+      case Unit::Volume:
+      case Unit::Temp:
+      case Unit::Time:
+      case Unit::Density:
          val = toSI(oldUnit,oldScale,force);
          amt = displayAmount(val,3);
          break;
-      case COLOR:
+      case Unit::Color:
          val = toSI(oldUnit,oldScale,force);
          amt = displayAmount(val,0);
          break;
-      case STRING:
+      case Unit::String:
          amt = text();
          break;
-      case GENERIC:
+      case Unit::None:
       default:
          val = Brewtarget::toDouble(text(),&ok);
          if ( ! ok )
-            Brewtarget::logW( QString("BtLineEdit::lineChanged: failed to convert %1 toDouble").arg(text()) );
+            Brewtarget::logW( QString("%1: failed to convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(text()).arg(_section).arg(_editField) );
          amt = displayAmount(val);
    }
    QLineEdit::setText(amt);
@@ -198,8 +128,6 @@ double BtLineEdit::toSI(Unit::unitDisplay oldUnit,Unit::unitScale oldScale,bool 
 
    if ( _section.isEmpty() )
       initializeSection();
-   if ( _property.isEmpty() )
-      initializeProperties();
 
    // If force is set, just use what is provided in the call. If we are
    // not forcing the unit & scale, we need to read the configured properties
@@ -209,13 +137,13 @@ double BtLineEdit::toSI(Unit::unitDisplay oldUnit,Unit::unitScale oldScale,bool 
       if ( _forceUnit != Unit::noUnit )
          dspUnit = _forceUnit;
       else
-         dspUnit   = (Unit::unitDisplay)Brewtarget::option(_property, Unit::noUnit, _section, Brewtarget::UNIT).toInt();
+         dspUnit   = (Unit::unitDisplay)Brewtarget::option(_editField, Unit::noUnit, _section, Brewtarget::UNIT).toInt();
 
       // If the display scale is forced, use this scale as the default one.
       if( _forceScale != Unit::noScale )
          dspScale = _forceScale;
       else
-         dspScale  = (Unit::unitScale)Brewtarget::option(_property, Unit::noUnit, _section, Brewtarget::SCALE).toInt();
+         dspScale  = (Unit::unitScale)Brewtarget::option(_editField, Unit::noUnit, _section, Brewtarget::SCALE).toInt();
    }
 
    // Find the unit system containing dspUnit
@@ -233,15 +161,15 @@ double BtLineEdit::toSI(Unit::unitDisplay oldUnit,Unit::unitScale oldScale,bool 
       // Force the issue in qstringToSI() unless dspScale is Unit::noScale.
       return temp->qstringToSI(text(), works, dspScale != Unit::noScale, dspScale);
    }
-   else if ( _type == STRING )
+   else if ( _type == Unit::String )
       return 0.0;
 
    // If all else fails, simply try to force the contents of the field to a
    // double. This doesn't seem advisable?
    bool ok = false;
-   double amt = Brewtarget::toDouble(text(), &ok);
+   double amt = toDouble(&ok);
    if ( ! ok )
-      Brewtarget::logW( QString("BtLineEdit::toSI : could not convert %1 to double").arg(text()) );
+      Brewtarget::logW( QString("%1 : could not convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(text()).arg(_section).arg(_editField) );
    return amt;
 }
 
@@ -252,15 +180,13 @@ QString BtLineEdit::displayAmount( double amount, int precision)
 
    if ( _section.isEmpty() )
       initializeSection();
-   if ( _property.isEmpty() )
-      initializeProperties();
 
    if ( _forceUnit != Unit::noUnit )
       unitDsp = _forceUnit;
    else
-      unitDsp  = (Unit::unitDisplay)Brewtarget::option(_property, Unit::noUnit, _section, Brewtarget::UNIT).toInt();
+      unitDsp  = (Unit::unitDisplay)Brewtarget::option(_editField, Unit::noUnit, _section, Brewtarget::UNIT).toInt();
 
-   scale    = (Unit::unitScale)Brewtarget::option(_property, Unit::noScale, _section, Brewtarget::SCALE).toInt();
+   scale    = (Unit::unitScale)Brewtarget::option(_editField, Unit::noScale, _section, Brewtarget::SCALE).toInt();
 
    // I find this a nice level of abstraction. This lets all of the setText()
    // methods make a single call w/o having to do the logic for finding the
@@ -306,19 +232,17 @@ void BtLineEdit::setText( BeerXMLElement* element, int precision )
 
    if ( _section.isEmpty() )
       initializeSection();
-   if ( _property.isEmpty() )
-      initializeProperties();
 
-   if ( _type == STRING )
-      display = element->property(_property.toLatin1().constData()).toString();
-   else if ( element->property(_property.toLatin1().constData()).canConvert(QVariant::Double) )
+   if ( _type == Unit::String )
+      display = element->property(_editField.toLatin1().constData()).toString();
+   else if ( element->property(_editField.toLatin1().constData()).canConvert(QVariant::Double) )
    {
       // Get the amount
       bool ok = false;
-      QString tmp = element->property(_property.toLatin1().constData()).toString();
+      QString tmp = element->property(_editField.toLatin1().constData()).toString();
       amount = Brewtarget::toDouble(tmp, &ok);
       if ( !ok )
-         Brewtarget::logW( QString("BtLineEdit::setText(BeerXMLElement*,int) could not convert %1 to double").arg(tmp) );
+         Brewtarget::logW( QString("%1 could not convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(tmp).arg(_section).arg(_editField) );
 
       display = displayAmount(amount, precision);
    }
@@ -335,13 +259,13 @@ void BtLineEdit::setText( QString amount, int precision)
    double amt;
    bool ok = false;
 
-   if ( _type == STRING )
+   if ( _type == Unit::String )
       QLineEdit::setText(amount);
    else
    {
       amt = Brewtarget::toDouble(amount,&ok);
       if ( !ok )
-         Brewtarget::logW( QString("BtLineEdit::setText(QString,int) could not conver %1 to double").arg(amount) );
+         Brewtarget::logW( QString("%1 could not convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(amount).arg(_section).arg(_editField) );
       QLineEdit::setText(displayAmount(amt, precision));
    }
 }
@@ -351,51 +275,105 @@ void BtLineEdit::setText( QVariant amount, int precision)
    setText(amount.toString(), precision);
 }
 
+int BtLineEdit::type() const { return (int)_type; }
+QString BtLineEdit::editField() const { return _editField; }
+QString BtLineEdit::configSection() const { return _section; }
+
+// Once we require >qt5.5, we can replace this noise with
+// QMetaEnum::fromType()
+QString BtLineEdit::forcedUnit() const 
+{ 
+   const QMetaObject &mo = Unit::staticMetaObject;
+   int index = mo.indexOfEnumerator("unitDisplay");
+   QMetaEnum unitEnum = mo.enumerator(index);
+
+   return QString( unitEnum.valueToKey(_forceUnit) );
+}
+
+QString BtLineEdit::forcedScale() const
+{ 
+   const QMetaObject &mo = Unit::staticMetaObject;
+   int index = mo.indexOfEnumerator("unitScale");
+   QMetaEnum scaleEnum = mo.enumerator(index);
+
+   return QString( scaleEnum.valueToKey(_forceScale) );
+}
+
+void BtLineEdit::setType(int type) { _type = (Unit::UnitType)type;}
+void BtLineEdit::setEditField( QString editField) { _editField = editField; }
+void BtLineEdit::setConfigSection( QString configSection) { _section = configSection; }
+
+// previous comment about qt5.5 applies
+void BtLineEdit::setForcedUnit( QString forcedUnit ) 
+{ 
+   const QMetaObject &mo = Unit::staticMetaObject;
+   int index = mo.indexOfEnumerator("unitDisplay");
+   QMetaEnum unitEnum = mo.enumerator(index);
+
+   _forceUnit = (Unit::unitDisplay)unitEnum.keyToValue(forcedUnit.toStdString().c_str());
+}
+
+void BtLineEdit::setForcedScale( QString forcedScale ) 
+{ 
+   const QMetaObject &mo = Unit::staticMetaObject;
+   int index = mo.indexOfEnumerator("unitScale");
+   QMetaEnum unitEnum = mo.enumerator(index);
+   _forceScale = (Unit::unitScale)unitEnum.keyToValue(forcedScale.toStdString().c_str());
+}
+
 BtGenericEdit::BtGenericEdit(QWidget *parent)
-   : BtLineEdit(parent,GENERIC)
+   : BtLineEdit(parent,Unit::None)
 {
+   _units = 0;
 }
 
 BtMassEdit::BtMassEdit(QWidget *parent)
-   : BtLineEdit(parent,MASS)
+   : BtLineEdit(parent,Unit::Mass)
 {
+   _units = Units::kilograms;
 }
 
 BtVolumeEdit::BtVolumeEdit(QWidget *parent)
-   : BtLineEdit(parent,VOLUME)
+   : BtLineEdit(parent,Unit::Volume)
 {
+   _units = Units::liters;
 }
 
 BtTemperatureEdit::BtTemperatureEdit(QWidget *parent)
-   : BtLineEdit(parent,TEMPERATURE)
+   : BtLineEdit(parent,Unit::Temp)
 {
+   _units = Units::celsius;
 }
 
 BtTimeEdit::BtTimeEdit(QWidget *parent)
-   : BtLineEdit(parent,TIME)
+   : BtLineEdit(parent,Unit::Time)
 {
+   _units = Units::minutes;
 }
 
 BtDensityEdit::BtDensityEdit(QWidget *parent)
-   : BtLineEdit(parent,DENSITY)
+   : BtLineEdit(parent,Unit::Density)
 {
+   _units = Units::sp_grav;
 }
 
 BtColorEdit::BtColorEdit(QWidget *parent)
-   : BtLineEdit(parent,COLOR)
+   : BtLineEdit(parent,Unit::Color)
 {
+   _units = Units::srm;
 }
 
 BtStringEdit::BtStringEdit(QWidget *parent)
-   : BtLineEdit(parent,STRING)
+   : BtLineEdit(parent,Unit::String)
 {
+   _units = 0;
 }
 
 BtMixedEdit::BtMixedEdit(QWidget *parent)
-   : BtLineEdit(parent,MIXED)
+   : BtLineEdit(parent,Unit::Mixed)
 {
    // This is probably pure evil I will later regret
-   _type = VOLUME;
+   _type = Unit::Volume;
    _units = Units::liters;
 }
 
@@ -404,17 +382,16 @@ void BtMixedEdit::setIsWeight(bool state)
    // But you have to admit, this is clever
    if (state)
    {
-      _type = MASS;
+      _type = Unit::Mass;
       _units = Units::kilograms;
    }
    else
    {
-      _type = VOLUME;
+      _type = Unit::Volume;
       _units = Units::liters;
    }
 
    // maybe? My head hurts now
    lineChanged();
-
 }
 

--- a/src/BtLineEdit.h
+++ b/src/BtLineEdit.h
@@ -48,21 +48,13 @@ class BtStringEdit;
 class BtLineEdit : public QLineEdit
 {
    Q_OBJECT
-   Q_ENUMS(FieldType)
+   Q_PROPERTY( int     type              READ type              WRITE setType              STORED false);
+   Q_PROPERTY( QString configSection     READ configSection     WRITE setConfigSection     STORED false);
+   Q_PROPERTY( QString editField         READ editField         WRITE setEditField         STORED false);
+   Q_PROPERTY( QString forcedUnit        READ forcedUnit        WRITE setForcedUnit        STORED false);
+   Q_PROPERTY( QString forcedScale       READ forcedScale       WRITE setForcedScale       STORED false);
 
 public:
-
-   enum FieldType {
-      GENERIC,
-      MASS,
-      VOLUME,
-      TEMPERATURE,
-      TIME,
-      DENSITY,
-      COLOR,
-      STRING,
-      MIXED // ick, but I have to figure this out.
-   };
 
    /*! \brief Initialize the BtLineEdit with the parent and do some things with the type
    * \param parent - QWidget* to the parent object
@@ -72,7 +64,7 @@ public:
    *       Not sure how to signal the parent to redisplay
    */
 
-   BtLineEdit(QWidget* parent = 0, FieldType type = GENERIC);
+   BtLineEdit(QWidget* parent = 0, Unit::UnitType type = Unit::None);
    double toSI(Unit::unitDisplay oldUnit = Unit::noUnit, Unit::unitScale oldScale = Unit::noScale, bool force = false);
    // Use this when you want to do something with the returned QString
    QString displayAmount( double amount, int precision = 3);
@@ -87,6 +79,23 @@ public:
    // gonna fix this.
    double  toDouble(bool* ok);
 
+   // By defining the setters/getters, we can remove the need for
+   // initializeProperties.
+   QString editField() const;
+   void setEditField( QString editField );
+
+   QString configSection() const;
+   void setConfigSection( QString configSection );
+
+   int type() const;
+   void setType(int type);
+
+   QString forcedUnit() const;
+   void setForcedUnit(QString forcedUnit);
+
+   QString forcedScale() const;
+   void setForcedScale(QString forcedScale);
+
 public slots:
    void lineChanged();
    void lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale);
@@ -96,13 +105,12 @@ signals:
 
 protected:
    QWidget *btParent;
-   QString _section, _property;
-   FieldType _type;
+   QString _section, _editField;
+   Unit::UnitType _type;
    Unit::unitDisplay _forceUnit;
    Unit::unitScale _forceScale;
    Unit* _units;
 
-   void initializeProperties();
    void initializeSection();
 
 };

--- a/src/unit.h
+++ b/src/unit.h
@@ -127,6 +127,8 @@ class Unit : public QObject
          Temp     = 0x400000,
          Color    = 0x500000,
          Density  = 0x600000,
+         String   = 0x700000,
+         Mixed    = 0x800000,
          None     = 0x000000
       };
 


### PR DESCRIPTION
This refactor does three things. There is no real change to functionality, I'm
just moving some code around and removing redundancies.

First, FieldType was mostly the same as Unit::UnitType. So I removed
FieldType, extended Unit::UnitType enough to cover the difference and modified
the code to use it. Trivial, but pleasing.

Second, I removed the switch() from the initialization. Each type now simply
sets what it wants for _unit. It's about the same number of lines of code, but
I think it reads slightly better.

Finally, the big one. In other experimental work, I discovered that using
Q_PROPERTY for the editField, forcedUnit and forcedScale along with providing
the READ and WRITE members caused Qt to automatically populate the information
based on what's in the UI files. This means I could get rid of
initializeProperties, which made me very happy. It also positions the QML work
nicely.