### PR TITLE
Some utility script changes.

### DIFF
--- a/scripts/add-to-default-db.py
+++ b/scripts/add-to-default-db.py
@@ -5,14 +5,10 @@ import json
 import sqlite3
 
 def addIng(cursor, x, tableName):
-   columnList = x.keys()
-   valueList = x.values()
-   cvList = zip(columnList, valueList)
-   
    setClause = ''
-   for c,v in cvList[:-1]:
+   for c, v in x.items():
       setClause = setClause + '{0} = "{1}", '.format(c,v)
-   setClause = setClause + '{0} = "{1}"'.format(cvList[-1][0], cvList[-1][1])
+   setClause = setClause[:-2]
    
    cursor.execute('INSERT INTO {0} DEFAULT VALUES'.format(tableName))
    newId = cursor.lastrowid
@@ -48,16 +44,16 @@ if __name__ == "__main__" :
    
    with open(jsonFilename) as jsonFile:
       bigDict = json.load(jsonFile)
-      ferm = bigDict['fermentable']
+      ferm = bigDict.get('fermentable', [])
       for f in ferm:
          addFermentable(c,f)
-      hop = bigDict['hop']
+      hop = bigDict.get('hop', [])
       for h in hop:
          addHop(c,h)
-      misc = bigDict['misc']
+      misc = bigDict.get('misc', [])
       for m in misc:
          addMisc(c,m)
-      yeast = bigDict['yeast']
+      yeast = bigDict.get('yeast', [])
       for y in yeast:
          addYeast(c, y)
 

--- a/scripts/sqlitediff.sh
+++ b/scripts/sqlitediff.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 # sqlitediff.sh file.sqlite commit-a commit-b
+# To compare commit to current (uncommitted) db:
+# sqlitediff.sh file.sqlite commit-a
+# To compare HEAD to current uncommitted db:
+# sqlitediff.sh file.sqlite
+
 DBFILE=$1
 COMMITA=$2
 COMMITB=$3
@@ -11,7 +16,12 @@ DUMPA=$(mktemp)
 DUMPB=$(mktemp)
 
 git show "$COMMITA:$DBFILE" > "$SQLITEA"
-git show "$COMMITB:$DBFILE" > "$SQLITEB"
+if [ $# -ge 3 ]
+then
+	git show "$COMMITB:$DBFILE" > "$SQLITEB"
+else
+	cp "$DBFILE" "$SQLITEB"
+fi
 
 sqlite3 "$SQLITEA" .dump > $DUMPA
 sqlite3 "$SQLITEB" .dump > $DUMPB


### PR DESCRIPTION
* sqlitediff.sh: allow comparing against current uncommitted changes. Useful for people adding items to the default database for checking what has been added before committing.

* add-to-default-db.py: fix `addIng()` to work with Python 3 (`zip()` doesn't return a list).

* add-to-default-db.py: don't require JSON to include all types of ingredients.