### PR TITLE
Link ingredients to the original parent.

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -40,6 +40,7 @@ for consumption by the typical end-user.
 * New ingredient can't be created into a folder [#117](https://github.com/Brewtarget/brewtarget/issues/117)
 * ibu/color formulas do not persist [#133](https://github.com/Brewtarget/brewtarget/issues/133)
 * Two running Brewtargets Resets Database [#73](https://github.com/Brewtarget/brewtarget/issues/73)
+* Keep inventory when copying a recipe [#72] (https://github.com/Brewtarget/brewtarget/issues/72)
 
 ## v2.3.1
 


### PR DESCRIPTION
When an ingredient is copied by copying a recipe the newly created
ingredient's parent was the original ingredient. This led to two issues:
* The ingredient could no longer be deleted from the original recipe.
* The inventory of the new ingredient was empty. (Issue #72)

Setting the parent of the newly created ingredient to the parent of the
original ingredient fixes both issue.

Note: since I'm not too familiar with the database structure, please
review carefully; I might have missed something.