### PR TITLE
2.4.0 - fixup for windows build and default DB location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,8 +402,6 @@ IF( WIN32 )
    GET_TARGET_PROPERTY(QtPrintSupport_location Qt5::PrintSupport LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtSql_location Qt5::Sql LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtSvg_location Qt5::Svg LOCATION_${CMAKE_BUILD_TYPE})
-   GET_TARGET_PROPERTY(QtWebKit_location Qt5::WebKit LOCATION_${CMAKE_BUILD_TYPE})
-   GET_TARGET_PROPERTY(QtWebKitWidgets_location Qt5::WebKitWidgets LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtWidgets_location Qt5::Widgets LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtXml_location Qt5::Xml LOCATION_${CMAKE_BUILD_TYPE})
 
@@ -412,7 +410,6 @@ IF( WIN32 )
    GET_TARGET_PROPERTY(QtQgif_location Qt5::QGifPlugin LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtQico_location Qt5::QICOPlugin LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtQjpeg_location Qt5::QJpegPlugin LOCATION_${CMAKE_BUILD_TYPE})
-   GET_TARGET_PROPERTY(QtQmng_location Qt5::QMngPlugin LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtQsvg_location Qt5::QSvgPlugin LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtQtiff_location Qt5::QTiffPlugin LOCATION_${CMAKE_BUILD_TYPE})
    GET_TARGET_PROPERTY(QtQWindows_location Qt5::QWindowsIntegrationPlugin LOCATION_${CMAKE_BUILD_TYPE})
@@ -427,9 +424,7 @@ IF( WIN32 )
         ${QtSql_location}
         ${QtSvg_location}
         ${QtXml_location}
-        ${QtWebKit_location}
         ${QtGui_location}
-        ${QtWebKitWidgets_location}
         ${QtOpenGL_location}
    )
    IF( NOT ${NO_QTMULTIMEDIA})
