### PR TITLE
Implement the diastatic power unit.

### DIFF
--- a/src/BtLabel.cpp
+++ b/src/BtLabel.cpp
@@ -123,6 +123,9 @@ void BtLabel::initializeMenu()
       case DATE:
          _menu = Brewtarget::setupDateMenu(btParent,unit); // unit only
          break;
+      case DIASTATIC_POWER:
+         _menu = Brewtarget::setupDiastaticPowerMenu(btParent,unit);
+         break;
       default:
          return;
    }
@@ -231,5 +234,10 @@ BtTimeLabel::BtTimeLabel(QWidget *parent)
 
 BtVolumeLabel::BtVolumeLabel(QWidget *parent)
    : BtLabel(parent,VOLUME)
+{
+}
+
+BtDiastaticPowerLabel::BtDiastaticPowerLabel(QWidget *parent)
+   : BtLabel(parent,DIASTATIC_POWER)
 {
 }

--- a/src/BtLabel.h
+++ b/src/BtLabel.h
@@ -39,6 +39,7 @@ class BtVolumeLabel;
 class BtTimeLabel;
 class BtMixedLabel;
 class BtDateLabel;
+class BtDiastaticPowerLabel;
 
 /*!
  * \class BtLabel
@@ -63,7 +64,8 @@ public:
       VOLUME,
       TIME,
       MIXED,
-      DATE
+      DATE,
+      DIASTATIC_POWER
    };
 
    BtLabel(QWidget* parent = 0, LabelType lType = NONE);
@@ -144,6 +146,13 @@ class BtDateLabel : public BtLabel
    Q_OBJECT
 public:
    BtDateLabel(QWidget* parent = 0);
+};
+
+class BtDiastaticPowerLabel : public BtLabel
+{
+   Q_OBJECT
+public:
+   BtDiastaticPowerLabel(QWidget* parent = 0);
 };
 
 #endif

--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -91,6 +91,10 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
       case Unit::String:
          amt = text();
          break;
+      case Unit::DiastaticPower:
+         val = toSI(oldUnit,oldScale,force);
+         amt = displayAmount(val,3);
+         break;
       case Unit::None:
       default:
          val = Brewtarget::toDouble(text(),&ok);
@@ -390,5 +394,11 @@ void BtMixedEdit::setIsWeight(bool state)
 
    // maybe? My head hurts now
    lineChanged();
+}
+
+BtDiastaticPowerEdit::BtDiastaticPowerEdit(QWidget *parent)
+   : BtLineEdit(parent,Unit::DiastaticPower)
+{
+   _units = Units::lintner;
 }
 

--- a/src/BtLineEdit.h
+++ b/src/BtLineEdit.h
@@ -34,6 +34,7 @@ class BtTimeEdit;
 class BtDensityEdit;
 class BtColorEdit;
 class BtMixedEdit;
+class BtDiastaticPowerEdit;
 class BtStringEdit;
 
 /*!
@@ -189,4 +190,13 @@ public slots:
    void setIsWeight(bool state);
 
 };
+
+class BtDiastaticPowerEdit : public BtLineEdit
+{
+   Q_OBJECT
+
+public:
+   BtDiastaticPowerEdit(QWidget* parent);
+};
+
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ SET( brewtarget_SRCS
     ${SRCDIR}/CustomComboBox.cpp
     ${SRCDIR}/database.cpp
     ${SRCDIR}/DatabaseSchemaHelper.cpp
+    ${SRCDIR}/DiastaticPowerUnitSystem.cpp
     ${SRCDIR}/equipment.cpp
     ${SRCDIR}/EbcColorUnitSystem.cpp
     ${SRCDIR}/EquipmentButton.cpp

--- a/src/DiastaticPowerUnitSystem.cpp
+++ b/src/DiastaticPowerUnitSystem.cpp
@@ -1,0 +1,85 @@
+/*
+ * DiastaticPowerUnitSystem.cpp is part of Brewtarget, and was written by
+ * Mark de Wever (koraq@xs4all.nl), copyright 2016
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DiastaticPowerUnitSystem.h"
+#include <QStringList>
+#include "unit.h"
+
+LintnerDiastaticPowerUnitSystem::LintnerDiastaticPowerUnitSystem()
+   : UnitSystem()
+{
+   _type = Unit::DiastaticPower;
+}
+
+QMap<Unit::unitScale, Unit*> const& LintnerDiastaticPowerUnitSystem::scaleToUnit()
+{
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
+   if( _scaleToUnit.empty() )
+   {
+      _scaleToUnit.insert(Unit::scaleWithout, Units::lintner);
+   }
+
+   return _scaleToUnit;
+}
+
+QMap<QString, Unit*> const& LintnerDiastaticPowerUnitSystem::qstringToUnit()
+{
+   static QMap<QString, Unit*> _qstringToUnit;
+   if( _qstringToUnit.empty() )
+   {
+      _qstringToUnit.insert("lintner", Units::lintner);
+   }
+
+   return _qstringToUnit;
+}
+
+QString LintnerDiastaticPowerUnitSystem::unitType() { return "DiastaticPower"; }
+Unit* LintnerDiastaticPowerUnitSystem::unit() { return Units::lintner; }
+
+
+WkDiastaticPowerUnitSystem::WkDiastaticPowerUnitSystem()
+   : UnitSystem()
+{
+   _type = Unit::DiastaticPower;
+}
+
+QMap<Unit::unitScale, Unit*> const& WkDiastaticPowerUnitSystem::scaleToUnit()
+{
+   static QMap<Unit::unitScale, Unit*> _scaleToUnit;
+   if( _scaleToUnit.empty() )
+   {
+      _scaleToUnit.insert(Unit::scaleWithout, Units::wk);
+   }
+
+   return _scaleToUnit;
+}
+
+QMap<QString, Unit*> const& WkDiastaticPowerUnitSystem::qstringToUnit()
+{
+   static QMap<QString, Unit*> _qstringToUnit;
+   if( _qstringToUnit.empty() )
+   {
+      _qstringToUnit.insert("wk", Units::wk);
+   }
+
+   return _qstringToUnit;
+}
+
+QString WkDiastaticPowerUnitSystem::unitType() { return "DiastaticPower"; }
+Unit* WkDiastaticPowerUnitSystem::unit() { return Units::wk; }
+

--- a/src/DiastaticPowerUnitSystem.h
+++ b/src/DiastaticPowerUnitSystem.h
@@ -1,0 +1,52 @@
+/*
+ * DiastaticPowerUnitSystem.h is part of Brewtarget, and was written by
+ * Mark de Wever (koraq@xs4all.nl), copyright 2016
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DIASTATICPOWERUNITSYSTEM_H
+#define DIASTATICPOWERUNITSYSTEM_H
+
+#include <QMap>
+#include "UnitSystem.h"
+
+class LintnerDiastaticPowerUnitSystem : public UnitSystem
+{
+public:
+   LintnerDiastaticPowerUnitSystem();
+   Unit* thicknessUnit() { return 0; }
+   QString unitType();
+
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
+   QMap<QString, Unit*> const& qstringToUnit();
+   Unit* unit();
+
+};
+
+class WkDiastaticPowerUnitSystem : public UnitSystem
+{
+public:
+   WkDiastaticPowerUnitSystem();
+   Unit* thicknessUnit() { return 0; }
+   QString unitType();
+
+   QMap<Unit::unitScale, Unit*> const& scaleToUnit();
+   QMap<QString, Unit*> const& qstringToUnit();
+   Unit* unit();
+
+};
+
+#endif /*DIASTATICPOWERUNITSYSTEM_H*/
+

