### PR TITLE
brewnotes: Add attenuation fields

### DIFF
--- a/src/BrewNoteWidget.cpp
+++ b/src/BrewNoteWidget.cpp
@@ -133,6 +133,12 @@ void BrewNoteWidget::setBrewNote(BrewNote* bNote)
       lcdnumber_abv->setLowLim( bNoteObs->projABV_pct() * low);
       lcdnumber_abv->setHighLim( bNoteObs->projABV_pct() * high);
 
+      lcdnumber_atten->setLowLim( bNoteObs->projAtten() * low );
+      lcdnumber_atten->setHighLim( bNoteObs->projAtten() * high );
+
+      lcdnumber_projAtten->setLowLim( bNoteObs->projAtten() * low );
+      lcdnumber_projAtten->setHighLim( bNoteObs->projAtten() * high );
+
       showChanges();
    }
 }
@@ -299,7 +305,8 @@ void BrewNoteWidget::showChanges(QString field)
    lcdnumber_brewhouseEff->display(bNoteObs->brewhouseEff_pct(),2);
    lcdnumber_projABV->display(bNoteObs->projABV_pct(),2);
    lcdnumber_abv->display(bNoteObs->abv(),2);
-   
+   lcdnumber_atten->display(bNoteObs->attenuation(),2);
+   lcdnumber_projAtten->display(bNoteObs->projAtten(),2);
 }
 
 void BrewNoteWidget::focusOutEvent(QFocusEvent *e)

--- a/src/DatabaseSchemaHelper.cpp
+++ b/src/DatabaseSchemaHelper.cpp
@@ -223,6 +223,7 @@ QString DatabaseSchemaHelper::colMashStepNumber("step_number");
 // Brewnotes table
 QString DatabaseSchemaHelper::tableBrewnote("brewnote");
 QString DatabaseSchemaHelper::colBNoteBrewDate("brewDate");
+QString DatabaseSchemaHelper::colBNoteAttenuation("attenuation");
 QString DatabaseSchemaHelper::colBNoteFermentDate("fermentDate");
 QString DatabaseSchemaHelper::colBNoteSg("sg");
 QString DatabaseSchemaHelper::colBNoteBkVolume("volume_into_bk");
@@ -1056,6 +1057,7 @@ bool DatabaseSchemaHelper::create_brewnote(QSqlQuery q)
       colBNoteBrewDate        + SEP + TYPEDATETIME + SEP + DEFAULT + SEP + THENOW + COMMA +
       colBNoteFermentDate     + SEP + TYPEDATETIME + SEP + DEFAULT + SEP + THENOW + COMMA +
       colBNoteSg              + SEP + TYPEREAL     + SEP + DEFAULT + SEP + "1.0"  + COMMA +
+      colBNoteAttenuation     + SEP + TYPEREAL     + SEP + DEFAULT + SEP + "0.0"  + COMMA +
       colBNoteBkVolume        + SEP + TYPEREAL     + SEP + DEFAULT + SEP + "0.0"  + COMMA +
       colBNoteStrikeTemp      + SEP + TYPEREAL     + SEP + DEFAULT + SEP + "70.0" + COMMA +
       colBNoteFinalMashTemp   + SEP + TYPEREAL     + SEP + DEFAULT + SEP + "67.0" + COMMA +

--- a/src/DatabaseSchemaHelper.h
+++ b/src/DatabaseSchemaHelper.h
@@ -243,6 +243,7 @@ private:
    
    // Brewnote table
    static QString tableBrewnote;
+   static QString colBNoteAttenuation;
    static QString colBNoteBrewDate;
    static QString colBNoteFermentDate;
    static QString colBNoteSg;

--- a/src/brewnote.cpp
+++ b/src/brewnote.cpp
@@ -37,6 +37,7 @@
 #include "yeast.h"
 
 const QString kBrewDate("brewDate");
+const QString kAttenuation("attenuation");
 const QString kFermentDate("fermentDate");
 const QString kNotes("notes");
 const QString kSpecificGravity("sg");
@@ -77,6 +78,7 @@ const QString kSpecificGravityProp("sg");
 const QString kOriginalGravityProp("og");
 const QString kFinalGravityProp("fg");
 const QString kABVProp("abv");
+const QString kAttenuationProp("attenuation");
 const QString kEfficiencyIntoBoilProp("effIntoBK_pct");
 const QString kStrikeTempProp("strikeTemp_c");
 const QString kMashFinalTempProp("mashFinTemp_c");
@@ -126,6 +128,7 @@ QHash<QString,QString> BrewNote::tagToPropHash()
    propHash["PREDICTED_OG"] = kProjectedOGProp;
    propHash["BREWHOUSE_EFF"] = kBrewhouseEfficiencyProp;
    propHash["ACTUAL_ABV"] = kABVProp;
