### PR TITLE
Cleanup on Fermentable editing

### DIFF
--- a/src/BeerXMLElement.cpp
+++ b/src/BeerXMLElement.cpp
@@ -27,6 +27,9 @@
 #include "brewtarget.h"
 #include "database.h"
 
+static const QString kFolder("folder");
+static const QString kName("name");
+
 BeerXMLElement::BeerXMLElement(Brewtarget::DBTable table, int key)
    : QObject(0),
      _key(key),
@@ -84,14 +87,14 @@ void BeerXMLElement::setDisplay(bool var)
 QString BeerXMLElement::folder() const
 {
    if ( _folder.isEmpty() )
-      _folder = get("folder").toString();
+      _folder = get(kFolder).toString();
 
    return _folder;
 }
 
 void BeerXMLElement::setFolder(const QString var, bool signal)
 {
-   set( "folder", "folder", var );
+   set( kFolder, kFolder, var );
    _folder = var;
    if ( signal )
       emit changedFolder(var);
@@ -107,7 +110,7 @@ QString BeerXMLElement::name() const
 
 void BeerXMLElement::setName(const QString var)
 {
-   set( "name", "name", var );
+   set( kName, kName, var );
    _name = var;
    emit changedName(var);
 }
@@ -258,9 +261,19 @@ void BeerXMLElement::set( const char* prop_name, const char* col_name, QVariant 
    }
 }
 
+void BeerXMLElement::set(const QString &prop_name, const QString &col_name, const QVariant &value, bool notify)
+{
+   set(prop_name.toUtf8().constData(), col_name.toUtf8().constData(), value, notify);
+}
+
 QVariant BeerXMLElement::get( const char* col_name ) const
 {
    return Database::instance().get( _table, _key, col_name );
+}
+
+QVariant BeerXMLElement::get( const QString& col_name ) const
+{
+   return get(col_name.toUtf8().constData());
 }
 
 void BeerXMLElement::setInventory( const char* prop_name, const char* col_name, QVariant const& value, bool notify )
@@ -277,6 +290,11 @@ void BeerXMLElement::setInventory( const char* prop_name, const char* col_name, 
     Database::instance().updateEntry( invtable, invkey, col_name, value, metaObject()->property(ndx), this, notify );
 }
 
+void BeerXMLElement::setInventory( const QString& prop_name, const QString& col_name, QVariant const& value, bool notify )
+{
+   setInventory(prop_name.toUtf8().constData(), col_name.toUtf8().constData(), value, notify);
+}
+
 QVariant BeerXMLElement::getInventory( const char* col_name ) const
 {
    int invkey = Database::instance().getInventoryID(_table, _key);
@@ -288,6 +306,11 @@ QVariant BeerXMLElement::getInventory( const char* col_name ) const
    return val;
 }
 
+QVariant BeerXMLElement::getInventory( const QString& col_name ) const
+{
+   return getInventory(col_name.toUtf8().constData());
+}
+
 bool BeerXMLElement::isValid()
 {
    return _valid;
@@ -296,4 +319,12 @@ bool BeerXMLElement::isValid()
 void BeerXMLElement::invalidate()
 {
    _valid = false;
+}
+
+QVariantMap BeerXMLElement::getColumnValueMap() const
+{
+   QVariantMap map;
+   map.insert(kFolder, folder());
+   map.insert(kName, name());
+   return map;
 }

--- a/src/BeerXMLElement.cpp
+++ b/src/BeerXMLElement.cpp
@@ -28,9 +28,10 @@
 #include "database.h"
 
 BeerXMLElement::BeerXMLElement()
+BeerXMLElement::BeerXMLElement(Brewtarget::DBTable table, int key)
    : QObject(0),
-     _key(-1),
-     _table(Brewtarget::NOTABLE),
+     _key(key),
+     _table(table),
      _folder(QString()),
      _name(QString()),
      _display(QVariant()),

--- a/src/BeerXMLElement.cpp
+++ b/src/BeerXMLElement.cpp
@@ -27,7 +27,6 @@
 #include "brewtarget.h"
 #include "database.h"
 
-BeerXMLElement::BeerXMLElement()
 BeerXMLElement::BeerXMLElement(Brewtarget::DBTable table, int key)
    : QObject(0),
      _key(key),

--- a/src/BeerXMLElement.h
+++ b/src/BeerXMLElement.h
@@ -156,15 +156,22 @@ protected:
     * 2) Call the NOTIFY method associated with \c prop_name if \c notify == true.
     */
    void set( const char* prop_name, const char* col_name, QVariant const& value, bool notify = true );
+   void set( const QString& prop_name, const QString& col_name, const QVariant& value, bool notify = true );
 
    /*!
     * \param col_name - The database column of the attribute we want to get.
     * Returns the value of the attribute specified by key/table/col_name.
     */
    QVariant get( const char* col_name ) const;
+   QVariant get( const QString& col_name ) const;
 
    void setInventory( const char* prop_name, const char* col_name, QVariant const& value, bool notify = true );
+   void setInventory( const QString& prop_name, const QString& col_name, QVariant const& value, bool notify = true );
    QVariant getInventory( const char* col_name ) const;
