### PR TITLE
fixing BtTextEdit so that it saves text on exit

### DIFF
--- a/src/BtTextEdit.cpp
+++ b/src/BtTextEdit.cpp
@@ -28,7 +28,7 @@ BtTextEdit::BtTextEdit(QWidget *parent)
    wasModified = false;
 
    // We will see if this works...
-   connect(this, &BtTextEdit::textChanged, this, &BtTextEdit::textChanged);
+   connect(this, &BtTextEdit::textChanged, this, &BtTextEdit::setTextChanged);
 
 }
 
@@ -39,7 +39,7 @@ BtTextEdit::BtTextEdit(const QString &text, QWidget *parent)
    wasModified = false;
 
    // We will see if this works...
-   connect(this, &BtTextEdit::textChanged, this, &BtTextEdit::textChanged);
+   connect(this, &BtTextEdit::textChanged, this, &BtTextEdit::setTextChanged);
 
 }
 
@@ -62,4 +62,4 @@ void BtTextEdit::focusOutEvent(QFocusEvent *e)
 }
 
 bool BtTextEdit::isModified()  { return wasModified; }
-void BtTextEdit::textChanged() { wasModified = true; }
+void BtTextEdit::setTextChanged() { wasModified = true; }

--- a/src/BtTextEdit.h
+++ b/src/BtTextEdit.h
@@ -49,7 +49,7 @@ public:
    void setPlainText( const QString& text);
 
 public slots:
-   void textChanged();
+   void setTextChanged();
 
 signals:
    void textModified();


### PR DESCRIPTION
Not being able to save the notes finally broke me. The textChanged signal was being overridden so it was never triggered, changing the function name works for me. Should fix #365