### PR TITLE
missing flag

### DIFF
--- a/images/flagNorway.svg
+++ b/images/flagNorway.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1100" height="800" id="Flag_of_Norway">
+<rect width="1100" height="800" fill="#ef2b2d"/>
+<rect width="200" height="800" x="300" fill="white"/>
+<rect width="1100" height="200" y="300" fill="white"/>
+<rect width="100" height="800" x="350" fill="#002868"/>
+<rect width="1100" height="100" y="350" fill="#002868"/>
+</svg>


### PR DESCRIPTION
Added missing flag: Norway.
Got from https://commons.wikimedia.org/wiki/File:Flag_of_Norway.svg
License: This image of simple geometry is ineligible for copyright and therefore in the public domain, because it consists entirely of information that is common property and contains no original authorship.