### PR TITLE
Closes #116 - Crash at closing after deleting hop

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1931,12 +1931,6 @@ void MainWindow::closeEvent(QCloseEvent* /*event*/)
    // cause any more queries.
    setVisible(false);
 
-   // Ask the user if they want to save changes, only if the dirty bit has
-   // been thrown
-   // We should also make sure the backup db still exists -- there's some edge
-   // cases where it doesn't.
-
-   Database::instance().unload();
 }
 
 void MainWindow::copyRecipe()

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -543,15 +543,14 @@ void Database::unload()
    // The postgres driver wants nothing to do with this. Core gets dumped if
    // we try it. Since we don't need to copy things about for postgres...
 
-   if ( Brewtarget::dbType() == Brewtarget::SQLITE ) {
 
-      QSqlDatabase::database( dbConName, false ).close();
+   QSqlDatabase::database( dbConName, false ).close();
+   QSqlDatabase::removeDatabase( dbConName );
 
-      QSqlDatabase::removeDatabase( dbConName );
-
+   if (loadWasSuccessful && Brewtarget::dbType() == Brewtarget::SQLITE )
+   {
       dbFile.close();
-      if (loadWasSuccessful)
-         automaticBackup();
+      automaticBackup();
    }
 }
 
@@ -664,6 +663,7 @@ void Database::dropInstance()
    static QMutex mutex;
 
    mutex.lock();
+   dbInstance->unload();
    delete dbInstance;
    dbInstance=0;
    mutex.unlock();


### PR DESCRIPTION
Deleting had nothing to do with it, but adding a new hop did. For reasons I still do NOT understand, the hop table was attempting to refresh itself on delete. I went through any number of interations, but could never quite figure out why.

This is the easiest of the fixes I found -- the database isn't closed until after we tear all the windows down. Since MainWindow doesn't open the DB, it shouldn't close it either. I still cannot explain why the hop editor alone does this, and not the misc editor.