### PR TITLE
Closes #309 - Database performance

### DIFF
--- a/src/BeerXMLElement.h
+++ b/src/BeerXMLElement.h
@@ -54,31 +54,37 @@ class BeerXMLElement : public QObject
 {
    Q_OBJECT
    Q_CLASSINFO("version","1")
-   
+
    friend class Database;
 public:
    BeerXMLElement();
    BeerXMLElement( BeerXMLElement const& other );
 
-   // Everything that inherits from BeerXML has delete, display and a folder
-   Q_PROPERTY( bool deleted READ deleted WRITE setDeleted )
-   Q_PROPERTY( bool display READ display WRITE setDisplay )
+   // Everything that inherits from BeerXML has a name, delete, display and a folder
+   Q_PROPERTY( QString name   READ name WRITE setName )
+   Q_PROPERTY( bool deleted   READ deleted WRITE setDeleted )
+   Q_PROPERTY( bool display   READ display WRITE setDisplay )
    Q_PROPERTY( QString folder READ folder WRITE setFolder )
 
    Q_PROPERTY( int key READ key )
    Q_PROPERTY( Brewtarget::DBTable table READ table )
-   
+
    //! Convenience method to determine if we are deleted or displayed
    bool deleted() const;
    bool display() const;
    //! Access to the folder attribute.
    QString folder() const;
+   //! Access to the name attribute.
+   QString name() const;
 
    //! And ways to set those flags
-   void setDeleted(bool var);
-   void setDisplay(bool var);
+   void setDeleted(const bool var);
+   void setDisplay(const bool var);
    //! and a way to set the folder
-   virtual void setFolder(QString var, bool signal=true);
+   virtual void setFolder(const QString var, bool signal=true);
+
+   //!
+   void setName(const QString var);
 
    //! \returns our key in the table we are stored in.
    int key() const;
@@ -90,7 +96,7 @@ public:
    QMetaProperty metaProperty(const char* name) const;
    //! Convenience method to get a meta property by name.
    QMetaProperty metaProperty(QString const& name) const;
-   
+
    // Some static helpers to convert to/from text.
    static double getDouble( const QDomText& textNode );
    static bool getBool( const QDomText& textNode );
@@ -106,14 +112,14 @@ public:
    static QString text(int val);
    //! Convert the date to string in Qt::ISODate format for storage NOT display.
    static QString text(QDate const& val);
-   
+
    //! Use this to pass pointers around in QVariants.
    static inline QVariant qVariantFromPtr( BeerXMLElement* ptr )
    {
       uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
       return QVariant::fromValue<uintptr_t>(addr);
    }
-   
+
    static inline BeerXMLElement* extractPtr( QVariant ptrVal )
    {
       uintptr_t addr = ptrVal.value<uintptr_t>();
@@ -122,7 +128,7 @@ public:
 
    bool isValid();
    void invalidate();
-   
+
 signals:
    /*!
     * Passes the meta property that has changed about this object.
@@ -131,9 +137,10 @@ signals:
     */
    void changed(QMetaProperty, QVariant value = QVariant());
    void changedFolder(QString);
-   
+   void changedName(QString);
+
 protected:
-   
+
    //! The key of this ingredient in its table.
    int _key;
    //! The table where this ingredient is stored.
@@ -149,24 +156,27 @@ protected:
     * 2) Call the NOTIFY method associated with \c prop_name if \c notify == true.
     */
    void set( const char* prop_name, const char* col_name, QVariant const& value, bool notify = true );
-   
+
    /*!
     * \param col_name - The database column of the attribute we want to get.
     * Returns the value of the attribute specified by key/table/col_name.
     */
    QVariant get( const char* col_name ) const;
-   
+
    void setInventory( const char* prop_name, const char* col_name, QVariant const& value, bool notify = true );
    QVariant getInventory( const char* col_name ) const;
-   
-   
-   
+
 private:
    /*!
     * \param valid - Indicates if the beerXML element was valid. There is a problem with importing invalid
     * XML. I'm hoping this helps fix it
     */
   bool _valid;
+  mutable QString _folder;
+  mutable QString _name;
+  mutable QVariant _display;
+  mutable QVariant _deleted;
+
 };
 
 

--- a/src/BtTreeItem.cpp
+++ b/src/BtTreeItem.cpp
@@ -108,7 +108,7 @@ int BtTreeItem::columnCount(int _type) const
          Brewtarget::logW( QString("BtTreeItem::columnCount Bad column: %1").arg(_type));
             return 0;
     }
-            
+
 }
 
 QVariant BtTreeItem::data(int _type, int column)
@@ -185,7 +185,7 @@ bool BtTreeItem::removeChildren(int position, int count)
    return true;
 }
 
-QVariant BtTreeItem::dataRecipe( int column ) 
+QVariant BtTreeItem::dataRecipe( int column )
 {
    Recipe* recipe = qobject_cast<Recipe*>(_thing);
    switch(column)
@@ -210,7 +210,7 @@ QVariant BtTreeItem::dataRecipe( int column )
    return QVariant();
 }
 
