### PR TITLE
Fixes #88: high dpi printing

### DIFF
--- a/css/brewday.css
+++ b/css/brewday.css
@@ -1,18 +1,21 @@
+html {
+   font-size: 100%;
+}
 body{
-   width: 8.5in;
-   margin: auto auto auto 10px; 
+   width: 90%;
+   margin: auto auto auto auto;
 }
 caption { caption-side:top; }
 ul { list-style-type:circle; }
 h1 
 { 
-   font-size:36px;
+   font-size:3rem;
    font-weight:bold;
    text-align:left;
 }
 h2
 {
-   font-size:20px;
+   font-size:2rem;
    font-weight:bold;
    text-align:center;
    border-bottom-style:solid;
@@ -82,7 +85,7 @@ img
 #steps td.check
 {
    width:10%;
-   font-size:3em;
+   font-size:3rem;
    text-align:center;
 }
 #steps td.time

--- a/css/recipe.css
+++ b/css/recipe.css
@@ -1,6 +1,9 @@
+html {
+   font-size: 100%;
+}
 body{
-   width: 8.5in;
-   margin: auto auto auto 10px; 
+   width: 90%;
+   margin: auto auto auto auto;
 }
 ul { list-style-type:circle; }
 caption 
@@ -10,20 +13,20 @@ caption
 }
 h1 
 { 
-   font-size:36px;
+   font-size:3rem;
    font-weight:bold;
    text-align:left;
 }
 h2
 {
-   font-size:18px;
+   font-size:1.5rem;
    font-weight:bold;
    text-align:left;
    border-bottom-style:solid;
 }
 h3
 {
-   font-size:14px;
+   font-size:1.17rem;
    text-align:left;
    font-weight:normal;
    border-bottom-width:1px;
@@ -32,7 +35,7 @@ h3
 
 h4
 {
-   font-size:12px;
+   font-size:1rem;
    text-align:left;
    font-weight:normal;
 }
@@ -63,20 +66,20 @@ img
 #header td.label
 {
     width:10%;
-    font-size:14px;
+    font-size:1.17rem;
    font-weight:bold;
    text-align:left;
 }
 #header td.value
 {
    width:60%;
-    font-size:14px;
+    font-size:1.17rem;
    font-weight:normal;
    text-align:left;
 }
 #header caption
 {
-    font-size:36px;
+    font-size:3rem;
     caption-side:top; 
     text-align: left;
 }

--- a/css/recipe.css
+++ b/css/recipe.css
@@ -6,6 +6,9 @@ body{
    margin: auto auto auto auto;
 }
 ul { list-style-type:circle; }
+table {
+   font-size: 1rem;
+}
 caption 
 { 
     caption-side:bottom; 

--- a/css/recipe.css
+++ b/css/recipe.css
@@ -29,7 +29,6 @@ h3
    font-size:1.17rem;
    text-align:left;
    font-weight:normal;
-   border-bottom-width:1px;
    border-bottom-style:solid;
 }
 
@@ -43,13 +42,13 @@ h4
 img
 {
    position:absolute;
-   right:0px;
-   top:0px;
+   right:0rem;
+   top:0rem;
    z-index:-1;
 }
 #headerdiv
 {
-    padding-bottom:30px;
+    padding-bottom:3rem;
 }
 #header
 {
@@ -59,8 +58,6 @@ img
 }
 #header td 
 {
-   border: 0px solid white;
-   padding: 3px 7px 2px 7px;
     empty-cells:hide;
 }
 #header td.label
@@ -93,7 +90,7 @@ img
 #title td, #title th
 {
    border: 0px solid white;
-   padding: 3px 7px 2px 7px;
+   padding-left: 0.5rem;
    empty-cells:show;
 }
 #title td.left
@@ -120,13 +117,11 @@ img
 #fermentables td
 {
    border: 0px solid white;
-   padding: 3px 7px 2px 7px;
    empty-cells:show;
 }
 #fermentables th
 {
    border: 0px solid white;
-   padding: 3px 7px 2px 7px;
    font-weight:bold;
    text-align:left;
    empty-cells:show;
@@ -147,13 +142,11 @@ img
 #hops td
 {
    border: 0px solid white;
-   padding: 3px 7px 2px 7px;
    empty-cells:show;
 }
 #hops th
 {
    border: 0px solid white;
-    padding: 3px 7px 2px 7px;
     font-weight:bold;
     text-align:left;
     empty-cells:show;
@@ -173,13 +166,11 @@ img
 #misc td
 {
    border: 0px solid white;
-   padding: 3px 7px 2px 7px;
    empty-cells:show;
 }
 #misc th
 {
    border: 0px solid white;
-    padding: 3px 7px 2px 7px;
     font-weight:bold;
     text-align:left;
     empty-cells:show;
@@ -199,13 +190,11 @@ img
 #yeast td
 {
    border: 0px solid white;
-   padding: 3px 7px 2px 7px;
    empty-cells:show;
 }
 #yeast th
 {
    border: 0px solid white;
-    padding: 3px 7px 2px 7px;
     font-weight:bold;
     text-align:left;
     empty-cells:show;
@@ -225,13 +214,11 @@ img
 #mash td
 {
    border: 0px solid white;
-   padding: 3px 7px 2px 7px;
    empty-cells:show;
 }
 #mash th
 {
    border: 0px solid white;
-   padding: 3px 7px 2px 7px;
    font-weight:bold;
    text-align:left;
    empty-cells:show;

--- a/css/recipe.css
+++ b/css/recipe.css
@@ -76,6 +76,7 @@ img
     font-size:1.17rem;
    font-weight:normal;
    text-align:left;
+   padding-left: 12px;
 }
 #header caption
 {
@@ -105,6 +106,7 @@ img
 {
    font-weight:normal;
    text-align:left;
+   padding-left: 12px;
 }
 #title td.right
 {


### PR DESCRIPTION
Really, this fixes a lot more than #88. It fixes a lot of html/css compatibility issues that were screwing up the rendering of the html in QTextBrowser and the printout. Something is still adding a large border to the printout version, but I will leave that for another bug fix.

## Relevant Links

 - http://doc.qt.io/qt-5/richtext-html-subset.html
 - https://validator.w3.org/check
 - https://www.sitepoint.com/understanding-and-using-rem-units-in-css/
 - https://www.w3.org/TR/1999/REC-html401-19991224/
 - http://www.freeformatter.com/html-formatter.html