### PR TITLE
Add Save/Cancel button to equipment warnings

### DIFF
--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -599,17 +599,33 @@ void EquipmentEditor::save()
 
    double ga_LKg = grainAbs * volumeUnit->toSI(1.0) * weightUnit->fromSI(1.0);
 
+   QMessageBox::StandardButton ret;
+
    // Do some prewarning things. I would prefer to do this only on change, but
    // we need to be worried about new equipment too.
    if ( lineEdit_tunVolume->toSI() <= 0.001 )
-      QMessageBox::warning(this, tr("Tun Volume Warning"), tr("The tun volume you entered is 0. This may cause problems"));
+      ret = QMessageBox::warning(this,
+               tr("Tun Volume Warning"),
+               tr("The tun volume you entered is 0. This may cause problems"),
+               QMessageBox::Save | QMessageBox::Cancel,
+               QMessageBox::Save);
 
-   if ( lineEdit_batchSize->toSI() <= 0.001 )
-      QMessageBox::warning(this, tr("Batch Size Warning"), tr("The batch size you entered is 0. This may cause problems"));
+   if ( ret != QMessageBox::Cancel && lineEdit_batchSize->toSI() <= 0.001 )
+      ret = QMessageBox::warning(this,
+               tr("Batch Size Warning"),
+               tr("The batch size you entered is 0. This may cause problems"),
+               QMessageBox::Save | QMessageBox::Cancel,
+               QMessageBox::Save);
 
-   if ( lineEdit_hopUtilization->toSI() < 0.001 )
-      QMessageBox::warning(this, tr("Hop Utilization Warning"), tr("The hop utilization percentage you entered is 0. This may cause problems"));
+   if ( ret != QMessageBox::Cancel && lineEdit_hopUtilization->toSI() < 0.001 )
+      ret = QMessageBox::warning(this,
+               tr("Hop Utilization Warning"),
+               tr("The hop utilization percentage you entered is 0. This may cause problems"),
+               QMessageBox::Save | QMessageBox::Cancel,
+               QMessageBox::Save);
 
+   if ( ret == QMessageBox::Cancel )
+      return;
 
    obsEquip->setName( lineEdit_name->text() );
    obsEquip->setBoilSize_l( lineEdit_boilSize->toSI() );


### PR DESCRIPTION
Currently if you make a mistake in the equipment editor you are warned
about the error, but are not given a chance to correct the problem
before the change is saved.

This commit removes the current default QMessageBox::OK button from the
warning box, and replaces it with QMessageBox::Save/Cancel buttons.
This change gives a user a chance to make corrections with a minimal
number of interactions without changing context.

I'm hoping this is a trivial change, but if it interferes with a larger vision for
interactions: let me know :bread: