### PR TITLE
Closes #267 - Moving mash steps doesn't update form.

### DIFF
--- a/src/MashStepTableModel.cpp
+++ b/src/MashStepTableModel.cpp
@@ -86,6 +86,23 @@ void MashStepTableModel::setMash( Mash* m )
    }
 }
 
+void MashStepTableModel::reorderMashSteps()
+{
+   if( mashObs && steps.size() > 0)
+   {
+      // I am NOT disconnecting the signals. I just want things redrawn
+      beginRemoveRows( QModelIndex(), 0, steps.size()-1 );
+      // Remove mashObs and all steps.
+      steps.clear();
+      endRemoveRows();
+
+      QList<MashStep*> tmpSteps = mashObs->mashSteps();
+      beginInsertRows( QModelIndex(), 0, tmpSteps.size()-1 );
+      steps = tmpSteps;
+      endInsertRows();
+   }
+}
+
 MashStep* MashStepTableModel::getMashStep(unsigned int i)
 {
    if( i < static_cast<unsigned int>(steps.size()) )
@@ -103,9 +120,13 @@ void MashStepTableModel::mashChanged()
 void MashStepTableModel::mashStepChanged(QMetaProperty prop, QVariant val)
 {
    int i;
+
    MashStep* stepSender = qobject_cast<MashStep*>(sender());
    if( stepSender && (i = steps.indexOf(stepSender)) >= 0 )
    {
+      if ( prop.name() == QStringLiteral("stepNumber") )
+         reorderMashSteps();
+
       emit dataChanged( QAbstractItemModel::createIndex(i, 0),
                         QAbstractItemModel::createIndex(i, MASHSTEPNUMCOLS-1));
    }

--- a/src/MashStepTableModel.h
+++ b/src/MashStepTableModel.h
@@ -90,6 +90,8 @@ private:
    Mash* mashObs;
    QTableView* parentTableWidget;
    QList<MashStep*> steps;
+
+   void reorderMashSteps();
 };
 
 /*!

--- a/src/MashStepTableModel.h
+++ b/src/MashStepTableModel.h
@@ -91,7 +91,8 @@ private:
    QTableView* parentTableWidget;
    QList<MashStep*> steps;
 
-   void reorderMashSteps();
+//   void reorderMashSteps();
+   void reorderMashStep(MashStep *step, int current);
 };
 
 /*!

--- a/src/MashStepTableWidget.cpp
+++ b/src/MashStepTableWidget.cpp
@@ -20,6 +20,7 @@
 
 #include <QTableView>
 #include <QWidget>
+#include <QDebug>
 #include "MashStepTableModel.h"
 #include "MashStepTableWidget.h"
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -806,8 +806,8 @@ Yeast*       Database::yeast(int key)       { return allYeasts[key]; }
 
 void Database::swapMashStepOrder(MashStep* m1, MashStep* m2)
 {
-   QString update = QString("UPDATE mashstep SET step_number = CASE mash_id WHEN %1 then %2 when %3 then %4 END WHERE mash_id IN (%5,%6)")
-                .arg(m1->_key).arg(m2->_key).arg(m2->_key).arg(m1->_key).arg(m1->_key).arg(m2->_key);
+   QString update = QString("UPDATE mashstep SET step_number = CASE id WHEN %1 then %2 when %3 then %4 END WHERE id IN (%1,%3)")
+                .arg(m1->_key).arg(m2->stepNumber()).arg(m2->_key).arg(m1->stepNumber());
 
    QSqlQuery q(sqlDatabase() );
 


### PR DESCRIPTION
That was .. a mess. I don't know how far back this error goes, but I think its
old.

First, the SQL statement in Database::swapMashStepOrder was wrong. As
@greggree noticed, it was using msid instead of mash_id. The update itself
changed the stepNumber to be the id of the steps, which ... well, just wasn't
right. So I fixed that, and reworked the QString a little.

Second, there was nothing in the MashStepTableModel to do the right thing when
the stepNumber changed signal was received. I added a method that just removes
the rows and re-adds them. I do not disconnect any signals, which may come to
haunt us later.

I think this fixes the issues.