### PR TITLE
Limit max infusion amount in Mash Designer by target boil size

### DIFF
--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -213,18 +213,24 @@ double MashDesigner::minAmt_l()
 // However much more we can add at this step.
 double MashDesigner::maxAmt_l()
 {
+   double amt = 0;
+
    if ( equip == 0 )
-      return 0;
+      return amt;
 
    // However much more we can fit in the tun.
    if( ! isSparge() )
    {
-      return equip->tunVolume_l() - mashVolume_l();
+      amt = equip->tunVolume_l() - mashVolume_l();
    }
    else
    {
-      return equip->tunVolume_l() - grainVolume_l();
+      amt = equip->tunVolume_l() - grainVolume_l();
    }
+
+   amt = std::min(amt, maxFromRecipe_l());
+
+   return amt;
 }
 
 // Returns the required volume of water to infuse if the strike water is
@@ -700,5 +706,19 @@ void MashDesigner::typeChanged(int t)
       horizontalSlider_amount->setEnabled(false);
       horizontalSlider_temp->setEnabled(false);
    }
+}
+
+double MashDesigner::maxFromRecipe_l() {
+
+   if ( recObs == 0 )
+      return 0.0;
+
+   double absorption_lKg;
+   if( equip )
+      absorption_lKg = equip->grainAbsorption_LKg();
+   else
+      absorption_lKg = PhysicalConstants::grainAbsorption_Lkg;
+
+   return recObs->boilSize_l() - addedWater_l + absorption_lKg * recObs->grainsInMash_kg();
 }
 

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -21,13 +21,9 @@
 
 #include "database.h"
 #include "MashDesigner.h"
-#include "equipment.h"
-#include "mash.h"
-#include "mashstep.h"
-#include "brewtarget.h"
 #include "HeatCalculations.h"
 #include "PhysicalConstants.h"
-#include "unit.h"
+#include "fermentable.h"
 #include <QMessageBox>
 #include <QInputDialog>
 
@@ -228,7 +224,7 @@ double MashDesigner::maxAmt_l()
       amt = equip->tunVolume_l() - grainVolume_l();
    }
 
-   amt = std::min(amt, maxFromRecipe_l());
+   amt = std::min(amt, targetTotalMashVol_l() - addedWater_l);
 
    return amt;
 }
@@ -348,7 +344,7 @@ bool MashDesigner::initializeMash()
    grain_kg = recObs->grainsInMash_kg();
 
    label_tunVol->setText(Brewtarget::displayAmount(equip->tunVolume_l(), Units::liters));
-   label_wortMax->setText(Brewtarget::displayAmount(recObs->boilSize_l(), Units::liters));
+   label_wortMax->setText(Brewtarget::displayAmount(targetCollectedWortVol_l(), Units::liters));
 
    updateMinAmt();
    updateMaxAmt();
@@ -415,7 +411,7 @@ void MashDesigner::updateCollectedWort()
    // double wort_l = recObs->wortFromMash_l();
    double wort_l = waterFromMash_l();
 
-   double ratio = wort_l / recObs->boilSize_l();
+   double ratio = wort_l / targetCollectedWortVol_l();
    if( ratio < 0 )
      ratio = 0;
    if( ratio > 1 )
@@ -666,7 +662,7 @@ MashStep::Type MashDesigner::type() const
    return static_cast<MashStep::Type>(curIdx);
 }
 
-void MashDesigner::typeChanged(int t)
+void MashDesigner::typeChanged()
 {
    MashStep::Type _type = type();
 
@@ -708,7 +704,29 @@ void MashDesigner::typeChanged(int t)
    }
 }
 
-double MashDesigner::maxFromRecipe_l() {
+double MashDesigner::targetCollectedWortVol_l() {
+
+   if ( recObs == 0 )
+      return 0.0;
+
+   // Need to account for extract/sugar volume also.
+   float postMashAdditionVolume_l = 0;
+   QList<Fermentable*> ferms = recObs->fermentables();
+         foreach( Fermentable* f, ferms )
+      {
+         Fermentable::Type type = f->type();
+         if( type == Fermentable::Extract )
+            postMashAdditionVolume_l  += f->amount_kg() / PhysicalConstants::liquidExtractDensity_kgL;
+         else if( type == Fermentable::Sugar )
+            postMashAdditionVolume_l  += f->amount_kg() / PhysicalConstants::sucroseDensity_kgL;
+         else if( type == Fermentable::Dry_Extract )
+            postMashAdditionVolume_l  += f->amount_kg() / PhysicalConstants::dryExtractDensity_kgL;
+      }
+
+   return recObs->boilSize_l() - equip->topUpKettle_l() - postMashAdditionVolume_l;
+}
+
+double MashDesigner::targetTotalMashVol_l() {
 
    if ( recObs == 0 )
       return 0.0;
@@ -719,6 +737,7 @@ double MashDesigner::maxFromRecipe_l() {
    else
       absorption_lKg = PhysicalConstants::grainAbsorption_Lkg;
 
-   return recObs->boilSize_l() - addedWater_l + absorption_lKg * recObs->grainsInMash_kg();
+
+   return targetCollectedWortVol_l() + absorption_lKg * recObs->grainsInMash_kg();
 }
 

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -62,7 +62,7 @@ private slots:
    void saveTargetTemp();
    void proceed(); // Go to next step.
    void saveAndClose();
-   void typeChanged(int t);
+   void typeChanged();
 
 private:
    bool nextStep(int step);
@@ -78,7 +78,8 @@ private:
    double volFromTemp_l( double temp_c );
    double getDecoctionAmount_l();
    double waterFromMash_l();
-   double maxFromRecipe_l();
+   double targetCollectedWortVol_l();
+   double targetTotalMashVol_l();
 
    // I have developed a distaste for "getBlah"
    double selectedAmount_l();

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -78,6 +78,7 @@ private:
    double volFromTemp_l( double temp_c );
    double getDecoctionAmount_l();
    double waterFromMash_l();
+   double maxFromRecipe_l();
 
    // I have developed a distaste for "getBlah"
    double selectedAmount_l();


### PR DESCRIPTION
When using the Mash Designer, the upper limit of the range for the "Infusion Amount" and "Infusion Temp" sliders is now restricted by the collected wort vs. target boil size as well as the mash tun fullness. 