### PR TITLE
Fix various crashes when no recipe is loaded

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2449,7 +2449,7 @@ void MainWindow::showEquipmentEditor()
 
 void MainWindow::showStyleEditor()
 {
-   if ( ! recipeObs->style() )
+   if ( recipeObs && ! recipeObs->style() )
    {
       QMessageBox::warning( this, tr("No style"), tr("You must select a style first."));
    }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2437,7 +2437,7 @@ void MainWindow::showPitchDialog()
 
 void MainWindow::showEquipmentEditor()
 {
-   if ( ! recipeObs->equipment() )
+   if ( recipeObs && ! recipeObs->equipment() )
    {
       QMessageBox::warning( this, tr("No equipment"), tr("You must select or define an equipment profile first."));
    }

--- a/src/database.h
+++ b/src/database.h
@@ -309,6 +309,9 @@ public:
 
    template <class T>void remove(T* ing, bool emitSignal = true)
    {
+      if (!ing)
+          return;
+
       const QMetaObject *meta = ing->metaObject();
       Brewtarget::DBTable ingTable = classNameToTable[ meta->className() ];
       QString propName;


### PR DESCRIPTION
This can be triggered by:
*  Creating a new Vagrant machine
* Build & run Brewtarget in VM
* Start brewtarget 
* Press style or equipment editor
or
* Press right mouse on top element in recipe, style, equipment, etc. and press remove.

I think it is related to no recipe being loaded.