### PR TITLE
Closes issue #237 -- Deleting equipment dumps core

### DIFF
--- a/src/equipment.h
+++ b/src/equipment.h
@@ -34,6 +34,9 @@
 class Equipment : public BeerXMLElement
 {
    Q_OBJECT
+
+   Q_CLASSINFO("signal", "equipments")
+   Q_CLASSINFO("prefix", "equipment")
    
    friend class Database;
 public:

--- a/src/mash.h
+++ b/src/mash.h
@@ -40,6 +40,8 @@ bool operator==(Mash &m1, Mash &m2);
 class Mash : public BeerXMLElement
 {
    Q_OBJECT
+   Q_CLASSINFO("signal", "mashs")
+   Q_CLASSINFO("prefix", "mash")
    
    friend class Database;
 public:

--- a/src/style.h
+++ b/src/style.h
@@ -40,6 +40,8 @@ bool operator==(Style &s1, Style &s2);
 class Style : public BeerXMLElement
 {
    Q_OBJECT
+   Q_CLASSINFO("signal", "styles")
+   Q_CLASSINFO("prefix", "style")
    
    friend class Database;
 public:


### PR DESCRIPTION
In all the work I did on the database, I somehow forgot to add the two
required properties to these three items. This patch fixes that oversight.