### PR TITLE
Closes #357 in version 2.3.1

### DIFF
--- a/src/MashWizard.cpp
+++ b/src/MashWizard.cpp
@@ -261,7 +261,7 @@ void MashWizard::wizardry()
          steps.append(mashStep);
       }
 
-      int lastMashStep = steps.size()-1;
+      int lastMashStep = steps.size()-2;
       tf = mash->spargeTemp_c();
       if( lastMashStep >= 0 )
          t1 = steps[lastMashStep]->stepTemp_c() - 10.0; // You will lose about 10C from last step.


### PR DESCRIPTION
Closes bug #357. The mash wizard calculates the wrong sparge water temperature in most instances.

There was an off-by-one error that caused MashWizard to reference a newly created MashStep when determining the temperature before the sparge. This meant that it always assumed the mash was at the default temperature (67 C) before sparging, and caused the sparge water temperature to be the same regardless of the actual mash temperature prior to sparging.

Since version 2.3.1 has already been released (but not on Windows!), should we create a new 2.3.2 branch for this?