### PR TITLE
Specific heat unit label fix #404

### DIFF
--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -488,7 +488,7 @@ void EquipmentEditor::retranslateUi()
    groupBox_mashTun->setTitle(tr("Mash Tun"));
    label_tunVolume->setText(tr("Volume"));
    label_tunWeight->setText(tr("Mass"));
-   label_tunSpecificHeat->setText(QApplication::translate("equipmentEditor", "Specific heat (cal/(g*K))", 0));
+   label_tunSpecificHeat->setText(QApplication::translate("equipmentEditor", "Specific heat (Cal/(g*C))", 0));
    groupBox_losses->setTitle(QApplication::translate("equipmentEditor", "Losses", 0));
    groupBox_losses->setProperty("configSection", QVariant(QApplication::translate("equipmentEditor", "equipmentEditor", 0)));
    label_trubChillerLoss->setText(QApplication::translate("equipmentEditor", "Kettle to fermenter", 0));


### PR DESCRIPTION
Fixes #404 for label in equipment editor. Image 7 on page 10 of the PDF needs to be updated accordingly. No text needs to be changed in the manual. 

@rocketman768 Is there a copy of the manual other than the pdf that can be updated, or do you and @mikfire handle the manual directly before each new version release?