### PR TITLE
Closes #94 - Negative Volumes from Mash Designer

### DIFF
--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -309,7 +309,7 @@ double MashDesigner::tempFromVolume_c( double vol_l )
 
 // Returns the maximum possible target temperature that can currently be reached.
 // If cooling, returns the minimum possible target temp
-double MashDesigner::maxTargetTemp()
+double MashDesigner::maxTargetTemp_c()
 {
    if (mashStep == 0 || mash == 0)
       return 0.0;
@@ -624,7 +624,7 @@ void MashDesigner::saveTargetTemp()
       // Do a sanity check the make sure the max volume available can actually hit the temperature we want
       double tempNeeded_c = tempFromVolume_c( maxAmt_l() );
       if ((tempNeeded_c > maxTemp_c()) || (tempNeeded_c < minTemp_c()))
-         lineEdit_temp->setText( maxTargetTemp() );
+         lineEdit_temp->setText( maxTargetTemp_c() );
    }
 
    if ( mashStep != 0 )

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -213,18 +213,24 @@ double MashDesigner::minAmt_l()
 // However much more we can add at this step.
 double MashDesigner::maxAmt_l()
 {
+   double amt = 0;
+
    if ( equip == 0 )
-      return 0;
+      return amt;
 
    // However much more we can fit in the tun.
    if( ! isSparge() )
    {
-      return equip->tunVolume_l() - mashVolume_l();
+      amt = equip->tunVolume_l() - mashVolume_l();
    }
    else
    {
-      return equip->tunVolume_l() - grainVolume_l();
+      amt = equip->tunVolume_l() - grainVolume_l();
    }
+
+   amt = std::min(amt, maxFromRecipe_l());
+
+   return amt;
 }
 
 // Returns the required volume of water to infuse if the strike water is
@@ -700,5 +706,19 @@ void MashDesigner::typeChanged(int t)
       horizontalSlider_amount->setEnabled(false);
       horizontalSlider_temp->setEnabled(false);
    }
+}
+
+double MashDesigner::maxFromRecipe_l() {
+
+   if ( recObs == 0 )
+      return 0.0;
+
+   double absorption_lKg;
+   if( equip )
+      absorption_lKg = equip->grainAbsorption_LKg();
+   else
+      absorption_lKg = PhysicalConstants::grainAbsorption_Lkg;
+
+   return recObs->boilSize_l() - addedWater_l + absorption_lKg * recObs->grainsInMash_kg();
 }
 

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -560,19 +560,18 @@ void MashDesigner::updateAmt()
    if( mashStep == 0 )
       return;
 
-   if( isInfusion() )
+   double vol;
+   if (isInfusion())
    {
-      double vol = horizontalSlider_amount->sliderPosition() / (double)(horizontalSlider_amount->maximum())* (maxAmt_l() - minAmt_l()) + minAmt_l();
-
-      label_amt->setText(Brewtarget::displayAmount( vol, Units::liters));
-
-      if( mashStep != 0 )
+      vol = horizontalSlider_amount->sliderPosition() / (double)(horizontalSlider_amount->maximum())* (maxAmt_l() - minAmt_l()) + minAmt_l();
+      if (mashStep != 0)
          mashStep->setInfuseAmount_l( vol );
    }
-   else if( isDecoction() )
-      label_amt->setText(Brewtarget::displayAmount(mashStep->decoctionAmount_l(), Units::liters));
+   else if (isDecoction())
+      vol = mashStep->decoctionAmount_l();
    else
-      label_amt->setText(Brewtarget::displayAmount(0, Units::liters));
+      vol = 0;
+   label_amt->setText( Brewtarget::displayAmount( vol, Units::liters ) );
 }
 
 void MashDesigner::updateTemp()

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -21,13 +21,9 @@
 
 #include "database.h"
 #include "MashDesigner.h"
-#include "equipment.h"
-#include "mash.h"
-#include "mashstep.h"
-#include "brewtarget.h"
 #include "HeatCalculations.h"
 #include "PhysicalConstants.h"
-#include "unit.h"
+#include "fermentable.h"
 #include <QMessageBox>
 #include <QInputDialog>
 
@@ -228,7 +224,7 @@ double MashDesigner::maxAmt_l()
       amt = equip->tunVolume_l() - grainVolume_l();
    }
 
