### PR TITLE
Fixes #270: avoid recipe recalc on load

### DIFF
--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1373,6 +1373,8 @@ void Recipe::recalcAll()
    // Infinite recursion possible, since these methods will emit changed(),
    // causing other objects to call finalVolume_l() for example, which may
    // cause another call to recalcAll() and so on.
+   //
+   // GSG: Now only emit when _uninitializedCalcs is true, which helps some.
 
    // Someone has already called this function back in the call stack, so return to avoid recursion.
    if( !_recalcMutex.tryLock() )
@@ -1406,7 +1408,10 @@ void Recipe::recalcABV_pct()
    if ( ret != _ABV_pct ) 
    {
       _ABV_pct = ret;
-      emit changed( metaProperty("ABV_pct"), _ABV_pct );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("ABV_pct"), _ABV_pct );
+      }
    }
 }
 
@@ -1430,7 +1435,10 @@ void Recipe::recalcColor_srm()
    if ( _color_srm != ret ) 
    {
       _color_srm = ret;
-      emit changed( metaProperty("color_srm"), _color_srm );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("color_srm"), _color_srm );
+      }
    }
 
 }
@@ -1464,7 +1472,10 @@ void Recipe::recalcIBU()
    if ( ibus != _IBU ) 
    {
       _IBU = ibus;
-      emit changed( metaProperty("IBU"), _IBU );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("IBU"), _IBU );
+      }
    }
 }
 
@@ -1543,25 +1554,37 @@ void Recipe::recalcVolumeEstimates()
    if ( tmp_wfm != _wortFromMash_l )
    {
       _wortFromMash_l = tmp_wfm;
-      emit changed( metaProperty("wortFromMash_l"), _wortFromMash_l );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("wortFromMash_l"), _wortFromMash_l );
+      }
    }
 
    if ( tmp_bv != _boilVolume_l )
    {
       _boilVolume_l = tmp_bv;
-      emit changed( metaProperty("boilVolume_l"), _boilVolume_l );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("boilVolume_l"), _boilVolume_l );
+      }
    }
    
    if ( tmp_fv != _finalVolume_l )
    {
       _finalVolume_l = tmp_fv;
-      emit changed( metaProperty("finalVolume_l"), _finalVolume_l );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("finalVolume_l"), _finalVolume_l );
+      }
    }
 
    if ( tmp_pbv != _postBoilVolume_l )
    {
       _postBoilVolume_l = tmp_pbv;
-      emit changed( metaProperty("postBoilVolume_l"), _postBoilVolume_l );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("postBoilVolume_l"), _postBoilVolume_l );
+      }
    }
 }
 
@@ -1584,7 +1607,10 @@ void Recipe::recalcGrainsInMash_kg()
    if ( ret != _grainsInMash_kg ) 
    {
       _grainsInMash_kg = ret;
-      emit changed( metaProperty("grainsInMash_kg"), _grainsInMash_kg );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("grainsInMash_kg"), _grainsInMash_kg );
+      }
    }
 }
 
@@ -1601,7 +1627,10 @@ void Recipe::recalcGrains_kg()
    if ( ret != _grains_kg ) 
    {
       _grains_kg = ret;
-      emit changed( metaProperty("grains_kg"), _grains_kg );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("grains_kg"), _grains_kg );
+      }
    }
 }
 
@@ -1612,7 +1641,10 @@ void Recipe::recalcSRMColor()
    if ( tmp != _SRMColor )
    {
       _SRMColor = tmp;
-      emit changed( metaProperty("SRMColor"), _SRMColor );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("SRMColor"), _SRMColor );
+      }
    }
 }
 
@@ -1648,7 +1680,10 @@ void Recipe::recalcCalories()
    if ( tmp != _calories ) 
    {
       _calories = tmp;
-      emit changed( metaProperty("calories"), _calories );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("calories"), _calories );
+      }
    }
 }
 
@@ -1727,7 +1762,10 @@ void Recipe::recalcBoilGrav()
    if ( ret != _boilGrav )
    {
       _boilGrav = ret;
-      emit changed( metaProperty("boilGrav"), _boilGrav );
+      if (!_uninitializedCalcs)
+      {
+        emit changed( metaProperty("boilGrav"), _boilGrav );
+      }
    }
 }
 
@@ -1753,6 +1791,10 @@ void Recipe::recalcOgFg()
    // database, not use the initialized values of 1. I (maf) tried putting
    // this in the initialize, but it just hung. So I moved it here, but only
    // if if we aren't initialized yet.
+   //
+   // GSG: This doesn't work, this og and fg are already set to 1.0 so
+   // until we load these values from the database on startup, we have
+   // to calculate.
    if ( _uninitializedCalcs )
    {
       _og = Brewtarget::toDouble(this,"og","Recipe::recalcOgFg()");
@@ -1833,22 +1875,30 @@ void Recipe::recalcOgFg()
    if ( _og != tmp_og ) 
    {
       _og     = tmp_og;
-      // NOTE: We don't want to do this on the first load of the recipe. The
-      // _og is initialized to 1, and we calculate that to be something
-      // different. So this code is being triggered and the OG and FG are
-      // being updated for no good reason.
+      // NOTE: We don't want to do this on the first load of the recipe.
       // NOTE: We are we recalculating all of these on load? Shouldn't we be
       // reading these values from the database somehow?
-      set( "og", "og", _og, false );
-      emit changed( metaProperty("og"), _og );
-      emit changed( metaProperty("points"), (_og-1.0)*1e3 );
+      //
+      // GSG: Yes we can, but until the code is added to intialize these calculated
+      // values from the database, we can calculate them on load. They should be
+      // the same as the database values since the database values were set with
+      // these functions in the first place.
+      if (!_uninitializedCalcs)
+      {
+        set( "og", "og", _og, false );
+        emit changed( metaProperty("og"), _og );
+        emit changed( metaProperty("points"), (_og-1.0)*1e3 );
+      }
    }
 
    if ( tmp_fg != _fg ) 
    {
       _fg     = tmp_fg;
-      set( "fg", "fg", _fg, false );
-      emit changed( metaProperty("fg"), _fg );
+      if (!_uninitializedCalcs)
+      {
+        set( "fg", "fg", _fg, false );
+        emit changed( metaProperty("fg"), _fg );
+      }
    }
 }
 


### PR DESCRIPTION
Since the recipes are not loading the calculated values from the database, we can use the _uninitializedCalcs bool to determine if we need to call set or emit. If the recipe is just being loaded, _uninitializedCalcs will be true. After the initial load, it will be set to false. If it is false, call set and or emit  for changes. This stops the database getting dirty when no changes are made, and is a minor code change. And if something is changed, the database will then get dirtied, I'm still working on getting the values from the database during loading, but haven't found the right location yet. Since the same functions are used to set the database values in the first place, they should match anyways.

Fixing should be faster now the I got the project loading and running in QtCreator. A lot easier to check values and properties out since qtcreator knows about QtObjects. ddd just shows pointer addresses and makes it hard to figure out what the pointer is pointing too.