### PR TITLE
Reduce fermentable inventory when brewing a recipe.

### DIFF
--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -318,9 +318,14 @@ void Fermentable::setInventoryAmount( double num )
    }
    else
    {
-      _inventoryAmt = num;
+      setInventory(kInventoryProp, kAmount, num);
    }
 }
+double Fermentable::inventory() const
+{
+   return getInventory(kAmount).toDouble();
+}
+
 void Fermentable::setYield_pct( double num )
 {
    if( num >= 0.0 && num <= 100.0 )
@@ -423,7 +428,6 @@ void Fermentable::save()
 
    Database::instance().updateColumns( _table, _key, map);
 
-   setInventory("", kAmount, inventory());
    emit saved();
 
 }

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -115,7 +115,7 @@ public:
    
    const Type type() const { return _type; }
    double amount_kg() const { return _amountKg; }
-   double inventory() const { return _inventoryAmt; }
+   double inventory() const;
    double yield_pct() const { return _yieldPct; }
    double color_srm() const { return _colorSrm; }
    bool addAfterBoil() const { return _isAfterBoil; }


### PR DESCRIPTION
Unlike the yeast and hop inventory handling, fermentables were storing
the inventory amount directly within the class. This wasn't being
updated properly when brewing a recipe. Switch to the BeerXMLElement
(base class) setInventory() and getInventory() methods to bring it
inline with the hops and yeast.

Fixes #396.