### PR TITLE
Closes #277 - Nested html documents in recipe printout

### DIFF
--- a/src/RecipeFormatter.cpp
+++ b/src/RecipeFormatter.cpp
@@ -1346,7 +1346,9 @@ QString RecipeFormatter::buildNotesHtml()
       return "";
 
    notes = QString("<h3>%1</h3>").arg(tr("Notes"));
-   notes += QString("%1").arg( QTextDocument(rec->notes()).toHtml());
+   // NOTE: (heh) Using the QTextDocument.toHtml() method doesn't really work
+   // here. So we cheat and use some newer functionality
+   notes += rec->notes().toHtmlEscaped();
 
    return notes;
 }


### PR DESCRIPTION
QTextDocument::toHtml() makes a full HTML doc, including all the necessary head, body, etc. tags.

Qt5 introduced QString::toHtmlEscaped(), which simply escapes the contents of the string for HTMLness, which is much more like what we need.