### PR TITLE
Properly escape SQL statements.

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1641,11 +1641,14 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table){
 
       while (nameq.next()) {
          QString name = nameq.record().value(0).toString();
-         queryString = QString( "SELECT id FROM %1 WHERE ( name='%2' AND display=%3 ) ORDER BY id ASC LIMIT 1")
+         queryString = QString( "SELECT id FROM %1 WHERE ( name=:name AND display=%2 ) ORDER BY id ASC LIMIT 1")
                      .arg(tableNames[table])
-                     .arg(name)
                      .arg(Brewtarget::dbTrue());
-         QSqlQuery parentq( queryString, sqlDatabase() );
+         QSqlQuery parentq( sqlDatabase() );
+
+         parentq.prepare(queryString);
+         parentq.bindValue(":name", name);
+         parentq.exec();
 
          if ( !parentq.isActive() )
             throw QString("%1 %2").arg(parentq.lastQuery()).arg(parentq.lastError().text());
@@ -1653,11 +1656,13 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table){
          parentq.first();
          QString parentID = parentq.record().value("id").toString();
 
-         queryString = QString( "SELECT id FROM %1 WHERE ( name='%2' AND display=%3 ) ORDER BY id ASC")
+         queryString = QString( "SELECT id FROM %1 WHERE ( name=:name AND display=%2 ) ORDER BY id ASC")
                      .arg(tableNames[table])
-                     .arg(name)
                      .arg(Brewtarget::dbFalse());
-         QSqlQuery childrenq( queryString, sqlDatabase() );
+         QSqlQuery childrenq( sqlDatabase() );
+         childrenq.prepare(queryString);
+         childrenq.bindValue(":name", name);
+         childrenq.exec();
 
          if ( !childrenq.isActive() )
             throw QString("%1 %2").arg(childrenq.lastQuery()).arg(childrenq.lastError().text());


### PR DESCRIPTION
While initialising the database for a new user a random issue occurred.
Every now and then the initialisation failed with a SQL error.
The issue seemed to happen with a record named something like
»Harry's rolled…«. I have not investigated why it is random, nor was I
able to find a similar record in the database.

In order to reproduce the issue I modified the default_db.sqlite database.
I changed the fermentable entry for »Acid Malt« to »Acid Malt'X«. This led
to a reproducible error:

[20:22:44.468] ERROR : void Database::populateChildTablesByName(Brewtarget::DBTable) SELECT id FROM fermentable WHERE ( name='Acid Malt'X' AND display=1 ) ORDER BY id ASC LIMIT 1 unrecognized token: "X' AND display=1 ) ORDER BY id ASC LIMIT 1" Unable to execute statement
[20:22:44.468] ERROR : void Database::populateChildTablesByName() void Database::populateChildTablesByName(Brewtarget::DBTable) SELECT id FROM fermentable WHERE ( name='Acid Malt'X' AND display=1 ) ORDER BY id ASC LIMIT 1 unrecognized token: "X' AND display=1 ) ORDER BY id ASC LIMIT 1" Unable to execute statement
[20:22:44.468] ERROR : bool Database::updateSchema(bool*) void Database::populateChildTablesByName(Brewtarget::DBTable) SELECT id FROM fermentable WHERE ( name='Acid Malt'X' AND display=1 ) ORDER BY id ASC LIMIT 1 unrecognized token: "X' AND display=1 ) ORDER BY id ASC LIMIT 1" Unable to execute statement
terminate called after throwing an instance of 'QString'

By changing the SQL statements to escape the name of the record the
issue has been fixed. Fixes issue #319.