### PR TITLE
Closes #292 -- Windows build fails

### DIFF
--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -355,8 +355,6 @@ const QDir Brewtarget::getConfigDir()
    // Now we should be in the base directory (i.e. Brewtarget-2.0.0/)
 
    dir.cd("data");
-   if( success != 0 )
-      *success = true;
    return dir.absolutePath() + "/";
 
 #else


### PR DESCRIPTION
Success is no longer tracked. The #ifdef prevented this error from being
surfaced until I actually tried building on windows.