### PR TITLE
Closes #230 -- buggy refactor

### DIFF
--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -32,25 +32,14 @@ BtLineEdit::BtLineEdit(QWidget *parent, Unit::UnitType type) :
 {
    btParent = parent;
    _type = type;
-
+   _section = property("configSection").toString();
+   
    connect(this,SIGNAL(editingFinished()),this,SLOT(lineChanged()));
 }
 
 void BtLineEdit::lineChanged()
 {
    lineChanged(Unit::noUnit,Unit::noScale);
-}
-
-void BtLineEdit::initializeSection()
-{
-
-   if ( property("configSection").isValid() )
-      _section = property("configSection").toString();
-   else if ( btParent->property("configSection").isValid() )
-      _section = btParent->property("configSection").toString();
-   else
-      _section = btParent->objectName();
-
 }
 
 void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale)
@@ -76,9 +65,6 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
    {
       force = true;
    }
-
-   if ( _section.isEmpty() )
-      initializeSection();
 
    if (text().isEmpty())
    {
@@ -125,9 +111,6 @@ double BtLineEdit::toSI(Unit::unitDisplay oldUnit,Unit::unitScale oldScale,bool 
    Unit*       works;
    Unit::unitDisplay dspUnit  = oldUnit;
    Unit::unitScale   dspScale = oldScale;
-
-   if ( _section.isEmpty() )
-      initializeSection();
 
    // If force is set, just use what is provided in the call. If we are
    // not forcing the unit & scale, we need to read the configured properties
@@ -178,9 +161,6 @@ QString BtLineEdit::displayAmount( double amount, int precision)
    Unit::unitDisplay unitDsp;
    Unit::unitScale scale;
 
-   if ( _section.isEmpty() )
-      initializeSection();
-
    if ( _forceUnit != Unit::noUnit )
       unitDsp = _forceUnit;
    else
@@ -230,9 +210,6 @@ void BtLineEdit::setText( BeerXMLElement* element, int precision )
    double amount = 0.0;
    QString display;
 
-   if ( _section.isEmpty() )
-      initializeSection();
-
    if ( _type == Unit::String )
       display = element->property(_editField.toLatin1().constData()).toString();
    else if ( element->property(_editField.toLatin1().constData()).canConvert(QVariant::Double) )
@@ -277,7 +254,14 @@ void BtLineEdit::setText( QVariant amount, int precision)
 
 int BtLineEdit::type() const { return (int)_type; }
 QString BtLineEdit::editField() const { return _editField; }
-QString BtLineEdit::configSection() const { return _section; }
+QString BtLineEdit::configSection()
+{ 
+   if ( _section.isEmpty() ) {
+      setConfigSection("");
+   }
+
+   return _section;
+}
 
 // Once we require >qt5.5, we can replace this noise with
 // QMetaEnum::fromType()
@@ -301,7 +285,18 @@ QString BtLineEdit::forcedScale() const
 
 void BtLineEdit::setType(int type) { _type = (Unit::UnitType)type;}
 void BtLineEdit::setEditField( QString editField) { _editField = editField; }
-void BtLineEdit::setConfigSection( QString configSection) { _section = configSection; }
+
+// The cascade looks a little odd, but it is intentional.
+void BtLineEdit::setConfigSection( QString configSection) 
+{
+   _section = configSection; 
+
+   if ( _section.isEmpty() )
+      _section = btParent->property("configSection").toString();
+
+   if ( _section.isEmpty() ) 
+      _section = btParent->objectName();
+}
 
 // previous comment about qt5.5 applies
 void BtLineEdit::setForcedUnit( QString forcedUnit ) 

--- a/src/BtLineEdit.h
+++ b/src/BtLineEdit.h
@@ -84,7 +84,7 @@ public:
    QString editField() const;
    void setEditField( QString editField );
 
-   QString configSection() const;
+   QString configSection();
    void setConfigSection( QString configSection );
 
    int type() const;
@@ -110,8 +110,6 @@ protected:
    Unit::unitDisplay _forceUnit;
    Unit::unitScale _forceScale;
    Unit* _units;
-
-   void initializeSection();
 
 };
 

--- a/ui/ogAdjuster.ui
+++ b/ui/ogAdjuster.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>601</width>
-    <height>179</height>
+    <width>638</width>
+    <height>181</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,7 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_11">
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_input">
      <property name="title">
       <string>Input</string>
      </property>
@@ -345,9 +345,12 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_3">
      <item>
-      <widget class="QGroupBox" name="groupBox_2">
+      <widget class="QGroupBox" name="groupBox_output">
        <property name="title">
         <string>Output</string>
+       </property>
+       <property name="configSection" stdset="0">
+        <string>ogAdjuster</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
@@ -571,6 +574,14 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>BtDensityEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
    <class>BtTemperatureEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
@@ -596,14 +607,6 @@
   </customwidget>
   <customwidget>
    <class>BtVolumeEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
-   <slots>
-    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtDensityEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>

--- a/ui/optionsDialog.ui
+++ b/ui/optionsDialog.ui
@@ -381,6 +381,9 @@
          <property name="title">
           <string>Configuration</string>
          </property>
+         <property name="configSection" stdset="0">
+          <string notr="true">optionsDialog</string>
+         </property>
          <layout class="QFormLayout" name="formLayout_2">
           <property name="fieldGrowthPolicy">
            <enum>QFormLayout::ExpandingFieldsGrow</enum>

--- a/ui/primingDialog.ui
+++ b/ui/primingDialog.ui
@@ -168,7 +168,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="primingdialog">
      <property name="title">
       <string>Output</string>
      </property>

--- a/ui/refractoDialog.ui
+++ b/ui/refractoDialog.ui
@@ -17,9 +17,12 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="groupBox_input">
        <property name="title">
         <string>Inputs</string>
+       </property>
+       <property name="configSection" stdset="0">
+        <string notr="true">refractoDialog</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
@@ -169,9 +172,12 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="groupBox_output">
      <property name="title">
       <string>Outputs</string>
+     </property>
+     <property name="configSection" stdset="0">
+      <string notr="true">refractoDialog</string>
      </property>
      <layout class="QFormLayout" name="formLayout_2">
       <item row="1" column="1">

--- a/ui/styleEditor.ui
+++ b/ui/styleEditor.ui
@@ -82,7 +82,7 @@
         <number>1</number>
        </property>
        <item>
-        <widget class="QGroupBox" name="groupBox_2">
+        <widget class="QGroupBox" name="groupBox_basic">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
@@ -91,6 +91,9 @@
          </property>
          <property name="title">
           <string>Basic Information</string>
+         </property>
+         <property name="configSection" stdset="0">
+          <string notr="true">styleEditor</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="0" column="0">
@@ -370,7 +373,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="styleEditor_vital">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
@@ -785,7 +788,7 @@
         <number>1</number>
        </property>
        <item>
-        <widget class="QTabWidget" name="tabWidget">
+        <widget class="QTabWidget" name="tabWidget_profile">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>

--- a/ui/yeastEditor.ui
+++ b/ui/yeastEditor.ui
@@ -29,6 +29,9 @@
          <property name="title">
           <string>Required Fields</string>
          </property>
+         <property name="configSection" stdset="0">
+          <string notr="true">yeastEditor</string>
+         </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <property name="spacing">
            <number>0</number>
@@ -711,6 +714,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>BtGenericEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+  </customwidget>
+  <customwidget>
    <class>BtTemperatureEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
@@ -725,11 +733,6 @@
    <slots>
     <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtGenericEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
   </customwidget>
   <customwidget>
    <class>BtMixedLabel</class>


### PR DESCRIPTION
Testing on _section.isValid() didn't work after I defined the Q_PROPERTY. It
set the property to an empty string, which was valid if empty. Since we almost
never defined configSection on a BtLineEdit, this meant we didn't invoke the
complex math to find the proper configSection.

This commit fixes that. In the process if chasing this problem down, I found a
few dialogs that were not properly defining the configSection, so I fixed that
too.