### PR TITLE
Fixes #489 fixing dependencies for Debian build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,9 +415,7 @@ IF( WIN32 )
         ${QtSql_location}
         ${QtSvg_location}
         ${QtXml_location}
-        ${QtWebKit_location}
         ${QtGui_location}
-        ${QtWebKitWidgets_location}
         ${QtOpenGL_location}
    )
    IF( NOT ${NO_QTMULTIMEDIA})
@@ -551,6 +549,11 @@ IF(EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
     SET( CPACK_PACKAGE_INSTALL_REGISTRY_KEY "Brewtarget-${brewtarget_VERSION_STRING}" )
     SET( CPACK_PACKAGE_INSTALL_DIRECTORY "Brewtarget-${brewtarget_VERSION_STRING}" )
     SET( CPACK_NSIS_MODIFY_PATH ON )
+
+    # The redistribution package from Microsoft is needed for Windows 7 installation.
+    # NSIS will install on target system if needed, but the file has to be included in the installer.
+    # Another approach would be to instruct the users of Windows 7 to download the redist for their platform and install it themselfs.
+    SET( CPACK_PACKAGE_REDIST_DIR "${ROOTDIR}/redist")
 
     # Extra start menu items.
     #SET( CPACK_NSIS_MENU_LINKS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,11 +523,13 @@ IF(EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
     #-----------------DEB----------------
     SET( CPACK_DEBIAN_PACKAGE_MAINTAINER "Philip G. Lee <rocketman768@gmail.com>" )
     # NOTE: Use the getdependencies script to get the dependencies!
-    SET( CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.3.6-6~), libc6 (>= 2.1.3), libgcc1 (>= 1:4.1.1), libphonon4 (>= 4:4.2.0), libqt4-dbus (>= 4:4.5.3), libqt4-network (>= 4:4.5.3), libqt4-svg (>= 4:4.5.3), libqtwebkit4 (>= 2.3.4.dfsg-9.1), libqt4-xml (>= 4:4.5.3), libqtcore4 (>= 4:4.6.1), libqtgui4 (>= 4:4.5.3), libstdc++6 (>= 4.1.1), phonon (>= 4:4.5.2)" )
-
+ 
     SET( CPACK_DEBIAN_PACKAGE_SECTION "misc" )
     SET( CPACK_DEBIAN_PACKAGE_VERSION "${brewtarget_VERSION_STRING}-1")
     SET( CPACK_DEBIAN_PACKAGE_PRIORITY "optional" )
+
+    # autogenerate dependency information
+    set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
     SET(CPACK_DEBIAN_PACKAGE_NAME ${CMAKE_PROJECT_NAME}_${brewtarget_VERSION_STRING})
 

--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -6,6 +6,7 @@
   !define VERSION "@CPACK_PACKAGE_VERSION@"
   !define PATCH  "@CPACK_PACKAGE_VERSION_PATCH@"
   !define INST_DIR "@CPACK_TEMPORARY_DIRECTORY@"
+  !define REDIST_DIR "@CPACK_PACKAGE_REDIST_DIR@"
 
 ;--------------------------------
 ;Variables
@@ -603,7 +604,6 @@ FunctionEnd
   !insertmacro MUI_PAGE_STARTMENU Application $STARTMENU_FOLDER
 
   @CPACK_NSIS_PAGE_COMPONENTS@
-
   !insertmacro MUI_PAGE_INSTFILES
   !insertmacro MUI_PAGE_FINISH
 
@@ -672,9 +672,9 @@ FunctionEnd
   ;These files should be inserted before other files in the data block
   ;Keep these lines before any File command
   ;Only for solid compression (by default, solid compression is enabled for BZIP2 and LZMA)
-
   ReserveFile "NSIS.InstallOptions.ini"
   !insertmacro MUI_RESERVEFILE_INSTALLOPTIONS
+  ReserveFile "${REDIST_DIR}\vcredist_x64.exe"
 
 ;--------------------------------
 ;Installer Sections
@@ -774,6 +774,33 @@ Section "-Add to path"
   StrCmp $DO_NOT_ADD_TO_PATH "1" doNotAddToPath 0
     Call AddToPath
   doNotAddToPath:
+SectionEnd
+
+; This section will check if VC redistributable package is installed to the correct version.
+; If not it will run the installer in the background
+Section "Visual Studio Runtime"
+   DetailPrint "Checking Previosly installed Visual Studio Runtime"
+   ReadRegDWORD $0 HKLM64 "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Major"
+   ReadRegDWORD $1 HKLM64 "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Minor"
+   ReadRegDWORD $2 HKLM64 "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Bld"
+
+   ${If} $0 == 0
+      ReadRegDWORD $0 HKLM "SOFTWARE\Wow6432node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Major"
+      ReadRegDWORD $1 HKLM "SOFTWARE\Wow6432node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Minor"
+      ReadRegDWORD $2 HKLM "SOFTWARE\Wow6432node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Bld"
+   ${EndIf}
+
+   ${If} $0 >= 14
+      ${AndIf} $1 >= 27
+         ${AndIf} $2 >= 29016
+            DetailPrint "VC redistributable package installed, skipping install"
+   ${Else}
+      DetailPrint "Correct version not found, installing Visual Studio runtime"
+      InitPluginsDir
+      SetOutPath "$PLUGINSDIR"
+      File "${REDIST_DIR}\vcredist_x64.exe"
+      ExecWait '"$PLUGINSDIR\vcredist_x64.exe" /install /quiet /norestart'
+   ${EndIf}
 SectionEnd
 
 ;--------------------------------

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -445,6 +445,22 @@ QDir Brewtarget::getDefaultUserDataDir()
 #endif
 }
 
+QDir Brewtarget::getDefaultUserDataDir()
+{
+#if defined(Q_OS_LINUX) || defined(Q_OS_MAC) // Linux OS or Mac OS.#if defined(Q_OS_LINUX) || defined(Q_OS_MAC) // Linux OS or Mac OS.
+   return getConfigDir();
+#elif defined(Q_OS_WIN) // Windows OS.
+   // On Windows the Programs directory is normally not writable so we need to get the appData path from the environment instead.
+   userDataDir.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+   if (!userDataDir.exists()) {
+      createDir(userDataDir);
+   }
+   return userDataDir;
+#else
+# error "Unsupported OS"
+#endif
+}
+
 bool Brewtarget::initialize(const QString &userDirectory)
 {
    // Need these for changed(QMetaProperty,QVariant) to be emitted across threads.


### PR DESCRIPTION
This fix will autogenerate dependencies for Debian build thus removing the manual step fr updating depency-list when QT updates.

also, with this generated package it is better to use "apt install ./<DEB-PACKAGE-FILE>" instead of "dpkg -i" because apt install will automatically install all dependencies with the package.

closes #489 