### PR TITLE
Possibly closes #166 and #158

### DIFF
--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -41,7 +41,7 @@ BtLineEdit::BtLineEdit(QWidget *parent, Unit::UnitType type) :
    _forceUnit = Unit::noUnit;
    _forceScale = Unit::noScale;
    */
-   
+
    connect(this,SIGNAL(editingFinished()),this,SLOT(lineChanged()));
 }
 
@@ -146,7 +146,7 @@ double BtLineEdit::toSI(Unit::unitDisplay oldUnit,Unit::unitScale oldScale,bool 
 
       // get the qstringToSI() from the unit system, using the found unit.
       // Force the issue in qstringToSI() unless dspScale is Unit::noScale.
-      
+
       return temp->qstringToSI(text(), works, dspScale != Unit::noScale, dspScale);
    }
    else if ( _type == Unit::String )
@@ -183,7 +183,7 @@ double BtLineEdit::toDouble(bool* ok)
 {
    QRegExp amtUnit;
 
-   if ( ok ) 
+   if ( ok )
       *ok = true;
    // Make sure we get the right decimal point (. or ,) and the right grouping
    // separator (, or .). Some locales write 1.000,10 and other write
@@ -219,12 +219,19 @@ void BtLineEdit::setText( BeerXMLElement* element, int precision )
       display = element->property(_editField.toLatin1().constData()).toString();
    else if ( element->property(_editField.toLatin1().constData()).canConvert(QVariant::Double) )
    {
-      // Get the amount
       bool ok = false;
-      QString tmp = element->property(_editField.toLatin1().constData()).toString();
-      amount = Brewtarget::toDouble(tmp, &ok);
-      if ( !ok )
-         Brewtarget::logW( QString("%1 could not convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(tmp).arg(_section).arg(_editField) );
+      // Get the value from the element, and put it in a QVariant
+      QVariant tmp = element->property(_editField.toLatin1().constData());
+      // It is important here to use QVariant::toDouble() instead of going
+      // through toString() and then Brewtarget::toDouble().
+      amount = tmp.toDouble(&ok);
+      if ( !ok ) {
+         Brewtarget::logW( QString("%1 could not convert %2 (%3:%4) to double")
+                              .arg(Q_FUNC_INFO)
+                              .arg(tmp.toString())
+                              .arg(_section)
+                              .arg(_editField) );
+      }
 
       display = displayAmount(amount, precision);
    }
@@ -260,7 +267,7 @@ void BtLineEdit::setText( QVariant amount, int precision)
 int BtLineEdit::type() const { return (int)_type; }
 QString BtLineEdit::editField() const { return _editField; }
 QString BtLineEdit::configSection()
-{ 
+{
    if ( _section.isEmpty() ) {
       setConfigSection("");
    }
@@ -270,8 +277,8 @@ QString BtLineEdit::configSection()
 
 // Once we require >qt5.5, we can replace this noise with
 // QMetaEnum::fromType()
-QString BtLineEdit::forcedUnit() const 
-{ 
+QString BtLineEdit::forcedUnit() const
+{
    const QMetaObject &mo = Unit::staticMetaObject;
    int index = mo.indexOfEnumerator("unitDisplay");
    QMetaEnum unitEnum = mo.enumerator(index);
@@ -280,7 +287,7 @@ QString BtLineEdit::forcedUnit() const
 }
 
 QString BtLineEdit::forcedScale() const
-{ 
+{
    const QMetaObject &mo = Unit::staticMetaObject;
    int index = mo.indexOfEnumerator("unitScale");
    QMetaEnum scaleEnum = mo.enumerator(index);
@@ -292,20 +299,20 @@ void BtLineEdit::setType(int type) { _type = (Unit::UnitType)type;}
 void BtLineEdit::setEditField( QString editField) { _editField = editField; }
 
 // The cascade looks a little odd, but it is intentional.
-void BtLineEdit::setConfigSection( QString configSection) 
+void BtLineEdit::setConfigSection( QString configSection)
 {
-   _section = configSection; 
+   _section = configSection;
 
    if ( _section.isEmpty() )
       _section = btParent->property("configSection").toString();
 
-   if ( _section.isEmpty() ) 
+   if ( _section.isEmpty() )
       _section = btParent->objectName();
 }
 
 // previous comment about qt5.5 applies
-void BtLineEdit::setForcedUnit( QString forcedUnit ) 
-{ 
+void BtLineEdit::setForcedUnit( QString forcedUnit )
+{
    const QMetaObject &mo = Unit::staticMetaObject;
    int index = mo.indexOfEnumerator("unitDisplay");
    QMetaEnum unitEnum = mo.enumerator(index);
@@ -313,8 +320,8 @@ void BtLineEdit::setForcedUnit( QString forcedUnit )
    _forceUnit = (Unit::unitDisplay)unitEnum.keyToValue(forcedUnit.toStdString().c_str());
 }
 
-void BtLineEdit::setForcedScale( QString forcedScale ) 
-{ 
+void BtLineEdit::setForcedScale( QString forcedScale )
+{
    const QMetaObject &mo = Unit::staticMetaObject;
    int index = mo.indexOfEnumerator("unitScale");
    QMetaEnum unitEnum = mo.enumerator(index);


### PR DESCRIPTION
This is a hard thing.

The essence is that in BtLineEdit::setText(BeerXMLElement *element), the conversion went from QVariant to QString to double. The problem was that the QString ended up as something like "1.045". The conversion from QString to double is locale aware, so en_US would get 1.045 but locales like bt_PR would get 1e3+45.

I fixed this by replacing the QVariant->QString->double conversion with a QVariant->double conversion. It *seems* to work -- I've tried this with en_US, bt_PR, de_DE and fr_FR and they all *appear* to do the right thing.

I don't think we need to fix anything else. The values written to the database are written as doubles, so this kind of conversion is irrelevant. On the other hand, I have demonstrated an annoying inability to test my own code and my database my not behave like anybody else. 