### PR TITLE
Database: Bump schema to version 7

### DIFF
--- a/src/DatabaseSchemaHelper.cpp
+++ b/src/DatabaseSchemaHelper.cpp
@@ -27,7 +27,7 @@
 #include <QDebug>
 #include <QSqlError>
 
-const int DatabaseSchemaHelper::dbVersion = 6;
+const int DatabaseSchemaHelper::dbVersion = 7;
 
 // Commands and keywords
 QString DatabaseSchemaHelper::CREATETABLE("CREATE TABLE");
@@ -459,6 +459,9 @@ bool DatabaseSchemaHelper::migrateNext(int oldVersion, QSqlDatabase db)
          break;
       case 5:
          ret &= migrate_to_6(q);
+         break;
+      case 6:
+         ret &= migrate_to_7(q);
          break;
       default:
          Brewtarget::logE(QString("Unknown version %1").arg(oldVersion));
@@ -1556,6 +1559,18 @@ bool DatabaseSchemaHelper::migrate_to_6(QSqlQuery q) {
    ret &= insert_meta(q,tableHopInventory,  Brewtarget::HOPINVTABLE);
    ret &= insert_meta(q,tableMiscInventory, Brewtarget::MISCINVTABLE);
    ret &= insert_meta(q,tableYeastInventory,Brewtarget::YEASTINVTABLE);
+
+   return ret;
+}
+
+bool DatabaseSchemaHelper::migrate_to_7(QSqlQuery q) {
+   bool ret = true;
+
+   // Add "attenuation" to brewnote table
+   ret &= q.exec(
+      ALTERTABLE + SEP + tableBrewnote + SEP +
+      ADDCOLUMN + SEP + "attenuation" + SEP + TYPEREAL + SEP + DEFAULT + SEP + "0.0"
+   );
 
    return ret;
 }

--- a/src/DatabaseSchemaHelper.h
+++ b/src/DatabaseSchemaHelper.h
@@ -429,5 +429,5 @@ private:
    static bool migrate_to_4(QSqlQuery q);
    static bool migrate_to_5(QSqlQuery q);
    static bool migrate_to_6(QSqlQuery q);
-   
+   static bool migrate_to_7(QSqlQuery q);
 };


### PR DESCRIPTION
This includes migration code for adding the "attenuation" field to the
brewnotes table.

This should fix the migration issue introduced by #401.

I verified the migration by checking that the "attenuation" field in the table "brewnote" is *not* present in version 6 of the database:
`
$ echo ".schema brewnote" | sqlite3 ~/.config/brewtarget_v6/database.sqlite | grep attenuation
`

.. and that when I copy the v6 database into ~/.config/brewtarget, restart brewtarget, and open up the brewnotes, the attenuation field *is* present in the database:

`
$ echo ".schema brewnote" | sqlite3 ~/.config/brewtarget/database.sqlite | grep attenuation
   recipe_id integer, attenuation REAL DEFAULT 0.0,
`