### PR TITLE
Improve fermentable, hop and yeast editor layout

### DIFF
--- a/ui/fermentableEditor.ui
+++ b/ui/fermentableEditor.ui
@@ -62,7 +62,7 @@
             </property>
             <property name="maximumSize">
              <size>
-              <width>100</width>
+              <width>1000</width>
               <height>16777215</height>
              </size>
             </property>
@@ -349,7 +349,7 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
+           <width>1000</width>
            <height>16777215</height>
           </size>
          </property>
@@ -382,7 +382,7 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
+           <width>1000</width>
            <height>16777215</height>
           </size>
          </property>
@@ -694,7 +694,7 @@
        <property name="maximumSize">
         <size>
          <width>1000</width>
-         <height>100</height>
+         <height>1000</height>
         </size>
        </property>
       </widget>

--- a/ui/hopEditor.ui
+++ b/ui/hopEditor.ui
@@ -100,7 +100,7 @@
               </property>
               <property name="maximumSize">
                <size>
-                <width>100</width>
+                <width>1000</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -806,7 +806,7 @@
          <property name="maximumSize">
           <size>
            <width>1000</width>
-           <height>100</height>
+           <height>1000</height>
           </size>
          </property>
         </widget>
@@ -838,7 +838,7 @@
          <property name="maximumSize">
           <size>
            <width>1000</width>
-           <height>100</height>
+           <height>1000</height>
           </size>
          </property>
         </widget>

--- a/ui/yeastEditor.ui
+++ b/ui/yeastEditor.ui
@@ -668,7 +668,7 @@
          <property name="maximumSize">
           <size>
            <width>1000</width>
-           <height>100</height>
+           <height>1000</height>
           </size>
          </property>
         </widget>
@@ -691,7 +691,7 @@
          <property name="maximumSize">
           <size>
            <width>1000</width>
-           <height>100</height>
+           <height>1000</height>
           </size>
          </property>
         </widget>


### PR DESCRIPTION
There are several fields in these editors that do not grow when the window
is resized larger or are not big enough to fit content. Increase the max
size of these fields so that they can accommodate the content.