@@ -561,6 +556,11 @@ IF(EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
     SET( CPACK_PACKAGE_INSTALL_REGISTRY_KEY "Brewtarget-${brewtarget_VERSION_STRING}" )
     SET( CPACK_PACKAGE_INSTALL_DIRECTORY "Brewtarget-${brewtarget_VERSION_STRING}" )
     SET( CPACK_NSIS_MODIFY_PATH ON )
+
+    # The redistribution package from Microsoft is needed for Windows 7 installation.
+    # NSIS will install on target system if needed, but the file has to be included in the installer.
+    # Another approach would be to instruct the users of Windows 7 to download the redist for their platform and install it themselfs.
+    SET( CPACK_PACKAGE_REDIST_DIR "${ROOTDIR}/redist")
 
     # Extra start menu items.
     #SET( CPACK_NSIS_MENU_LINKS

--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -6,6 +6,7 @@
   !define VERSION "@CPACK_PACKAGE_VERSION@"
   !define PATCH  "@CPACK_PACKAGE_VERSION_PATCH@"
   !define INST_DIR "@CPACK_TEMPORARY_DIRECTORY@"
+  !define REDIST_DIR "@CPACK_PACKAGE_REDIST_DIR@"
 
 ;--------------------------------
 ;Variables
@@ -435,6 +436,42 @@ FunctionEnd
 !insertmacro IsNT ""
 !insertmacro IsNT "un."
 
+
+
+; ConvertToCanonicalPath
+; input, top of stack = Path string to convert to Canonical path
+; usage:
+;     Push "C:\Path\to\Folder"
+;     Call ConvertToCanonicalPath
+;     Pop $R0
+;     $R0 will be C:/Path/to/Folder
+
+Function ConvertToCanonicalPath
+   Exch $R0 ;input string
+   Push $R1
+   ${StrRep} $R1 $R0 "\" "/"
+   StrCpy $R0 $R1
+   Pop $R1
+   Exch $R0 ;output string
+FunctionEnd
+
+; ConvertFromCanonicalPath
+; input, top of stack = Path string to convert to Canonical path
+; usage:
+;     Push "C:/Path/to/Folder"
+;     Call ConvertFromCanonicalPath
+;     Pop $R0
+;     $R0 will be C:\Path\to\Folder
+
+Function ConvertFromCanonicalPath
+   Exch $R0 ;input string
+   Push $R1
+   ${StrRep} $R1 $R0 "/" "\"
+   StrCpy $R0 $R1
+   Pop $R1
+   Exch $R0 ;output string
+FunctionEnd
+
 ; StrStr
 ; input, top of stack = string to search for
 ;        top of stack-1 = string to search in
@@ -567,7 +604,6 @@ FunctionEnd
   !insertmacro MUI_PAGE_STARTMENU Application $STARTMENU_FOLDER
 
   @CPACK_NSIS_PAGE_COMPONENTS@
-
   !insertmacro MUI_PAGE_INSTFILES
   !insertmacro MUI_PAGE_FINISH
 
@@ -636,9 +672,9 @@ FunctionEnd
   ;These files should be inserted before other files in the data block
   ;Keep these lines before any File command
   ;Only for solid compression (by default, solid compression is enabled for BZIP2 and LZMA)
-
   ReserveFile "NSIS.InstallOptions.ini"
   !insertmacro MUI_RESERVEFILE_INSTALLOPTIONS
+  ReserveFile "${REDIST_DIR}\vcredist_x64.exe"
 
 ;--------------------------------
 ;Installer Sections
@@ -740,6 +776,33 @@ Section "-Add to path"
   doNotAddToPath:
 SectionEnd
 
+; This section will check if VC redistributable package is installed to the correct version.
+; If not it will run the installer in the background
+Section "Visual Studio Runtime"
+   DetailPrint "Checking Previosly installed Visual Studio Runtime"
+   ReadRegDWORD $0 HKLM64 "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Major"
+   ReadRegDWORD $1 HKLM64 "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Minor"
+   ReadRegDWORD $2 HKLM64 "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Bld"
+
+   ${If} $0 == 0
+      ReadRegDWORD $0 HKLM "SOFTWARE\Wow6432node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Major"
+      ReadRegDWORD $1 HKLM "SOFTWARE\Wow6432node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Minor"
+      ReadRegDWORD $2 HKLM "SOFTWARE\Wow6432node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Bld"
+   ${EndIf}
+
+   ${If} $0 >= 14
+      ${AndIf} $1 >= 27
+         ${AndIf} $2 >= 29016
+            DetailPrint "VC redistributable package installed, skipping install"
+   ${Else}
+      DetailPrint "Correct version not found, installing Visual Studio runtime"
+      InitPluginsDir
+      SetOutPath "$PLUGINSDIR"
+      File "${REDIST_DIR}\vcredist_x64.exe"
+      ExecWait '"$PLUGINSDIR\vcredist_x64.exe" /install /quiet /norestart'
+   ${EndIf}
+SectionEnd
+
 ;--------------------------------
 ; Create custom pages
 Function InstallOptionsPage
@@ -752,6 +815,7 @@ FunctionEnd
 ; brewtarget specific instructions
 
 Var btPath
+Var btWindowsPath
 Var btPathVersion
 var prevInst
 Var targetDir
@@ -759,27 +823,35 @@ Var fileName
 Var locateHandle
 Var nouse1
 Var nouse2
+Var btRegPath
 
 !include "Locate.nsh"
 
 ; Set up the browser page. This happens post install, so I'm confused about
 ; what's already on disk and isn't.
+Section "-upgrade-old-database"
+   ${If} $prevInst == "found"
+      ;If old database was found, make sure it is moved to the Roaming folder.
+      Call btCopyAllFiles
+      MessageBox MB_ICONINFORMATION "Brewtarget has been successfully installed. Your database will automatically be upgraded on startup."
+      StrCpy $prevInst "CopyDone"
+   ${EndIf}
+SectionEnd
+
 PageEx Directory
-    DirVar $btPath
-    DirVerify leave
-    PageCallbacks btPageSkip btPageShow btPageLeave
-    DirText "Select old brewtarget install folder. Press skip if this is a new install,or you want to manually upgrade your database" "Brewtarget Install Folder" "" "Select Brewtarget Install Folder"
+   DirVar $btPath
+   DirVerify leave
+   PageCallbacks btPageSkip btPageShow btPageLeave
+   DirText "Select old brewtarget install folder. Press skip if this is a new install,or you want to manually upgrade your database" "Brewtarget Install Folder" "" "Select Brewtarget Install Folder"
 PageExEnd
 
-; If we found a key already in the registry, pop a message saying w00t and
-; that's it
 Function btPageSkip
-   ${If} $prevInst == "found"
-      MessageBox MB_ICONINFORMATION "Brewtarget has been successfully installed. Your database will automatically be upgraded on startup."
+   ${If} $prevInst == "CopyDone"
       Abort
    ${EndIf}
 FunctionEnd
 
+; If we found the Registrykey, don't display the dialog?
 Function btPageShow
    ;Hide space texts
    FindWindow $0 "#32770" "" $HWNDPARENT
@@ -798,31 +870,9 @@ Function btPageShow
    GetDlgItem $R0 $HWNDPARENT 2
    SendMessage $R0 ${WM_SETTEXT} 1 "STR:Skip"
    EnableWindow $R0 1
-
 FunctionEnd
 
-; Do all the copying
-; If this function is called, it means we didn't find the registry key and
-; believe we need to upgrade. The logic works like this:
-;  1. Prompt the user for the path to the brewtarget install
-;  2. If it is brewtarget-2.x, 
-;       search c:\users\[name]\AppData\Local for database.sqlite
-;     else 
-;       search c:\users\[name]\AppData\Local for database.xml
-;  3. If we find it
-;       copy the found file(s) to c:\users\[name]\AppData\Roaming\brewtarget
-;     else
-;       complain and give teh user another chance.
-;  4. Poke the value 
-;  
-
 Function btPageLeave
-   ; This is important to have $APPDATA variable
-   ; NOT point to C:\ProgramData
-   ; but to current user's Roaming folder
-   SetShellVarContext current
-   
-   StrCpy $targetDir "$APPDATA\brewtarget"
    
    GetInstDirError $0
 
@@ -832,21 +882,52 @@ Function btPageLeave
       Abort
    ${EndIf}
 
-   ; Create the target data directory if it isn't there
-   ${IfNot} ${FileExists} $targetDir
-      CreateDirectory $targetDir
+   Call btCopyAllFiles
+
+   MessageBox MB_ICONINFORMATION "Brewtarget has been successfully installed. Your database will automatically be upgraded on startup."
+FunctionEnd
+
+; Does all the copying
+; Set $btPath to where Database is located, or brewtargets install directory
+; Function will try to locate the database in local appdata aswell.
+
+Function btCopyAllFiles
+   ; Convert the path from canonicalPath / format to Windows \ instead for comparison.
+   ; Brewtarget 2.3.0 saves the user_data_dir in canonical format. so we need to convert to Windows \ due to all Environment variables.
+   ; otherwise the comparison fails.
+   Push $btPath
+   Call ConvertFromCanonicalPath
+   Pop $btWindowsPath
+
+   ; Make sure the files is not already in the Roaming Path
+   Push $btpath
+   Push $APPDATA
+   Call StrStr
+   Pop $R0
+   ${If} $R0 != ""
+      Goto btCopyAllFiles_done
    ${EndIf}
 
-   ; If the user points us at the program files directory, we have to worry
-   ; about virtual stores
-   Push $btPath
+   ;If database.sqlite is located in Programs files folder, or rather the user_data_dir reg key is pointing to it, we need to do all the copying and so on as if in "not located" scenario.
+   Push $btWindowsPath
    Push $PROGRAMFILES
    Call StrStr
    Pop $R0
 
-   ; We have to worry
    ${If} $R0 != ""
-      ; Need some more info. 
+      ; This is important to have $APPDATA variable
+      ; NOT point to C:\ProgramData
+      ; but to current user's Roaming folder
+      SetShellVarContext current
+
+      StrCpy $targetDir "$APPDATA\brewtarget\brewtarget"
+
+      ; Create the target data directory if it isn't there
+      ${IfNot} ${FileExists} $targetDir
+         CreateDirectory $targetDir
+      ${EndIf}
+
+      ; Need some more info.
       Push $btPath
       Push "t-2"
       Call StrStr
@@ -860,26 +941,27 @@ Function btPageLeave
          StrCpy $fileName 'database.xml'
       ${EndIf}
 
-	  ; $btPathVersion should be 'Brewtarget-1.2.4', 'Brewtarget-2.0.0', 'Brewtarget-2.0.1' etc.
-	  Push $btPath
-	  Push 'Brewtarget-'
-	  Call StrStr
-	  Pop $btPathVersion
-	  
+      ; $btPathVersion should be 'Brewtarget-1.2.4', 'Brewtarget-2.0.0', 'Brewtarget-2.0.1' etc.
+      Push $btPath
+      Push 'Brewtarget-'
+      Call StrStr
+      Call ConvertFromCanonicalPath
+      Pop $btPathVersion
       ; If there is no data file where the user pointed us,
       ; look for in LOCALAPPDATA
       ${IfNot} ${FileExists} "$btPath\$fileName"
-		 ${locate::Open} "$LOCALAPPDATA" "/M=$fileName" $locateHandle
-		 findloop:
-		 ${locate::Find} $locateHandle $R9 $R8 $R7 $R6 $nouse1 $nouse2
-                 StrCmp $R9 '' stoplocate
-		 Call whereisDb
-		 StrCmp $0 'StopLocate' stoplocate findloop
-		 stoplocate:
-		 ${locate::Close} $locateHandle
-		 ${locate::Unload}
+         ${locate::Open} "$LOCALAPPDATA" "/M=$fileName" $locateHandle
+         findloop:
+         ${locate::Find} $locateHandle $R9 $R8 $R7 $R6 $nouse1 $nouse2
+         StrCmp $R9 '' stoplocate
+         Call whereisDb
+         StrCmp $0 'StopLocate' stoplocate findloop
+         stoplocate:
+         ${locate::Close} $locateHandle
+         ${locate::Unload}
          ${If} $R4 != ""
             StrCpy $btPath $R4
+
          ; If we can't find anything, warn the user and send them back to the
          ; selection screen
          ${Else}
@@ -887,41 +969,43 @@ Function btPageLeave
             Abort
          ${EndIf}
       ${EndIf}
+   ${EndIF}
+   ${If} ${FileExists} "$btPath\$fileName"
+      ; this copies the database.xml or database.sqlite file to the new location.
+      CopyFiles "$btPath\$fileName" $targetDir
 
-   ${EndIf}
-
-   ; I dislike the duplicated code. I need to do this better.
-   ${If} ${FileExists} "$btPath\database.sqlite"
-      CopyFiles "$btPath\database.sqlite" $targetDir
-      CopyFiles "$btPath\options.xml" $targetDir
-      WriteRegStr HKCU "SOFTWARE\brewtarget\OrganizationDefaults" 'hadOldConfig' "1"
-      MessageBox MB_ICONINFORMATION "Your old databases have been copied into place. Please start brewtarget to have them automatically upgraded."
-   ${Else}
-      ${If} ${FileExists} "$btPath\database.xml"
-         ; database
-         CopyFiles "$btPath\database.xml" $targetDir
+      ; If we're upgrading from brewtarget 1.2.x, also copy the remaining xml-files.
+      ${If} $filename == "database.xml"
          ; mashes
          CopyFiles "$btPath\mashes.xml" $targetDir
          ; recipes
          CopyFiles "$btPath\recipes.xml" $targetDir
          ; options file last
          CopyFiles "$btPath\options.xml" $targetDir
-         ; update the registry, so we know to do the final conversion of the
-         ; options file
-         WriteRegStr HKCU "SOFTWARE\brewtarget\OrganizationDefaults" 'hadOldConfig' "1"
-         ; Tell the user they are good.
-         MessageBox MB_ICONINFORMATION "Your old databases have been copied into place. Please start brewtarget to have them automatically upgraded."
-      ${Else}
-         MessageBox mb_iconstop "Couldn't find an existing database to copy!"
-         Abort
       ${EndIf}
-   ${EndIf}
-   ; Always set the new user_data_dir flag
-   ; WriteRegStr HKCU "SOFTWARE\${APP_NAME}\OrganizationDefaults" 'user_data_dir' "$APPDATA\${APP_NAME}\"
 
-   WriteRegStr HKCU "SOFTWARE\brewtarget\OrganizationDefaults" 'user_data_dir' "$APPDATA\brewtarget\"
-      
+      ; update the registry, so we know to do the final conversion of the
+      ; options file
+      WriteRegStr HKCU "SOFTWARE\brewtarget\OrganizationDefaults" 'hadOldConfig' "1"
+
+      ; make the targetdir conform to canonical path format.
+      Push $targetDir
+      Call ConvertToCanonicalPath
+      Pop $targetDir
+      ; Always set the new user_data_dir flag
+      WriteRegStr HKCU $btRegPath 'user_data_dir' $targetDir
+   ${EndIf}
+btCopyAllFiles_done:
 FunctionEnd
+
+; Function to determin if the database is located in the directory.
+; Will put resulting path in $R4
+; $0 will be 'Stoplocate' if the database is found.
+;
+; usage:
+;     push "C:\PATH\TO\SOME\FOLDER"
+;     Call whereisDb
+;
 
 Function whereIsDb
 
@@ -945,14 +1029,19 @@ Function whereIsDb
    Push $btPathVersion
    Call StrStr
    Pop $R1
-   
+   nsislog::log "$EXEDIR\install.log" "btPathVersion: $btPathVersion"
+   nsislog::log "$EXEDIR\install.log" "R2: $R2"
+   nsislog::log "$EXEDIR\install.log" "R3: $R3"
+   nsislog::log "$EXEDIR\install.log" "R1: $R1"
+   nsislog::log "$EXEDIR\install.log" "R8: $R8"
+   nsislog::log "$EXEDIR\install.log" "R9: $R9"
    ${If} $R2 == ""
    ${AndIf} $R3 != ""
    ${AndIf} $R1 != ""
       StrCpy $R4 $R8
       StrCpy $0 StopLocate
    ${EndIf}
-
+   nsislog::log "$EXEDIR\install.log" "0: $0"
    Push $0
 FunctionEnd
 
@@ -1193,12 +1282,21 @@ inst:
    ReadRegStr $btPath HKCU "SOFTWARE\brewtarget\OrganizationDefaults" 'user_data_dir'
    StrLen $0 $btPath
 
-   ; If we did not find the registry key
+   ; If we did not find the registry key in the OrganizationDefalts, let's look in the brewtarget folder as well.
    ${If} $0 == 0
-      StrCpy $prevInst "none"
-      StrCpy $btPath $PROGRAMFILES
+      ReadRegStr $btPath HKCU "SOFTWARE\brewtarget\brewtarget" 'user_data_dir'
+      StrLen $0 $btPath
+      ${If} $0 == 0
+         StrCpy $prevInst "none"
+         StrCpy $btPath $PROGRAMFILES
+         StrCpy $btRegPath "SOFTWARE\brewtarget\OrganizationDefaults"
+      ${Else}
+         StrCpy $prevInst "found"
+         StrCpy $btRegPath "SOFTWARE\brewtarget\brewtarget"
+      ${EndIf}
    ${Else}
       StrCpy $prevInst "found"
+      StrCpy $btRegPath "SOFTWARE\brewtarget\OrganizationDefaults"
    ${Endif}
 
   noOptionsPage:

--- a/src/MashWizard.cpp
+++ b/src/MashWizard.cpp
@@ -33,6 +33,7 @@
 #include "brewtarget.h"
 #include "equipment.h"
 #include "PhysicalConstants.h"
+#include <QButtonGroup>
 
 MashWizard::MashWizard(QWidget* parent) : QDialog(parent)
 {

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -148,7 +148,7 @@ bool Brewtarget::ensureDirectoriesExist()
   // A missing dataDir is a serious issue, without it we're missing the default DB, sound files & translations.
   // An attempt could be made to created it, like the other config directories, but an empty data dir is just as bad as a missing one.
   // Because of that, we'll display a little more dire warning, and not try to create it.
-  QDir dataDir = getDataDir();
+  QDir dataDir = getUserDataDir();
   bool dataDirSuccess = true;
 
   if (! dataDir.exists())
@@ -372,6 +372,22 @@ QDir Brewtarget::getUserDataDir()
 //      return userDataDir + "/";
 }
 
+QDir Brewtarget::getDefaultUserDataDir()
+{
+#if defined(Q_OS_LINUX) || defined(Q_OS_MAC) // Linux OS or Mac OS.#if defined(Q_OS_LINUX) || defined(Q_OS_MAC) // Linux OS or Mac OS.
+   return getConfigDir();
+#elif defined(Q_OS_WIN) // Windows OS.
+   // On Windows the Programs directory is normally not writable so we need to get the appData path from the environment instead.
+   userDataDir.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+   if (!userDataDir.exists()) {
+      createDir(userDataDir);
+   }
+   return userDataDir;
+#else
+# error "Unsupported OS"
+#endif
+}
+
 bool Brewtarget::initialize(const QString &userDirectory)
 {
    // Need these for changed(QMetaProperty,QVariant) to be emitted across threads.
@@ -399,7 +415,7 @@ bool Brewtarget::initialize(const QString &userDirectory)
    }
    // Guess where to put it.
    else {
-      userDataDir = getConfigDir();
+      userDataDir = getDefaultUserDataDir();
    }
 
    // If the old options file exists, convert it. Otherwise, just get the

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -172,6 +172,8 @@ public:
    static const QDir getConfigDir();
    //! \return user-specified directory where the database files reside.
    static QDir getUserDataDir();
+   //! \return The System path for users applicationpath. on windows: c:\\users\\<USERNAME>\\AppData\\Roaming\\<APPNAME>
+   static QDir getDefaultUserDataDir();
    /*!
     * \brief Blocking call that executes the application.
     * \param userDirectory If !isEmpty, overwrites the current settings.


### PR DESCRIPTION
This PR fixes the Following issues with Stable/2.4.0

* Building on Windows, removed old QT-dependencies from CmakeLists.txt
* Modify the NSIS-Installer template to include Visual Studio Runtime for making brewtarget run on Winodws 7 (automatically installs if not present at target system)
* Fixing missing Include in MashWizard.cpp
* Fixing NSIS installer to copy old DB to the users Roaming folder
* modify brewtarget.cpp to use Users Roaming folder as default db location
* adds the vcredist to repository so others can build the windows installer.

Some of these changes is not present in Develop, maybe fix a PR for those?
Not available in Develop-branch:
* VS Runtime installer
* NSIS settings for installing VS Runtime

_All above is tested on Windows 10 an Windows 7, including upgrading from 2.3.0 -> 2.4.0_

