### PR TITLE
Closes #311 - Core dump when closing brewtarget

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -539,10 +539,11 @@ QSqlDatabase Database::sqlDatabase()
 
 void Database::unload()
 {
-   // The postgres driver wants nothing to do with this. Core gets dumped if
-   // we try it. Since we don't need to copy things about for postgres...
 
 
+   // selectSome saves context. If we close the database before we tear that
+   // context down, core gets dumped
+   selectSome.clear();
    QSqlDatabase::database( dbConName, false ).close();
    QSqlDatabase::removeDatabase( dbConName );
 


### PR DESCRIPTION
Just had to make sure we cleared selectSome before we closed the connection to the database.