### PR TITLE
Update Vagrant box to Ubuntu Xenial64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   #config.vm.box = "ubuntu/trusty64"
-  config.vm.box = "ubuntu/wily64"
+  config.vm.box = "ubuntu/xenial64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -44,13 +44,11 @@ Vagrant.configure(2) do |config|
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "2048"
+  end
+
   #
   # View the documentation for the provider you are using for more
   # information on available options.

--- a/vagrant/provision.yml
+++ b/vagrant/provision.yml
@@ -1,5 +1,12 @@
 ---
 - hosts: all
+  gather_facts: False
+
+  tasks:
+  - name: Install Python 2
+    raw: test -e /usr/bin/python || (sudo apt -y update && sudo apt install -y python-minimal)
+
+- hosts: all
   become: true
 
   tasks:
@@ -58,15 +65,15 @@
     - name: Create config directories
       file:
         state=directory
-        path=/home/vagrant/.config/brewtarget/
+        path=/home/ubuntu/.config/brewtarget/
         recurse=yes
-        owner=vagrant
+        owner=ubuntu
 
     - name: Install default config
       copy:
         src=brewtarget.conf
-        dest=/home/vagrant/.config/brewtarget/brewtarget.conf
-        owner=vagrant
+        dest=/home/ubuntu/.config/brewtarget/brewtarget.conf
+        owner=ubuntu
         mode=0644
 
 # vim: ft=ansible


### PR DESCRIPTION
The old wily box had too old versions of Qt and cmake, so update to Xenial.

The Xenial box does not have python installed, so it can not run Ansible scripts - so install python first in the playbook.

Lastly, increase ram of the virtualbox to 2GB, otherwise compilation fails with out-of-memory errors.