+   propHash["ATTENUATION"] = kAttenuationProp;
    propHash["PROJECTED_BOIL_GRAV"] = kProjectedBoilGravityProp;
    propHash["PROJECTED_STRIKE_TEMP"] = kProjectedStrikeTempProp;
    propHash["PROJECTED_MASH_FIN_TEMP"] = kProjectedMashFinishTempProp;
@@ -328,6 +331,7 @@ void BrewNote::setOg(double var)
    calculateBrewHouseEff_pct();
    calculateABV_pct();
    calculateActualABV_pct();
+   calculateAttenuation_pct();
 }
 
 void BrewNote::setVolumeIntoFerm_l(double var)
@@ -348,6 +352,7 @@ void BrewNote::setFg(double var)
       return;
 
    calculateActualABV_pct();
+   calculateAttenuation_pct();
 }
 
 // This one is a bit of an odd ball. We need to convert to pure glucose points
@@ -389,6 +394,11 @@ void BrewNote::setProjFermPoints(double var)
 void BrewNote::setABV(double var)
 {
    set(kABVProp, kABV, var);
+}
+
+void BrewNote::setAttenuation(double var)
+{
+   set(kAttenuationProp, kAttenuation, var);
 }
 
 void BrewNote::setEffIntoBK_pct(double var)
@@ -525,6 +535,11 @@ double BrewNote::sg() const
 double BrewNote::abv() const
 {
    return get(kABV).toDouble();
+}
+
+double BrewNote::attenuation() const
+{
+    return get(kAttenuation).toDouble();
 }
 
 double BrewNote::volumeIntoBK_l() const
@@ -742,3 +757,13 @@ double BrewNote::calculateActualABV_pct()
    return abv;
 }
 
+double BrewNote::calculateAttenuation_pct()
+{
+    // Calculate measured attenuation based on user-reported values for
+    // post-boil OG and post-ferment FG
+    double attenuation = ((og() - fg()) / (og() - 1)) * 100;
+
+    setAttenuation(attenuation);
+
+    return attenuation;
+}

--- a/src/brewnote.h
+++ b/src/brewnote.h
@@ -88,6 +88,7 @@ public:
 
    // Setters
    void setABV(double var);
+   void setAttenuation(double var);
    void setBrewDate(QDateTime const& date = QDateTime::currentDateTime());
    void setFermentDate(QDateTime const& date);
    void setNotes(const QString& var, bool notify = true);
@@ -122,6 +123,7 @@ public:
    QString   fermentDate_short() const;
    double sg() const;
    double abv() const;
+   double attenuation() const;
    double volumeIntoBK_l() const;
    double effIntoBK_pct() const;
    double brewhouseEff_pct() const;
@@ -148,6 +150,8 @@ public:
    double calculateABV_pct();
    //! Actual ABV after we have measured og/fg.
    double calculateActualABV_pct();
+   //! Actual attenuation, based on measured og/fg
+   double calculateAttenuation_pct();
 
    // Projected values
    void setProjBoilGrav(double var);

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -2628,6 +2628,11 @@ void Database::toXml( BrewNote* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    bNode.appendChild(tmpElement);
 
+   tmpElement = doc.createElement("ATTENUATION");
+   tmpText = doc.createTextNode(BeerXMLElement::text(a->attenuation()));
+   tmpElement.appendChild(tmpText);
+   bNode.appendChild(tmpElement);
+
    tmpElement = doc.createElement("PROJECTED_BOIL_GRAV");
    tmpText = doc.createTextNode(BeerXMLElement::text(a->projBoilGrav()));
    tmpElement.appendChild(tmpText);

--- a/ui/brewNoteWidget.ui
+++ b/ui/brewNoteWidget.ui
@@ -706,6 +706,40 @@
                </property>
               </widget>
              </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="btLabel_yeastProjAtten">
+               <property name="statusTip">
+                <string>Yeast attenuation based on yeast specified in recipe</string>
+               </property>
+               <property name="text">
+                <string>Projected yeast attenuation</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="BtDigitWidget" name="lcdnumber_projAtten">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="0">
+              <widget class="QLabel" name="btLabel_yeastAtten">
+               <property name="statusTip">
+                <string>Yeast attentuation based on user-reported OG and FG</string>
+               </property>
+               <property name="text">
+                <string>Measured yeast attenuation</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="BtDigitWidget" name="lcdnumber_atten">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
             </layout>
            </item>
           </layout>


### PR DESCRIPTION
This adds projected and actual attenuation to the brewnotes view. Also
adds actual attenuation field to brewnote database, which requires the
database to be updated with the "attenuation" field.