--- a/src/OptionDialog.cpp
+++ b/src/OptionDialog.cpp
@@ -33,6 +33,7 @@
 #include "SrmColorUnitSystem.h"
 #include "PlatoDensityUnitSystem.h"
 #include "SgDensityUnitSystem.h"
+#include "DiastaticPowerUnitSystem.h"
 #include "CelsiusTempUnitSystem.h"
 #include "database.h"
 #include <QMessageBox>
@@ -136,6 +137,9 @@ OptionDialog::OptionDialog(QWidget* parent)
 
    colorComboBox->addItem(tr("SRM"), QVariant(Brewtarget::SRM));
    colorComboBox->addItem(tr("EBC"), QVariant(Brewtarget::EBC));
+
+   diastaticPowerComboBox->addItem(tr("Lintner"), QVariant(Brewtarget::LINTNER));
+   diastaticPowerComboBox->addItem(tr("WK"), QVariant(Brewtarget::WK));
 
    // Populate combo boxes on the "Formulas" tab
    ibuFormulaComboBox->addItem(tr("Tinseth's approximation"), QVariant(Brewtarget::TINSETH));
@@ -388,6 +392,19 @@ void OptionDialog::saveAndClose()
          break;
    }
 
+   switch (diastaticPowerComboBox->itemData(diastaticPowerComboBox->currentIndex()).toInt(&okay))
+   {
+      case Brewtarget::LINTNER:
+      default:
+         Brewtarget::thingToUnitSystem.insert(Unit::DiastaticPower,UnitSystems::lintnerDiastaticPowerUnitSystem());
+         Brewtarget::diastaticPowerUnit = Brewtarget::LINTNER;
+         break;
+      case Brewtarget::WK:
+         Brewtarget::thingToUnitSystem.insert(Unit::DiastaticPower,UnitSystems::wkDiastaticPowerUnitSystem());
+         Brewtarget::diastaticPowerUnit = Brewtarget::WK;
+         break;
+   }
+
    int ndx = ibuFormulaComboBox->itemData(ibuFormulaComboBox->currentIndex()).toInt(&okay);
    Brewtarget::ibuFormula = static_cast<Brewtarget::IbuType>(ndx);
    ndx = colorFormulaComboBox->itemData(colorFormulaComboBox->currentIndex()).toInt(&okay);
