### PR TITLE
Closes bug #54

### DIFF
--- a/ui/brewNoteWidget.ui
+++ b/ui/brewNoteWidget.ui
@@ -211,7 +211,7 @@
                 </size>
                </property>
                <property name="toolTip">
-                <string>Temperature of mash after dough in</string>
+                <string>Temperature of strike water before dough in</string>
                </property>
                <property name="editField" stdset="0">
                 <string notr="true">strikeTemp_c</string>


### PR DESCRIPTION
Bug #54 started with an inconsistency on some tooltip labels between the brewnote ui and the help manual. This PR (along with one in the [manual repo](https://github.com/Brewtarget/manual/pull/18)) resolves that inconsistency. I suggest that additional fields and UI changes (as mooted in #54) can be added in future releases with the appropriate DB schema.

I need someone to confirm I've used sane tooltips for Strike Temp and Final Temp.