### PR TITLE
Removed Default Amount field from several editors 

### DIFF
--- a/src/FermentableEditor.cpp
+++ b/src/FermentableEditor.cpp
@@ -61,7 +61,6 @@ void FermentableEditor::save()
    // order as the combobox.
    obsFerm->setType( static_cast<Fermentable::Type>(comboBox_type->currentIndex()) );
 
-   obsFerm->setAmount_kg(lineEdit_amount->toSI());
    obsFerm->setInventoryAmount(lineEdit_inventory->toSI());
    obsFerm->setYield_pct(lineEdit_yield->toSI());
    obsFerm->setColor_srm(lineEdit_color->toSI());
@@ -115,12 +114,6 @@ void FermentableEditor::showChanges(QMetaProperty* metaProp)
        if( ! updateAll )
          return;
    }
-   if( propName == "amount_kg" || updateAll) {
-      lineEdit_amount->setText(obsFerm);
-      if( ! updateAll )
-         return;
-   }
-
    if( propName == "inventory" || updateAll) {
       lineEdit_inventory->setText(obsFerm);
       if( ! updateAll )

--- a/src/HopEditor.cpp
+++ b/src/HopEditor.cpp
@@ -67,7 +67,6 @@ void HopEditor::save()
 
    h->setName(lineEdit_name->text());
    h->setAlpha_pct(lineEdit_alpha->toSI());
-   h->setAmount_kg(lineEdit_amount->toSI());
    h->setInventoryAmount(lineEdit_inventory->toSI());
    h->setUse(static_cast<Hop::Use>(comboBox_use->currentIndex()));
    h->setTime_min(lineEdit_time->toSI());
@@ -122,11 +121,6 @@ void HopEditor::showChanges(QMetaProperty* prop)
    }
    if( propName == "alpha_pct" || updateAll ) {
       lineEdit_alpha->setText(obsHop);
-      if( ! updateAll )
-         return;
-   }
-   if( propName == "amount_kg" || updateAll ) {
-      lineEdit_amount->setText(obsHop);
       if( ! updateAll )
          return;
    }

--- a/src/MiscEditor.cpp
+++ b/src/MiscEditor.cpp
@@ -66,7 +66,6 @@ void MiscEditor::save()
    m->setUse( static_cast<Misc::Use>(comboBox_use->currentIndex()) );
    m->setTime(lineEdit_time->toSI());
    m->setAmountIsWeight( (checkBox_isWeight->checkState() == Qt::Checked)? true : false );
-   m->setAmount( lineEdit_amount->toSI());
    m->setInventoryAmount(lineEdit_inventory->toSI());
    m->setUseFor(textEdit_useFor->toPlainText());
    m->setNotes( textEdit_notes->toPlainText() );
@@ -124,12 +123,6 @@ void MiscEditor::showChanges(QMetaProperty* metaProp)
    if( propName == "time" || updateAll )
    {
       lineEdit_time->setText(obsMisc);
-      if( ! updateAll )
-         return;
-   }
-   if( propName == "amount" || updateAll )
-   {
-      lineEdit_amount->setText(obsMisc);
       if( ! updateAll )
          return;
    }

--- a/src/YeastEditor.cpp
+++ b/src/YeastEditor.cpp
@@ -63,7 +63,6 @@ void YeastEditor::save()
    y->setType(static_cast<Yeast::Type>(comboBox_type->currentIndex()));
    y->setForm(static_cast<Yeast::Form>(comboBox_form->currentIndex()));
    y->setAmountIsWeight( (checkBox_amountIsWeight->checkState() == Qt::Checked)? true : false );
-   y->setAmount( lineEdit_amount->toSI());
    y->setInventoryQuanta( lineEdit_inventory->text().toInt() );
 
 
@@ -125,11 +124,6 @@ void YeastEditor::showChanges(QMetaProperty* metaProp)
    }
    if( propName == "form" || updateAll ) {
       comboBox_form->setCurrentIndex(obsYeast->form());
-      if( ! updateAll )
-         return;
-   }
-   if( propName == "amount" || updateAll ) {
-      lineEdit_amount->setText( obsYeast );
       if( ! updateAll )
          return;
    }

--- a/ui/fermentableEditor.ui
+++ b/ui/fermentableEditor.ui
@@ -120,45 +120,6 @@
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="BtMassLabel" name="label_amount">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="text">
-             <string>Default Amount</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_amount</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="BtMassEdit" name="lineEdit_amount">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Amount</string>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">amount_kg</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QLabel" name="label_yield">
@@ -790,7 +751,6 @@
  <tabstops>
   <tabstop>lineEdit_name</tabstop>
   <tabstop>comboBox_type</tabstop>
-  <tabstop>lineEdit_amount</tabstop>
   <tabstop>lineEdit_yield</tabstop>
   <tabstop>lineEdit_color</tabstop>
   <tabstop>checkBox_addAfterBoil</tabstop>
@@ -839,22 +799,6 @@
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>label_amount</sender>
-   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>65</x>
-     <y>90</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>165</x>
-     <y>90</y>
     </hint>
    </hints>
   </connection>