@@ -460,6 +477,7 @@ void OptionDialog::showChanges()
    gravityComboBox->setCurrentIndex(gravityComboBox->findData(Brewtarget::densityUnit));
    dateComboBox->setCurrentIndex(dateComboBox->findData(Brewtarget::dateFormat));
    colorComboBox->setCurrentIndex(colorComboBox->findData(Brewtarget::colorUnit));
+   diastaticPowerComboBox->setCurrentIndex(diastaticPowerComboBox->findData(Brewtarget::diastaticPowerUnit));
 
    colorFormulaComboBox->setCurrentIndex(colorFormulaComboBox->findData(Brewtarget::colorFormula));
    ibuFormulaComboBox->setCurrentIndex(ibuFormulaComboBox->findData(Brewtarget::ibuFormula));

--- a/src/UnitSystems.cpp
+++ b/src/UnitSystems.cpp
@@ -30,6 +30,7 @@
 #include "SrmColorUnitSystem.h"
 #include "SgDensityUnitSystem.h"
 #include "PlatoDensityUnitSystem.h"
+#include "DiastaticPowerUnitSystem.h"
 #include "unit.h"
 #include <QDebug>
 
@@ -103,5 +104,17 @@ PlatoDensityUnitSystem* UnitSystems::platoDensityUnitSystem()
 {
    static PlatoDensityUnitSystem* p = new PlatoDensityUnitSystem();
    return p;
+}
+
+LintnerDiastaticPowerUnitSystem* UnitSystems::lintnerDiastaticPowerUnitSystem()
+{
+   static LintnerDiastaticPowerUnitSystem* result = new LintnerDiastaticPowerUnitSystem();
+   return result;
+}
+
+WkDiastaticPowerUnitSystem* UnitSystems::wkDiastaticPowerUnitSystem()
+{
+   static WkDiastaticPowerUnitSystem* result = new WkDiastaticPowerUnitSystem();
+   return result;
 }
 

--- a/src/UnitSystems.h
+++ b/src/UnitSystems.h
@@ -32,6 +32,8 @@ class EbcColorUnitSystem;
 class SrmColorUnitSystem;
 class SgDensityUnitSystem;
 class PlatoDensityUnitSystem;
