### PR TITLE
Refactoring MainWindow's constructor

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -122,8 +122,6 @@ public slots:
    void changed(QMetaProperty,QVariant);
 
    void treeActivated(const QModelIndex &index);
-   //! \brief Set recipe given an QModelIndex
-   void setRecipe(const QModelIndex &index);
    //! \brief View the given recipe.
    void setRecipe(Recipe* recipe);
 
@@ -366,6 +364,32 @@ private:
    void setupShortCuts();
    //! \brief Set the context menus.
    void setupContextMenu();
+   //! \brief Create the CSS strings
+   void setupCSS();
+   //! \brief Create the dialogs, including the file dialogs
+   void setupDialogs();
+   //! \brief Configure the range sliders
+   void setupRanges();
+   //! \brief Configure combo boxes and their list models
+   void setupComboBoxes();
+   //! \brief Configure the tables and their proxies
+   void setupTables();
+   //! \brief Restore any saved states
+   void restoreSavedState();
+   //! \brief Connect the signal/slots for actions
+   void setupTriggers();
+   //! \brief Connect signal/slots for buttons
+   void setupClicks();
+   //! \brief Connect signal/slots for combo boxes
+   void setupActivate();
+   //! \brief Connect signal/slots for combo boxes
+   void setupLabels();
+   //! \brief Connect signal/slots for text edits
+   void setupTextEdit();
+   //! \brief Connect signal/slots drag/drop
+   void setupDrops();
+
+
 
    void updateDensitySlider(QString attribute, RangedSlider* slider, double max);
    void updateColorSlider(QString attribute, RangedSlider* slider);

--- a/ui/mainWindow.ui
+++ b/ui/mainWindow.ui
@@ -39,7 +39,7 @@
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
-      <widget class="QWidget" name="layoutWidget">
+      <widget class="QWidget" name="widget_tree" native="true">
        <layout class="QVBoxLayout" name="verticalLayout_12">
         <item>
          <widget class="QLabel" name="label_Brewtarget">
@@ -218,6 +218,12 @@
        </layout>
       </widget>
       <widget class="QSplitter" name="splitter_horizontal">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>1</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
        <property name="acceptDrops">
         <bool>true</bool>
        </property>
@@ -233,8 +239,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>637</width>
-           <height>437</height>
+           <width>636</width>
+           <height>386</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -271,7 +277,7 @@
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string>Name</string>
+                   <string>&amp;Name</string>
                   </property>
                   <property name="buddy">
                    <cstring>lineEdit_name</cstring>
@@ -326,7 +332,7 @@
                        <enum>Qt::CustomContextMenu</enum>
                       </property>
                       <property name="text">
-                       <string>Target Boil Size</string>
+                       <string>Tar&amp;get Boil Size</string>
                       </property>
                       <property name="buddy">
                        <cstring>lineEdit_boilSize</cstring>
@@ -431,7 +437,7 @@
                        <enum>Qt::CustomContextMenu</enum>
                       </property>
                       <property name="text">
-                       <string>Calculated Boil Size</string>
+                       <string>Calc&amp;ulated Boil Size</string>
                       </property>
                       <property name="buddy">
                        <cstring>lineEdit_calcBoilSize</cstring>
@@ -566,7 +572,7 @@
                        </sizepolicy>
                       </property>
                       <property name="text">
-                       <string>Equipment</string>
+                       <string>E&amp;quipment</string>
                       </property>
                       <property name="buddy">
                        <cstring>equipmentButton</cstring>
@@ -616,7 +622,7 @@
                        <enum>Qt::CustomContextMenu</enum>
                       </property>
                       <property name="text">
-                       <string>Target Batch Size</string>
+                       <string>Target Batch Si&amp;ze</string>
                       </property>
                       <property name="buddy">
                        <cstring>lineEdit_batchSize</cstring>
@@ -1096,8 +1102,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>653</width>
-           <height>313</height>
+           <width>636</width>
+           <height>337</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1649,7 +1655,7 @@
      <x>0</x>
      <y>0</y>
      <width>1050</width>
-      <height>19</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuAbout">
@@ -1695,7 +1701,7 @@
     </widget>
     <widget class="QMenu" name="menuInventory">
      <property name="title">
-      <string>I&amp;nventory</string>
+      <string>In&amp;ventory</string>
      </property>
      <addaction name="actionInventoryPreview"/>
      <addaction name="actionInventoryPrint"/>
@@ -1836,7 +1842,7 @@
      <normaloff>:/images/smallQuestion.svg</normaloff>:/images/smallQuestion.svg</iconset>
    </property>
    <property name="text">
-    <string>&amp;Miscs</string>
+    <string>M&amp;iscs</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+M</string>
@@ -1884,7 +1890,7 @@
      <normaloff>:/images/exit.svg</normaloff>:/images/exit.svg</iconset>
    </property>
    <property name="text">
-    <string>&amp;Exit</string>
+    <string>E&amp;xit</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Q</string>
@@ -1905,7 +1911,7 @@
      <normaloff>:/images/preferences-other.png</normaloff>:/images/preferences-other.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Options</string>
+    <string>Optio&amp;ns</string>
    </property>
   </action>
   <action name="actionManual">
@@ -2142,7 +2148,7 @@
      <normaloff>:/images/clock.svg</normaloff>:/images/clock.svg</iconset>
    </property>
    <property name="text">
-    <string>Timers</string>
+    <string>Ti&amp;mers</string>
    </property>
    <property name="toolTip">
     <string>Show timers</string>
@@ -2187,7 +2193,7 @@
   </action>
   <action name="actionStrikeWater_Calculator">
    <property name="text">
-    <string>Strike Water Calculator</string>
+    <string>Strike &amp;Water Calculator</string>
    </property>
   </action>
   <action name="actionRecipeBBCode">
@@ -2201,7 +2207,7 @@
   </action>
   <action name="actionHydrometer_Temp_Adjustment">
    <property name="text">
-    <string>Hydrometer Temp Adjustment</string>
+    <string>&amp;Hydrometer Temp Adjustment</string>
    </property>
   </action>
   <action name="actionInventoryPreview">


### PR DESCRIPTION
I've reduced the almost 400 line MainWindow constructor to 66 lines (including comments), mostly by moving the obvious groupings into other private methods. I find this a lot easier to search and read.

I've also moved a few of the signals to the newer method pointer syntax, because I think the syntax is cleaner and easier to read. It also provides compile time checking instead of runtime. And that is always better. This required removing the setRecipe(QModelIndex) method, but that's no great loss. It was only used in two places, and both of those can handle null pointers on
their own.