+   QVariant getInventory( const QString& col_name ) const;
+
+
+   QVariantMap getColumnValueMap() const;
 
 private:
    /*!

--- a/src/BeerXMLElement.h
+++ b/src/BeerXMLElement.h
@@ -57,7 +57,7 @@ class BeerXMLElement : public QObject
 
    friend class Database;
 public:
-   BeerXMLElement();
+   BeerXMLElement(Brewtarget::DBTable table, int key);
    BeerXMLElement( BeerXMLElement const& other );
 
    // Everything that inherits from BeerXML has a name, delete, display and a folder

--- a/src/FermentableEditor.cpp
+++ b/src/FermentableEditor.cpp
@@ -60,6 +60,7 @@ void FermentableEditor::save()
    // NOTE: the following assumes that Fermentable::Type is enumerated in the same
    // order as the combobox.
    obsFerm->setType( static_cast<Fermentable::Type>(comboBox_type->currentIndex()) );
+
    obsFerm->setAmount_kg(lineEdit_amount->toSI());
    obsFerm->setInventoryAmount(lineEdit_inventory->toSI());
    obsFerm->setYield_pct(lineEdit_yield->toSI());
@@ -76,6 +77,7 @@ void FermentableEditor::save()
    obsFerm->setIsMashed( (checkBox_isMashed->checkState() == Qt::Checked) ? true : false );
    obsFerm->setIbuGalPerLb( lineEdit_ibuGalPerLb->toSI() );
    obsFerm->setNotes( textEdit_notes->toPlainText() );
+   obsFerm->save();
 
    setVisible(false);
 }

--- a/src/FermentableEditor.cpp
+++ b/src/FermentableEditor.cpp
@@ -29,7 +29,7 @@
 #include "brewtarget.h"
 
 FermentableEditor::FermentableEditor( QWidget* parent )
-        : QDialog(parent), obsFerm(0)
+        : QDialog(parent), obsFerm(nullptr)
 {
    setupUi(this);
 
@@ -38,22 +38,18 @@ FermentableEditor::FermentableEditor( QWidget* parent )
 
 }
 
-void FermentableEditor::setFermentable( Fermentable* f )
+void FermentableEditor::setFermentable( Fermentable* newFerm )
 {
-   if( obsFerm )
-      disconnect( obsFerm, 0, this, 0 );
-
-   obsFerm = f;
-   if( obsFerm )
+   if(newFerm)
    {
-      connect( obsFerm, SIGNAL(changed(QMetaProperty,QVariant)), this, SLOT(changed(QMetaProperty,QVariant)) );
+      obsFerm = newFerm;
       showChanges();
    }
 }
 
 void FermentableEditor::save()
 {
-   if( obsFerm == 0 )
+   if( !obsFerm )
    {
       setVisible(false);
       return;
@@ -98,7 +94,7 @@ void FermentableEditor::changed(QMetaProperty prop, QVariant /*val*/)
 
 void FermentableEditor::showChanges(QMetaProperty* metaProp)
 {
-   if( obsFerm == 0 )
+   if( !obsFerm )
       return;
 
    QString propName;

--- a/src/FermentableEditor.cpp
+++ b/src/FermentableEditor.cpp
@@ -86,12 +86,6 @@ void FermentableEditor::clearAndClose()
    setVisible(false); // Hide the window.
 }
 
-void FermentableEditor::changed(QMetaProperty prop, QVariant /*val*/)
-{
-   if( sender() == obsFerm )
-      showChanges(&prop);
-}
-
 void FermentableEditor::showChanges(QMetaProperty* metaProp)
 {
    if( !obsFerm )

--- a/src/FermentableEditor.h
+++ b/src/FermentableEditor.h
@@ -50,7 +50,6 @@ public:
 public slots:
    void save();
    void clearAndClose();
-   void changed(QMetaProperty,QVariant);
 
 private:
    Fermentable* obsFerm;

--- a/src/FermentableTableModel.cpp
+++ b/src/FermentableTableModel.cpp
@@ -645,6 +645,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
          Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
          return false;
    }
+   row->save();
    return retVal;
 }
 

--- a/src/Testing.cpp
+++ b/src/Testing.cpp
@@ -120,7 +120,7 @@ void Testing::recipeCalcTest_allGrain()
 
    // Add grain
    twoRow->setAmount_kg(grain_kg);
-   Database::instance().addToRecipe(rec, twoRow);
+   rec->addFermentable(twoRow);
 
    // Add mash
    Database::instance().addToRecipe(rec, singleConversion);
@@ -202,8 +202,8 @@ void Testing::postBoilLossOgTest()
 
    // Add grain
    twoRow->setAmount_kg(grain_kg);
-   Database::instance().addToRecipe(recNoLoss, twoRow);
-   Database::instance().addToRecipe(recLoss, twoRow);
+   recNoLoss->addFermentable(twoRow);
+   recLoss->addFermentable(twoRow);
 
    // Single conversion, no sparge
    Mash* singleConversion = Database::instance().newMash();

--- a/src/Testing.cpp
+++ b/src/Testing.cpp
@@ -120,6 +120,7 @@ void Testing::recipeCalcTest_allGrain()
 
    // Add grain
    twoRow->setAmount_kg(grain_kg);
+   twoRow->save();
    rec->addFermentable(twoRow);
 
    // Add mash
@@ -202,6 +203,7 @@ void Testing::postBoilLossOgTest()
 
    // Add grain
    twoRow->setAmount_kg(grain_kg);
+   twoRow->save();
    recNoLoss->addFermentable(twoRow);
    recLoss->addFermentable(twoRow);
 

--- a/src/brewnote.cpp
+++ b/src/brewnote.cpp
@@ -87,8 +87,8 @@ bool operator==(BrewNote const& lhs, BrewNote const& rhs)
 }
 
 // Initializers
-BrewNote::BrewNote()
-   : BeerXMLElement()
+BrewNote::BrewNote(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
    loading = false;
 }

--- a/src/brewnote.cpp
+++ b/src/brewnote.cpp
@@ -38,6 +38,12 @@
 
 QHash<QString,QString> BrewNote::tagToProp = BrewNote::tagToPropHash();
 