+class LintnerDiastaticPowerUnitSystem;
+class WkDiastaticPowerUnitSystem;
 
 class UnitSystems
 {
@@ -54,6 +56,9 @@ public:
 
    static SgDensityUnitSystem* sgDensityUnitSystem();
    static PlatoDensityUnitSystem* platoDensityUnitSystem();
+
+   static LintnerDiastaticPowerUnitSystem* lintnerDiastaticPowerUnitSystem();
+   static WkDiastaticPowerUnitSystem* wkDiastaticPowerUnitSystem();
 };
 
 #endif /*UNITSYSTEMS_H*/

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -69,6 +69,7 @@
 #include "SrmColorUnitSystem.h"
 #include "SgDensityUnitSystem.h"
 #include "PlatoDensityUnitSystem.h"
+#include "DiastaticPowerUnitSystem.h"
 
 #include "BtSplashScreen.h"
 #include "MainWindow.h"
@@ -107,6 +108,7 @@ Brewtarget::ColorType Brewtarget::colorFormula = Brewtarget::MOREY;
 Brewtarget::IbuType Brewtarget::ibuFormula = Brewtarget::TINSETH;
 Brewtarget::ColorUnitType Brewtarget::colorUnit = Brewtarget::SRM;
 Brewtarget::DensityUnitType Brewtarget::densityUnit = Brewtarget::SG;
+Brewtarget::DiastaticPowerUnitType Brewtarget::diastaticPowerUnit = Brewtarget::LINTNER;
 
 QHash<int, UnitSystem*> Brewtarget::thingToUnitSystem;
 
@@ -251,6 +253,14 @@ Unit::unitDisplay Brewtarget::getColorUnit()
       return Unit::displaySrm;
 
    return Unit::displayEbc;
+}
+
+Unit::unitDisplay Brewtarget::getDiastaticPowerUnit()
+{
+   if ( diastaticPowerUnit == Brewtarget::LINTNER )
+      return Unit::displayLintner;
+
+   return Unit::displayWK;
 }
 
 Unit::unitDisplay Brewtarget::getDateFormat()
@@ -714,6 +724,26 @@ void Brewtarget::convertPersistentOptions()
          Brewtarget::logW(QString("Bad color_unit type: %1").arg(text));
    }
 
+   //=======================Diastatic power unit===================
+   text = getOptionValue(*optionsDoc, "diastatic_power_unit", &hasOption);
+   if( hasOption )
+   {
+      if( text == "Lintner" )
+      {
+         diastaticPowerUnit = LINTNER;
+         thingToUnitSystem.insert(Unit::DiastaticPower,UnitSystems::lintnerDiastaticPowerUnitSystem());
+      }
+      else if( text == "WK" )
+      {
+         diastaticPowerUnit = WK;
+         thingToUnitSystem.insert(Unit::DiastaticPower,UnitSystems::wkDiastaticPowerUnitSystem());
+      }
+      else
+      {
+         Brewtarget::logW(QString("Bad diastatic_power_unit type: %1").arg(text));
+      }
+   }
+
    delete optionsDoc;
    optionsDoc = 0;
    xmlFile.close();
@@ -884,6 +914,23 @@ void Brewtarget::readSystemOptions()
    else
       Brewtarget::logW(QString("Bad color_unit type: %1").arg(text));
 
+   //=======================Diastatic power unit===================
+   text = option("diastatic_power_unit", "Linter").toString();
+   if( text == "Lintner" )
+   {
+      diastaticPowerUnit = LINTNER;
+      thingToUnitSystem.insert(Unit::DiastaticPower,UnitSystems::lintnerDiastaticPowerUnitSystem());
+   }
+   else if( text == "WK" )
+   {
+      diastaticPowerUnit = WK;
+      thingToUnitSystem.insert(Unit::DiastaticPower,UnitSystems::wkDiastaticPowerUnitSystem());
+   }
+   else
+   {
+      Brewtarget::logW(QString("Bad diastatic_power_unit type: %1").arg(text));
+   }
+
    //=======================Date format===================
    dateFormat = (Unit::unitDisplay)option("date_format",Unit::displaySI).toInt();
 
