### PR TITLE
Fix for Issue #497 – (Bugs 1109751 and 1372087 from launchpad)

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1894,12 +1894,19 @@ void MainWindow::brewAgainHelper()
 
 void MainWindow::backup()
 {
-   QString dir = QFileDialog::getExistingDirectory(this, tr("Backup Database"));
+   // NB: QDir does all the necessary magic of translating '/' to whatever current platform's directory separator is
+   QString defaultBackupFileName = QDir::currentPath() + "/" + Database::getDefaultBackupFileName();
+   QString backupFileName = QFileDialog::getSaveFileName(this, tr("Backup Database"), defaultBackupFileName);
+   Brewtarget::logD( QString("Database backup filename \"%1\"").arg(backupFileName) );
 
-   bool success = Database::backupToDir(dir);
+   // If the filename returned from the dialog is empty, it means the user clicked cancel, so we should stop trying to do the backup
+   if (!backupFileName.isEmpty())
+   {
+      bool success = Database::backupToFile(backupFileName);
 
-   if( ! success )
-      QMessageBox::warning( this, tr("Oops!"), tr("Could not copy the files for some reason."));
+      if( ! success )
+         QMessageBox::warning( this, tr("Oops!"), tr("Could not copy the files for some reason."));
+   }
 }
 
 void MainWindow::restoreFromBackup()

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -695,27 +695,40 @@ void Database::dropInstance()
 
 }
 
-bool Database::backupToDir(QString dir,QString filename)
+char const * Database::getDefaultBackupFileName()
 {
-   // Make sure the singleton exists.
+    return "database.sqlite";
+}
+
+bool Database::backupToFile(QString newDbFileName)
+{
+   // Make sure the singleton exists - otherwise there's nothing to backup.
    instance();
 
    bool success = true;
-   QString prefix = dir + "/";
-   QString newDbFileName = prefix + "database.sqlite";
-
-   if ( filename.isEmpty() ) {
-      newDbFileName = prefix + "database.sqlite";
-   }
-   else {
-      newDbFileName = prefix + filename;
-   }
 
    // Remove the files if they already exist so that
    // the copy() operation will succeed.
    QFile::remove(newDbFileName);
 
    success = dbFile.copy( newDbFileName );
+
+   Brewtarget::logD( QString("Database backup to \"%1\" %2").arg(newDbFileName, success ? "succeeded" : "failed") );
+
+   return success;
+}
+
+bool Database::backupToDir(QString dir,QString filename)
+{
+   bool success = true;
+   QString prefix = dir + "/";
+   QString newDbFileName = prefix + getDefaultBackupFileName();
+
+   if ( !filename.isEmpty() ) {
+      newDbFileName = prefix + filename;
+   }
+
+   success = backupToFile( newDbFileName );
 
    return success;
 }

--- a/src/database.h
+++ b/src/database.h
@@ -99,6 +99,11 @@ public:
    //! \brief Create a blank database in the given file
    static bool createBlank(QString const& filename);
 
+   static char const * getDefaultBackupFileName();
+
+   //! backs up database to chosen file
+   static bool backupToFile(QString newDbFileName);
+
    //! backs up database to 'dir' in chosen directory
    static bool backupToDir(QString dir, QString filename="");
 


### PR DESCRIPTION
(This is my first pull request for brewtarget, so grateful for any feedback about process, standards, etc.)
Bug #1109751 is basically a small feature request for the user to be able to choose the file name into which a manual DB backup is created.
I modified database class to:
 - Be able to report the default name it uses for the backup file - new method getDefaultBackupFileName()
 - Be able to do a backup to a fully qualified file name - new method backupToFile()
 - Have existing method backupToDir() work by calling backupToFile() - to avoid duplicate code
 - Add some debug-level logging
I modified MainWindow::backup() to:
 - Ask the user to select a file instead of a directory, but have the default filename already in the dialog - so the user doesn't have to specify anything more than now if they are happy with the default
 - Correct what happens if the user clicks 'Cancel' on the dialog.  (Currently, the user sees an error message, but it seems better for this to just cancel the backup.)
 - Add some debug-level logging