### PR TITLE
Removed the Debian /usr/local warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,8 @@ ELSE()
 ENDIF()
 
 IF( APPLE AND NOT CMAKE_OSX_ARCHITECTURES )
-   SET( CMAKE_OSX_ARCHITECTURES x86_64 ) # Build intel 64-bit binary. 
-   #SET( CMAKE_OSX_ARCHITECTURES i386 x86_64 ) # Build intel binary. 
+   SET( CMAKE_OSX_ARCHITECTURES x86_64 ) # Build intel 64-bit binary.
+   #SET( CMAKE_OSX_ARCHITECTURES i386 x86_64 ) # Build intel binary.
    #SET( CMAKE_OSX_ARCHITECTURES ppc i386 ppc64 x86_64 ) # Build universal binary.
 ENDIF()
 
@@ -220,23 +220,13 @@ IF( GZIP_CMD )
    ADD_CUSTOM_TARGET(changelog ALL DEPENDS ${CHANGELOG})
 ENDIF()
 
-#=========================Detect Debian======================================== 
-IF( EXISTS "/etc/debian_version" )
-  MESSAGE( STATUS "Debian detected..." )
-
-  IF( NOT ${CMAKE_INSTALL_PREFIX} STREQUAL "/usr" )
-    MESSAGE( WARNING "Debian system, but CMAKE_INSTALL_PREFIX != /usr" )
-    MESSAGE( WARNING "CMAKE_INSTALL_PREFIX = \"${CMAKE_INSTALL_PREFIX}\"" )
-  ENDIF()
-ENDIF()
-
 #========================Construct the directories=============================
 
 # Debian standard directories.
 IF( NOT EXEC_PREFIX )
    SET( EXEC_PREFIX ${CMAKE_INSTALL_PREFIX} )
 ENDIF()
-   
+
 SET( DATAROOTDIR "${EXEC_PREFIX}/share" )
 SET( BINDIR "${EXEC_PREFIX}/bin" )
 IF( NOT DOCDIR )
@@ -254,7 +244,7 @@ ELSEIF( WIN32 )
   #SET( DATAPATH "brewtarget-${brewtarget_VERSION_STRING}" )
   #SET( TARGETPATH "brewtarget-${brewtarget_VERSION_STRING}" )
   #SET( DOCPATH "brewtarget-${brewtarget_VERSION_STRING}/doc" )
-  
+
   # For some damn reason, for the NSIS installer,
   # the prefix needs to be empty. Also, seems that the .exe
   # needs to be in bin/. Fucking piece of shit CPack...
@@ -489,7 +479,7 @@ IF(EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
   SET(CPACK_SET_DESTDIR "on")
   SET(CPACK_PACKAGING_INSTALL_PREFIX "/tmp")
   SET(CPACK_SOURCE_GENERATOR "TBZ2;")
-  SET(CPACK_SOURCE_IGNORE_FILES 
+  SET(CPACK_SOURCE_IGNORE_FILES
       "/.svn/"
       "~$"
       "/CMakeFiles/"
@@ -553,7 +543,7 @@ IF(EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
   ELSEIF(WIN32)
     # http://www.thegigsite.com/cmake-2.6.0/CMakeCPackOptions.cmake
     SET( CPACK_GENERATOR "NSIS" )
-   
+
     SET( CPACK_RESOURCE_FILE_LICENSE "${ROOTDIR}/COPYING.GPLv3" )
 
     SET( CPACK_NSIS_PACKAGE_NAME "Brewtarget-${brewtarget_VERSION_STRING}" )
@@ -648,5 +638,3 @@ ELSE()
    MESSAGE( STATUS "Building Brewtarget." )
    ADD_SUBDIRECTORY(${SRCDIR})
 ENDIF()
-
-


### PR DESCRIPTION
The CMake code seems to really not like having the CMAKE_INSTALL_PREFIX
as anything else than "/usr/" on Debian but as far as I can see, there
is no reason for it.

Obviously, that must have been done for a reason in 2010, but it's not
obvious to me. Furthermore, the Filesystem Hierarchy Standard
specifically mentions that sys admin should install software in
/usr/local and not /usr, the last being only for read-only files.

Furthermore, I think a newer practice is to install apps in /opt/
instead.

The goal of this push request is mainly to stop CMake shooting at me
every time because I want to install in the standard location.