@@ -941,6 +988,16 @@ void Brewtarget::saveSystemOptions()
          setOption("color_unit", "ebc");
          break;
    }
+
+   switch(diastaticPowerUnit)
+   {
+      case LINTNER:
+         setOption("diastatic_power_unit", "Lintner");
+         break;
+      case EBC:
+         setOption("diastatic_power_unit", "WK");
+         break;
+   }
 }
 
 // the defaults come from readSystemOptions. This just fleshes out the hash
@@ -970,6 +1027,10 @@ void Brewtarget::loadMap()
    // ==== density ====
    thingToUnitSystem.insert(Unit::Density | Unit::displaySg,   UnitSystems::sgDensityUnitSystem() );
    thingToUnitSystem.insert(Unit::Density | Unit::displayPlato,UnitSystems::platoDensityUnitSystem() );
+
+   // ==== diastatic power ====
+   thingToUnitSystem.insert(Unit::DiastaticPower | Unit::displayLintner,UnitSystems::lintnerDiastaticPowerUnitSystem() );
+   thingToUnitSystem.insert(Unit::DiastaticPower | Unit::displayWK,UnitSystems::wkDiastaticPowerUnitSystem() );
 }
 
 void Brewtarget::logE( QString message )
@@ -1248,6 +1309,17 @@ QString Brewtarget::colorUnitName(Unit::unitDisplay display)
       return QString("SRM");
    else
       return QString("EBC");
+}
+
+QString Brewtarget::diastaticPowerUnitName(Unit::unitDisplay display)
+{
+   if ( display == Unit::noUnit )
+      display = getDiastaticPowerUnit();
+
+   if ( display == Unit::displayLintner )
+      return QString("Lintner");
+   else
+      return QString("WK");
 }
 
 bool Brewtarget::hasUnits(QString qstr)
@@ -1554,6 +1626,18 @@ QMenu* Brewtarget::setupVolumeMenu(QWidget* parent, Unit::unitDisplay unit, Unit
    }
    sMenu->setTitle(tr("Scale"));
    menu->addMenu(sMenu);
+
+   return menu;
+}
+
+QMenu* Brewtarget::setupDiastaticPowerMenu(QWidget* parent, Unit::unitDisplay unit)
+{
+   QMenu* menu = new QMenu(parent);
+   QActionGroup* qgrp = new QActionGroup(parent);
+
+   generateAction(menu, tr("Default"), Unit::noUnit, unit, qgrp);
+   generateAction(menu, tr("WK"), Unit::displayWK, unit, qgrp);
+   generateAction(menu, tr("Lintner"), Unit::displayLintner, unit, qgrp);
 
    return menu;
 }

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -82,6 +82,8 @@ public:
    enum ColorUnitType {SRM, EBC};
    //! \brief Units for density
    enum DensityUnitType {SG,PLATO};
+   //! \brief The units for the diastatic power.
+   enum DiastaticPowerUnitType {LINTNER, WK};
    //! \brief The formula used to get IBUs.
    enum IbuType {TINSETH, RAGER, NOONAN};
    //! \brief Controls how units and scales are stored in the options file
@@ -263,6 +265,7 @@ public:
    // One method to rule them all, and in darkness bind them
    static UnitSystem* findUnitSystem(Unit* unit, Unit::unitDisplay display);
    static QString colorUnitName(Unit::unitDisplay display);
+   static QString diastaticPowerUnitName(Unit::unitDisplay display);
 
    //! \return true iff the string has a valid unit substring at the end.
    static bool hasUnits(QString qstr);
@@ -318,6 +321,7 @@ public:
    static QMenu* setupMassMenu(QWidget* parent, Unit::unitDisplay unit, Unit::unitScale scale = Unit::noScale, bool generateScale = true);
    static QMenu* setupTemperatureMenu(QWidget* parent, Unit::unitDisplay unit);
    static QMenu* setupVolumeMenu(QWidget* parent, Unit::unitDisplay unit, Unit::unitScale scale = Unit::noScale, bool generateScale = true);