-   amt = std::min(amt, maxFromRecipe_l());
+   amt = std::min(amt, targetTotalMashVol_l() - addedWater_l);
 
    return amt;
 }
@@ -348,7 +344,7 @@ bool MashDesigner::initializeMash()
    grain_kg = recObs->grainsInMash_kg();
 
    label_tunVol->setText(Brewtarget::displayAmount(equip->tunVolume_l(), Units::liters));
-   label_wortMax->setText(Brewtarget::displayAmount(recObs->boilSize_l(), Units::liters));
+   label_wortMax->setText(Brewtarget::displayAmount(targetCollectedWortVol_l(), Units::liters));
 
    updateMinAmt();
    updateMaxAmt();
@@ -415,7 +411,7 @@ void MashDesigner::updateCollectedWort()
    // double wort_l = recObs->wortFromMash_l();
    double wort_l = waterFromMash_l();
 
-   double ratio = wort_l / recObs->boilSize_l();
+   double ratio = wort_l / targetCollectedWortVol_l();
    if( ratio < 0 )
      ratio = 0;
    if( ratio > 1 )
@@ -666,7 +662,7 @@ MashStep::Type MashDesigner::type() const
    return static_cast<MashStep::Type>(curIdx);
 }
 
-void MashDesigner::typeChanged(int t)
+void MashDesigner::typeChanged()
 {
    MashStep::Type _type = type();
 
@@ -708,7 +704,29 @@ void MashDesigner::typeChanged(int t)
    }
 }
 
