### PR TITLE
Resolving bug 340: The current equipment needed to be set before the …

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2336,6 +2336,7 @@ void MainWindow::showEquipmentEditor()
    }
    else
    {
+      singleEquipEditor->setEquipment(recipeObs->equipment());
       singleEquipEditor->show();
    }
 }
@@ -2348,6 +2349,7 @@ void MainWindow::showStyleEditor()
    }
    else
    {
+      singleStyleEditor->setStyle(recipeObs->style());
       singleStyleEditor->show();
    }
 }


### PR DESCRIPTION
The editor retained the latest shown equipment. It seems that all it took was  to set the current recipe equipment in the editor before showing it.