-QVariant BtTreeItem::dataEquipment(int column) 
+QVariant BtTreeItem::dataEquipment(int column)
 {
    Equipment* kit = qobject_cast<Equipment*>(_thing);
    switch(column)
@@ -373,7 +373,7 @@ QVariant BtTreeItem::dataFolder(int column)
    if ( ! folder && column == FOLDERNAMECOL )
       return QVariant(QObject::tr("Folder"));
 
-   if ( ! folder ) 
+   if ( ! folder )
       return QVariant(QObject::tr("Folder"));
    else if ( column == FOLDERNAMECOL )
       return QVariant( folder->name() );
@@ -410,28 +410,28 @@ Fermentable* BtTreeItem::fermentable()
 
 Hop* BtTreeItem::hop()
 {
-    if ( _type == HOP ) 
+    if ( _type == HOP )
        return qobject_cast<Hop*>(_thing);
     return 0;
 }
 
 Misc* BtTreeItem::misc()
 {
-    if ( _type == MISC ) 
+    if ( _type == MISC )
        return qobject_cast<Misc*>(_thing);
     return 0;
 }
 
 Yeast* BtTreeItem::yeast()
 {
-    if ( _type == YEAST ) 
+    if ( _type == YEAST )
        return qobject_cast<Yeast*>(_thing);
     return 0;
 }
 
 BrewNote* BtTreeItem::brewNote()
 {
-    if ( _type == BREWNOTE && _thing ) 
+    if ( _type == BREWNOTE && _thing )
        return qobject_cast<BrewNote*>(_thing);
 
     return 0;
@@ -439,7 +439,7 @@ BrewNote* BtTreeItem::brewNote()
 
 Style* BtTreeItem::style()
 {
-    if ( _type == STYLE && _thing ) 
+    if ( _type == STYLE && _thing )
        return qobject_cast<Style*>(_thing);
 
     return 0;
@@ -447,7 +447,7 @@ Style* BtTreeItem::style()
 
 BtFolder* BtTreeItem::folder()
 {
-    if ( _type == FOLDER && _thing ) 
+    if ( _type == FOLDER && _thing )
        return qobject_cast<BtFolder*>(_thing);
 
     return 0;
@@ -463,26 +463,9 @@ BeerXMLElement* BtTreeItem::thing()
 
 QString BtTreeItem::name()
 {
+   BeerXMLElement *tmp;
    if ( ! _thing )
       return QString();
-   switch(_type)
-   {
-      case RECIPE:
-         return qobject_cast<Recipe*>(_thing)->name();
-      case EQUIPMENT:
-         return qobject_cast<Equipment*>(_thing)->name();
-      case FERMENTABLE:
-         return qobject_cast<Fermentable*>(_thing)->name();
-      case FOLDER:
-         return qobject_cast<BtFolder*>(_thing)->name();
-      case HOP:
-         return qobject_cast<Hop*>(_thing)->name();
-      case MISC:
-         return qobject_cast<Misc*>(_thing)->name();
-      case STYLE:
-         return qobject_cast<Style*>(_thing)->name();
-      case YEAST:
-         return qobject_cast<Yeast*>(_thing)->name();
-   }
-   return QString();
+   tmp = qobject_cast<BeerXMLElement*>(_thing);
+   return tmp->name();
 }

--- a/src/BtTreeModel.cpp
+++ b/src/BtTreeModel.cpp
@@ -754,7 +754,7 @@ int BtTreeModel::type(const QModelIndex &index) const
 
 QString BtTreeModel::name(const QModelIndex &idx)
 {
-   return idx.isValid() ? item(idx)->name() : "";
+   return idx.isValid() ? item(idx)->name() : QString();
 }
 
 int BtTreeModel::mask()

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -329,7 +329,7 @@ bool Database::load()
    }
 
    // Initialize the SELECT * query hashes.
-   selectAll = Database::selectAllHash();
+   // selectAll = Database::selectAllHash();
    // See if there are new ingredients that we need to merge from the data-space db.
    if( dataDbFile.fileName() != dbFile.fileName()
       && ! Brewtarget::userDatabaseDidNotExist // Don't do this if we JUST copied the dataspace database.
@@ -2127,6 +2127,7 @@ void Database::sqlDelete( Brewtarget::DBTable table, QString const& whereClause 
    q.finish();
 }
 
+/*
 QHash<Brewtarget::DBTable,QSqlQuery> Database::selectAllHash()
 {
    QHash<Brewtarget::DBTable,QSqlQuery> ret;
@@ -2142,7 +2143,7 @@ QHash<Brewtarget::DBTable,QSqlQuery> Database::selectAllHash()
 
    return ret;
 }
-
+*/
 // Now the payoff for a lot of hard work elsewhere
 QHash<Brewtarget::DBTable,QString> Database::tableNamesHash()
 {

--- a/src/database.h
+++ b/src/database.h
@@ -126,8 +126,21 @@ public:
    //! \brief Get the contents of the cell specified by table/key/col_name.
    QVariant get( Brewtarget::DBTable table, int key, const char* col_name )
    {
-      QSqlQuery& q = selectAll[table];
-      q.bindValue( ":id", key );
+      QSqlQuery q;
+      QString index = QString("%1_%2").arg(tableNames[table]).arg(col_name);
+
+      if ( ! selectSome.contains(index) ) {
+         QString query = QString("SELECT %1 from %2 WHERE id=:id")
+                           .arg(col_name)
+                           .arg(tableNames[table]);
+         q = QSqlQuery( sqlDatabase() );
+         q.prepare(query);
+         selectSome.insert(index,q);
+      }
+
+      q = selectSome.value(index);
+      q.bindValue(":id", key);
+
       q.exec();
       if( !q.next() )
       {
@@ -172,7 +185,7 @@ public:
 
       tmp->_key = key;
       tmp->_table = table;
-      
+
       all->insert(tmp->_key,tmp);
 
       return tmp;
@@ -277,7 +290,7 @@ public:
 
    // Or you can mark whole lists as deleted.
    // ONE METHOD TO CALL THEM ALL AND IN DARKNESS BIND THEM!
-   template<class T> void remove(QList<T*> list) 
+   template<class T> void remove(QList<T*> list)
    {
       if ( list.empty() )
          return;
@@ -290,7 +303,7 @@ public:
       if ( ndx != -1 ) {
          propName = meta->classInfo(ndx).value();
       }
-      else 
+      else
          throw QString("%1 cannot find signal property on %2").arg(Q_FUNC_INFO).arg(meta->className());
 
       foreach( T* dead, list ) {
@@ -480,7 +493,7 @@ private:
    static QString dbUsername;
    static QString dbPassword;
 
-   static QHash<Brewtarget::DBTable,QSqlQuery> selectAllHash();
+//   static QHash<Brewtarget::DBTable,QSqlQuery> selectAllHash();
    static QHash<Brewtarget::DBTable,QString> tableNames;
    static QHash<Brewtarget::DBTable,QString> tableNamesHash();
    static QHash<QString,Brewtarget::DBTable> classNameToTable;
@@ -517,7 +530,8 @@ private:
    QHash< int, Style* > allStyles;
    QHash< int, Water* > allWaters;
    QHash< int, Yeast* > allYeasts;
-   QHash<Brewtarget::DBTable,QSqlQuery> selectAll;
+//   QHash<Brewtarget::DBTable,QSqlQuery> selectAll;
+   QHash<QString,QSqlQuery> selectSome;
 
    //! Get the right database connection for the calling thread.
    static QSqlDatabase sqlDatabase();
@@ -568,7 +582,7 @@ private:
       q.setForwardOnly(true);
       QString queryString;
 
-      if ( id.isEmpty() ) 
+      if ( id.isEmpty() )
          id = "id";
 
       if( !filter.isEmpty() )
@@ -577,7 +591,7 @@ private:
          queryString = QString("SELECT %1 as id FROM %2").arg(id).arg(tableNames[table]);
 
       try {
-         if ( ! q.exec(queryString) ) 
+         if ( ! q.exec(queryString) )
             throw QString("could not execute query: %2 : %3").arg(queryString).arg(q.lastError().text());
       }
       catch (QString e) {
@@ -670,7 +684,7 @@ private:
       QString propName, relTableName, ingKeyName, childTableName;
       const QMetaObject* meta = ing->metaObject();
       int ndx = meta->indexOfClassInfo("signal");
-    
+
       if( rec == 0 || ing == 0 )
          return 0;
 
@@ -689,7 +703,7 @@ private:
             ingKeyName = QString("%1_id").arg(prefix);
             childTableName = QString("%1_children").arg(prefix);
          }
-         else 
+         else
             throw QString("could not locate classInfo for signal on %2").arg(meta->className());
          // Ensure this ingredient is not already in the recipe.
          QString select = QString("SELECT recipe_id from %1 WHERE %2=%3 AND recipe_id=%4")
@@ -703,7 +717,6 @@ private:
          if( q.next() )
             throw QString("Ingredient already exists in recipe." );
 
-
          q.finish();
 
          if ( noCopy )
@@ -716,7 +729,6 @@ private:
          }
          else
          {
-
             newIng = copy<T>(ing, false, keyHash);
             if ( newIng == 0 )
                throw QString("error copying ingredient");
@@ -733,7 +745,7 @@ private:
          q.bindValue(":ingredient", newIng->key());
          q.bindValue(":recipe", rec->_key);
 
-         if ( ! q.exec() ) 
+         if ( ! q.exec() )
             throw QString("%2 : %1.").arg(q.lastQuery()).arg(q.lastError().text());
 
          emit rec->changed( rec->metaProperty(propName), QVariant() );
@@ -793,7 +805,7 @@ private:
       QString tName = tableNames[t];
 
       QSqlQuery q(sqlDatabase());
-     
+
       try {
          QString select = QString("SELECT * FROM %1 WHERE id = %2").arg(tName).arg(object->_key);
 
@@ -801,7 +813,7 @@ private:
             throw QString("%1 %2").arg(q.lastQuery()).arg(q.lastError().text());
          else 
             q.next();
-        
+
          QSqlRecord oldRecord = q.record();
          q.finish();
 

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -100,127 +100,7 @@ Equipment::Equipment( Equipment const& other )
 {
 }
 
-/*
-void Equipment::fromNode(const QDomNode& equipmentNode)
-{
-   QDomNode node, child;
-   QDomText textNode;
-   QString property, value;
-   bool hasRealEvapRate = false;
-   
-   setDefaults();
-   
-   for( node = equipmentNode.firstChild(); ! node.isNull(); node = node.nextSibling() )
-   {
-      if( ! node.isElement() )
-      {
-         Brewtarget::log(Brewtarget::WARNING, QObject::tr("Node at line %1 is not an element.").arg(textNode.lineNumber()) );
-         continue;
-      }
-      
-      child = node.firstChild();
-      if( child.isNull() || ! child.isText() )
-         continue;
-      
-      property = node.nodeName();
-      textNode = child.toText();
-      value = textNode.nodeValue();
-      
-      if( property == "NAME" )
-      {
-         name = value;
-      }
-      else if( property == "VERSION" )
-      {
-         if( version != getInt(textNode) )
-            Brewtarget::log(Brewtarget::ERROR, QObject::tr("EQUIPMENT says it is not version %1. Line %2").arg(version).arg(textNode.lineNumber()) );
-      }
-      else if( property == "BOIL_SIZE" )
-      {
-         setBoilSize_l(getDouble(textNode));
-      }
-      else if( property == "BATCH_SIZE" )
-      {
-         setBatchSize_l(getDouble(textNode));
-      }
-      else if( property == "TUN_VOLUME" )
-      {
-         setTunVolume_l(getDouble(textNode));
-      }
-      else if( property == "TUN_WEIGHT" )
-      {
-         setTunWeight_kg(getDouble(textNode));
-      }
-      else if( property == "TUN_SPECIFIC_HEAT" )
-      {
-         setTunSpecificHeat_calGC(getDouble(textNode));
-      }
-      else if( property == "TOP_UP_WATER" )
-      {
-         setTopUpWater_l(getDouble(textNode));
-      }
-      else if( property == "TRUB_CHILLER_LOSS" )
-      {
-         setTrubChillerLoss_l(getDouble(textNode));
-      }
-      else if( property == "EVAP_RATE" && ! hasRealEvapRate )
-      {
-         setEvapRate_pctHr(getDouble(textNode));
-      }
-      else if( property == "REAL_EVAP_RATE" )
-      {
-         setEvapRate_lHr(getDouble(textNode));
-         hasRealEvapRate = true;
-      }
-      else if( property == "BOIL_TIME" )
-      {
-         setBoilTime_min(getDouble(textNode));
-      }
-      else if( property == "CALC_BOIL_VOLUME" )
-      {
-         setCalcBoilVolume(getBool(textNode));
-      }
-      else if( property == "LAUTER_DEADSPACE" )
-      {
-         setLauterDeadspace_l(getDouble(textNode));
-      }
-      else if( property == "TOP_UP_KETTLE" )
-      {
-         setTopUpKettle_l(getDouble(textNode));
-      }
-      else if( property == "HOP_UTILIZATION" )
-      {
-         setHopUtilization_pct(getDouble(textNode));
-      }
-      else if( property == "NOTES" )
-      {
-         setNotes(value);
-      }
-      else if( property == "ABSORPTION" ) // My extension.
-      {
-         setGrainAbsorption_LKg( getDouble(textNode) );
-      }
-      else if ( property == "BOILING_POINT")
-      {
-         setBoilingPoint_c( getDouble(textNode) );
-      }
-      else
-         Brewtarget::log(Brewtarget::WARNING, QObject::tr("Unsupported EQUIPMENT property: %1. Line %2").arg(property).arg(node.lineNumber()) );
-   }
-   
-   // Estimate the actual evaporation rate if we didn't get one.
-   if( ! hasRealEvapRate )
-      setEvapRate_lHr( evapRate_pctHr/(double)100 * boilSize_l );
-}
-*/
-
 //============================"SET" METHODS=====================================
-
-void Equipment::setName( const QString &var )
-{
-   set( "name", "name", var );
-   emit changedName(var);
-}
 
 void Equipment::setBoilSize_l( double var )
 {
@@ -441,7 +321,6 @@ void Equipment::setBoilingPoint_c(double var)
 
 //============================"GET" METHODS=====================================
 
-QString Equipment::name() const { return get("name").toString(); }
 QString Equipment::notes() const { return get("notes").toString(); }
 bool Equipment::calcBoilVolume() const { return get("calc_boil_volume").toBool(); }
 

--- a/src/equipment.h
+++ b/src/equipment.h
@@ -43,8 +43,6 @@ public:
 
    virtual ~Equipment() {}
    
-   //! \brief The name.
-   Q_PROPERTY( QString name                 READ name                  WRITE setName                  NOTIFY changedName )
    //! \brief The boil size in liters.
    Q_PROPERTY( double boilSize_l            READ boilSize_l            WRITE setBoilSize_l            NOTIFY changedBoilSize_l )
    //! \brief The batch size in liters.
@@ -81,7 +79,6 @@ public:
    Q_PROPERTY( double boilingPoint_c        READ boilingPoint_c        WRITE setBoilingPoint_c        NOTIFY changedBoilingPoint_c )
 
    // Set
-   void setName( const QString &var );
    void setBoilSize_l( double var );
    void setBatchSize_l( double var );
    void setTunVolume_l( double var );
@@ -101,7 +98,6 @@ public:
    void setBoilingPoint_c(double var);
 
    // Get
-   QString name() const;
    double boilSize_l() const;
    double batchSize_l() const;
    double tunVolume_l() const;

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -77,140 +77,7 @@ Fermentable::Fermentable( Fermentable const& other )
 {
 }
 
-/*
-void Fermentable::fromNode(const QDomNode& fermentableNode)
-{
-   QDomNode node, child;
-   QDomText textNode;
-   QString property, value;
-   
-   setDefaults();
-   
-   for( node = fermentableNode.firstChild(); ! node.isNull(); node = node.nextSibling() )
-   {
-      if( ! node.isElement() )
-      {
-         Brewtarget::log(Brewtarget::WARNING, QObject::tr("Node at line %1 is not an element.").arg(textNode.lineNumber()) );
-         continue;
-      }
-      
-      child = node.firstChild();
-      if( child.isNull() || ! child.isText() )
-         continue;
-      
-      property = node.nodeName();
-      textNode = child.toText();
-      value = textNode.nodeValue();
-      
-      if( property == "NAME" )
-      {
-         name = value;
-      }
-      else if( property == "VERSION" )
-      {
-         if( version != getInt(textNode) )
-            Brewtarget::log(Brewtarget::ERROR, QObject::tr("FERMENTABLE says it is not version %1. Line %2").arg(version).arg(textNode.lineNumber()) );
-      }
-      else if( property == "TYPE" )
-      {
-         int ndx = types.indexOf(value);
-         if( ndx < 0 )
-            Brewtarget::log(Brewtarget::ERROR, QObject::tr("%1 is not a valid type for FERMENTABLE. Line %2").arg(value).arg(textNode.lineNumber()) );
-         else
-            type = static_cast<Fermentable::Type>( ndx );
-      }
-      else if( property == "AMOUNT" )
-      {
-         setAmount_kg(getDouble(textNode));
-      }
-      else if( property == "YIELD" )
-      {
-         setYield_pct(getDouble(textNode));
-      }
-      else if( property == "COLOR" )
-      {
-         setColor_srm(getDouble(textNode));
-      }
-      else if( property == "ADD_AFTER_BOIL" )
-      {
-         setAddAfterBoil(getBool(textNode));
-      }
-      else if( property == "ORIGIN" )
-      {
-         setOrigin(value);
-      }
-      else if( property == "SUPPLIER" )
-      {
-         setSupplier(value);
-      }
-      else if( property == "NOTES" )
-      {
-         setNotes(value);
-      }
-      else if( property == "COARSE_FINE_DIFF" )
-      {
-         setCoarseFineDiff_pct(getDouble(textNode));
-      }
-      else if( property == "MOISTURE" )
-      {
-         setMoisture_pct(getDouble(textNode));
-      }
-      else if( property == "DIASTATIC_POWER" )
-      {
-         setDiastaticPower_lintner(getDouble(textNode));
-      }
-      else if( property == "PROTEIN" )
-      {
-         setProtein_pct(getDouble(textNode));
-      }
-      else if( property == "MAX_IN_BATCH" )
-      {
-         setMaxInBatch_pct(getDouble(textNode));
-      }
-      else if( property == "RECOMMEND_MASH" )
-      {
-         setRecommendMash(getBool(textNode));
-      }
-      else if( property == "IS_MASHED" )
-      {
-         setIsMashed(getBool(textNode));
-      }
-      else if( property == "IBU_GAL_PER_LB" )
-      {
-         setIbuGalPerLb(getDouble(textNode));
-      }
-      else
-         Brewtarget::log(Brewtarget::WARNING, QObject::tr("Unsupported FERMENTABLE property: %1. Line %2").arg(property).arg(node.lineNumber()) );
-   }
-}
-*/
-
-/*
-void Fermentable::setDefaults()
-{
-   name = "";
-   type = TYPEGRAIN;
-   amount_kg = 0.0;
-   yield_pct = 0.0;
-   color_srm = 0.0;
-
-   addAfterBoil = false;
-   origin = "";
-   supplier = "";
-   notes = "";
-   coarseFineDiff_pct = 0.0;
-   moisture_pct = 0.0;
-   diastaticPower_lintner = 0.0;
-   protein_pct = 0.0;
-   maxInBatch_pct = 0.0;
-   recommendMash = false;
-   isMashed = false;
-   ibuGalPerLb = 0.0;
-}
-*/
-
 // Get
-const QString Fermentable::name() const { return get("name").toString(); }
 const Fermentable::Type Fermentable::type() const { return static_cast<Fermentable::Type>(types.indexOf(get("ftype").toString())); }
 const Fermentable::AdditionMethod Fermentable::additionMethod() const
 {
@@ -298,7 +165,18 @@ bool Fermentable::recommendMash() const { return get("recommend_mash").toBool();
 bool Fermentable::isMashed() const { return get("is_mashed").toBool(); }
 bool Fermentable::isExtract() { return ((type() == Extract) || (type() == Dry_Extract)); }
 bool Fermentable::isSugar() { return (type() == Sugar); }
+bool Fermentable::isValidType( const QString& str ) { return (types.indexOf(str) >= 0); }
 
+void Fermentable::setType( Type t ) { set("type", "ftype", types.at(t)); }
+void Fermentable::setAdditionMethod( Fermentable::AdditionMethod m ) { setIsMashed(m == Fermentable::Mashed); }
+void Fermentable::setAdditionTime( Fermentable::AdditionTime t ) { setAddAfterBoil(t == Fermentable::Late ); }
+void Fermentable::setAddAfterBoil( bool b ) { set("addAfterBoil", "add_after_boil", b); }
+void Fermentable::setOrigin( const QString& str ) { set("origin","origin",str);}
+void Fermentable::setSupplier( const QString& str) { set("supplier","supplier",str);}
+void Fermentable::setNotes( const QString& str ) { set("notes","notes",str);}
+void Fermentable::setRecommendMash( bool b ) { set("recommendMash","recommend_mash",b);}
+void Fermentable::setIsMashed(bool var) { set("isMashed","is_mashed",var); }
+void Fermentable::setIbuGalPerLb( double num ) { set("ibuGalPerLb","ibu_gal_per_lb",num);}
 
 double Fermentable::equivSucrose_kg() const
 {
@@ -310,41 +188,6 @@ double Fermentable::equivSucrose_kg() const
    else
       return ret;
 }
-
-// disabled per-cell work
-/*
-unitDisplay Fermentable::displayUnit() const  { return (unitDisplay)get("display_unit").toInt(); }
-unitScale Fermentable::displayScale() const { return (unitScale)get("display_scale").toInt(); }
-*/
-
-// Set
-void Fermentable::setName( const QString& str )
-{
-   set("name", "name", str);
-   emit changedName(str);
-}
-
-void Fermentable::setType( Type t )
-{
-   set("type", "ftype", types.at(t));
-}
-
-void Fermentable::setAdditionMethod( Fermentable::AdditionMethod m )
-{
-   if( m == Fermentable::Mashed )
-      setIsMashed(true);
-   else
-      setIsMashed(false);
-}
-
-void Fermentable::setAdditionTime( Fermentable::AdditionTime t )
-{
-   if( t == Fermentable::Late )
-      setAddAfterBoil(true);
-   else
-      setAddAfterBoil(false);
-}
-
 void Fermentable::setAmount_kg( double num )
 {
    if( num < 0.0 )
@@ -392,14 +235,6 @@ void Fermentable::setColor_srm( double num )
       set("color_srm", "color", num);
    }
 }
-
-void Fermentable::setAddAfterBoil( bool b )
-{
-   set("addAfterBoil", "add_after_boil", b);
-}
-void Fermentable::setOrigin( const QString& str ) { set("origin","origin",str);}
-void Fermentable::setSupplier( const QString& str) { set("supplier","supplier",str);}
-void Fermentable::setNotes( const QString& str ) { set("notes","notes",str);}
 void Fermentable::setCoarseFineDiff_pct( double num )
 {
    if( num >= 0.0 && num <= 100.0 )
@@ -456,22 +291,4 @@ void Fermentable::setMaxInBatch_pct( double num )
       Brewtarget::logW( QString("Fermentable: 0 < maxinbatch < 100: %1").arg(num) );
    }
 }
-void Fermentable::setRecommendMash( bool b ) { set("recommendMash","recommend_mash",b);}
-void Fermentable::setIsMashed(bool var) { set("isMashed","is_mashed",var); }
-void Fermentable::setIbuGalPerLb( double num ) { set("ibuGalPerLb","ibu_gal_per_lb",num);}
 
-bool Fermentable::isValidType( const QString& str )
-{
-   return (types.indexOf(str) >= 0);
-}
-
-// disabled per-cell work
-/*
-void Fermentable::setDisplayUnit( unitDisplay unit ) 
-{ 
-   set("displayUnit", "display_unit", unit); 
-   set("displayScale", "display_scale", noScale);
-}
-
-void Fermentable::setDisplayScale( unitScale scale ) { set("displayScale", "display_scale", scale); }
-*/

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -60,8 +60,6 @@ public:
 
    virtual ~Fermentable() {}
    
-   //! \brief The name.
-   Q_PROPERTY( QString name                  READ name                   WRITE setName                   NOTIFY changedName )
    //! \brief The \c Type.
    Q_PROPERTY( Type type                     READ type                   WRITE setType                   /*NOTIFY changed*/ /*changedType*/ )
    //! \brief The \c Type string.
@@ -115,15 +113,17 @@ public:
    //! \brief Whether this fermentable is a sugar. Somewhat redundant, but it makes for nice symetry elsewhere
    Q_PROPERTY( bool isSugar                  READ isSugar STORED false)
    
-   const QString name() const;
    const Type type() const;
    const QString typeString() const;
+
    //! Returns a translated type string.
    const QString typeStringTr() const;
    const AdditionMethod additionMethod() const;
+
    //! Returns a translated addition method string.
    const QString additionMethodStringTr() const;
    const AdditionTime additionTime() const;
+
    //! Returns a translated addition time string.
    const QString additionTimeStringTr() const;
    double amount_kg() const;
@@ -142,15 +142,9 @@ public:
    bool recommendMash() const;
    double ibuGalPerLb() const;
 
-   /* disabled per-cell
-   unitDisplay displayUnit() const;
-   unitScale displayScale() const;
-   */
-
    // Calculated getters.
    double equivSucrose_kg() const;
 
-   void setName( const QString& str );
    void setType( Type t );
    void setAdditionMethod( AdditionMethod m );
    void setAdditionTime( AdditionTime t );

--- a/src/hop.cpp
+++ b/src/hop.cpp
@@ -80,29 +80,6 @@ bool Hop::isValidForm(const QString& str)
    return (forms.indexOf(str) >= 0);
 }
 
-/*
-void Hop::setDefaults()
-{
-   name = "";
-   use = USEBOIL;
-   notes = "";
-   type = TYPEBOTH;
-   form = FORMPELLET;
-   origin = "";
-   substitutes = "";
-   
-   alpha_pct = 0.0;
-   amount_kg = 0.0;
-   time_min = 0.0;
-   beta_pct = 0.0;
-   hsi_pct = 0.0;
-   humulene_pct = 0.0;
-   caryophyllene_pct = 0.0;
-   cohumulone_pct = 0.0;
-   myrcene_pct = 0.0;
-}
-*/
-
 Hop::Hop()
    : BeerXMLElement()
 {
@@ -114,12 +91,6 @@ Hop::Hop( Hop const& other )
 }
 
 //============================="SET" METHODS====================================
-void Hop::setName( const QString& str )
-{
-   set("name","name",str);
-   emit changedName(str);
-}
-
 void Hop::setAlpha_pct( double num )
 {
    if( num < 0.0 || num > 100.0 )
@@ -285,7 +256,6 @@ void Hop::setMyrcene_pct( double num )
 
 //============================="GET" METHODS====================================
 
-const QString Hop::name() const { return get("name").toString(); }
 Hop::Use Hop::use() const { return static_cast<Hop::Use>(uses.indexOf(get("use").toString())); }
 const QString Hop::useString() const { return get("use").toString(); }
 Hop::Form Hop::form() const { return static_cast<Hop::Form>(forms.indexOf(get("form").toString())); }
@@ -311,7 +281,6 @@ double Hop::inventory() const
 {
    return getInventory("amount").toDouble();
 }
- 
 
 const QString Hop::useStringTr() const
 {

--- a/src/hop.h
+++ b/src/hop.h
@@ -58,8 +58,6 @@ public:
    
    virtual ~Hop() {}
    
-   //! \brief The name.
-   Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The percent alpha.
    Q_PROPERTY( double alpha_pct READ alpha_pct WRITE setAlpha_pct /*NOTIFY changed*/ /*changedAlpha_pct*/ )
    //! \brief The amount in kg.
@@ -93,12 +91,12 @@ public:
    //! \brief Myrcene as a percentage of total hop oil.
    Q_PROPERTY( double myrcene_pct READ myrcene_pct WRITE setMyrcene_pct /*NOTIFY changed*/ /*changedMyrcene_pct*/ )
    
-   const QString name() const;
    double alpha_pct() const;
    double amount_kg() const;
    double inventory() const;
    Use use() const;
    const QString useString() const;
+
    //! \brief A translated use string.
    const QString useStringTr() const;
    double time_min() const;
@@ -121,7 +119,6 @@ public:
    double myrcene_pct() const;
    
    //set
-   void setName( const QString& str );
    void setAlpha_pct( double num );
    void setAmount_kg( double num );
    void setInventoryAmount( double num );

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -45,11 +45,6 @@ Instruction::Instruction()
 }
 
 // Setters ====================================================================
-void Instruction::setName(const QString& n)
-{
-   set("name", "name", n);
-}
-
 void Instruction::setDirections(const QString& dir)
 {
    set("directions", "directions", dir);
@@ -89,43 +84,16 @@ void Instruction::addReagent(const QString& reagent)
 }
 
 // Accessors ==================================================================
+QString Instruction::directions() { return get("directions").toString(); }
 
-QString Instruction::name()
-{
-   return get("name").toString();
-}
+bool Instruction::hasTimer() { return get("hasTimer").toBool(); }
 
-QString Instruction::directions()
-{
-   return get("directions").toString();
-}
+QString Instruction::timerValue() { return get("timerValue").toString(); }
 
-bool Instruction::hasTimer()
-{
-   return get("hasTimer").toBool();
-}
+bool Instruction::completed() { return get("completed").toBool(); }
 
-QString Instruction::timerValue()
-{
-   return get("timerValue").toString();
-}
+QList<QString> Instruction::reagents() { return _reagents; }
 
-bool Instruction::completed()
-{
-   return get("completed").toBool();
-}
+double Instruction::interval() { return get("interval").toDouble(); }
 
-QList<QString> Instruction::reagents()
-{
-   return _reagents;
-}
-
-double Instruction::interval() 
-{
-   return get("interval").toDouble();
-}
-
-int Instruction::instructionNumber() const
-{
-   return Database::instance().instructionNumber(this);
-}
+int Instruction::instructionNumber() const { return Database::instance().instructionNumber(this); }

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -45,7 +45,6 @@ public:
    
    virtual ~Instruction() {}
 
-   Q_PROPERTY( QString name READ name WRITE setName /*NOTIFY changed*/ /*changedName*/ )
    Q_PROPERTY( QString directions READ directions WRITE setDirections /*NOTIFY changed*/ /*changedDirections*/ )
    Q_PROPERTY( bool hasTimer READ hasTimer WRITE setHasTimer /*NOTIFY changed*/ /*changedHasTimer*/ )
    Q_PROPERTY( QString timerValue READ timerValue WRITE setTimerValue /*NOTIFY changed*/ /*changedTimerValue*/ )
@@ -56,7 +55,6 @@ public:
    Q_PROPERTY( int instructionNumber READ instructionNumber /*WRITE*/ /*NOTIFY changed*/ STORED false )
    
    // "set" methods.
-   void setName(const QString& n);
    void setDirections(const QString& dir);
    void setHasTimer(bool has);
    void setTimerValue(const QString& timerVal);
@@ -65,7 +63,6 @@ public:
    void addReagent(const QString& reagent);
 
    // "get" methods.
-   QString name();
    QString directions();
    bool hasTimer();
    QString timerValue();

--- a/src/mash.cpp
+++ b/src/mash.cpp
@@ -61,31 +61,11 @@ Mash::Mash()
 {
 }
 
-void Mash::setName( const QString& var )
-{
-   set("name", "name", var);
-   emit changedName(var);
-}
-
-void Mash::setGrainTemp_c( double var )
-{
-   set("grainTemp_c", "grain_temp", var);
-}
-
-void Mash::setNotes( const QString& var )
-{
-   set("notes", "notes", var);
-}
-
-void Mash::setTunTemp_c( double var )
-{
-   set("tunTemp_c", "tun_temp", var);
-}
-
-void Mash::setSpargeTemp_c( double var )
-{
-   set("spargeTemp_c", "sparge_temp", var);
-}
+void Mash::setGrainTemp_c( double var ) { set("grainTemp_c", "grain_temp", var); }
+void Mash::setNotes( const QString& var ) { set("notes", "notes", var); }
+void Mash::setTunTemp_c( double var ) { set("tunTemp_c", "tun_temp", var); }
+void Mash::setSpargeTemp_c( double var ) { set("spargeTemp_c", "sparge_temp", var); }
+void Mash::setEquipAdjust( bool var ) { set("equipAdjust", "equip_adjust", var); }
 
 void Mash::setPh( double var )
 {
@@ -126,11 +106,6 @@ void Mash::setTunSpecificHeat_calGC( double var )
    }
 }
 
-void Mash::setEquipAdjust( bool var )
-{
-   set("equipAdjust", "equip_adjust", var);
-}
-
 void Mash::removeAllMashSteps()
 {
    int i, size;
@@ -142,17 +117,13 @@ void Mash::removeAllMashSteps()
 }
 
 //============================="GET" METHODS====================================
-
-QString Mash::name()                 const { return get("name").toString(); }
 QString Mash::notes()                const { return get("notes").toString(); }
-
 double Mash::grainTemp_c()           const { return get("grain_temp").toDouble(); }
 double Mash::tunTemp_c()             const { return get("tun_temp").toDouble(); }
 double Mash::spargeTemp_c()          const { return get("sparge_temp").toDouble(); }
 double Mash::ph()                    const { return get("ph").toDouble(); }
 double Mash::tunWeight_kg()          const { return get("tun_weight").toDouble(); }
 double Mash::tunSpecificHeat_calGC() const { return get("tun_specific_heat").toDouble(); }
-
 bool Mash::equipAdjust()             const { return get("equip_adjust").toBool(); }
 
 // === other methods ===

--- a/src/mash.h
+++ b/src/mash.h
@@ -48,8 +48,6 @@ public:
 
    virtual ~Mash() {}
    
-   //! \brief The name.
-   Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The initial grain temp in Celsius.
    Q_PROPERTY( double grainTemp_c READ grainTemp_c WRITE setGrainTemp_c /*NOTIFY changed*/ /*changedGrainTemp_c*/ )
    //! \brief The notes.
@@ -75,7 +73,6 @@ public:
    Q_PROPERTY( QList<MashStep*> mashSteps  READ mashSteps /*WRITE*/ /*NOTIFY changed*/ /*changedTotalTime*/ STORED false )
    
    // Setters
-   void setName( const QString &var );
    void setGrainTemp_c( double var );
    void setNotes( const QString &var );
    void setTunTemp_c( double var );
@@ -86,7 +83,6 @@ public:
    void setEquipAdjust( bool var );
 
    // Getters
-   QString name() const;
    double grainTemp_c() const;
    unsigned int numMashSteps() const;
    QString notes() const;

--- a/src/mashstep.cpp
+++ b/src/mashstep.cpp
@@ -53,109 +53,12 @@ bool operator==(MashStep &m1, MashStep &m2)
 
 //==============================CONSTRUCTORS====================================
 
-/*
-void MashStep::setDefaults()
-{
-   name = "";
-   type = TYPEINFUSION;
-   infuseAmount_l = 0.0;
-   infuseTemp_c = 0.0;
-   stepTemp_c = 0.0;
-   stepTime_min = 0.0;
-   rampTime_min = 0.0;
-   endTemp_c = 0.0;
-   decoctionAmount_l = 0.0;
-}
-*/
-
 MashStep::MashStep()
    : BeerXMLElement()
 {
 }
 
-/*
-void MashStep::fromNode(const QDomNode& mashStepNode)
-{
-   QDomNode node, child;
-   QDomText textNode;
-   QString property, value;
-   
-   setDefaults();
-   
-   for( node = mashStepNode.firstChild(); ! node.isNull(); node = node.nextSibling() )
-   {
-      if( ! node.isElement() )
-      {
-         Brewtarget::log(Brewtarget::WARNING, QObject::tr("Node at line %1 is not an element.").arg(textNode.lineNumber()) );
-         continue;
-      }
-      
-      child = node.firstChild();
-      if( child.isNull() || ! child.isText() )
-         continue;
-      
-      property = node.nodeName();
-      textNode = child.toText();
-      value = textNode.nodeValue();
-      
-      if( property == "NAME" )
-      {
-         name = value;
-      }
-      else if( property == "VERSION" )
-      {
-         if( version != getInt(textNode) )
-            Brewtarget::log(Brewtarget::ERROR, QObject::tr("YEAST says it is not version %1. Line %2").arg(version).arg(textNode.lineNumber()) );
-      }
-      else if( property == "TYPE" )
-      {
-         int ndx = types.indexOf(value);
-         if( ndx < 0 )
-            Brewtarget::log(Brewtarget::ERROR, QObject::tr("%1 is not a valid type for MASHSTEP. Line %2").arg(value).arg(textNode.lineNumber()) );
-         else
-            setType(static_cast<MashStep::Type>(ndx));
-      }
-      else if( property == "INFUSE_AMOUNT" )
-      {
-         setInfuseAmount_l(getDouble(textNode));
-      }
-      else if( property == "STEP_TEMP" )
-      {
-         setStepTemp_c(getDouble(textNode));
-      }
-      else if( property == "STEP_TIME" )
-      {
-         setStepTime_min(getDouble(textNode));
-      }
-      else if( property == "RAMP_TIME" )
-      {
-         setRampTime_min(getDouble(textNode));
-      }
-      else if( property == "END_TEMP" )
-      {
-         setEndTemp_c(getDouble(textNode));
-      }
-      else if( property == "INFUSE_TEMP" )
-      {
-         setInfuseTemp_c(getDouble(textNode));
-      }
-      else if( property == "DECOCTION_AMOUNT" )
-      {
-         setDecoctionAmount_l(getDouble(textNode));
-      }
-      else
-         Brewtarget::log(Brewtarget::WARNING, QObject::tr("Unsupported MASHSTEP property: %1. Line %2").arg(property).arg(node.lineNumber()) );
-   }
-}
-*/
-
 //================================"SET" METHODS=================================
-void MashStep::setName( const QString &var )
-{
-   set("name", "name", var);
-   emit changedName(var);
-}
-
 void MashStep::setInfuseTemp_c(double var)
 {
    set("infuseTemp_c", "infuse_temp", var);
@@ -238,14 +141,9 @@ void MashStep::setDecoctionAmount_l(double var)
 }
 
 //============================="GET" METHODS====================================
-
-QString MashStep::name() const { return get("name").toString(); }
-
 MashStep::Type MashStep::type()        const { return static_cast<MashStep::Type>(types.indexOf(get("mstype").toString())); }
-
 const QString MashStep::typeString()   const { return get("mstype").toString(); }
 const QString MashStep::typeStringTr() const { return typesTr.at(type()); }
-
 double MashStep::infuseTemp_c()        const { return get("infuse_temp").toDouble(); }
 double MashStep::infuseAmount_l()      const { return get("infuse_amount").toDouble(); }
 double MashStep::stepTemp_c()          const { return get("step_temp").toDouble(); }
@@ -253,17 +151,18 @@ double MashStep::stepTime_min()        const { return get("step_time").toDouble(
 double MashStep::rampTime_min()        const { return get("ramp_time").toDouble(); }
 double MashStep::endTemp_c()           const { return get("end_temp").toDouble(); }
 double MashStep::decoctionAmount_l()   const { return get("decoction_amount").toDouble(); }
-
 int MashStep::stepNumber()             const { return get("step_number").toInt(); }
 
-bool MashStep::isInfusion() const {
+bool MashStep::isInfusion() const
+{
    MashStep::Type _type = type();
    return ( _type == MashStep::Infusion    ||
             _type == MashStep::batchSparge ||
             _type == MashStep::flySparge );
 }
 
-bool MashStep::isSparge() const {
+bool MashStep::isSparge() const
+{
    MashStep::Type _type = type();
    return ( _type == MashStep::batchSparge ||
             _type == MashStep::flySparge   || 

--- a/src/mashstep.h
+++ b/src/mashstep.h
@@ -50,8 +50,6 @@ public:
    
    virtual ~MashStep() {}
 
-   //! \brief The name.
-   Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The \c Type.
    Q_PROPERTY( Type type READ type WRITE setType /*NOTIFY changed*/ /*changedType*/ )
    //! \brief The translated \c Type string.
@@ -73,7 +71,6 @@ public:
    //! \brief The step number in a sequence of other steps.
    Q_PROPERTY( int stepNumber READ stepNumber /*WRITE*/ /*NOTIFY changed*/ STORED false )
    
-   void setName( const QString &var );
    void setType( Type t );
    void setInfuseAmount_l( double var );
    void setStepTemp_c( double var );
@@ -83,7 +80,6 @@ public:
    void setInfuseTemp_c( double var );
    void setDecoctionAmount_l( double var );
    
-   QString name() const;
    Type type() const;
    const QString typeString() const;
    const QString typeStringTr() const;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -59,35 +59,23 @@ Misc::Misc(Misc const& other) : BeerXMLElement(other)
 }
 
 //============================"GET" METHODS=====================================
-QString Misc::name() const
-{
-   return get( "name" ).toString();
-}
-
-Misc::Type Misc::type() const
-{
-   return static_cast<Misc::Type>(types.indexOf(get("mtype").toString()));
-}
-
-const QString Misc::typeString() const
-{
-   return types.at(type());
-}
+Misc::Type Misc::type() const { return static_cast<Misc::Type>(types.indexOf(get("mtype").toString())); }
+const QString Misc::typeString() const { return types.at(type()); }
+Misc::Use Misc::use() const { return static_cast<Misc::Use>(uses.indexOf(get("use").toString())); }
+const QString Misc::useString() const { return uses.at(use()); }
+double Misc::amount()    const { return get("amount").toDouble(); }
+double Misc::time()      const { return get("time").toDouble(); }
+bool Misc::amountIsWeight() const { return get("amount_is_weight").toBool(); }
+QString Misc::useFor() const { return get("use_for").toString(); }
+QString Misc::notes() const { return get("notes").toString(); }
+double Misc::inventory() const { return getInventory("amount").toDouble(); }
+Misc::AmountType Misc::amountType() const { return amountIsWeight() ? AmountType_Weight : AmountType_Volume; }
+const QString Misc::amountTypeString() const { return amountTypes.at(amountType()); }
 
 const QString Misc::typeStringTr() const
 {
    QStringList typesTr = QStringList() << tr("Spice") << tr("Fining") << tr("Water Agent") << tr("Herb") << tr("Flavor") << tr("Other");
    return typesTr.at(type());
-}
-
-Misc::Use Misc::use() const
-{
-   return static_cast<Misc::Use>(uses.indexOf(get("use").toString()));
-}
-
-const QString Misc::useString() const
-{
-   return uses.at(use());
 }
 
 const QString Misc::useStringTr() const
@@ -96,56 +84,19 @@ const QString Misc::useStringTr() const
    return usesTr.at(use());
 }
 
-Misc::AmountType Misc::amountType() const
-{
-   return amountIsWeight() ? AmountType_Weight : AmountType_Volume;
-}
-
-const QString Misc::amountTypeString() const
-{
-   return amountTypes.at(amountType());
-}
-
 const QString Misc::amountTypeStringTr() const
 {
    QStringList amountTypesTr = QStringList() << tr("Weight") << tr("Volume");
    return amountTypesTr.at(amountType());
 }
 
-double Misc::amount()    const { return get("amount").toDouble(); }
-double Misc::time()      const { return get("time").toDouble(); }
-
-bool Misc::amountIsWeight() const { return get("amount_is_weight").toBool(); }
-
-QString Misc::useFor() const { return get("use_for").toString(); }
-QString Misc::notes() const { return get("notes").toString(); }
-
-double Misc::inventory() const 
-{ 
-   return getInventory("amount").toDouble();
-}
-
 //============================"SET" METHODS=====================================
-void Misc::setName( const QString& var )
-{
-   set( "name", "name", var );
-   emit changedName(var);
-}
-
-void Misc::setType( Type t )
-{
-   set( "type", "mtype", types.at(t) );
-}
-
-void Misc::setUse( Use u )
-{
-   set( "use", "use", uses.at(u) );
-}
-
-void Misc::setAmountType( AmountType t )
-{
-   setAmountIsWeight(t == AmountType_Weight ? true : false);
-}
+void Misc::setType( Type t ) { set( "type", "mtype", types.at(t) ); }
+void Misc::setUse( Use u ) { set( "use", "use", uses.at(u) ); }
+void Misc::setAmountType( AmountType t ) { setAmountIsWeight(t == AmountType_Weight ? true : false); }
+void Misc::setUseFor( const QString& var ) { set( "useFor", "use_for", var ); }
+void Misc::setNotes( const QString& var ) { set( "notes", "notes", var ); }
+void Misc::setAmountIsWeight( bool var ) { set( "amountIsWeight", "amount_is_weight", var ); }
 
 void Misc::setAmount( double var )
 {
@@ -169,21 +120,6 @@ void Misc::setTime( double var )
       Brewtarget::logW( QString("Misc: time < 0: %1").arg(var) );
    else
       set( "time", "time", var );
-}
-
-void Misc::setAmountIsWeight( bool var )
-{
-   set( "amountIsWeight", "amount_is_weight", var );
-}
-
-void Misc::setUseFor( const QString& var )
-{
-   set( "useFor", "use_for", var );
-}
-
-void Misc::setNotes( const QString& var )
-{
-   set( "notes", "notes", var );
 }
 
 //========================OTHER METHODS=========================================

--- a/src/misc.h
+++ b/src/misc.h
@@ -54,8 +54,6 @@ public:
    
    virtual ~Misc() {}
    
-   //! \brief The name.
-   Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The \c Type.
    Q_PROPERTY( Type type READ type WRITE setType /*NOTIFY changed*/ /*changedType*/ )
    //! \brief The  \c Type string.
@@ -88,7 +86,6 @@ public:
    Q_PROPERTY( QString notes READ notes WRITE setNotes /*NOTIFY changed*/ /*changedNotes*/ )
    
    // Set
-   void setName( const QString &var );
    void setType( Type t );
    void setUse( Use u );
    void setAmountType( AmountType t );
@@ -100,7 +97,7 @@ public:
    void setNotes( const QString &var );
    
    // Get
-   QString name() const;
+//   QString name() const;
    Type type() const;
    const QString typeString() const;
    const QString typeStringTr() const;

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -799,12 +799,6 @@ void Recipe::addWater( Water* var )
 }
 
 //==============================="SET" METHODS=================================
-void Recipe::setName( const QString &var )
-{
-   set( "name", "name", var );
-   emit changedName(var);
-}
-
 void Recipe::setType( const QString &var )
 {
    QString tmp;
@@ -1260,7 +1254,6 @@ double Recipe::points()
 }
 
 //=========================Relational Getters=============================
-
 Style* Recipe::style() const
 {
    return Database::instance().style(this);
@@ -1312,7 +1305,6 @@ QList<Water*> Recipe::waters() const
 }
 
 //==============================Getters===================================
-QString Recipe::name()             const { return get("name").toString(); }
 QString Recipe::type()             const { return get("type").toString(); }
 QString Recipe::brewer()           const { return get("brewer").toString(); }
 QString Recipe::asstBrewer()       const { return get("assistant_brewer").toString(); }

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -81,8 +81,6 @@ public:
    //! \brief Retains only the name, but sets everything else to defaults.
    void clear();
    
-   //! \brief The name.
-   Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The type (lager, ale, etc.).
    Q_PROPERTY( QString type READ type WRITE setType /*NOTIFY changed*/ /*changedType*/ )
    //! \brief The brewer.
@@ -209,9 +207,7 @@ public:
    void addMisc( Misc* var );
    void addYeast( Yeast* var );
    void addWater( Water* var );
-   //void addBrewNote(BrewNote* var);
    void removeBrewNote(BrewNote* var);
-   //void addInstruction( Instruction* ins );
    void removeInstruction( Instruction* ins );
    /*!
     * \brief Swap instructions \c ins1 and \c ins2
@@ -232,7 +228,6 @@ public:
    QString nextAddToBoil(double& time);
 
    // Getters
-   QString name() const;
    QString type() const;
    QString brewer() const;
    double batchSize_l() const;
@@ -327,8 +322,7 @@ public slots:
    void acceptYeastChange(Yeast* yeast);
    void acceptMashChange(Mash* mash);
 
-   // Setters
-   void setName( const QString &var );
+   // Setters -- why are these slots?
    void setType( const QString &var );
    void setBrewer( const QString &var );
    void setBatchSize_l( double var );

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -69,12 +69,6 @@ Style::Style()
 }
 
 //==============================="SET" METHODS==================================
-void Style::setName( const QString& var )
-{
-   set( "name", "name", var );
-   emit changedName(var);
-}
-
 void Style::setCategory( const QString& var )
 {
    set( "category", "category", var );
@@ -241,7 +235,6 @@ void Style::setExamples( const QString& var )
 }
 
 //============================="GET" METHODS====================================
-QString Style::name() const { return get("name").toString(); }
 QString Style::category() const { return get("category").toString(); }
 QString Style::categoryNumber() const { return get("category_number").toString(); }
 QString Style::styleLetter() const { return get("style_letter").toString(); }

--- a/src/style.h
+++ b/src/style.h
@@ -52,8 +52,6 @@ public:
    enum Type {Lager, Ale, Mead, Wheat, Mixed, Cider};
    Q_ENUMS( Type )
    
-   //! \brief The name.
-   Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The category.
    Q_PROPERTY( QString category READ category WRITE setCategory /*NOTIFY changed*/ /*changedCategory*/ )
    //! \brief The category number.
@@ -97,7 +95,6 @@ public:
    //! \brief The commercial examples.
    Q_PROPERTY( QString examples READ examples WRITE setExamples /*NOTIFY changed*/ /*changedExamples*/ )
    
-   void setName( const QString& var );
    void setCategory( const QString& var );
    void setCategoryNumber( const QString& var );
    void setStyleLetter( const QString& var );
@@ -120,7 +117,6 @@ public:
    void setIngredients( const QString& var );
    void setExamples( const QString& var );
 
-   QString name() const;
    QString category() const;
    QString categoryNumber() const;
    QString styleLetter() const;

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -54,33 +54,12 @@ bool operator==(Water &w1, Water &w2)
    return w1.name() == w2.name();
 }
 
-/*
-void Water::setDefaults()
-{
-   name = "";
-   amount_l = 0.0;
-   calcium_ppm = 0.0;
-   bicarbonate_ppm = 0.0;
-   chloride_ppm = 0.0;
-   sodium_ppm = 0.0;
-   magnesium_ppm = 0.0;
-   ph = 7.0;
-   notes = "";
-}
-*/
-
 Water::Water()
    : BeerXMLElement()
 {
 }
 
 //================================"SET" METHODS=================================
-void Water::setName( const QString &var )
-{
-   set("name", "name", var);
-   emit changedName(var);
-}
-
 void Water::setAmount_l( double var )
 {
    set("amount_l", "amount", var);
@@ -127,7 +106,6 @@ void Water::setNotes( const QString &var )
 }
 
 //=========================="GET" METHODS=======================================
-QString Water::name() const { return get("name").toString(); }
 QString Water::notes() const { return get("notes").toString(); }
 
 double Water::sulfate_ppm() const { return get("sulfate").toDouble(); }

--- a/src/water.h
+++ b/src/water.h
@@ -47,8 +47,6 @@ public:
 
    virtual ~Water() {}
    
-   //! \brief The name.
-   Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The amount in liters.
    Q_PROPERTY( double amount_l READ amount_l WRITE setAmount_l /*NOTIFY changed*/ /*changedAmount_l*/ )
    //! \brief The ppm of calcium.
@@ -68,7 +66,6 @@ public:
    //! \brief The notes.
    Q_PROPERTY( QString notes READ notes WRITE setNotes /*NOTIFY changed*/ /*changedNotes*/ )
    
-   QString name() const;
    double amount_l() const;
    double calcium_ppm() const;
    double bicarbonate_ppm() const;
@@ -79,7 +76,6 @@ public:
    double ph() const;
    QString notes() const;
 
-   void setName( const QString &var );
    void setAmount_l( double var );
    void setCalcium_ppm( double var );
    void setSulfate_ppm( double var );

--- a/src/yeast.cpp
+++ b/src/yeast.cpp
@@ -76,7 +76,6 @@ Yeast::Yeast(Yeast const& other) : BeerXMLElement(other)
 }
 
 //============================="GET" METHODS====================================
-QString Yeast::name() const { return get("name").toString(); }
 QString Yeast::laboratory() const { return get("laboratory").toString();; }
 QString Yeast::productID() const { return get("product_id").toString(); }
 QString Yeast::notes() const { return get("notes").toString(); }
@@ -130,12 +129,6 @@ const QString Yeast::flocculationStringTr() const
 }
 
 //============================="SET" METHODS====================================
-void Yeast::setName( const QString& var )
-{
-   set("name", "name", var);
-   emit changedName(var);
-}
-
 void Yeast::setType( Yeast::Type t )
 {
    set("type", "ytype", types.at(t));
@@ -238,7 +231,6 @@ void Yeast::setAddToSecondary( bool var )
 }
 
 //========================OTHER METHODS=========================================
-
 bool Yeast::isValidType(const QString& str) const
 {
    static const QString types[] = {"Ale", "Lager", "Wheat", "Wine", "Champagne"};

--- a/src/yeast.h
+++ b/src/yeast.h
@@ -56,8 +56,6 @@ public:
    
    virtual ~Yeast() {}
    
-   //! \brief The name.
-   Q_PROPERTY( QString name READ name WRITE setName NOTIFY changedName )
    //! \brief The \c Type.
    Q_PROPERTY( Type type READ type WRITE setType /*NOTIFY changed*/ /*changedType*/ )
    //! \brief The \c Type string.
@@ -104,7 +102,6 @@ public:
    Q_PROPERTY( bool addToSecondary READ addToSecondary WRITE setAddToSecondary /*NOTIFY changed*/ /*changedAddToSecondary*/ )
    
    // Setters
-   void setName( const QString& var );
    void setType( Type t );
    void setForm( Form f );
    void setAmount( double var );
@@ -123,7 +120,6 @@ public:
    void setAddToSecondary( bool var );
    
    // Getters
-   QString name() const;
    Type type() const;
    const QString typeString() const;
    const QString typeStringTr() const;
@@ -151,23 +147,6 @@ signals:
 
    //! \brief Emitted when \c name() changes.
    void changedName(QString);
-   /*
-   void changedType(Type);
-   void changedForm(Form);
-   void changedAmount(double);
-   void changedAmountIsWeight(bool);
-   void changedLaboratory(QString);
-   void changedProductID(QString);
-   void changedMinTemperature_c(double);
-   void changedMaxTemperature_c(double);
-   void changedFlocculation(Flocculation);
-   void changedAttenuation_pct(double);
-   void changedNotes(QString);
-   void changedBestFor(QString);
-   void changedTimesCultured(int);
-   void changedMaxReuse(int);
-   void changedAddToSecondary(bool);
-   */
 
 private:
    Yeast();
@@ -181,7 +160,6 @@ private:
    bool isValidType(const QString& str) const;
    bool isValidForm(const QString& str) const;
    bool isValidFlocculation(const QString& str) const;
-   //void setDefaults();
    
    static QHash<QString,QString> tagToProp;
    static QHash<QString,QString> tagToPropHash();


### PR DESCRIPTION
If you read the issue, most of this commit should look familiar. The big changes are explained in there.

Previously, we requested the entire row for an item, and then returned one column. Now, we request the one column we want, for a 50% speed improvement. This required us to change how we prepare and cache our queries. selectAll is gone, as is the method that created it. selectSome is used now, and built on the fly.

We now cache four attributes: name, folder, deleted and display. Each of those attributes is now defined in BeerXMLElement. This required removing all of the code from equipment, fermentable, hop, instruction, mash, mashstep, misc, recipe, style, water and yeast that dealt with setting and getting names.

These two changes resulted in the load times for brewtarget to drop from 15 seconds to 2 seconds when using postgresql, and we now load the sqlite database in about 0.5 seconds.

While I was messing about, I also deleted some commented out code.