### PR TITLE
Fixed misc editor to save inventory amount

### DIFF
--- a/src/MiscEditor.cpp
+++ b/src/MiscEditor.cpp
@@ -64,10 +64,10 @@ void MiscEditor::save()
    m->setName(lineEdit_name->text());
    m->setType( static_cast<Misc::Type>(comboBox_type->currentIndex()) );
    m->setUse( static_cast<Misc::Use>(comboBox_use->currentIndex()) );
-   // TODO: fill in the rest of the "set" methods.
    m->setTime(lineEdit_time->toSI());
    m->setAmountIsWeight( (checkBox_isWeight->checkState() == Qt::Checked)? true : false );
    m->setAmount( lineEdit_amount->toSI());
+   m->setInventoryAmount(lineEdit_inventory->toSI());
    m->setUseFor(textEdit_useFor->toPlainText());
    m->setNotes( textEdit_notes->toPlainText() );
 


### PR DESCRIPTION
The misc editor was not storing inventory amount for an entry. Also, I checked other editors to make sure nothing was missing, seems like that was the only one.