### PR TITLE
Closes #255 - Adjusting volume on preboil tab

### DIFF
--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -57,6 +57,7 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
    QString amt;
    bool force = Brewtarget::hasUnits(text());
    bool ok = false;
+   bool wasChanged = sender() == this;
 
    // editingFinished happens on focus being lost, regardless of anything
    // being changed. I am hoping this short circuits properly and we do
@@ -99,8 +100,7 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
    }
    QLineEdit::setText(amt);
 
-   if ( ! force )
-   {
+   if ( wasChanged ) {
       emit textModified();
    }
 }


### PR DESCRIPTION
Somewhat simple fix. Basically, when I did the scales for input, I changed the
symantics of what the "force" flag means in BtLineEdit. I just didn't change
everything.

There's a signal that needs to be emitted when the field changes, but I only
want it emitted when the user enters a new value in the field. The previous
logic used the forced flag, which was clever but wrong. When I changed the
symantics, I should have changed the flag. This commit fixes that.

And a new rule. Don't use one flag to do two different things. Use different
flags.