-double MashDesigner::maxFromRecipe_l() {
+double MashDesigner::targetCollectedWortVol_l() {
+
+   if ( recObs == 0 )
+      return 0.0;
+
+   // Need to account for extract/sugar volume also.
+   float postMashAdditionVolume_l = 0;
+   QList<Fermentable*> ferms = recObs->fermentables();
+         foreach( Fermentable* f, ferms )
+      {
+         Fermentable::Type type = f->type();
+         if( type == Fermentable::Extract )
+            postMashAdditionVolume_l  += f->amount_kg() / PhysicalConstants::liquidExtractDensity_kgL;
+         else if( type == Fermentable::Sugar )
+            postMashAdditionVolume_l  += f->amount_kg() / PhysicalConstants::sucroseDensity_kgL;
+         else if( type == Fermentable::Dry_Extract )
+            postMashAdditionVolume_l  += f->amount_kg() / PhysicalConstants::dryExtractDensity_kgL;
+      }
+
+   return recObs->boilSize_l() - equip->topUpKettle_l() - postMashAdditionVolume_l;
+}
+
+double MashDesigner::targetTotalMashVol_l() {
 
    if ( recObs == 0 )
       return 0.0;
@@ -719,6 +737,7 @@ double MashDesigner::maxFromRecipe_l() {
    else
       absorption_lKg = PhysicalConstants::grainAbsorption_Lkg;
 
-   return recObs->boilSize_l() - addedWater_l + absorption_lKg * recObs->grainsInMash_kg();
+
+   return targetCollectedWortVol_l() + absorption_lKg * recObs->grainsInMash_kg();
 }
 

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -1,9 +1,10 @@
 /*
  * MashDesigner.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2014
+ * authors 2009-2017
  * - Dan Cavanagh <dan@dancavanagh.com>
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
+ * - Jonathon Harding <github@jrhardin.net>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -433,10 +433,12 @@ void MashDesigner::updateFullness()
    label_thickness->setText(Brewtarget::displayThickness( (addedWater_l + (isInfusion() ? selectedAmount_l() : 0) )/grain_kg ));
 }
 
+// How much water will be released from the mash?
 double MashDesigner::waterFromMash_l()
 {
    double waterAdded_l = mash->totalMashWater_l();
    double absorption_lKg;
+   double amt;
 
    if ( recObs == 0 )
       return 0.0;
@@ -446,7 +448,10 @@ double MashDesigner::waterFromMash_l()
    else
       absorption_lKg = PhysicalConstants::grainAbsorption_Lkg;
 
-   return (waterAdded_l - absorption_lKg * recObs->grainsInMash_kg());
+   amt = (waterAdded_l - absorption_lKg * recObs->grainsInMash_kg());
+
+   // Not possible to get negative volume from the mash
+   return std::max(0.0, amt);
 }
 
 void MashDesigner::updateCollectedWort()

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -186,41 +186,30 @@ bool MashDesigner::heating()
 
 double MashDesigner::maxTemp_c()
 {
-   double max_t;
+   double maxT = (recObs && recObs->equipment()) ? recObs->equipment()->boilingPoint_c() : 100.;
 
-   if ( heating() )
-   {
-      if (recObs && recObs->equipment())
-      {
-         max_t = recObs->equipment()->boilingPoint_c();
-      }
-      else
-         max_t = 100;
-   }
-   else
-   {
-      // If we're cooling down, then the max temp actually
-      // corresponds to the maximum volume added!
-      max_t = tempFromVolume_c( maxAmt_l() );
-   }
-   max_t = std::min( max_t, 100.0 );
-   max_t = std::max( max_t, 0.0 );
+   // If cooling down, maxT is limited by temperature from the max amount of water added
+   if (!heating())
+      maxT = std::min(tempFromVolume_c(maxAmt_l()), maxT);
 
-   return max_t;
+   // Make sure maxT isn't below freezing
+   maxT = std::max(maxT, 0.0);
+
+   return maxT;
 }
 
 double MashDesigner::minTemp_c()
 {
-   double min_t;
+   double minT = 0.0;
 
-   if ( heating() )
-      min_t = tempFromVolume_c( maxAmt_l() );
-   else
-      min_t = 0.0;
-   min_t = std::min( min_t, 100.0 );
-   min_t = std::max( min_t, 0.0 );
+   // If heating, minT is limited by the temperature from the max amount of water added
+   if (heating())
+      minT = std::max(tempFromVolume_c(maxAmt_l()), minT);
 
-   return min_t;
+   // Make sure minT doesn't exceed boiling
+   minT = std::min(minT, (recObs && recObs->equipment()) ? recObs->equipment()->boilingPoint_c() : 100.);
+
+   return minT;
 }
 
 // The mash volume up to and not including the step currently being edited.
@@ -231,22 +220,11 @@ double MashDesigner::mashVolume_l()
 
 double MashDesigner::minAmt_l()
 {
-   double minVol_l;
+   double minVol_l = (heating()) ? volFromTemp_l(maxTemp_c()) : volFromTemp_l(minTemp_c());
 
-   if (heating())
-      minVol_l = volFromTemp_l( maxTemp_c() );
-   else
-      minVol_l = volFromTemp_l( minTemp_c() );
-
-   // minAmt_l should always be less then maxAmt_l, but might not be if user requests an impossible
-   // temperature
-   if (minVol_l > maxAmt_l())
-   {
-      // TODO: Pop up a warning dialog?
-      minVol_l = maxAmt_l();
-   }
-
-   minVol_l = std::max( minVol_l, 0. );
+   // minAmt_l might exceed maxAmt_l if the user requests an impossible temperature
+   minVol_l = std::min(minVol_l, maxAmt_l());
+   minVol_l = std::max( minVol_l, 0. );  // Cannot have negative volumes
    return minVol_l;
 }
 
@@ -256,21 +234,17 @@ double MashDesigner::maxAmt_l()
    double amt = 0;
 
    if ( equip == 0 )
-      return amt;
+      return amt;  // If we have no equipment, give up
 
    // However much more we can fit in the tun.
    if( ! isSparge() )
-   {
       amt = equip->tunVolume_l() - mashVolume_l();
-   }
    else
-   {
       amt = equip->tunVolume_l() - grainVolume_l();
-   }
 
    // How much more can we fit in the brew pot
    amt = std::min( amt, targetTotalMashVol_l() - addedWater_l );
-   amt = std::max( amt, 0. );
+   amt = std::max( amt, 0. );  // Cannot have negative volumes
 
    return amt;
 }

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -576,7 +576,7 @@ void MashDesigner::updateAmt()
 
 void MashDesigner::updateTemp()
 {
-   double temp,maxT;
+   double temp;
 
    if( mashStep == 0 )
       return;
@@ -584,21 +584,19 @@ void MashDesigner::updateTemp()
    if( isInfusion() )
    {
       temp = horizontalSlider_temp->sliderPosition() / (double)(horizontalSlider_temp->maximum()) * (maxTemp_c() - minTemp_c()) + minTemp_c();
-      maxT = maxTemp_c();
-      if ( temp > maxT )
-         temp = maxT;
 
-      label_temp->setText(Brewtarget::displayAmount( temp, Units::celsius));
+      // Not sure how temp could ever be outside these bounds, but a similar check was already here
+      temp = heating() ? std::min( temp, maxTemp_c() ) : std::max( temp, minTemp_c() );
 
       if( mashStep != 0 )
          mashStep->setInfuseTemp_c( temp );
    }
-   else if( isDecoction() )
-      label_temp->setText(Brewtarget::displayAmount( maxTemp_c(), Units::celsius));
+   else if (isDecoction())
+      temp = maxTemp_c();
    else {
-   
-      label_temp->setText(Brewtarget::displayAmount( stepTemp_c(), Units::celsius));
+      temp = stepTemp_c();
    }
+   label_temp->setText( Brewtarget::displayAmount( temp, Units::celsius ) );
 }
 
 void MashDesigner::saveTargetTemp()

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -753,10 +753,15 @@ void MashDesigner::typeChanged()
    else if ( ! pushButton_next->isEnabled() )
       pushButton_next->setEnabled(true);
 
-   if( isInfusion() || isSparge() )
+   if ( isInfusion() || isSparge() )
    {
       horizontalSlider_amount->setEnabled(true);
       horizontalSlider_temp->setEnabled(true);
+      if (isSparge())
+      {
+         lineEdit_temp->setText(mash->spargeTemp_c());
+         lineEdit_time->setText(15.0);
+      }
       saveTargetTemp();
    }
    else if( isDecoction() )

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -179,6 +179,11 @@ double MashDesigner::stepTemp_c()
    return lineEdit_temp->toSI();
 }
 
+bool MashDesigner::heating()
+{
+   return stepTemp_c() > ((prevStep) ? prevStep->stepTemp_c() : mash->grainTemp_c());
+}
+
 double MashDesigner::maxTemp_c()
 {
    if ( recObs && recObs->equipment())

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -729,11 +729,11 @@ void MashDesigner::typeChanged()
    else if ( ! pushButton_next->isEnabled() )
       pushButton_next->setEnabled(true);
 
-   if( isInfusion() )
+   if( isInfusion() || isSparge() )
    {
       horizontalSlider_amount->setEnabled(true);
       horizontalSlider_temp->setEnabled(true);
-      updateMaxAmt();
+      saveTargetTemp();
    }
    else if( isDecoction() )
    {

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -62,7 +62,7 @@ MashDesigner::MashDesigner(QWidget* parent) : QDialog(parent)
    // Move to next step.
    connect( pushButton_next, SIGNAL(clicked()), this, SLOT(proceed()) );
    // Do correct calcs when the mash step type is selected.
-   connect( comboBox_type, SIGNAL(activated(int)), this, SLOT(typeChanged(int)) );
+   connect( comboBox_type, SIGNAL(activated(int)), this, SLOT(typeChanged()) );
 
    // I still dislike this part. But I also need to "fix" the form
    // connect( checkBox_batchSparge, SIGNAL(clicked()), this, SLOT(updateMaxAmt()) );

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -284,7 +284,6 @@ double MashDesigner::volFromTemp_l( double temp_c )
 
    double tw = temp_c;
    // Final temp is target temp.
-   // double tf = mashStep->stepTemp_c();
    double tf = stepTemp_c();
    // Initial temp is the last step's temp if the last step exists, otherwise the grain temp.
    double t1 = (prevStep==0)? mash->grainTemp_c() : prevStep->stepTemp_c();
@@ -310,7 +309,6 @@ double MashDesigner::tempFromVolume_c( double vol_l )
    else
       absorption_LKg = PhysicalConstants::grainAbsorption_Lkg;
 
-   // double tf = mashStep->stepTemp_c();
    double tf = stepTemp_c();
 
    // NOTE: This needs to be changed. Assumes 1L = 1 kg.
@@ -321,8 +319,8 @@ double MashDesigner::tempFromVolume_c( double vol_l )
    // Initial temp is the last step's temp if the last step exists, otherwise the grain temp.
    double t1 = (prevStep==0)? mash->grainTemp_c() : prevStep->stepTemp_c();
    // When batch sparging, you lose about 10C from previous step.
-   if( isSparge() )
-      t1 = (prevStep==0)? mash->grainTemp_c() : prevStep->stepTemp_c() - 10;
+   if ( isSparge() && (prevStep != 0) )
+      t1 -= 10;
    double mt = mash->tunSpecificHeat_calGC();
    double ct = mash->tunWeight_kg();
 
@@ -485,9 +483,6 @@ void MashDesigner::updateMaxAmt()
 void MashDesigner::updateMinTemp()
 {
    double minTemp = minTemp_c();
-
-   if ( minTemp > 100 )
-      minTemp = maxTemp_c();
 
    label_tempMin->setText(Brewtarget::displayAmount(minTemp, Units::celsius));
 }

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -80,6 +80,7 @@ private:
    double waterFromMash_l();
    double targetCollectedWortVol_l();
    double targetTotalMashVol_l();
+   double maxTargetTemp();
    bool heating();
 
    // I have developed a distaste for "getBlah"

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -62,7 +62,7 @@ private slots:
    void saveTargetTemp();
    void proceed(); // Go to next step.
    void saveAndClose();
-   void typeChanged(int t);
+   void typeChanged();
 
 private:
    bool nextStep(int step);
@@ -78,7 +78,8 @@ private:
    double volFromTemp_l( double temp_c );
    double getDecoctionAmount_l();
    double waterFromMash_l();
-   double maxFromRecipe_l();
+   double targetCollectedWortVol_l();
+   double targetTotalMashVol_l();
 
    // I have developed a distaste for "getBlah"
    double selectedAmount_l();

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -80,6 +80,7 @@ private:
    double waterFromMash_l();
    double targetCollectedWortVol_l();
    double targetTotalMashVol_l();
+   bool heating();
 
    // I have developed a distaste for "getBlah"
    double selectedAmount_l();

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -78,6 +78,7 @@ private:
    double volFromTemp_l( double temp_c );
    double getDecoctionAmount_l();
    double waterFromMash_l();
+   double maxFromRecipe_l();
 
    // I have developed a distaste for "getBlah"
    double selectedAmount_l();

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -80,7 +80,7 @@ private:
    double waterFromMash_l();
    double targetCollectedWortVol_l();
    double targetTotalMashVol_l();
-   double maxTargetTemp();
+   double maxTargetTemp_c();
    bool heating();
 
    // I have developed a distaste for "getBlah"


### PR DESCRIPTION
Bug #94 notes that the mash designer behaves badly when one step was cooler than the previous step, resulting in negative volumes becoming available. This was due to implicit assumptions within `maxTemp_c()`, `minTemp_c()`, and `minAmt_l()`, all of which assumed that the mash must heat up with each step. This PR fixes this behavior, and adds some enhancements to the Mash Designer besides:

- I've added a heating() private method in MashDesigner that checks if the current step is warmer or cooler than the previous one. The min/max temp/amt functions are all updated to check heating() and then perform the appropriate calculation.
- These functions also now have sanity checks that bound temperatures between 0 C to boiling and volumes between 0 and the amount going into the brew pot.
- These changes opened up additional edge cases, where the user could enter a target temperature that could not be achieved within the bounds above. I created an additional function `maxTargetTemp_c()` that determines the maximum (if heating) or minimum (if cooling) target temperature that can be achieved without overflowing. `saveTargetTemp()` was modified to check the requested target against maxTargetTemp - if the original target is out-of-bounds, it is reset to be the value of maxTargetTemp_c() before the target is saved.
- The typeChanged SLOT call is fixed so that `typeChanged()` actually executes when the user changes the step type.
- I changed default behaviors to be more user friendly:
    - If the user selects a sparge type, the target temp is automatically set to the mash's sparge temp,
      and the time is set to 15 minutes
    - On the first infusion, the amount added is initially set to target a mash thickness of 1.0 qt/lb
    - On all later infusions, the amount added is initially set to the minimum possible
    - On sparges, the amount added is initially set to the maximum possible
- Changes from PR #343 are cherry-picked into this PR, as I made use of the `targetCollectedWortVol_l()` and `targetTotalMashVol_l()` functions.

Things that should probably be checked before this PR gets merged:
1. Someone should do some abuse testing on the Mash Designer to make sure these mods work when the user enters in crazy things (cooling steps, out-of-range targets, etc.).
2. Someone should probably also double check my formula in `maxTargetTemp_c()` to make sure it works right (I derived it from the formula in `tempFromVolume_c()`)
3. Feedback on the new default behaviors is appreciated