### PR TITLE
set date for first brewed to today's date

### DIFF
--- a/src/BtDatePopup.cpp
+++ b/src/BtDatePopup.cpp
@@ -34,6 +34,7 @@ BtDatePopup::BtDatePopup(QWidget* parent) : QDialog(parent, Qt::Popup)
    calendar = new QCalendarWidget(widget);
    calendar->setObjectName(QString("btDatePopup_calendar"));
    calendar->setNavigationBarVisible(true);
+   calendar->setSelectedDate(QDate::currentDate());
 
 
    buttonbox = new QDialogButtonBox(widget);


### PR DESCRIPTION
This PR automatically defaults the "First Brewed Date" for new recipes to the current date and fixes #301 

Potential Gotchas: 

* Since it's in the code for `BtDatePopup`, does that mean this modification will only be called when the app is opened? Or maybe compiled? Sorry, still getting familiar with the codebase.