### PR TITLE
Resolves #94 in develop branch

### DIFF
--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -600,6 +600,9 @@ void MashDesigner::saveTargetTemp()
    updateMaxAmt();
    updateMinTemp();
    updateMaxTemp();
+   updateAmt();
+   updateTempSlider();
+   updateTemp();
    updateFullness();
    updateCollectedWort();
 }

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -1,9 +1,10 @@
 /*
  * MashDesigner.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2014
+ * authors 2009-2017
  * - Dan Cavanagh <dan@dancavanagh.com>
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
+ * - Jonathon Harding <github@jrhardin.net>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -238,7 +239,6 @@ double MashDesigner::volFromTemp_l( double temp_c )
 
    double tw = temp_c;
    // Final temp is target temp.
-   // double tf = mashStep->stepTemp_c();
    double tf = stepTemp_c();
    // Initial temp is the last step's temp if the last step exists, otherwise the grain temp.
    double t1 = (prevStep==0)? mash->grainTemp_c() : prevStep->stepTemp_c();
@@ -264,7 +264,6 @@ double MashDesigner::tempFromVolume_c( double vol_l )
    else
       absorption_LKg = PhysicalConstants::grainAbsorption_Lkg;
 
-   // double tf = mashStep->stepTemp_c();
    double tf = stepTemp_c();
 
    // NOTE: This needs to be changed. Assumes 1L = 1 kg.

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -81,6 +81,7 @@ private:
    double waterFromMash_l();
    bool heating();
    double boilingTemp_c();
+   double bound_temp_c(double temp_c);
 
    // I have developed a distaste for "getBlah"
    double selectedAmount_l();

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -3,6 +3,7 @@
  * authors 2009-2014
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
+ * - Jonathon Harding <github@jrhardin.net>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -79,6 +79,8 @@ private:
    double volFromTemp_l( double temp_c );
    double getDecoctionAmount_l();
    double waterFromMash_l();
+   bool heating();
+   double boilingTemp_c();
 
    // I have developed a distaste for "getBlah"
    double selectedAmount_l();


### PR DESCRIPTION
I got too aggressive in making changes/improvements in my last PR - this is a much more scaled back attempt to resolve #94 in the develop branch.

This PR updates MashDesigner to check if the current step being worked on is heating or cooling the mash. Key changes were then made to `minTemp_c()`, `maxTemp_c()`, and `minAmt_l()` so that these methods behave appropriately when the mash is cooling rather than heating. Sanity checks were updated in a number of other methods - previous assumptions that the mash must be getting hotter were broken.

In addition, I made one small change to update slider positions/values when a new target temperature is entered. This ensures that values held over from the previous step don't carry over if a user does not move either slider on the new step.

All changes are contained to MashDesigner. I have tested it some with some edge cases when designing a mash (create a step that's cooler, a step that's impossibly cool, and a step that's impossibly hot), but someone else should test this out too.

These changes were made on the `develop` branch. Once approved, this update should be back-ported to the `2.4.0` branch to resolve bug #94 in that version too.