--- a/ui/hopEditor.ui
+++ b/ui/hopEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>515</width>
-    <height>390</height>
+    <width>539</width>
+    <height>567</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -154,57 +154,6 @@
               </property>
               <property name="editField" stdset="0">
                <string notr="true">alpha_pct</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="BtMassLabel" name="label_amount">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="contextMenuPolicy">
-               <enum>Qt::CustomContextMenu</enum>
-              </property>
-              <property name="text">
-               <string>Default Amount </string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_amount</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="BtMassEdit" name="lineEdit_amount">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>100</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>100</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Amount</string>
-              </property>
-              <property name="editField" stdset="0">
-               <string notr="true">amount_kg</string>
               </property>
              </widget>
             </item>
@@ -876,6 +825,15 @@
    </slots>
   </customwidget>
   <customwidget>
+   <class>BtMassLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+    <slot>popContextMenu(QPoint)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
    <class>BtTimeEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
@@ -889,15 +847,6 @@
    <header>BtLabel.h</header>
    <slots>
     <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtMassLabel</class>
-   <extends>QLabel</extends>
-   <header>BtLabel.h</header>
-   <slots>
-    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-    <slot>popContextMenu(QPoint)</slot>
    </slots>
   </customwidget>
  </customwidgets>
@@ -932,22 +881,6 @@
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>label_amount</sender>
-   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>87</x>
-     <y>91</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>168</x>
-     <y>93</y>
     </hint>
    </hints>
   </connection>

--- a/ui/miscEditor.ui
+++ b/ui/miscEditor.ui
@@ -245,60 +245,6 @@
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <item>
-          <widget class="BtMixedLabel" name="label_amount">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="text">
-            <string>Default Amount</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_amount</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtMixedEdit" name="lineEdit_amount">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Amount</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">amount</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_6">
          <item>
           <widget class="QLabel" name="label_isWeight">
@@ -546,22 +492,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>label_amount</sender>
-   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>69</x>
-     <y>138</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>176</x>
-     <y>137</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>label_inventory</sender>
    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_inventory</receiver>
@@ -574,22 +504,6 @@
     <hint type="destinationlabel">
      <x>151</x>
      <y>195</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkBox_isWeight</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>lineEdit_amount</receiver>
-   <slot>setIsWeight(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>222</x>
-     <y>163</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>218</x>
-     <y>136</y>
     </hint>
    </hints>
   </connection>

--- a/ui/yeastEditor.ui
+++ b/ui/yeastEditor.ui
@@ -181,45 +181,6 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="BtMixedLabel" name="label_amount">
-              <property name="contextMenuPolicy">
-               <enum>Qt::CustomContextMenu</enum>
-              </property>
-              <property name="text">
-               <string>Default Amount</string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_amount</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="BtMixedEdit" name="lineEdit_amount">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Amount</string>
-              </property>
-              <property name="editField" stdset="0">
-               <string notr="true">amount</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
              <widget class="QLabel" name="label_amountIsWeight">
@@ -719,14 +680,6 @@
    <header>BtLineEdit.h</header>
   </customwidget>
   <customwidget>
-   <class>BtTemperatureEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
-   <slots>
-    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   </slots>
-  </customwidget>
-  <customwidget>
    <class>BtTemperatureLabel</class>
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
@@ -735,20 +688,11 @@
    </slots>
   </customwidget>
   <customwidget>
-   <class>BtMixedLabel</class>
-   <extends>QLabel</extends>
-   <header>BtLabel.h</header>
-   <slots>
-    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtMixedEdit</class>
+   <class>BtTemperatureEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>
     <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-    <slot>setIsWeight(bool)</slot>
    </slots>
   </customwidget>
  </customwidgets>
@@ -787,22 +731,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>label_amount</sender>
-   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>48</x>
-     <y>114</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>140</x>
-     <y>114</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>label_minTemperature</sender>
    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    <receiver>lineEdit_minTemperature</receiver>
@@ -831,22 +759,6 @@
     <hint type="destinationlabel">
      <x>143</x>
      <y>275</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkBox_amountIsWeight</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>lineEdit_amount</receiver>
-   <slot>setIsWeight(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>200</x>
-     <y>171</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>171</x>
-     <y>143</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Attached are screenshots of the change + local build
<img width="502" alt="fermentable_editor_update" src="https://user-images.githubusercontent.com/4052699/46925509-cd1b8180-cff1-11e8-911b-eab773af9e46.png">
<img width="541" alt="hop_editor_update" src="https://user-images.githubusercontent.com/4052699/46925511-d0167200-cff1-11e8-88d7-8bb072c669d8.png">

<img width="506" alt="misc_editor_update" src="https://user-images.githubusercontent.com/4052699/46925513-d0167200-cff1-11e8-8232-654b6a2fa42d.png">
<img width="455" alt="yeast_editor_update" src="https://user-images.githubusercontent.com/4052699/46925514-d0167200-cff1-11e8-90e9-0474485551f6.png">
<img width="838" alt="local_build" src="https://user-images.githubusercontent.com/4052699/46925512-d0167200-cff1-11e8-9936-f60e5473a221.png">
