### PR TITLE
Closes #306 - Copy databsae doesn't copy the settings table properly

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -5063,7 +5063,8 @@ void Database::convertDatabase(QString const& Hostname, QString const& DbName,
    }
 }
 
-QString Database::makeQueryString( QSqlRecord here, QString realName ) {
+QString Database::makeInsertString( QSqlRecord here, QString realName )
+{
    QString columns,qmarks;
 
    // Yes. I went from named to positional place holders. Such is life
@@ -5080,7 +5081,25 @@ QString Database::makeQueryString( QSqlRecord here, QString realName ) {
    return QString("INSERT INTO %1 (%2) VALUES(%3)").arg(realName).arg(columns).arg(qmarks);
 }
 
-QVariant Database::convertValue(Brewtarget::DBTypes newType, QSqlField field) {
+QString Database::makeUpdateString( QSqlRecord here, QString realName, int key )
+{
+   QString columns;
+
+   // Yes. I am still using positional place holders, and you are still dealing
+   // with it
+   for(int i=0; i < here.count(); ++i) {
+      if ( ! columns.isEmpty() ) {
+         columns += QString(",%1=?").arg( here.fieldName(i) );
+      }
+      else {
+         columns = QString("%1=?").arg( here.fieldName(i) );
+      }
+   }
+   return QString("UPDATE %1 SET %2 where id=%3").arg(realName).arg(columns).arg(key);
+}
+
+QVariant Database::convertValue(Brewtarget::DBTypes newType, QSqlField field)
+{
    QVariant retVar = field.value();
    if ( field.type() == QVariant::Bool ) {
       switch(newType) {
@@ -5098,7 +5117,8 @@ QVariant Database::convertValue(Brewtarget::DBTypes newType, QSqlField field) {
    return retVar;
 }
 
-QStringList Database::allTablesInOrder(QSqlQuery q) {
+QStringList Database::allTablesInOrder(QSqlQuery q)
+{
    QString query = "SELECT name FROM bt_alltables ORDER BY table_id";
    QStringList tmp;
 
@@ -5119,13 +5139,13 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
    // There are a lot of tables to process
    foreach( QString table, tables ) {
       QSqlField field;
-      QString columns,qmarks;
       bool mustPrepare = true;
       int maxid = -1;
 
-      // settings and bt_alltables don't get copied; metatables are created
-      // when the database is
-      if ( table == "settings" || table == "bt_alltables" )
+      // bt_alltables don't get copied; metatables are created
+      // when the database is. I used to say this about settings. I was wrong
+      // about settings
+      if ( table == "bt_alltables" )
          continue;
 
       QString findAllQuery = QString("SELECT * FROM %1").arg(table);
@@ -5136,13 +5156,13 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
 
          newDb.transaction();
 
-         QSqlQuery insertNew(newDb); // we will prepare this in a bit
+         QSqlQuery upsertNew(newDb); // we will prepare this in a bit
 
          // Start reading the records from the old db
          while(readOld.next()) {
             int idx;
             QSqlRecord here = readOld.record();
-            QString insertQuery;
+            QString upsertQuery;
 
             idx = here.indexOf("id");
 
@@ -5155,22 +5175,27 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
 
             // Prepare the insert for this table if required
             if ( mustPrepare ) {
-               insertQuery = makeQueryString(here,table);
-               insertNew.prepare(insertQuery);
+               if ( table == QStringLiteral("settings") ) {
+                  upsertQuery = makeUpdateString(here,table,here.value(idx).toInt());
+               }
+               else {
+                  upsertQuery = makeInsertString(here,table);
+               }
+               upsertNew.prepare(upsertQuery);
                // but do it only once for this table
                mustPrepare = false;
             }
             // All that's left is to bind
             for(int i=0; i < here.count(); ++i) {
-               insertNew.bindValue(i,
+               upsertNew.bindValue(i,
                         convertValue(newType, here.field(i)),
                         QSql::In
                );
             }
 
             // and execute
-            if ( ! insertNew.exec() )
-               throw QString("Could not insert new row %1 : %2").arg(insertNew.lastQuery()).arg(insertNew.lastError().text());
+            if ( ! upsertNew.exec() )
+               throw QString("Could not insert new row %1 : %2").arg(upsertNew.lastQuery()).arg(upsertNew.lastError().text());
          }
          // We need to manually reset the sequences
          if ( newType == Brewtarget::PGSQL ) {

--- a/src/database.h
+++ b/src/database.h
@@ -897,7 +897,8 @@ private:
                              int Portnum);
    //! \brief makes a query string we can prepare. Needed this in two places,
    // so it got a method
-   QString makeQueryString( QSqlRecord here, QString realName );
+   QString makeInsertString( QSqlRecord here, QString realName );
+   QString makeUpdateString( QSqlRecord here, QString realName, int key );
 
    //! \brief converts sqlite values (mostly booleans) into something postgres
    // wants


### PR DESCRIPTION
I had previously been skipping the settings table when copying a database. That didn't work, but I couldn't use an insert line. This solution is to special case the settings table and use an SQL UPDATE instead of an INSERT.

It required a new method, renaming an existing method and changing some variable names to better indicate what they are doing.