+   static QMenu* setupDiastaticPowerMenu(QWidget* parent, Unit::unitDisplay unit);
    static QMenu* setupTimeMenu(QWidget* parent, Unit::unitScale scale);
    static void generateAction(QMenu* menu, QString text, QVariant data, QVariant currentVal, QActionGroup* qgrp = 0);
 
@@ -378,6 +382,7 @@ private:
    static ColorType colorFormula;
    static ColorUnitType colorUnit;
    static DensityUnitType densityUnit;
+   static DiastaticPowerUnitType diastaticPowerUnit;
    static IbuType ibuFormula;
    static Unit::unitDisplay dateFormat;
    //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -449,6 +454,8 @@ private:
    static TempScale getTemperatureScale();
    //! \return the color units
    static Unit::unitDisplay getColorUnit();
+   //! \return the diastatic power units
+   static Unit::unitDisplay getDiastaticPowerUnit();
 };
 
 Q_DECLARE_METATYPE( Brewtarget::DBTable )

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -70,6 +70,9 @@ EBCUnit* Units::ebc = new EBCUnit();
 // == density ===
 SgUnit* Units::sp_grav = new SgUnit();
 PlatoUnit* Units::plato = new PlatoUnit();
+// == diastatic power ==
+LintnerUnit* Units::lintner = new LintnerUnit();;
+WKUnit* Units::wk = new WKUnit();
 
 QString Unit::unitFromString(QString qstr)
 {
@@ -228,6 +231,9 @@ void Unit::setupMap()
 
    Unit::nameToUnit.insert(Units::sp_grav->getUnitName(), Units::sp_grav);
    Unit::nameToUnit.insert(Units::plato->getUnitName(), Units::plato);
+
+   Unit::nameToUnit.insert(Units::lintner->getUnitName(), Units::lintner);
+   Unit::nameToUnit.insert(Units::wk->getUnitName(), Units::wk);
 
    Unit::isMapSetup = true;
 }
@@ -798,3 +804,39 @@ double PlatoUnit::fromSI(double amt) const
    return Algorithms::SG_20C20C_toPlato(amt);
 }
 
+// == diastatic power ==
+LintnerUnit::LintnerUnit()
+{
+   unitName   = "L";
+   SIUnitName = "L";
+   _type = DiastaticPower;
+   _unitSystem = Any;
+}
+
+double LintnerUnit::toSI( double amt ) const
+{
+   return amt;
+}
+
+double LintnerUnit::fromSI( double amt ) const
+{
+   return amt;
+}
+
+WKUnit::WKUnit()
+{
+   unitName = "WK";
+   SIUnitName = "L";
+   _type = DiastaticPower;
+   _unitSystem = Any;
+}
+
+double WKUnit::toSI( double amt ) const
+{
+   return (amt + 16) / 3.5;
+}
+
+double WKUnit::fromSI(double amt) const
+{
+   return 3.5 * amt - 16;
+}

--- a/src/unit.h
+++ b/src/unit.h
@@ -51,6 +51,8 @@ class EBCUnit;
 class SRMUnit;
 class PlatoUnit;
 class SgUnit;
+class LintnerUnit;
+class WKUnit;
 
 #include <QString>
 #include <QObject>
@@ -75,7 +77,7 @@ enum TempScale
     Kelvin
 };
 
