### PR TITLE
Update README - correct dependencies

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -72,7 +72,8 @@ On Debian systems like Ubuntu, the packages for dependencies are:
 * qtmultimedia5-dev
 * libqt5webkit5-dev
 * libqt5sql5-sqlite
-* libqt5svg5
+* libqt5sql-psql
+* libqt5svg5-dev
 * libqt5multimedia5-plugins
 * doxygen (optional, for source documentation)
 


### PR DESCRIPTION
As per comments in Issue #337 I have made the following changes:

- added libqt5sql-psql as a dependency
- changed libqt5svg5 to libqt5svg5-dev

I tested the build and it worked fine [as far as I can see].