+QString BrewNote::classNameStr()
+{
+   static const QString name("BrewNote");
+   return name;
+}
+
 QHash<QString,QString> BrewNote::tagToPropHash()
 {
    QHash<QString,QString> propHash;

--- a/src/brewnote.h
+++ b/src/brewnote.h
@@ -178,7 +178,7 @@ signals:
    void brewDateChanged(const QDateTime&);
 
 private:
-   BrewNote();
+   BrewNote(Brewtarget::DBTable table, int key);
    BrewNote(BrewNote const& other);
    bool loading;
 

--- a/src/brewnote.h
+++ b/src/brewnote.h
@@ -54,6 +54,8 @@ public:
 
    virtual ~BrewNote() {}
 
+   static QString classNameStr();
+
    Q_PROPERTY( QDateTime brewDate READ brewDate WRITE setBrewDate /*NOTIFY changed*/ STORED false )
    Q_PROPERTY( QDateTime fermentDate READ fermentDate  WRITE setFermentDate /*NOTIFY changed*/ STORED false )
    Q_PROPERTY( QString notes READ notes WRITE setNotes /*NOTIFY changed*/ STORED false )

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1100,7 +1100,7 @@ QList<Yeast*> Database::yeasts(Recipe const* parent)
 
 BrewNote* Database::newBrewNote(BrewNote* other, bool signal)
 {
-   BrewNote* tmp = copy<BrewNote>(other, true, &allBrewNotes);
+   BrewNote* tmp = copy<BrewNote>(other, &allBrewNotes);
 
    if ( tmp ) {
       if ( signal )
@@ -1148,7 +1148,7 @@ Equipment* Database::newEquipment(Equipment* other)
    Equipment* tmp;
 
    if (other)
-      tmp = copy(other, true, &allEquipments);
+      tmp = copy(other, &allEquipments);
    else
       tmp = newIngredient(&allEquipments);
 
@@ -1168,7 +1168,7 @@ Fermentable* Database::newFermentable(Fermentable* other)
    Fermentable* tmp;
 
    if (other)
-      tmp = copy(other, true, &allFermentables);
+      tmp = copy(other, &allFermentables);
    else
       tmp = newIngredient(&allFermentables);
 
@@ -1188,7 +1188,7 @@ Hop* Database::newHop(Hop* other)
    Hop* tmp;
 
    if ( other )
-      tmp = copy(other, true, &allHops);
+      tmp = copy(other, &allHops);
    else
       tmp = newIngredient(&allHops);
 
@@ -1257,7 +1257,7 @@ Mash* Database::newMash(Mash* other, bool displace)
 
    try {
       if ( other )
-         tmp = copy<Mash>(other, true, &allMashs);
+         tmp = copy<Mash>(other, &allMashs);
       else
          tmp = newIngredient(&allMashs);
 
@@ -1377,7 +1377,7 @@ Misc* Database::newMisc(Misc* other)
    Misc* tmp;
 
    if ( other )
-     tmp = copy(other, true, &allMiscs);
+     tmp = copy(other, &allMiscs);
    else
       tmp = newIngredient(&allMiscs);
 
@@ -1427,7 +1427,7 @@ Recipe* Database::newRecipe(Recipe* other)
 
    sqlDatabase().transaction();
    try {
-      tmp = copy<Recipe>(other, true, &allRecipes);
+      tmp = copy<Recipe>(other, &allRecipes);
 
       // Copy fermentables, hops, miscs and yeasts. We've the convenience
       // methods, so use them? And now I have to instruct all of them to not do
@@ -1462,7 +1462,7 @@ Style* Database::newStyle(Style* other)
 
    try {
       if ( other )
-         tmp = copy(other, true, &allStyles);
+         tmp = copy(other, &allStyles);
       else
          tmp = newIngredient(&allStyles);
    }
@@ -1484,7 +1484,7 @@ Water* Database::newWater(Water* other)
 
    try {
       if ( other )
-         tmp = copy(other,true,&allWaters);
+         tmp = copy(other,&allWaters);
       else
          tmp = newIngredient(&allWaters);
    }
@@ -1506,7 +1506,7 @@ Yeast* Database::newYeast(Yeast* other)
 
    try {
       if (other)
-         tmp = copy(other, true, &allYeasts);
+         tmp = copy(other, &allYeasts);
       else
          tmp = newIngredient(&allYeasts);
    }
@@ -1551,7 +1551,7 @@ void Database::duplicateMashSteps(Mash *oldMash, Mash *newMash)
       for( ms=tmpMS.begin(); ms != tmpMS.end(); ++ms)
       {
          // Copy the old mash step.
-         MashStep* newStep = copy<MashStep>(*ms,true,&allMashSteps);
+         MashStep* newStep = copy<MashStep>(*ms,&allMashSteps);
 
          // Put it in the new mash.
          sqlUpdate( Brewtarget::MASHSTEPTABLE,
@@ -1818,7 +1818,7 @@ void Database::addToRecipe( Recipe* rec, Equipment* e, bool noCopy, bool transac
    try {
       // Make a copy of equipment.
       if ( ! noCopy ) {
-         newEquip = copy<Equipment>(e,false,&allEquipments);
+         newEquip = copy<Equipment>(e, &allEquipments, false);
       }
 
       // Update equipment_id
@@ -1959,7 +1959,7 @@ void Database::addToRecipe( Recipe* rec, Mash* m, bool noCopy, bool transact )
    try {
       if ( ! noCopy )
       {
-         newMash = copy<Mash>(m, false, &allMashs);
+         newMash = copy<Mash>(m, &allMashs, false);
          duplicateMashSteps(m,newMash);
       }
 
@@ -2053,7 +2053,7 @@ void Database::addToRecipe( Recipe* rec, Style* s, bool noCopy, bool transact )
 
    try {
       if ( ! noCopy )
-         newStyle = copy<Style>(s,false,&allStyles);
+         newStyle = copy<Style>(s, &allStyles, false);
 
       sqlUpdate(Brewtarget::RECTABLE,
                 QString("style_id=%1").arg(newStyle->key()),

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1625,13 +1625,13 @@ void Database::updateEntry( Brewtarget::DBTable table, int key, const char* col_
 
 }
 
-void Database::updateColumns(Brewtarget::DBTable table, int key, QVariantMap colValMap)
+void Database::updateColumns(Brewtarget::DBTable table, int key, const QVariantMap& colValMap)
 {
    // Assumes the table has a column called 'deleted'.
    QString tableName = tableNames[table];
    try {
 
-      static const QString kSetStr("%1=:value, ");
+      static const QString kSetStr("%1=?, ");
       static const QString kSetStrLast("%1=?");
       QStringList cols = colValMap.keys();
       QString setValsStr;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -99,10 +99,7 @@ Database::Database()
    //.setUndoLimit(100);
    // Lock this here until we actually construct the first database connection.
    _threadToConnectionMutex.lock();
-
    converted = false;
-
-   loadWasSuccessful = load();
 }
 
 Database::~Database()
@@ -279,6 +276,7 @@ bool Database::load()
 
    createFromScratch=false;
    schemaUpdated=false;
+   loadWasSuccessful = false;
 
    if ( Brewtarget::dbType() == Brewtarget::PGSQL )
    {
@@ -411,7 +409,8 @@ bool Database::load()
          connect( *n, SIGNAL(changed(QMetaProperty,QVariant)), *m, SLOT(acceptMashStepChange(QMetaProperty,QVariant)) );
    }
 
-   return true;
+   loadWasSuccessful = true;
+   return loadWasSuccessful;
 }
 
 bool Database::createBlank(QString const& filename)
@@ -649,8 +648,10 @@ Database& Database::instance()
    {
       mutex.lock();
 
-      if( ! dbInstance )
+      if( ! dbInstance ) {
          dbInstance = new Database();
+         dbInstance->load();
+      }
 
       mutex.unlock();
    }
@@ -1667,6 +1668,9 @@ void Database::updateColumns(Brewtarget::DBTable table, int key, QVariantMap col
       Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e) );
       throw;
    }
+
+   /*if ( notify )
+      emit object->changed(prop,value);*/
 }
 
 // Inventory functions ========================================================

--- a/src/database.h
+++ b/src/database.h
@@ -440,7 +440,7 @@ public:
                         QString const& Username, QString const& Password,
                         int Portnum, Brewtarget::DBTypes newType);
 
-   void updateColumns(Brewtarget::DBTable table, int key, QVariantMap colValMap);
+   void updateColumns(Brewtarget::DBTable table, int key, const QVariantMap& colValMap);
 
 signals:
    void changed(QMetaProperty prop, QVariant value);

--- a/src/database.h
+++ b/src/database.h
@@ -439,6 +439,9 @@ public:
    void convertDatabase(QString const& Hostname, QString const& DbName,
                         QString const& Username, QString const& Password,
                         int Portnum, Brewtarget::DBTypes newType);
+
+   void updateColumns(Brewtarget::DBTable table, int key, QVariantMap colValMap);
+
 signals:
    void changed(QMetaProperty prop, QVariant value);
    void newEquipmentSignal(Equipment*);
@@ -538,9 +541,6 @@ private:
    //! Helper to populate all* hashes. T should be a BeerXMLElement subclass.
    template <class T> void populateElements( QHash<int,T*>& hash, Brewtarget::DBTable table )
    {
-      int key;
-      T* et;
-
       QSqlQuery q(sqlDatabase());
       q.setForwardOnly(true);
       QString queryString = QString("SELECT id FROM %1").arg(tableNames[table]);
@@ -558,11 +558,11 @@ private:
 
       while( q.next() )
       {
-         key = q.record().value("id").toInt();
+         int key = q.record().value("id").toInt();
 
-         et = new T(table, key);
+         T* e = new T(table, key);
          if( ! hash.contains(key) )
-            hash.insert(key,et);
+            hash.insert(key, e);
       }
 
       q.finish();
@@ -571,7 +571,6 @@ private:
    //! Helper to populate the list using the given filter.
    template <class T> bool getElements( QList<T*>& list, QString filter, Brewtarget::DBTable table, QHash<int,T*> allElements, QString id=QString("") )
    {
-      int key;
       QSqlQuery q(sqlDatabase());
       q.setForwardOnly(true);
       QString queryString;
@@ -596,7 +595,7 @@ private:
 
       while( q.next() )
       {
-         key = q.record().value("id").toInt();
+         int key = q.record().value("id").toInt();
          if( allElements.contains(key) )
             list.append( allElements[key] );
       }

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -90,8 +90,8 @@ void Equipment::setDefaults()
 }
 */
 
-Equipment::Equipment()
-   : BeerXMLElement()
+Equipment::Equipment(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
 }
 

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -90,6 +90,12 @@ void Equipment::setDefaults()
 }
 */
 
+QString Equipment::classNameStr()
+{
+   static const QString name("Equipment");
+   return name;
+}
+
 Equipment::Equipment(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {

--- a/src/equipment.h
+++ b/src/equipment.h
@@ -119,6 +119,8 @@ public:
    //! \brief Calculate how much wort is left immediately at knockout.
    double wortEndOfBoil_l( double kettleWort_l ) const;
 
+   static QString classNameStr();
+
 signals:
    
    void changedName(QString);

--- a/src/equipment.h
+++ b/src/equipment.h
@@ -141,7 +141,7 @@ signals:
    void changedBoilingPoint_c(double);
    
 private:
-   Equipment();
+   Equipment(Brewtarget::DBTable table, int key);
    Equipment( Equipment const& other);
    
    // Calculate the boil size.

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -96,7 +96,7 @@ QString Fermentable::classNameStr()
 Fermentable::Fermentable(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {
-   setType( static_cast<Fermentable::Type>(get(kType).toInt()) );
+   setType( static_cast<Fermentable::Type>(types.indexOf(get(kType).toString())) );
    setAmount_kg( get(kAmount).toDouble() );
    setInventoryAmount( getInventory(kAmount).toDouble() );
    setYield_pct( get(kYield).toDouble() );

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -67,6 +67,12 @@ bool operator==(Fermentable &f1, Fermentable &f2)
    return f1.name() == f2.name();
 }
 
+QString Fermentable::classNameStr()
+{
+   static const QString name("Fermentable");
+   return name;
+}
+
 Fermentable::Fermentable(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -27,9 +27,29 @@
 #include <QDebug>
 #include "fermentable.h"
 #include "brewtarget.h"
+#include "database.h"
+
+#define SUPER BeerXMLElement
 
 QStringList Fermentable::types = QStringList() << "Grain" << "Sugar" << "Extract" << "Dry Extract" << "Adjunct";
 QHash<QString,QString> Fermentable::tagToProp = Fermentable::tagToPropHash();
+
+static const QString kAmount("amount");
+static const QString kYield("yield");
+static const QString kColor("color");
+static const QString kCoarseFineDiff("coarse_fine_diff");
+static const QString kMoisture("moisture");
+static const QString kDiastaticPower("diastatic_power");
+static const QString kProtein("protein");
+static const QString kMaxInBatch("max_in_batch");
+static const QString kIBUGalPerLb("ibu_gal_per_lb");
+static const QString kType("ftype");
+static const QString kAddAfterBoil("add_after_boil");
+static const QString kOrigin("origin");
+static const QString kSupplier("supplier");
+static const QString kNotes("notes");
+static const QString kRecomendMash("recommend_mash");
+static const QString kIsMashed("is_mashed");
 
 QHash<QString,QString> Fermentable::tagToPropHash()
 {
@@ -76,15 +96,47 @@ QString Fermentable::classNameStr()
 Fermentable::Fermentable(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {
+   setType( static_cast<Fermentable::Type>(get(kType).toInt()) );
+   setAmount_kg( get(kAmount).toDouble() );
+   setInventoryAmount( getInventory(kAmount).toDouble() );
+   setYield_pct( get(kYield).toDouble() );
+   setColor_srm( get(kColor).toDouble() );
+   setAddAfterBoil( get(kAddAfterBoil).toBool() );
+   setOrigin( get(kOrigin).toString() );
+   setSupplier( get(kSupplier).toString() );
+   setNotes( get(kNotes).toString() );
+   setCoarseFineDiff_pct( get(kCoarseFineDiff).toDouble() );
+   setMoisture_pct( get(kMoisture).toDouble() );
+   setDiastaticPower_lintner( get(kDiastaticPower).toDouble() );
+   setProtein_pct( get(kProtein).toDouble() );
+   setMaxInBatch_pct( get(kMaxInBatch).toDouble() );
+   setRecommendMash( get(kRecomendMash).toBool() );
+   setIbuGalPerLb( get(kIBUGalPerLb).toDouble() );
+   setIsMashed( get(kIsMashed).toBool() );
 }
 
 Fermentable::Fermentable( Fermentable const& other )
         : BeerXMLElement( other )
 {
+   setType( other.type() );
+   setAmount_kg( other.amount_kg() );
+   setInventoryAmount( other.inventory() );
+   setYield_pct( other.yield_pct() );
+   setColor_srm( other.color_srm() );
+   setAddAfterBoil( other.addAfterBoil() );
+   setOrigin( other.origin() );
+   setSupplier( other.supplier() );
+   setNotes( other.notes() );
+   setCoarseFineDiff_pct( other.coarseFineDiff_pct() );
+   setMoisture_pct( other.moisture_pct() );
+   setDiastaticPower_lintner( other.diastaticPower_lintner() );
+   setProtein_pct( other.protein_pct() );
+   setMaxInBatch_pct( other.maxInBatch_pct() );
+   setRecommendMash( other.recommendMash() );
+   setIbuGalPerLb( other.ibuGalPerLb() );
+   setIsMashed(other.isMashed());
 }
 
-// Get
-const Fermentable::Type Fermentable::type() const { return static_cast<Fermentable::Type>(types.indexOf(get("ftype").toString())); }
 const Fermentable::AdditionMethod Fermentable::additionMethod() const
 {
    Fermentable::AdditionMethod additionMethod;
@@ -147,42 +199,70 @@ const QString Fermentable::additionTimeStringTr() const
     return retString;
 }
 
-double Fermentable::amount_kg()              const { return get("amount").toDouble(); }
-double Fermentable::yield_pct()              const { return get("yield").toDouble(); }
-double Fermentable::color_srm()              const { return get("color").toDouble(); }
-double Fermentable::coarseFineDiff_pct()     const { return get("coarse_fine_diff").toDouble(); }
-double Fermentable::moisture_pct()           const { return get("moisture").toDouble(); }
-double Fermentable::diastaticPower_lintner() const { return get("diastatic_power").toDouble(); }
-double Fermentable::protein_pct()            const { return get("protein").toDouble(); }
-double Fermentable::maxInBatch_pct()         const { return get("max_in_batch").toDouble(); }
-double Fermentable::ibuGalPerLb()            const { return get("ibu_gal_per_lb").toDouble(); }
-
-// inventory must be handled separately, to my great annoyance
-double Fermentable::inventory() const 
-{ 
-   return getInventory("amount").toDouble();
+bool Fermentable::isExtract() const
+{
+   return ((type() == Extract) || (type() == Dry_Extract));
 }
 
-bool Fermentable::addAfterBoil() const { return get("add_after_boil").toBool(); }
-const QString Fermentable::origin() const { return get("origin").toString(); }
-const QString Fermentable::supplier() const { return get("supplier").toString(); }
-const QString Fermentable::notes() const { return get("notes").toString(); }
-bool Fermentable::recommendMash() const { return get("recommend_mash").toBool(); }
-bool Fermentable::isMashed() const { return get("is_mashed").toBool(); }
-bool Fermentable::isExtract() { return ((type() == Extract) || (type() == Dry_Extract)); }
-bool Fermentable::isSugar() { return (type() == Sugar); }
-bool Fermentable::isValidType( const QString& str ) { return (types.indexOf(str) >= 0); }
+bool Fermentable::isSugar() const
+{
+   return (type() == Sugar);
+}
 
-void Fermentable::setType( Type t ) { set("type", "ftype", types.at(t)); }
-void Fermentable::setAdditionMethod( Fermentable::AdditionMethod m ) { setIsMashed(m == Fermentable::Mashed); }
-void Fermentable::setAdditionTime( Fermentable::AdditionTime t ) { setAddAfterBoil(t == Fermentable::Late ); }
-void Fermentable::setAddAfterBoil( bool b ) { set("addAfterBoil", "add_after_boil", b); }
-void Fermentable::setOrigin( const QString& str ) { set("origin","origin",str);}
-void Fermentable::setSupplier( const QString& str) { set("supplier","supplier",str);}
-void Fermentable::setNotes( const QString& str ) { set("notes","notes",str);}
-void Fermentable::setRecommendMash( bool b ) { set("recommendMash","recommend_mash",b);}
-void Fermentable::setIsMashed(bool var) { set("isMashed","is_mashed",var); }
-void Fermentable::setIbuGalPerLb( double num ) { set("ibuGalPerLb","ibu_gal_per_lb",num);}
+bool Fermentable::isValidType( const QString& str )
+{
+   return (types.indexOf(str) >= 0);
+}
+
+void Fermentable::setType( Type t )
+{
+   _type = t;
+}
+
+void Fermentable::setAdditionMethod( Fermentable::AdditionMethod m )
+{
+   setIsMashed(m == Fermentable::Mashed);
+}
+
+void Fermentable::setAdditionTime( Fermentable::AdditionTime t )
+{
+   setAddAfterBoil(t == Fermentable::Late );
+}
+
+void Fermentable::setAddAfterBoil( bool b )
+{
+   _isAfterBoil = b;
+}
+
+void Fermentable::setOrigin( const QString& str )
+{
+   _origin = str;
+}
+
+void Fermentable::setSupplier( const QString& str)
+{
+   _supplier = str;
+}
+
+void Fermentable::setNotes( const QString& str )
+{
+   _notes = str;
+}
+
+void Fermentable::setRecommendMash( bool b )
+{
+   _recommendMash = b;
+}
+
+void Fermentable::setIsMashed(bool var)
+{
+   _isMashed = var;
+}
+
+void Fermentable::setIbuGalPerLb( double num )
+{
+   _ibuGalPerLb = num;
+}
 
 double Fermentable::equivSucrose_kg() const
 {
@@ -203,7 +283,7 @@ void Fermentable::setAmount_kg( double num )
    }
    else
    {
-      set("amount_kg", "amount", num);
+      _amountKg = num;
    }
 }
 void Fermentable::setInventoryAmount( double num )
@@ -215,14 +295,14 @@ void Fermentable::setInventoryAmount( double num )
    }
    else
    {
-      setInventory("inventory", "amount", num);
+      _inventoryAmt = num;
    }
 }
 void Fermentable::setYield_pct( double num )
 {
    if( num >= 0.0 && num <= 100.0 )
    {
-      set("yield_pct", "yield", num);
+      _yieldPct = num;
    }
    else
    {
@@ -238,14 +318,14 @@ void Fermentable::setColor_srm( double num )
    }
    else
    {
-      set("color_srm", "color", num);
+      _colorSrm = num;
    }
 }
 void Fermentable::setCoarseFineDiff_pct( double num )
 {
    if( num >= 0.0 && num <= 100.0 )
    {
-      set("coarseFineDiff_pct", "coarse_fine_diff", num);
+      _coarseFineDiff = num;
    }
    else
    {
@@ -256,7 +336,7 @@ void Fermentable::setMoisture_pct( double num )
 {
    if( num >= 0.0 && num <= 100.0 )
    {
-      set("moisture_pct", "moisture", num);
+      _moisturePct = num;
    }
    else
    {
@@ -272,14 +352,14 @@ void Fermentable::setDiastaticPower_lintner( double num )
    }
    else
    {
-      set("diastaticPower_lintner", "diastatic_power", num);
+      _diastaticPower = num;
    }
 }
 void Fermentable::setProtein_pct( double num )
 {
    if( num >= 0.0 && num <= 100.0 )
    {
-      set("protein_pct", "protein", num);
+      _proteinPct = num;
    }
    else
    {
@@ -290,7 +370,7 @@ void Fermentable::setMaxInBatch_pct( double num )
 {
    if( num >= 0.0 && num <= 100.0 )
    {
-      set("maxInBatch_pct", "max_in_batch", num);
+      _maxInBatchPct = num;
    }
    else
    {
@@ -298,3 +378,28 @@ void Fermentable::setMaxInBatch_pct( double num )
    }
 }
 
+void Fermentable::save()
+{
+   QVariantMap map = SUPER::getColumnValueMap();
+   map.insert(kMaxInBatch, maxInBatch_pct());
+   map.insert(kProtein, protein_pct());
+   map.insert(kDiastaticPower, diastaticPower_lintner());
+   map.insert(kMoisture, moisture_pct());
+   map.insert(kCoarseFineDiff, coarseFineDiff_pct());
+   map.insert(kColor, color_srm());
+   map.insert(kYield, yield_pct());
+   map.insert(kAmount, amount_kg());
+   map.insert(kIBUGalPerLb, ibuGalPerLb());
+   map.insert(kType, typeString());
+   map.insert(kAddAfterBoil, addAfterBoil());
+   map.insert(kOrigin, origin());
+   map.insert(kSupplier, supplier());
+   map.insert(kNotes, notes());
+   map.insert(kRecomendMash, recommendMash());
+   map.insert(kIsMashed, isMashed());
+
+   Database::instance().updateColumns( _table, _key, map);
+
+   setInventory("", kAmount, inventory());
+
+}

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -67,8 +67,8 @@ bool operator==(Fermentable &f1, Fermentable &f2)
    return f1.name() == f2.name();
 }
 
-Fermentable::Fermentable()
-   : BeerXMLElement()
+Fermentable::Fermentable(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
 }
 

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -401,5 +401,6 @@ void Fermentable::save()
    Database::instance().updateColumns( _table, _key, map);
 
    setInventory("", kAmount, inventory());
+   emit saved();
 
 }

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -174,27 +174,7 @@ signals:
    
    //! \brief Emitted when \c name() changes.
    void changedName(QString);
-   /*
-   void changedType( Type newType );
-   void changedTypeString( QString newTypeString );
-   void changedTypeStringTr( QString newTypeStringTr );
-   void changedAmount_kg( double newAmount_kg );
-   void changedInventory( double newInventory );
-   void changedYield_pct( double newYield_pct );
-   void changedColor_srm( double newColor_srm );
-   void changedAddAfterBoil( bool newAddAfterBoil );
-   void changedOrigin( QString newOrigin );
-   void changedSupplier( QString newSupplier );
-   void changedNotes( QString newNotes );
-   void changedCoarseFineDiff_pct( double newCoarseFineDiff_pct );
-   void changedMoisture_pct( double newMoisture_pct );
-   void changedDiastaticPower_lintner( double newDiastaticPower_lintner );
-   void changedProtein_pct( double newProtein_pct );
-   void changedMaxInBatch_pct( double newMaxInBatch_pct );
-   void changedRecommendMash( bool newRecommendMash );
-   void changedIbuGalPerLb( double newIbuGalPerLb );
-   void changedIsMashed( bool newIsMashed );
-   */
+   void saved();
    
 private:
    Fermentable(Brewtarget::DBTable table, int key);

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -113,37 +113,38 @@ public:
    //! \brief Whether this fermentable is a sugar. Somewhat redundant, but it makes for nice symetry elsewhere
    Q_PROPERTY( bool isSugar                  READ isSugar STORED false)
    
-   const Type type() const;
-   const QString typeString() const;
+   const Type type() const { return _type; }
+   double amount_kg() const { return _amountKg; }
+   double inventory() const { return _inventoryAmt; }
+   double yield_pct() const { return _yieldPct; }
+   double color_srm() const { return _colorSrm; }
+   bool addAfterBoil() const { return _isAfterBoil; }
+   const QString origin() const { return _origin; }
+   const QString supplier() const { return _supplier; }
+   const QString notes() const { return _notes; }
+   double coarseFineDiff_pct() const { return _coarseFineDiff; }
+   double moisture_pct() const { return _moisturePct; }
+   double diastaticPower_lintner() const { return _diastaticPower; }
+   double protein_pct() const { return _proteinPct; }
+   double maxInBatch_pct() const { return _maxInBatchPct; }
+   bool recommendMash() const { return _recommendMash; }
+   double ibuGalPerLb() const { return _ibuGalPerLb; }
+   bool isMashed() const { return _isMashed; }
 
+   const QString typeString() const;
    //! Returns a translated type string.
    const QString typeStringTr() const;
    const AdditionMethod additionMethod() const;
-
    //! Returns a translated addition method string.
    const QString additionMethodStringTr() const;
    const AdditionTime additionTime() const;
-
    //! Returns a translated addition time string.
    const QString additionTimeStringTr() const;
-   double amount_kg() const;
-   double inventory() const;
-   double yield_pct() const;
-   double color_srm() const;
-   bool addAfterBoil() const;
-   const QString origin() const;
-   const QString supplier() const;
-   const QString notes() const;
-   double coarseFineDiff_pct() const;
-   double moisture_pct() const;
-   double diastaticPower_lintner() const;
-   double protein_pct() const;
-   double maxInBatch_pct() const;
-   bool recommendMash() const;
-   double ibuGalPerLb() const;
-
    // Calculated getters.
    double equivSucrose_kg() const;
+   bool isExtract() const;
+   bool isSugar() const;
+
 
    void setType( Type t );
    void setAdditionMethod( AdditionMethod m );
@@ -151,8 +152,7 @@ public:
    void setAmount_kg( double num );
    void setInventoryAmount( double num );
    void setYield_pct( double num );
-   void setColor_srm( double num );
-   
+   void setColor_srm( double num );   
    void setAddAfterBoil( bool b );
    void setOrigin( const QString& str );
    void setSupplier( const QString& str);
@@ -164,11 +164,9 @@ public:
    void setMaxInBatch_pct( double num );
    void setRecommendMash( bool b );
    void setIbuGalPerLb( double num );
-   
-   bool isMashed() const;
-   bool isExtract();
-   bool isSugar();
    void setIsMashed(bool var);
+
+   void save();
 
    static QString classNameStr();
 
@@ -207,6 +205,24 @@ private:
    
    static QHash<QString,QString> tagToProp;
    static QHash<QString,QString> tagToPropHash();
+
+   Type _type;
+   double _amountKg;
+   double _inventoryAmt;
+   double _yieldPct;
+   double _colorSrm;
+   bool _isAfterBoil;
+   QString _origin;
+   QString _supplier;
+   QString _notes;
+   double _coarseFineDiff;
+   double _moisturePct;
+   double _diastaticPower;
+   double _proteinPct;
+   double _maxInBatchPct;
+   bool _recommendMash;
+   double _ibuGalPerLb;
+   bool _isMashed;
 };
 
 Q_DECLARE_METATYPE( QList<Fermentable*> )

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -170,6 +170,8 @@ public:
    bool isSugar();
    void setIsMashed(bool var);
 
+   static QString classNameStr();
+
 signals:
    
    //! \brief Emitted when \c name() changes.

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -197,7 +197,7 @@ signals:
    */
    
 private:
-   Fermentable();
+   Fermentable(Brewtarget::DBTable table, int key);
    Fermentable( Fermentable const& other );
    
    static bool isValidType( const QString& str );

--- a/src/hop.cpp
+++ b/src/hop.cpp
@@ -80,8 +80,8 @@ bool Hop::isValidForm(const QString& str)
    return (forms.indexOf(str) >= 0);
 }
 
-Hop::Hop()
-   : BeerXMLElement()
+Hop::Hop(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
 }
 

--- a/src/hop.cpp
+++ b/src/hop.cpp
@@ -80,6 +80,12 @@ bool Hop::isValidForm(const QString& str)
    return (forms.indexOf(str) >= 0);
 }
 
+QString Hop::classNameStr()
+{
+   static const QString name("Hop");
+   return name;
+}
+
 Hop::Hop(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {

--- a/src/hop.h
+++ b/src/hop.h
@@ -137,6 +137,7 @@ public:
    void setCohumulone_pct( double num );
    void setMyrcene_pct( double num );
 
+   static QString classNameStr();
 signals:
    //! \brief Emitted when \c name() changes.
    void changedName(QString);

--- a/src/hop.h
+++ b/src/hop.h
@@ -160,7 +160,7 @@ signals:
    */
    
 private:
-   Hop();
+   Hop(Brewtarget::DBTable table, int key);
    Hop( Hop const& other );
    
    void setDefaults();

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -38,8 +38,8 @@ QHash<QString,QString> Instruction::tagToPropHash()
    return propHash;
 }
 
-Instruction::Instruction()
-   : BeerXMLElement()
+Instruction::Instruction(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
    setObjectName("Instruction"); 
 }

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -38,6 +38,12 @@ QHash<QString,QString> Instruction::tagToPropHash()
    return propHash;
 }
 
+QString Instruction::classNameStr()
+{
+   static const QString name("Instruction");
+   return name;
+}
+
 Instruction::Instruction(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -85,7 +85,7 @@ signals:
 
 private:
    //! Only database gets to construct instances.
-   Instruction();
+   Instruction(Brewtarget::DBTable table, int key);
    Instruction( Instruction const& other );
    /*
    Instruction( const QString& name,

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -72,6 +72,9 @@ public:
    double interval();
 
    int instructionNumber() const;
+
+   static QString classNameStr();
+
 signals:
    /*
    void changedName(QString);

--- a/src/mash.cpp
+++ b/src/mash.cpp
@@ -56,6 +56,12 @@ bool operator==(Mash &m1, Mash &m2)
    return m1.name() == m2.name();
 }
 
+QString Mash::classNameStr()
+{
+   static const QString name("Mash");
+   return name;
+}
+
 Mash::Mash(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {

--- a/src/mash.cpp
+++ b/src/mash.cpp
@@ -56,8 +56,8 @@ bool operator==(Mash &m1, Mash &m2)
    return m1.name() == m2.name();
 }
 
-Mash::Mash()
-   : BeerXMLElement()
+Mash::Mash(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
 }
 

--- a/src/mash.h
+++ b/src/mash.h
@@ -114,7 +114,7 @@ signals:
    void mashStepsChanged();
    
 private:
-   Mash();
+   Mash(Brewtarget::DBTable table, int key);
    Mash( Mash const& other );
    
    // Get via the relational relationship.

--- a/src/mash.h
+++ b/src/mash.h
@@ -103,6 +103,8 @@ public:
    // NOTE: should this be completely in Database?
    void removeAllMashSteps();
 
+   static QString classNameStr();
+
 public slots:
    void acceptMashStepChange(QMetaProperty, QVariant);
    

--- a/src/mashstep.cpp
+++ b/src/mashstep.cpp
@@ -51,6 +51,12 @@ bool operator==(MashStep &m1, MashStep &m2)
    return m1.name() == m2.name();
 }
 
+QString MashStep::classNameStr()
+{
+   static const QString name("MashStep");
+   return name;
+}
+
 //==============================CONSTRUCTORS====================================
 
 MashStep::MashStep(Brewtarget::DBTable table, int key)

--- a/src/mashstep.cpp
+++ b/src/mashstep.cpp
@@ -53,8 +53,8 @@ bool operator==(MashStep &m1, MashStep &m2)
 
 //==============================CONSTRUCTORS====================================
 
-MashStep::MashStep()
-   : BeerXMLElement()
+MashStep::MashStep(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
 }
 

--- a/src/mashstep.h
+++ b/src/mashstep.h
@@ -100,6 +100,8 @@ public:
    bool isTemperature() const;
    bool isDecoction() const;
 
+   static QString classNameStr();
+
 signals:
 
    //! \brief Emitted when \c name() changes.

--- a/src/mashstep.h
+++ b/src/mashstep.h
@@ -116,7 +116,7 @@ signals:
    */
    
 private:
-   MashStep();
+   MashStep(Brewtarget::DBTable table, int key);
    MashStep( MashStep const& other );
    
    bool isValidType( const QString &str ) const;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -50,7 +50,7 @@ QHash<QString,QString> Misc::tagToPropHash()
    return propHash;
 }
 //============================CONSTRUCTORS======================================
-Misc::Misc() : BeerXMLElement()
+Misc::Misc(Brewtarget::DBTable table, int key) : BeerXMLElement(table, key)
 {
 }
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -49,6 +49,13 @@ QHash<QString,QString> Misc::tagToPropHash()
    propHash["NOTES"] = "notes";
    return propHash;
 }
+
+QString Misc::classNameStr()
+{
+   static const QString name("Misc");
+   return name;
+}
+
 //============================CONSTRUCTORS======================================
 Misc::Misc(Brewtarget::DBTable table, int key) : BeerXMLElement(table, key)
 {

--- a/src/misc.h
+++ b/src/misc.h
@@ -113,6 +113,8 @@ public:
    bool amountIsWeight() const;
    QString useFor() const;
    QString notes() const;
+
+   static QString classNameStr();
    
 signals:
    

--- a/src/misc.h
+++ b/src/misc.h
@@ -130,7 +130,7 @@ signals:
    */
    
 private:
-   Misc();
+   Misc(Brewtarget::DBTable table, int key);
    Misc(Misc const& other);
    
    bool isValidType( const QString &var );

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -110,8 +110,8 @@ void Recipe::clear()
    */
 }
 
-Recipe::Recipe()
-   : BeerXMLElement(),
+Recipe::Recipe(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key),
      _ABV_pct(0),
      _color_srm(0),
      _boilGrav(1.000),

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -110,6 +110,12 @@ void Recipe::clear()
    */
 }
 
+QString Recipe::classNameStr()
+{
+   static const QString name("Recipe");
+   return name;
+}
+
 Recipe::Recipe(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key),
      _ABV_pct(0),

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -786,6 +786,7 @@ void Recipe::addHop( Hop *var )
 
 void Recipe::addFermentable( Fermentable* var )
 {
+   connect(var, &Fermentable::saved, this, &Recipe::onFermentableChanged);
    Database::instance().addToRecipe( this, var );
 }
 
@@ -2061,7 +2062,7 @@ void Recipe::acceptFermChange(QMetaProperty prop, QVariant val)
    recalcAll();
 }
 
-void Recipe::acceptFermChange(Fermentable *ferm)
+void Recipe::onFermentableChanged()
 {
    recalcAll();
 }

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -319,7 +319,7 @@ public slots:
    void acceptYeastChange(QMetaProperty prop, QVariant val);
    void acceptMashChange(QMetaProperty prop, QVariant val);
 
-   void acceptFermChange(Fermentable* ferm);
+   void onFermentableChanged();
    void acceptHopChange(Hop* hop);
    void acceptYeastChange(Yeast* yeast);
    void acceptMashChange(Mash* mash);

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -354,7 +354,7 @@ public slots:
    
 private:
    
-   Recipe();
+   Recipe(Brewtarget::DBTable table, int key);
    Recipe(Recipe const& other);
    
    // Calculated properties.

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -306,6 +306,8 @@ public:
    QList<QString> getReagents( QList<Hop*> hops, bool firstWort = false );
    QHash<QString,double> calcTotalPoints();
    
+   static QString classNameStr();
+
 signals:
    //! \brief Emitted when \c name() changes.
    void changedName(const QString&);

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -63,6 +63,12 @@ bool operator==(Style &s1, Style &s2)
    return s1.key() == s2.key();
 }
 
+QString Style::classNameStr()
+{
+   static const QString name("Style");
+   return name;
+}
+
 Style::Style(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -63,8 +63,8 @@ bool operator==(Style &s1, Style &s2)
    return s1.key() == s2.key();
 }
 
-Style::Style()
-   : BeerXMLElement()
+Style::Style(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
 }
 

--- a/src/style.h
+++ b/src/style.h
@@ -169,7 +169,7 @@ signals:
    */
 
 private:
-   Style();
+   Style(Brewtarget::DBTable table, int key);
    Style( Style const& other );
    
    bool isValidType( const QString &str );

--- a/src/style.h
+++ b/src/style.h
@@ -140,6 +140,8 @@ public:
    QString ingredients() const;
    QString examples() const;
 
+   static QString classNameStr();
+
 signals:
    //! \brief Emitted when \c name() changes.
    void changedName(QString);

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -54,8 +54,8 @@ bool operator==(Water &w1, Water &w2)
    return w1.name() == w2.name();
 }
 
-Water::Water()
-   : BeerXMLElement()
+Water::Water(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
 }
 

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -54,6 +54,12 @@ bool operator==(Water &w1, Water &w2)
    return w1.name() == w2.name();
 }
 
+QString Water::classNameStr()
+{
+   static const QString name("Water");
+   return name;
+}
+
 Water::Water(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)
 {

--- a/src/water.h
+++ b/src/water.h
@@ -103,7 +103,7 @@ signals:
    */
    
 private:
-   Water();
+   Water(Brewtarget::DBTable table, int key);
    Water( Water const& other );
    
    static QHash<QString,QString> tagToProp;

--- a/src/water.h
+++ b/src/water.h
@@ -85,6 +85,8 @@ public:
    void setMagnesium_ppm( double var );
    void setPh( double var );
    void setNotes( const QString &var );
+
+   static QString classNameStr();
    
 signals:
    

--- a/src/yeast.cpp
+++ b/src/yeast.cpp
@@ -66,8 +66,8 @@ bool operator==(Yeast &y1, Yeast &y2)
 }
 
 //============================CONSTRUCTORS======================================
-Yeast::Yeast()
-   : BeerXMLElement()
+Yeast::Yeast(Brewtarget::DBTable table, int key)
+   : BeerXMLElement(table, key)
 {
 }
 

--- a/src/yeast.cpp
+++ b/src/yeast.cpp
@@ -65,6 +65,12 @@ bool operator==(Yeast &y1, Yeast &y2)
    return y1.name() == y2.name();
 }
 
+QString Yeast::classNameStr()
+{
+   static const QString name("Yeast");
+   return name;
+}
+
 //============================CONSTRUCTORS======================================
 Yeast::Yeast(Brewtarget::DBTable table, int key)
    : BeerXMLElement(table, key)

--- a/src/yeast.h
+++ b/src/yeast.h
@@ -149,7 +149,7 @@ signals:
    void changedName(QString);
 
 private:
-   Yeast();
+   Yeast(Brewtarget::DBTable table, int key);
    Yeast(Yeast const& other);
    
    static QStringList types;

--- a/src/yeast.h
+++ b/src/yeast.h
@@ -142,6 +142,8 @@ public:
    int timesCultured() const;
    int maxReuse() const;
    bool addToSecondary() const;
+
+   static QString classNameStr();
    
 signals:
 


### PR DESCRIPTION
This is the first of a lot of refactoring/cleanup I'd like to do.
This changes BeerXMLElement to not have a default constructor, it now requires a table and key.
Doing this allows a BeerXMLElement to gather it's values from the database in it's constructor.
The next change is the Fermentable object now gathers all it's values from the database in the constructor and stores them in member variables. the getter functions now just return the member variable, the setters no longer write to the DB, instead the save() function has to be called on the Fermentable which commits everything to the database all as 1 SQL statement. This is much more efficient in the FermentableEditor scenario, but a little less efficient in the FermentableTableModel scenario where a user can actually change and save 1 column of the fermentable, the save function could be optimized to only save what has been changed if people don't like this. I've also started creating static const QString's for strings that are used multiple times as this is common programming best practice.