-// TODO: implement ppm, percent, diastatic power, ibuGalPerLb,
+// TODO: implement ppm, percent, ibuGalPerLb,
 
 /*!
  * \class Unit
@@ -96,15 +98,17 @@ class Unit : public QObject
       // Qt to see them?
       enum unitDisplay
       {
-         noUnit       = -1,
-         displayDef   = 0x000,
-         displaySI    = 0x100,
-         displayUS    = 0x101,
-         displayImp   = 0x102,
-         displaySrm   = 0x200,
-         displayEbc   = 0x201,
-         displaySg    = 0x300,
-         displayPlato = 0x301
+         noUnit         = -1,
+         displayDef     = 0x000,
+         displaySI      = 0x100,
+         displayUS      = 0x101,
+         displayImp     = 0x102,
+         displaySrm     = 0x200,
+         displayEbc     = 0x201,
+         displaySg      = 0x300,
+         displayPlato   = 0x301,
+         displayLintner = 0x400,
+         displayWK      = 0x401
       };
 
       enum unitScale
@@ -121,15 +125,16 @@ class Unit : public QObject
 
       enum UnitType
       {
-         Mass     = 0x100000,
-         Volume   = 0x200000,
-         Time     = 0x300000,
-         Temp     = 0x400000,
-         Color    = 0x500000,
-         Density  = 0x600000,
-         String   = 0x700000,
-         Mixed    = 0x800000,
-         None     = 0x000000
+         Mass           = 0x100000,
+         Volume         = 0x200000,
+         Time           = 0x300000,
+         Temp           = 0x400000,
+         Color          = 0x500000,
+         Density        = 0x600000,
+         String         = 0x700000,
+         Mixed          = 0x800000,
+         DiastaticPower = 0x900000,
+         None           = 0x000000
       };
 
       virtual ~Unit() {}
@@ -486,6 +491,31 @@ public:
    double fromSI( double amt ) const;
 };
 
+// == diastatic power ==
+// Lintner will be the standard unit, since that is how we store things in the
+// database.
+//
+class LintnerUnit : public Unit
+{
+public:
+   LintnerUnit();
+
+   // Inherited methods.
+   double toSI( double amt ) const;
+   double fromSI( double amt ) const;
+};
+
+class WKUnit : public Unit
+{
+public:
+   WKUnit();
+
+   // Inherited methods.
+   double toSI( double amt ) const;
+   double fromSI( double amt ) const;
+};
+
+
 class Units
 {
 public:
@@ -527,6 +557,9 @@ public:
    // == Density ===
    static SgUnit *sp_grav;
    static PlatoUnit *plato;
+   // == diastatic power ==
+   static LintnerUnit *lintner;
+   static WKUnit *wk;
 };
 
 #endif // _UNIT_H

--- a/ui/fermentableEditor.ui
+++ b/ui/fermentableEditor.ui
@@ -475,9 +475,12 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_11">
        <item>
-        <widget class="QLabel" name="label_diastaticPower">
+        <widget class="BtDiastaticPowerLabel" name="label_diastaticPower">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
          <property name="text">
-          <string>DP (Lintner)</string>
+          <string>Diastatic power</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_diastaticPower</cstring>
@@ -485,7 +488,7 @@
         </widget>
        </item>
        <item>
-        <widget class="BtGenericEdit" name="lineEdit_diastaticPower">
+        <widget class="BtDiastaticPowerEdit" name="lineEdit_diastaticPower">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -499,7 +502,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Diastatic power in Lintner</string>
+          <string>Diastatic power</string>
          </property>
          <property name="editField" stdset="0">
           <string notr="true">diastaticPower_lintner</string>
@@ -767,6 +770,22 @@
     <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
+  <customwidget>
+   <class>BtDiastaticPowerEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtDiastaticPowerLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>lineEdit_name</tabstop>
@@ -868,6 +887,38 @@
     <hint type="destinationlabel">
      <x>169</x>
      <y>133</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_diastaticPower</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_diastaticPower</receiver>
+   <slot>cut()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>301</x>
+     <y>46</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>393</x>
+     <y>49</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_diastaticPower</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_diastaticPower</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>346</x>
+     <y>52</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>48</y>
     </hint>
    </hints>
   </connection>

--- a/ui/optionsDialog.ui
+++ b/ui/optionsDialog.ui
@@ -87,6 +87,9 @@
          </property>
         </widget>
        </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="colorComboBox"/>
+       </item>
        <item row="5" column="0">
         <widget class="QLabel" name="colorLabel">
          <property name="text">
@@ -94,8 +97,15 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
-        <widget class="QComboBox" name="colorComboBox"/>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="diastaticPowerComboBox"/>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="diastaticPowerLabel">
+         <property name="text">
+          <string>Diastatic power</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
It adds the diastatic power units Lintner and Windisch–Kolbach. They are
selectable for the user in:
- The options dialogue.
- The fermentable editor dialogue.

Note since your collaborating guide likes to merge all changes in a squashed commit, I didn't split this patch in smaller chunks.