### PR TITLE
Signals overload removal from all BeerXMLElement subclasses

### DIFF
--- a/src/equipment.h
+++ b/src/equipment.h
@@ -125,9 +125,6 @@ public:
    static QString classNameStr();
 
 signals:
-   
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
    void changedBoilSize_l(double);
    void changedBatchSize_l(double);
    void changedTunVolume_l(double);

--- a/src/equipment.h
+++ b/src/equipment.h
@@ -126,7 +126,8 @@ public:
 
 signals:
    
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
    void changedBoilSize_l(double);
    void changedBatchSize_l(double);
    void changedTunVolume_l(double);

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -179,7 +179,8 @@ public:
 signals:
 
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
 private:
    Fermentable(Brewtarget::DBTable table, int key);

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -178,10 +178,6 @@ public:
 
 signals:
 
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
-
 private:
    Fermentable(Brewtarget::DBTable table, int key);
    Fermentable(Brewtarget::DBTable table, int key, QSqlRecord rec);

--- a/src/hop.h
+++ b/src/hop.h
@@ -155,7 +155,8 @@ public:
    static QString classNameStr();
 signals:
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
 private:
    Hop(Brewtarget::DBTable table, int key);

--- a/src/hop.h
+++ b/src/hop.h
@@ -154,9 +154,6 @@ public:
 
    static QString classNameStr();
 signals:
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
 
 private:
    Hop(Brewtarget::DBTable table, int key);

--- a/src/mash.h
+++ b/src/mash.h
@@ -119,10 +119,6 @@ public slots:
    void acceptMashStepChange(QMetaProperty, QVariant);
 
 signals:
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
-
    // Emitted when the number of steps change, or when you should call mashSteps() again.
    void mashStepsChanged();
 

--- a/src/mash.h
+++ b/src/mash.h
@@ -120,7 +120,8 @@ public slots:
 
 signals:
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
    // Emitted when the number of steps change, or when you should call mashSteps() again.
    void mashStepsChanged();

--- a/src/mashstep.h
+++ b/src/mashstep.h
@@ -113,7 +113,8 @@ public:
 signals:
 
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
 private:
    MashStep(Brewtarget::DBTable table, int key);

--- a/src/mashstep.h
+++ b/src/mashstep.h
@@ -112,10 +112,6 @@ public:
 
 signals:
 
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
-
 private:
    MashStep(Brewtarget::DBTable table, int key);
    MashStep(Brewtarget::DBTable table, int key, QSqlRecord rec);

--- a/src/misc.h
+++ b/src/misc.h
@@ -125,7 +125,8 @@ public:
 signals:
 
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
 private:
    Misc(Brewtarget::DBTable table, int key);

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -354,9 +354,6 @@ public:
    void setCacheOnly( bool cache );
 
 signals:
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(const QString&);
 
 public slots:
    void acceptEquipChange(QMetaProperty prop, QVariant val);

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -355,7 +355,8 @@ public:
 
 signals:
    //! \brief Emitted when \c name() changes.
-   void changedName(const QString&);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(const QString&);
 
 public slots:
    void acceptEquipChange(QMetaProperty prop, QVariant val);

--- a/src/salt.h
+++ b/src/salt.h
@@ -120,10 +120,6 @@ public:
 
 signals:
 
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
-
 private:
    Salt(Brewtarget::DBTable table, int key);
    Salt(Brewtarget::DBTable table, int key, QSqlRecord rec);

--- a/src/salt.h
+++ b/src/salt.h
@@ -121,7 +121,8 @@ public:
 signals:
 
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
 private:
    Salt(Brewtarget::DBTable table, int key);

--- a/src/style.h
+++ b/src/style.h
@@ -145,9 +145,6 @@ public:
    static QString classNameStr();
 
 signals:
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
 
 private:
    Style(Brewtarget::DBTable table, int key);

--- a/src/style.h
+++ b/src/style.h
@@ -146,7 +146,8 @@ public:
 
 signals:
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
 private:
    Style(Brewtarget::DBTable table, int key);

--- a/src/water.h
+++ b/src/water.h
@@ -133,9 +133,6 @@ public:
 
 signals:
 
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
 
 private:
    Water(Brewtarget::DBTable table, int key);

--- a/src/water.h
+++ b/src/water.h
@@ -134,7 +134,8 @@ public:
 signals:
 
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
 private:
    Water(Brewtarget::DBTable table, int key);

--- a/src/yeast.h
+++ b/src/yeast.h
@@ -154,7 +154,8 @@ public:
 signals:
 
    //! \brief Emitted when \c name() changes.
-   void changedName(QString);
+   // Declared in Base Class BeerXMLElement, should not be overloaded
+   //void changedName(QString);
 
 private:
    Yeast(Brewtarget::DBTable table, int key);

--- a/src/yeast.h
+++ b/src/yeast.h
@@ -153,10 +153,6 @@ public:
 
 signals:
 
-   //! \brief Emitted when \c name() changes.
-   // Declared in Base Class BeerXMLElement, should not be overloaded
-   //void changedName(QString);
-
 private:
    Yeast(Brewtarget::DBTable table, int key);
    Yeast(Brewtarget::DBTable table, int key, QSqlRecord rec);


### PR DESCRIPTION
All Subclasses of BeerXMLElement had an overload to the signal changedName signal.
They are now removed and instead inherited from Base class.
