### PR TITLE
Closes #283 -- temperature slider reversal

### DIFF
--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -97,7 +97,6 @@ void MashDesigner::show()
       );
       return;
    }
-
    setVisible(nextStep(0));
 }
 
@@ -149,19 +148,29 @@ bool MashDesigner::nextStep(int step)
 
 void MashDesigner::saveStep()
 {
+   double temp,maxT;
+
    MashStep::Type type = static_cast<MashStep::Type>(comboBox_type->currentIndex());
+
+   temp = lineEdit_temp->toSI();
+   maxT = maxTemp_c();
+   if ( temp > maxT ) 
+      temp = maxT;
 
    mashStep->setName( lineEdit_name->text() );
    mashStep->setType( type );
-   mashStep->setStepTemp_c(   Brewtarget::qStringToSI(lineEdit_temp->text(), Units::celsius) );
-   mashStep->setStepTime_min( Brewtarget::qStringToSI(lineEdit_time->text(), Units::minutes) );
+   mashStep->setStepTemp_c( temp );
+   mashStep->setStepTime_min( lineEdit_time->toSI() );
 
    // finish a few things -- this may be premature optimization
    connect( mashStep, SIGNAL(changed(QMetaProperty,QVariant)), mash, SLOT(acceptMashStepChange(QMetaProperty,QVariant)) );
    if( isInfusion() )
    {
       mashStep->setInfuseAmount_l( selectedAmount_l() );
-      mashStep->setInfuseTemp_c( selectedTemp_c() );
+      temp = selectedTemp_c();
+      if ( temp > maxT ) 
+         temp = maxT;
+      mashStep->setInfuseTemp_c( temp );
    }
    emit mash->mashStepsChanged();
 }
@@ -420,12 +429,19 @@ void MashDesigner::updateMaxAmt()
 
 void MashDesigner::updateMinTemp()
 {
-   label_tempMin->setText(Brewtarget::displayAmount(minTemp_c(), Units::celsius));
+   double minTemp = minTemp_c();
+
+   if ( minTemp > 100 )
+      minTemp = maxTemp_c();
+
+   label_tempMin->setText(Brewtarget::displayAmount(minTemp, Units::celsius));
 }
 
 void MashDesigner::updateMaxTemp()
 {
-   label_tempMax->setText(Brewtarget::displayAmount(maxTemp_c(), Units::celsius));
+   double maxTemp = maxTemp_c();
+
+   label_tempMax->setText(Brewtarget::displayAmount(maxTemp, Units::celsius));
 }
 
 double MashDesigner::selectedAmount_l()
@@ -511,12 +527,17 @@ void MashDesigner::updateAmt()
 
 void MashDesigner::updateTemp()
 {
+   double temp,maxT;
+
    if( mashStep == 0 )
       return;
 
    if( isInfusion() )
    {
-      double temp = horizontalSlider_temp->sliderPosition() / (double)(horizontalSlider_temp->maximum()) * (maxTemp_c() - minTemp_c()) + minTemp_c();
+      temp = horizontalSlider_temp->sliderPosition() / (double)(horizontalSlider_temp->maximum()) * (maxTemp_c() - minTemp_c()) + minTemp_c();
+      maxT = maxTemp_c();
+      if ( temp > maxT )
+         temp = maxT;
 
       label_temp->setText(Brewtarget::displayAmount( temp, Units::celsius));
 
@@ -525,14 +546,19 @@ void MashDesigner::updateTemp()
    }
    else if( isDecoction() )
       label_temp->setText(Brewtarget::displayAmount( maxTemp_c(), Units::celsius));
-   else
-      // label_temp->setText(Brewtarget::displayAmount( mashStep->stepTemp_c(), Units::celsius));
+   else {
+   
       label_temp->setText(Brewtarget::displayAmount( stepTemp_c(), Units::celsius));
+   }
 }
 
 void MashDesigner::saveTargetTemp()
 {
    double temp = stepTemp_c();
+   double maxT = maxTemp_c();
+
+   if ( temp > maxT ) 
+      temp = maxT;
 
    // be nice and reset the field so it displays in proper units
    lineEdit_temp->setText(temp);


### PR DESCRIPTION
The slider didn't really reverse. Its behavior simply didn't make sense.

The max temp label is taken either as the configured boiling point of water (bpow, for short) or 100C. In other words, it is treated mostly like a constant and not calculated.

The min temp label, on the other hand, is calculated. We never bothered to check if the results made any sense. While I kind of see the point of staying true to the maths, I think we should consider physics too.

I have put a number of checks in place to make sure if the temperature exceeds the configured bpow, the temperature is set to the bpow. The min/max labels will not exceed the bpow, the temperature label will not, the step starting or target temps will not either.