### PR TITLE
Add missing combo box items in mash step editor

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -4552,6 +4552,7 @@ Recipe* Database::recipeFromXml( QDomNode const& node )
       Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
       sqlDatabase().rollback();
       blockSignals(false);
+      throw;
    }
 }
 

--- a/ui/mashStepEditor.ui
+++ b/ui/mashStepEditor.ui
@@ -105,6 +105,16 @@
            <string>Decoction</string>
           </property>
          </item>
+         <item>
+          <property name="text">
+           <string>Fly Sparge</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Batch Sparge</string>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
Those new type of mash steps were available in the main window, but not on the edit window. This fixes it.