### PR TITLE
Added a call to recipe->recalcAll in removeIngredientFromRecipe in Database

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -781,6 +781,7 @@ void Database::removeIngredientFromRecipe( Recipe* rec, BeerXMLElement* ing )
 
    }
 
+   rec->recalcAll();
    sqlDatabase().commit();
 
    q.finish();


### PR DESCRIPTION
This fixes #341 
It looks like the display wasn't being updated when an ingredient is removed.  Calling recalcAll seems to be the simplest solution.  One could figure out what type of ingredient was being removed and call that ingredient's recalc method, but I think recalcAll is simple and less prone to bugs.