### PR TITLE
Improve handling of fatal exceptions.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QMessageBox>
 #include "config.h"
 #include "brewtarget.h"
 #include "database.h"
@@ -66,8 +67,30 @@ int main(int argc, char **argv)
 
    if (parser.isSet(importFromXmlOption)) importFromXml(parser.value(importFromXmlOption));
    if (parser.isSet(createBlankDBOption)) createBlankDb(parser.value(createBlankDBOption));
-   
-   return Brewtarget::run(parser.value(userDirectoryOption));
+
+   try
+   {
+      return Brewtarget::run(parser.value(userDirectoryOption));
+   }
+   catch (const QString &error)
+   {
+      QMessageBox::critical(0,
+            QApplication::tr("Application terminates"),
+            QApplication::tr("The application encountered a fatal error.\nError message:\n%1").arg(error));
+   }
+   catch (std::exception &exception)
+   {
+      QMessageBox::critical(0,
+            QApplication::tr("Application terminates"),
+            QApplication::tr("The application encountered a fatal error.\nError message:\n%1").arg(exception.what()));
+   }
+   catch (...)
+   {
+      QMessageBox::critical(0,
+            QApplication::tr("Application terminates"),
+            QApplication::tr("The application encountered a fatal error."));
+   }
+   return EXIT_FAILURE;
 }
 
 /*!


### PR DESCRIPTION
While working on issue #319 the application terminated with the following
error message on the console:
terminate called after throwing an instance of 'QString'

Instead of logging this message on the console show a message box to the
user with the contests of the QString thrown. Do the same for
std::exceptions, and a generic message if the exception is of another
type.