### PR TITLE
Use default directory in case of misconfiguration.

### DIFF
--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -404,11 +404,12 @@ bool Brewtarget::initialize(const QString &userDirectory)
       userDataDir = QDir(userDirectory).canonicalPath();
    }
    // Use directory from app settings.
-   else if (hasOption("user_data_dir")) {
+   else if (hasOption("user_data_dir") && QDir(option("user_data_dir","").toString()).exists()) {
       userDataDir = QDir(option("user_data_dir","").toString()).canonicalPath();
    }
    // Guess where to put it.
    else {
+      logW(QString("User data directory not specified or doesn't exist - using default."));
       userDataDir = getConfigDir();
    }
 


### PR DESCRIPTION
If brewtarget directory is configured but non-existent, we should fall back to default location.
Use case for this is when brewtarget directory is shared amongst many users.
Since config file takes absolute path, we can't just set ~/.config/brewtarget to accommodate.

With this patch if directory is misconfigured or doesn't exist, we would use the same guessing mechanism.

Please let me know if there is anything I still need to do and thank you for this awesome piece of software.