### PR TITLE
Rewriting the Log library to better suite the QT framework.

### DIFF
--- a/src/BtDigitWidget.cpp
+++ b/src/BtDigitWidget.cpp
@@ -64,11 +64,9 @@ void BtDigitWidget::display(QString str)
       display(m_lastNum,m_lastPrec);
    else
    {
-      Brewtarget::logW( 
-            QString("%1 : could not convert %2 to double")
+      qWarning() << QString("%1 : could not convert %2 to double")
             .arg(Q_FUNC_INFO)
-            .arg(str)
-      );
+            .arg(str);
       QLabel::setText("-");
    }
 }
@@ -175,7 +173,7 @@ void BtDigitWidget::setHighMsg( QString msg ) { m_high_msg = msg; update();}
 void BtDigitWidget::setMessages( QStringList msgs )
 {
    if ( msgs.size() != 3 ) {
-      Brewtarget::logW("Wrong number of messages");
+      qWarning() << "Wrong number of messages";
       return;
    }
    m_low_msg = msgs[0];
@@ -275,7 +273,7 @@ void BtDigitWidget::displayChanged(Unit::unitDisplay oldUnit, Unit::unitScale ol
       default:
          val = Brewtarget::toDouble(text(),&ok);
          if ( ! ok )
-            Brewtarget::logW( QString("%1: failed to convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(text()).arg(m_section).arg(m_editField) );
+            qWarning() << QString("%1: failed to convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(text()).arg(m_section).arg(m_editField);
          amt = displayAmount(val);
    }
    QLabel::setText(amt);
@@ -308,11 +306,11 @@ void BtDigitWidget::setText(QString amount, int precision)
    {
       amt = Brewtarget::toDouble(amount,&ok);
       if ( !ok ) {
-         Brewtarget::logW( QString("%1 could not convert %2 (%3:%4) to double")
+         qWarning() << QString("%1 could not convert %2 (%3:%4) to double")
                .arg(Q_FUNC_INFO)
                .arg(amount)
                .arg(m_section)
-               .arg(m_editField) );
+               .arg(m_editField);
       }
       m_lastNum = amt;
       m_lastPrec = precision;

--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -102,7 +102,7 @@ void BtLineEdit::lineChanged(Unit::unitDisplay oldUnit, Unit::unitScale oldScale
       default:
          val = Brewtarget::toDouble(text(),&ok);
          if ( ! ok )
-            Brewtarget::logW( QString("%1: failed to convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(text()).arg(_section).arg(_editField) );
+            qWarning() << QString("%1: failed to convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(text()).arg(_section).arg(_editField);
          amt = displayAmount(val);
    }
    QLineEdit::setText(amt);
@@ -160,7 +160,7 @@ double BtLineEdit::toSI(Unit::unitDisplay oldUnit,Unit::unitScale oldScale,bool 
    bool ok = false;
    double amt = toDouble(&ok);
    if ( ! ok )
-      Brewtarget::logW( QString("%1 : could not convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(text()).arg(_section).arg(_editField) );
+      qWarning() << QString("%1 : could not convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(text()).arg(_section).arg(_editField);
    return amt;
 }
 
@@ -231,11 +231,11 @@ void BtLineEdit::setText( Ingredient* element, int precision )
       // through toString() and then Brewtarget::toDouble().
       amount = tmp.toDouble(&ok);
       if ( !ok ) {
-         Brewtarget::logW( QString("%1 could not convert %2 (%3:%4) to double")
+         qWarning() << QString("%1 could not convert %2 (%3:%4) to double")
                               .arg(Q_FUNC_INFO)
                               .arg(tmp.toString())
                               .arg(_section)
-                              .arg(_editField) );
+                              .arg(_editField);
       }
 
       display = displayAmount(amount, precision);
@@ -261,7 +261,7 @@ void BtLineEdit::setText( QString amount, int precision)
    {
       amt = Brewtarget::toDouble(amount,&ok);
       if ( !ok )
-         Brewtarget::logW( QString("%1 could not convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(amount).arg(_section).arg(_editField) );
+         qWarning() << QString("%1 could not convert %2 (%3:%4) to double").arg(Q_FUNC_INFO).arg(amount).arg(_section).arg(_editField);
       QLineEdit::setText(displayAmount(amt, precision));
    }
 

--- a/src/BtTreeItem.cpp
+++ b/src/BtTreeItem.cpp
@@ -109,7 +109,7 @@ int BtTreeItem::columnCount(int _type) const
         case WATER:
             return WATERNUMCOLS;
         default:
-         Brewtarget::logW( QString("BtTreeItem::columnCount Bad column: %1").arg(_type));
+           qWarning() << QString("BtTreeItem::columnCount Bad column: %1").arg(_type);
             return 0;
     }
 
@@ -141,7 +141,7 @@ QVariant BtTreeItem::data(int _type, int column)
       case WATER:
          return dataWater(column);
       default:
-         Brewtarget::logW( QString("BtTreeItem::data Bad column: %1").arg(column));
+         qWarning() << QString("BtTreeItem::data Bad column: %1").arg(column);
          return QVariant();
     }
 }
@@ -210,7 +210,7 @@ QVariant BtTreeItem::dataRecipe( int column )
             return QVariant(recipe->style()->name());
          break;
       default :
-         Brewtarget::logW( QString("BtTreeItem::dataRecipe Bad column: %1").arg(column));
+         qWarning() << QString("BtTreeItem::dataRecipe Bad column: %1").arg(column);
    }
    return QVariant();
 }
@@ -230,7 +230,7 @@ QVariant BtTreeItem::dataEquipment(int column)
             return QVariant(kit->boilTime_min());
          break;
       default :
-         Brewtarget::logW( QString("BtTreeItem::dataEquipment Bad column: %1").arg(column));
+         qWarning() << QString("BtTreeItem::dataEquipment Bad column: %1").arg(column);
    }
    return QVariant();
 }
@@ -266,7 +266,7 @@ QVariant BtTreeItem::dataFermentable(int column)
          }
          break;
       default :
-         Brewtarget::logW( QString("BtTreeItem::dataFermentable Bad column: %1").arg(column));
+         qWarning() << QString("BtTreeItem::dataFermentable Bad column: %1").arg(column);
    }
    return QVariant();
 }
@@ -290,7 +290,7 @@ QVariant BtTreeItem::dataHop(int column)
             return QVariant(hop->useStringTr());
          break;
       default :
-         Brewtarget::logW( QString("BtTreeItem::dataHop Bad column: %1").arg(column));
+         qWarning() << QString("BtTreeItem::dataHop Bad column: %1").arg(column);
    }
    return QVariant();
 }
@@ -314,7 +314,7 @@ QVariant BtTreeItem::dataMisc(int column)
             return QVariant(misc->useStringTr());
          break;
       default :
-         Brewtarget::logW( QString("BtTreeItem::dataMisc Bad column: %1").arg(column));
+         QString("BtTreeItem::dataMisc Bad column: %1").arg(column);
    }
    return QVariant();
 }
@@ -338,7 +338,7 @@ QVariant BtTreeItem::dataYeast(int column)
             return QVariant(yeast->formStringTr());
          break;
       default :
-         Brewtarget::logW( QString("BtTreeItem::dataYeast Bad column: %1").arg(column));
+         qWarning() << QString("BtTreeItem::dataYeast Bad column: %1").arg(column);
    }
    return QVariant();
 }
@@ -376,7 +376,7 @@ QVariant BtTreeItem::dataStyle(int column)
          case STYLEGUIDECOL:
                return QVariant(style->styleGuide());
          default :
-            Brewtarget::logW( QString("BtTreeItem::dataStyle Bad column: %1").arg(column));
+            qWarning() << QString("BtTreeItem::dataStyle Bad column: %1").arg(column);
       }
    }
    return QVariant();
@@ -424,7 +424,7 @@ QVariant BtTreeItem::dataWater(int column)
          case WATERpHCOL:
                return QVariant(water->ph());
          default :
-            Brewtarget::logW( QString("BtTreeItem::dataWater Bad column: %1").arg(column));
+            qWarning() << QString("BtTreeItem::dataWater Bad column: %1").arg(column);
       }
    }
 

--- a/src/BtTreeModel.cpp
+++ b/src/BtTreeModel.cpp
@@ -116,7 +116,7 @@ BtTreeModel::BtTreeModel(BtTreeView *parent, TypeMasks type)
          _mimeType = "application/x-brewtarget-ingredient";
          break;
       default:
-         Brewtarget::logW(QString("Invalid treemask: %1").arg(type));
+         qWarning() << QString("Invalid treemask: %1").arg(type);
    }
 
    treeMask = type;
@@ -371,7 +371,7 @@ QVariant BtTreeModel::recipeHeader(int section) const
       return QVariant(tr("Style"));
    }
 
-   Brewtarget::logW( QString("BtTreeModel::getRecipeHeader Bad column: %1").arg(section));
+   qWarning() << QString("BtTreeModel::getRecipeHeader Bad column: %1").arg(section);
    return QVariant();
 }
 
@@ -385,7 +385,7 @@ QVariant BtTreeModel::equipmentHeader(int section) const
       return QVariant(tr("Boil Time"));
    }
 
-   Brewtarget::logW( QString("BtTreeModel::getEquipmentHeader Bad column: %1").arg(section));
+   qWarning() << QString("BtTreeModel::getEquipmentHeader Bad column: %1").arg(section);
    return QVariant();
 }
 
@@ -401,7 +401,7 @@ QVariant BtTreeModel::fermentableHeader(int section) const
       return QVariant(tr("Type"));
    }
 
-   Brewtarget::logW( QString("BtTreeModel::getFermentableHeader Bad column: %1").arg(section));
+   qWarning() << QString("BtTreeModel::getFermentableHeader Bad column: %1").arg(section);
    return QVariant();
 }
 
@@ -417,7 +417,7 @@ QVariant BtTreeModel::hopHeader(int section) const
       return QVariant(tr("Use"));
    }
 
-   Brewtarget::logW( QString("BtTreeModel::getHopHeader Bad column: %1").arg(section));
+   qWarning() << QString("BtTreeModel::getHopHeader Bad column: %1").arg(section);
    return QVariant();
 }
 
@@ -433,7 +433,7 @@ QVariant BtTreeModel::miscHeader(int section) const
       return QVariant(tr("Use"));
    }
 
-   Brewtarget::logW( QString("BtTreeModel::getMiscHeader Bad column: %1").arg(section));
+   qWarning() << QString("BtTreeModel::getMiscHeader Bad column: %1").arg(section);
    return QVariant();
 }
 
@@ -449,7 +449,7 @@ QVariant BtTreeModel::yeastHeader(int section) const
       return QVariant(tr("Form"));
    }
 
-   Brewtarget::logW( QString("BtTreeModel::getYeastHeader Bad column: %1").arg(section) );
+   qWarning() << QString("BtTreeModel::getYeastHeader Bad column: %1").arg(section);
    return QVariant();
 }
 
@@ -469,7 +469,7 @@ QVariant BtTreeModel::styleHeader(int section) const
       return QVariant(tr("Guide"));
    }
 
-   Brewtarget::logW( QString("BtTreeModel::getYeastHeader Bad column: %1").arg(section) );
+   qWarning() << QString("BtTreeModel::getYeastHeader Bad column: %1").arg(section);
    return QVariant();
 }
 
@@ -485,7 +485,7 @@ QVariant BtTreeModel::folderHeader(int section) const
          return QVariant(tr("FULLPATH"));
    }
 
-   Brewtarget::logW( QString("BtTreeModel::getFolderHeader Bad column: %1").arg(section) );
+   qWarning() << QString("BtTreeModel::getFolderHeader Bad column: %1").arg(section);
    return QVariant();
 }
 
@@ -510,7 +510,7 @@ QVariant BtTreeModel::waterHeader(int section) const
    case BtTreeItem::WATERpHCOL:
       return QVariant(tr("pH"));
    }
-   Brewtarget::logW( QString("BtTreeModel::waterHeader Bad column: %1").arg(section) );
+   qWarning() << QString("BtTreeModel::waterHeader Bad column: %1").arg(section);
    return QVariant();
 
 }
@@ -630,7 +630,7 @@ QList<Ingredient*> BtTreeModel::elements()
          elements.append(elem);
       break;
    default:
-      Brewtarget::logW(QString("Invalid treemask: %1").arg(treeMask));
+      qWarning() << QString("Invalid treemask: %1").arg(treeMask);
    }
    return elements;
 }
@@ -649,7 +649,7 @@ void BtTreeModel::loadTreeModel()
          ndxLocal = findFolder( elem->folder(), rootItem->child(0), true );
          // I cannot imagine this failing, but what the hell
          if ( ! ndxLocal.isValid() ) {
-            Brewtarget::logW("Invalid return from findFolder in loadTreeModel()");
+            qWarning() << "Invalid return from findFolder in loadTreeModel()";
             continue;
          }
          local = item(ndxLocal);
@@ -662,7 +662,7 @@ void BtTreeModel::loadTreeModel()
       }
 
       if ( ! insertRow(i,ndxLocal,elem,_type) ) {
-         Brewtarget::logW("Insert failed in loadTreeModel()");
+         qWarning() << "Insert failed in loadTreeModel()";
          continue;
       }
 
@@ -687,7 +687,7 @@ void BtTreeModel::addBrewNoteSubTree(Recipe* rec, int i, BtTreeItem* parent)
       // will do that here too
       if ( ! insertRow(j, createIndex(i,0,temp), note, BtTreeItem::BREWNOTE) )
       {
-         Brewtarget::logW("Brewnote insert failed in loadTreeModel()");
+         qWarning() << "Brewnote insert failed in loadTreeModel()";
          continue;
       }
       observeElement(note);
@@ -899,7 +899,7 @@ void BtTreeModel::copySelected(QList< QPair<QModelIndex, QString> > toBeCopied)
                failed = true;
             break;
          default:
-            Brewtarget::logW(QString("copySelected:: unknown type %1").arg(type(ndx)));
+            qWarning() << QString("copySelected:: unknown type %1").arg(type(ndx));
       }
       if ( failed ) {
          QMessageBox::warning(nullptr,
@@ -952,7 +952,7 @@ void BtTreeModel::deleteSelected(QModelIndexList victims)
             removeFolder(ndx);
             break;
          default:
-            Brewtarget::logW(QString("deleteSelected:: unknown type %1").arg(type(ndx)));
+            qWarning() << QString("deleteSelected:: unknown type %1").arg(type(ndx));
       }
    }
 }
@@ -980,7 +980,7 @@ void BtTreeModel::folderChanged(QString name)
    ndx = findElement(test);
    if ( ! ndx.isValid() )
    {
-      Brewtarget::logW("folderChanged:: could not find element");
+      qWarning() << "folderChanged:: could not find element";
       return;
    }
 
@@ -994,7 +994,7 @@ void BtTreeModel::folderChanged(QString name)
    // Remove it
    if ( ! removeRows(i, 1, pIndex) )
    {
-      Brewtarget::logW("folderChanged:: could not remove row");
+      qWarning() << "folderChanged:: could not remove row";
       return;
    }
 
@@ -1013,7 +1013,7 @@ void BtTreeModel::folderChanged(QString name)
 
    if ( !  insertRow(j,newNdx,test,_type) )
    {
-      Brewtarget::logW("folderChanged:: could not insert row");
+      qWarning() << "folderChanged:: could not insert row";
       return;
    }
    // If we have brewnotes, set them up here.

--- a/src/BtTreeView.cpp
+++ b/src/BtTreeView.cpp
@@ -288,7 +288,7 @@ QMimeData* BtTreeView::mimeData(QModelIndexList indexes)
       if ( _type != BtTreeItem::FOLDER )
       {
          if ( _model->thing( _filter->mapToSource(index)) == nullptr ) {
-            Brewtarget::logW(QString("Couldn't map that thing"));
+            qWarning() << QString("Couldn't map that thing");
             id = -1;
          }
          else {
@@ -376,7 +376,7 @@ void BtTreeView::newIngredient() {
          qobject_cast<WaterEditor*>(_editor)->newWater(folder);
          break;
       default:
-         Brewtarget::logW(QString("BtTreeView::setupContextMenu unrecognized mask %1").arg(_type));
+         qWarning() << QString("BtTreeView::setupContextMenu unrecognized mask %1").arg(_type);
    }
 
 }
@@ -432,7 +432,7 @@ void BtTreeView::setupContextMenu(QWidget* top, QWidget* editor)
          _newMenu->addAction(tr("Water"), this, SLOT(newIngredient()));
          break;
       default:
-         Brewtarget::logW(QString("BtTreeView::setupContextMenu unrecognized mask %1").arg(_type));
+         qWarning() << QString("BtTreeView::setupContextMenu unrecognized mask %1").arg(_type);
    }
 
    _newMenu->addAction(tr("Folder"), top, SLOT(newFolder()));
@@ -533,7 +533,7 @@ void BtTreeView::copySelected(QModelIndexList selected)
             newName = verifyCopy(tr("Water"),_model->name(trans), &abort);
             break;
          default:
-            Brewtarget::logW( QString("BtTreeView::copySelected Unknown type: %1").arg(_model->type(trans)));
+            qWarning() << QString("BtTreeView::copySelected Unknown type: %1").arg(_model->type(trans));
       }
       if ( !abort && !newName.isEmpty() )
          names.append(qMakePair(trans,newName));
@@ -618,7 +618,7 @@ void BtTreeView::deleteSelected(QModelIndexList selected)
             confirmDelete = verifyDelete(confirmDelete,tr("Water"),_model->name(trans));
             break;
          default:
-            Brewtarget::logW( QString("BtTreeView::deleteSelected Unknown type: %1").arg(_model->type(trans)));
+            qWarning() << QString("BtTreeView::deleteSelected Unknown type: %1").arg(_model->type(trans));
       }
       // If they selected "Yes" or "Yes To All", push and loop
       if ( confirmDelete == QMessageBox::Yes || confirmDelete == QMessageBox::YesToAll )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -514,6 +514,10 @@ ADD_TEST(
    NAME postBoilLossOgTest
    COMMAND brewtarget_tests postBoilLossOgTest
 )
+add_test(
+   NAME testLogRotation
+   COMMAND brewtarget_tests testLogRotation
+)
 #=================================Installs=====================================
 
 # Install executable.

--- a/src/ColorMethods.cpp
+++ b/src/ColorMethods.cpp
@@ -42,7 +42,7 @@ double ColorMethods::mcuToSrm(double mcu)
       case Brewtarget::MOSHER:
          return mosher(mcu);
       default:
-         Brewtarget::logE(QObject::tr("Invalid color formula type: %1").arg(Brewtarget::colorFormula) );
+         qCritical() << QObject::tr("Invalid color formula type: %1").arg(Brewtarget::colorFormula);
          return morey(mcu);
    }
 }

--- a/src/DatabaseSchemaHelper.cpp
+++ b/src/DatabaseSchemaHelper.cpp
@@ -116,7 +116,7 @@ bool DatabaseSchemaHelper::create(QSqlDatabase db, DatabaseSchema* defn, Brewtar
       ret = db.commit();
 
    if ( ! ret ) {
-      Brewtarget::logE("db.commit() failed");
+      qCritical() << "db.commit() failed";
    }
 
    return ret;
@@ -160,7 +160,7 @@ bool DatabaseSchemaHelper::migrateNext(int oldVersion, QSqlDatabase db )
          ret &= migrate_to_9(q,defn);
          break;
       default:
-         Brewtarget::logE(QString("Unknown version %1").arg(oldVersion));
+         qCritical() << QString("Unknown version %1").arg(oldVersion);
          return false;
    }
 
@@ -206,7 +206,7 @@ bool DatabaseSchemaHelper::migrate(int oldVersion, int newVersion, QSqlDatabase 
       ret &= db.commit();
    else
    {
-      Brewtarget::logE("Rolling back");
+      qCritical() << "Rolling back";
       db.rollback();
    }
 
@@ -248,7 +248,7 @@ int DatabaseSchemaHelper::currentVersion(QSqlDatabase db)
          return 3;
    }
 
-   Brewtarget::logE("Could not find database version");
+   qCritical() << "Could not find database version";
    return -1;
 }
 
@@ -587,7 +587,7 @@ bool DatabaseSchemaHelper::migrate_to_8(QSqlQuery q, DatabaseSchema* defn)
    ret = drop_columns(q,defn->table(Brewtarget::BREWNOTETABLE),QStringList() << "predicted_og" << "predicted_abv");
 
    // Now that we've had that fun, let's have this fun
-   Brewtarget::logI(QString("rearranging inventory"));
+   qInfo() << QString("rearranging inventory");
    ret &= migration_aide_8(q, defn, Brewtarget::FERMTABLE);
    if ( ret )
       ret &= migration_aide_8(q, defn, Brewtarget::HOPTABLE);
@@ -601,7 +601,7 @@ bool DatabaseSchemaHelper::migrate_to_8(QSqlQuery q, DatabaseSchema* defn)
    // Instead of inventory knowing about ingredients, we now have ingredients
    // knowing about inventory. I am concerned that leaving these in place
    // will cause circular references
-   Brewtarget::logI(QString("dropping inventory columns"));
+   qInfo() << QString("dropping inventory columns");
    if ( ret ) {
       ret &= drop_columns(q, defn->table(Brewtarget::FERMINVTABLE),  QStringList() << "fermentable_id");
    }
@@ -616,7 +616,7 @@ bool DatabaseSchemaHelper::migrate_to_8(QSqlQuery q, DatabaseSchema* defn)
    }
 
    // Finally, the btalltables table isn't needed, so drop it
-   Brewtarget::logI(QString("dropping bt_alltables"));
+   qInfo() << QString("dropping bt_alltables");
    if ( ret )
       ret &= q.exec( DROPTABLE + SEP + "IF EXISTS bt_alltables");
 

--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -595,7 +595,7 @@ void EquipmentEditor::save()
 
    double grainAbs = Brewtarget::toDouble( lineEdit_grainAbsorption->text(), &ok );
    if ( ! ok )
-      Brewtarget::logW( QString("EquipmentEditor::save() could not convert %1 to double").arg(lineEdit_grainAbsorption->text()));
+      qWarning() << QString("EquipmentEditor::save() could not convert %1 to double").arg(lineEdit_grainAbsorption->text());
 
    double ga_LKg = grainAbs * volumeUnit->toSI(1.0) * weightUnit->fromSI(1.0);
 

--- a/src/FermentableSortFilterProxyModel.cpp
+++ b/src/FermentableSortFilterProxyModel.cpp
@@ -87,7 +87,7 @@ double FermentableSortFilterProxyModel::toDouble(QVariant side) const
 
    amt = Brewtarget::toDouble(side.toString(), &ok);
    if ( ! ok )
-      Brewtarget::logW( QString("FermentableSortFilterProxyModel::lessThan could not convert %1 to double").arg(side.toString()));
+      qWarning() << QString("FermentableSortFilterProxyModel::lessThan could not convert %1 to double").arg(side.toString());
    return amt;
 }
 

--- a/src/FermentableTableModel.cpp
+++ b/src/FermentableTableModel.cpp
@@ -109,7 +109,7 @@ void FermentableTableModel::observeDatabase(bool val)
 
 void FermentableTableModel::addFermentable(Fermentable* ferm)
 {
-   Brewtarget::logD(QString("FermentableTableModel::addFermentable() \"%1\"").arg(ferm->name()));
+   qDebug() << QString("FermentableTableModel::addFermentable() \"%1\"").arg(ferm->name());
 
    //Check to see if it's already in the list
    if( fermObs.contains(ferm) )
@@ -130,7 +130,7 @@ void FermentableTableModel::addFermentable(Fermentable* ferm)
 
 void FermentableTableModel::addFermentables(QList<Fermentable*> ferms)
 {
-   Brewtarget::logD(QString("FermentableTableModel::addFermentables() Add up to %1 fermentables to existing list of %2").arg(ferms.size()).arg(this->fermObs.size()));
+   qDebug() << QString("FermentableTableModel::addFermentables() Add up to %1 fermentables to existing list of %2").arg(ferms.size()).arg(this->fermObs.size());
 
    QList<Fermentable*>::iterator i;
    QList<Fermentable*> tmp;
@@ -143,7 +143,7 @@ void FermentableTableModel::addFermentables(QList<Fermentable*> ferms)
          tmp.append(*i);
    }
 
-   Brewtarget::logD(QString("FermentableTableModel::addFermentables() After de-duping, adding %1 fermentables").arg(tmp.size()));
+   qDebug() << QString("FermentableTableModel::addFermentables() After de-duping, adding %1 fermentables").arg(tmp.size());
 
    int size = fermObs.size();
    if (size+tmp.size()) {
@@ -232,7 +232,7 @@ void FermentableTableModel::changedInventory(Brewtarget::DBTable table, int invK
 
 void FermentableTableModel::changed(QMetaProperty prop, QVariant /*val*/)
 {
-   Brewtarget::logD(QString("FermentableTableModel::changed() %1").arg(prop.name()));
+   qDebug() << QString("FermentableTableModel::changed() %1").arg(prop.name());
 
    int i;
 
@@ -282,7 +282,7 @@ QVariant FermentableTableModel::data( const QModelIndex& index, int role ) const
    // Ensure the row is ok.
    if( index.row() >= static_cast<int>(fermObs.size() ))
    {
-      Brewtarget::logE(tr("Bad model index. row = %1").arg(index.row()));
+      qCritical() << tr("Bad model index. row = %1").arg(index.row());
       return QVariant();
    }
    else
@@ -347,7 +347,7 @@ QVariant FermentableTableModel::data( const QModelIndex& index, int role ) const
 
          return QVariant( Brewtarget::displayAmount(row->color_srm(), Units::srm, 0, unit) );
       default :
-         Brewtarget::logE(tr("Bad column: %1").arg(col));
+         qCritical() << tr("Bad column: %1").arg(col);
          return QVariant();
    }
 }
@@ -376,7 +376,7 @@ QVariant FermentableTableModel::headerData( int section, Qt::Orientation orienta
          case FERMCOLORCOL:
             return QVariant(tr("Color"));
          default:
-            Brewtarget::logW(tr("Bad column: %1").arg(section));
+            qWarning() << tr("Bad column: %1").arg(section);
             return QVariant();
       }
    }
@@ -696,7 +696,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
          }
          break;
       default:
-         Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
+         qWarning() << tr("Bad column: %1").arg(index.column());
          return false;
    }
    return retVal;

--- a/src/HopSortFilterProxyModel.cpp
+++ b/src/HopSortFilterProxyModel.cpp
@@ -48,11 +48,11 @@ bool HopSortFilterProxyModel::lessThan(const QModelIndex &left,
       case HOPALPHACOL:
          lAlpha = Brewtarget::toDouble(leftHop.toString(), &ok );
          if ( ! ok )
-            Brewtarget::logW( QString("HopSortFilterProxyModel::lessThan() could not convert %1 to double").arg(leftHop.toString()));
+            qWarning() << QString("HopSortFilterProxyModel::lessThan() could not convert %1 to double").arg(leftHop.toString());
 
          rAlpha = Brewtarget::toDouble(rightHop.toString(), &ok );
          if ( ! ok )
-            Brewtarget::logW( QString("HopSortFilterProxyModel::lessThan() could not convert %1 to double").arg(rightHop.toString()));
+            qWarning() << QString("HopSortFilterProxyModel::lessThan() could not convert %1 to double").arg(rightHop.toString());
 
          return lAlpha < rAlpha;
 

--- a/src/HopTableModel.cpp
+++ b/src/HopTableModel.cpp
@@ -264,7 +264,7 @@ QVariant HopTableModel::data( const QModelIndex& index, int role ) const
    // Ensure the row is ok.
    if( index.row() >= static_cast<int>(hopObs.size() ))
    {
-      Brewtarget::logW(QString("Bad model index. row = %1").arg(index.row()));
+      qWarning() << QString("Bad model index. row = %1").arg(index.row());
       return QVariant();
    }
    else
@@ -320,7 +320,7 @@ QVariant HopTableModel::data( const QModelIndex& index, int role ) const
         else
            return QVariant();
       default :
-         Brewtarget::logW(QString("HopTableModel::data Bad column: %1").arg(index.column()));
+         qWarning() << QString("HopTableModel::data Bad column: %1").arg(index.column());
          return QVariant();
    }
 }
@@ -346,7 +346,7 @@ QVariant HopTableModel::headerData( int section, Qt::Orientation orientation, in
          case HOPFORMCOL:
             return QVariant(tr("Form"));
          default:
-            Brewtarget::logW(QString("HopTableModel::headerdata Bad column: %1").arg(section));
+            qWarning() << QString("HopTableModel::headerdata Bad column: %1").arg(section);
             return QVariant();
       }
    }
@@ -397,7 +397,7 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
          {
             amt = Brewtarget::toDouble( value.toString(), &retVal );
             if ( ! retVal )
-               Brewtarget::logW( QString("HopTableModel::setData() could not convert %1 to double").arg(value.toString()));
+               qWarning() << QString("HopTableModel::setData() could not convert %1 to double").arg(value.toString());
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
                                                      "alpha_pct",
                                                      amt,
@@ -451,7 +451,7 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
          }
          break;
       default:
-         Brewtarget::logW(QString("HopTableModel::setdata Bad column: %1").arg(index.column()));
+         qWarning() << QString("HopTableModel::setdata Bad column: %1").arg(index.column());
          return false;
    }
    if ( retVal )
@@ -581,7 +581,7 @@ Hop* HopTableModel::getHop(int i) {
             return hopObs[i];
     }
     else
-        Brewtarget::logW( QString("HopTableModel::getHop( %1/%2 )").arg(i).arg(hopObs.size()) );
+       qWarning() << QString("HopTableModel::getHop( %1/%2 )").arg(i).arg(hopObs.size());
     return nullptr;
 }
 

--- a/src/IbuMethods.cpp
+++ b/src/IbuMethods.cpp
@@ -46,7 +46,7 @@ double IbuMethods::getIbus(double AArating, double hops_grams, double finalVolum
          return noonan(AArating, hops_grams, finalVolume_liters, wort_grav, minutes);
          break;
       default:
-         Brewtarget::logE( QObject::tr("Unrecognized IBU formula type. %1").arg(Brewtarget::ibuFormula) );
+         qCritical() << QObject::tr("Unrecognized IBU formula type. %1").arg(Brewtarget::ibuFormula);
          return tinseth(AArating, hops_grams, finalVolume_liters, wort_grav, minutes);
          break;
    }

--- a/src/InventoryFormatter.cpp
+++ b/src/InventoryFormatter.cpp
@@ -65,9 +65,9 @@ static QString createInventoryTableFermentable()
 
          if (!fermentable)
          {
-            Brewtarget::logE(QString("The fermentable %1 has a record in the "
+            qCritical() << QString("The fermentable %1 has a record in the "
                                      "inventory, but does not exist.")
-                                   .arg(itor.key()));
+                                   .arg(itor.key());
             continue;
          }
 
@@ -109,9 +109,9 @@ static QString createInventoryTableHop()
 
          if (!hop)
          {
-            Brewtarget::logE(QString("The hop %1 has a record in the "
+            qCritical() << QString("The hop %1 has a record in the "
                                      "inventory, but does not exist.")
-                                   .arg(itor.key()));
+                                   .arg(itor.key());
             continue;
          }
 
@@ -152,9 +152,9 @@ static QString createInventoryTableMiscellaneous()
 
          if (!miscellaneous)
          {
-            Brewtarget::logE(QString("The miscellaneous %1 has a record in the "
+            qCritical() << QString("The miscellaneous %1 has a record in the "
                                      "inventory, but does not exist.")
-                                   .arg(itor.key()));
+                                   .arg(itor.key());
             continue;
          }
 
@@ -197,9 +197,9 @@ static QString createInventoryTableYeast()
 
          if (!yeast)
          {
-            Brewtarget::logE(QString("The yeast %1 has a record in the "
+            qCritical() << QString("The yeast %1 has a record in the "
                                      "inventory, but does not exist.")
-                                   .arg(itor.key()));
+                                   .arg(itor.key());
             continue;
          }
 

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -32,8 +32,8 @@ namespace Log
    LogType logLevel = LogType_INFO;
    QDir logFilePath;
    bool logUseConfigDir = true;
-   const int logFileSize = 500 * 1024;
-   const int  logFileCount = 5;
+   int const logFileSize = 500 * 1024;
+   int const logFileCount = 5;
    QString logFileName;
    QString timeFormat;
    QString tmpl;

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1,7 +1,8 @@
 /*
  * Log.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2015
+ * authors 2009-2020
  * - Maxime Lavigne <duguigne@gmail.com>
+ * - Mattias Måhl <mattias@kejsarsten.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,154 +19,292 @@
  */
 
 #include "Log.h"
+namespace Log
+{
+   QTextStream errStream(stderr);
+   QFile logFile;
+   bool isLoggingToStderr(true);
+   QTextStream* stream;
+   QMutex mutex;
 
-#include <QDir>
-#include <QTime>
-#include <QString>
+   // options set by the end user.
+   bool loggingEnabled = false;
+   LogType logLevel = LogType_INFO;
+   QDir logFilePath;
+   bool logUseConfigDir = true;
 
-const QString Log::filename = "brewtarget_log.txt";
-const QString Log::timeFormat = "hh:mm:ss.zzz";
-const QString Log::tmpl = "[%1] %2 : %3";
+   QString logFileName;
+   QString timeFormat;
+   QString tmpl;
 
-Log::Log(bool isLoggingToStderr)
-   : errStream(stderr),
-     file(),
-     isLoggingToStderr(isLoggingToStderr),
-     stream(nullptr) {
-}
-
-Log::~Log() {
-   delete stream;
-   stream = nullptr;
-   if( file.isOpen() )
-      file.close();
-}
-
-void Log::changeDirectory(const QDir defaultDir) {
-   if (stream) {
-      doLog(LogType_ERROR, "Cannot change logging directory after it is initialized.");
-      return;
-   }
-   // Test default location
-   file.setFileName(defaultDir.filePath(filename));
-   if( file.open(QIODevice::WriteOnly | QIODevice::Truncate) ) {
-      stream = new QTextStream(&file);
-      return;
-   }
-
-   // Defaults to temporary
-   file.setFileName(QDir::temp().filePath(filename));
-   if( file.open(QFile::WriteOnly | QFile::Truncate) ) {
-      stream = new QTextStream(&file);
-      warn(QString("Log is in a temporary directory: %1").arg(file.fileName()));
-      return;
-   }
-
-   warn(QString("Could not create a log file."));
-}
-
-void Log::changeDirectory() {
-   //If it's the same, just return, no need to do anything.
-   if ( LogFilePath.filePath(filename) == file.fileName() ) {
-      return;
-   }
-
-   //If the file is already initialize, it needs to be closed and redefined.
-   if (stream) {
-      delete stream;
-      stream = nullptr;
-      if( file.isOpen() )
-         file.close();
-      //Preserving the old logfile
-      if ( ! file.copy(LogFilePath.filePath(filename)) ) {
-         error("Error while copying to the new file location\nReverting settings");
-         LogFilePath = QDir(QFileInfo(file).filePath());
+   bool initializeLog()
+   {
+      initLogFileName();
+      timeFormat = "hh:mm:ss.zzz";
+      tmpl = "[%1] %2 : %3";
+      //need to test if we're running in a test and ajust the location for the logfiles accordingly, this to not clutter the application path with dummy data.
+      if (QCoreApplication::applicationName() == "brewtarget-test")
+      {
+         logFilePath.setPath(QDir::tempPath());
       }
+      else
+      {
+         logFilePath.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+      }
+      //check if Logging directory exists and if not create it.
+      if (!QDir(logFilePath).exists())
+      {
+         QDir().mkpath(logFilePath.canonicalPath());
+      }
+      //Delete old files
+      pruneLogFiles();
+      //Generate a new logfile and open a stream for writing
+      initLogFileName();
+      //Register the Message handler with QT framwork to enable the qDebug macro
+      qInstallMessageHandler(Log::logMessageHandler);
+
+      return true;
    }
 
-   // Test default location
-   file.setFileName(LogFilePath.filePath(filename));
-   if( file.open(QIODevice::Append) ) {
-      stream = new QTextStream(&file);
-      return;
+   void changeDirectory(const QDir defaultDir) {
+      if (stream) {
+         doLog(LogType_ERROR, "Cannot change logging directory after it is initialized.");
+         return;
+      }
+      // default location
+      logFile.setFileName(defaultDir.filePath(logFileName));
+      if (logFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+         stream = new QTextStream(&logFile);
+         return;
+      }
+
+      // Defaults to temporary
+      logFile.setFileName(QDir::temp().filePath(logFileName));
+      if (logFile.open(QFile::WriteOnly | QFile::Truncate)) {
+         stream = new QTextStream(&logFile);
+         qWarning() << QString("Log is in a temporary directory: %1").arg(logFile.fileName());
+         return;
+      }
+
+      qWarning() << "Could not create a log file.";
    }
 
-   // Defaults to temporary
-   file.setFileName(QDir::temp().filePath(filename));
-   if( file.open(QFile::WriteOnly | QFile::Truncate) ) {
-      stream = new QTextStream(&file);
-      warn(QString("Log is in a temporary directory: %1").arg(file.fileName()));
-      return;
+   void changeDirectory() {
+      //If it's the same, just return, no need to do anything.
+      if (logFilePath.filePath(logFileName) == logFile.fileName()) {
+         return;
+      }
+
+      //Check if the new directory exists, if not create it.
+      if (!logFilePath.exists())
+      {
+         if (!logFilePath.mkpath(logFilePath.canonicalPath()))
+         {
+            qCritical() << QString("Could not create directory as location '%1'").arg(logFilePath.canonicalPath());
+            logFilePath = QDir(QFileInfo(logFile).filePath());
+            return;
+         }
+      }
+
+      /*If the file is already initialize, it needs to be closed and redefined.
+         * Note! This only coppies the current Logfile, the older ones will be left behind.
+         * May be a later refraction/development though.
+         */
+      if (stream)
+      {
+         delete stream;
+         stream = nullptr;
+         if (logFile.isOpen())
+         {
+            logFile.close();
+         }
+         //Preserving the old logfiles
+         if (!logFile.copy(logFilePath.filePath(logFileName)))
+         {
+            qCritical() << "Error while copying to the new file location. Reverting settings";
+            logFilePath = QDir(QFileInfo(logFile).filePath());
+            return;
+         }
+      }
+
+      // Generate a new filename to save the logs in
+      if (initLogFileName())
+      {
+         return;
+      }
+
+      qWarning() << QString("Could not create a log file.");
    }
 
-   warn(QString("Could not create a log file."));
-}
-
-void Log::debug(const QString message) {
-   doLog(LogType_DEBUG, message);
-}
-
-void Log::info(const QString message) {
-   doLog(LogType_INFO, message);
-}
-
-void Log::warn(const QString message) {
-   doLog(LogType_WARNING, message);
-}
-
-void Log::error(const QString message) {
-   doLog(LogType_ERROR, message);
-}
-
-void Log::doLog(const LogType lt, const QString message) {
-   QString logEntry = tmpl
+   void doLog(const LogType lt, const QString message) {
+      QString logEntry = tmpl
          .arg(QTime::currentTime().toString(timeFormat))
          .arg(getTypeName(lt))
          .arg(message);
 
-   mutex.lock();
+      mutex.lock();
 #if QT_VERSION < QT_VERSION_CHECK(5,15,0)
-   if (isLoggingToStderr)
-      errStream << logEntry << endl;
-   if (stream)
-      *stream << logEntry << endl;
+      if (isLoggingToStderr)
+         errStream << logEntry << endl;
+      if (stream)
+         *stream << logEntry << endl;
 #else
-   if (isLoggingToStderr)
-      errStream << logEntry << Qt::endl;
-   if (stream)
-      *stream << logEntry << Qt::endl;
+      if (isLoggingToStderr)
+         errStream << logEntry << Qt::endl;
+      if (stream)
+         *stream << logEntry << Qt::endl;
 #endif
-   mutex.unlock();
+      mutex.unlock();
 
-   emit wroteEntry(logEntry);
-}
-
-QString Log::getTypeName(const LogType type) const {
-   switch(type) {
-      case LogType_DEBUG: return tr("DEBUG");
-      case LogType_INFO: return tr("INFO");
-      case LogType_WARNING: return tr("WARNING");
-      case LogType_ERROR: return tr("ERROR");
+      //emit wroteEntry(logEntry);
    }
-   return tr("ERROR");
-}
 
-Log::LogType Log::getLogTypeFromString(QString type)
-{
-   if (type == "INFO") return LogType_INFO;
-   else if (type == "WARNING") return LogType_WARNING;
-   else if (type == "ERROR") return LogType_ERROR;
-   else if (type == "DEBUG") return LogType_DEBUG;
-   else return LogType_INFO;
-}
-
-QString Log::getOptionStringFromLogType(const LogType type)
-{
-   switch(type) {
+   QString Log::getTypeName(const LogType type) {
+      switch (type) {
       case LogType_DEBUG: return QString("DEBUG");
       case LogType_INFO: return QString("INFO");
       case LogType_WARNING: return QString("WARNING");
       case LogType_ERROR: return QString("ERROR");
+      }
+      return QString("ERROR");
    }
-   return QString("INFO");
+
+   LogType getLogTypeFromString(QString type)
+   {
+      if (type == "INFO") return LogType_INFO;
+      else if (type == "WARNING") return LogType_WARNING;
+      else if (type == "ERROR") return LogType_ERROR;
+      else if (type == "DEBUG") return LogType_DEBUG;
+      else return LogType_INFO;
+   }
+
+   QString getOptionStringFromLogType(const LogType type)
+   {
+      switch (type) {
+      case LogType_DEBUG: return QString("DEBUG");
+      case LogType_INFO: return QString("INFO");
+      case LogType_WARNING: return QString("WARNING");
+      case LogType_ERROR: return QString("ERROR");
+      }
+      return QString("INFO");
+   }
+
+   bool initLogFileName()
+   {
+      logFileName = QString("Brewtarget_Log_%1__%2.txt").arg(QDate::currentDate().toString("yyyy_MM_dd")).arg(QTime::currentTime().toString("hh_mm_ss_zzz"));
+
+      // Test default location
+      logFile.setFileName(logFilePath.filePath(logFileName));
+      if (logFile.open(QIODevice::WriteOnly | QIODevice::Append)) {
+         stream = new QTextStream(&logFile);
+         return true;
+      }
+
+      // Defaults to temporary
+      logFile.setFileName(QDir::temp().filePath(logFileName));
+      if (logFile.open(QFile::WriteOnly | QFile::Truncate)) {
+         logFile.setPermissions(QFileDevice::WriteUser | QFileDevice::ReadUser | QFileDevice::ExeUser);
+         stream = new QTextStream(&logFile);
+         qWarning() << QString("Log is in a temporary directory: %1").arg(logFile.fileName());
+         return true;
+      }
+      return false;
+   }
+
+   void logMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& message)
+   {
+      /* First things first, Let's convert the QtMsgType into our own definition for compatability woth the rest of the library.
+      * Then we check if we're actually writing to a File or to the stderr output. because if we're writing to the stderr there potentially no files to prune.
+      * If we are ing fact not writing to stderr then we can continue to do all the file pruning and log file creations as normally.
+      *
+      * the case here is that when the application starts there is no referens to any logfile, as the settings has not yet been loaded.
+      * Therefor we avoid doing any file-system work until all is set according to the users settings.
+      */
+
+      LogType lType;
+      switch (type)
+      {
+      case QtDebugMsg:
+         lType = LogType_DEBUG;
+         break;
+      case QtWarningMsg:
+         lType = LogType_WARNING;
+         break;
+      case QtInfoMsg:
+         lType = LogType_INFO;
+         break;
+      case QtCriticalMsg:
+         lType = LogType_ERROR;
+         break;
+      case QtFatalMsg:
+         lType = LogType_DEBUG;
+         break;
+      }
+      /* Check if there is a file actually set yet, in a rare case if the logfile was not created at initialization.
+         * then we won't be logging to a file, the location may not yet have been loaded from the settings, thus only logging to the stderr.
+         * I this case we cannot do any of the pruning or filename generation.
+         */
+      if (stream)
+      {
+         if (logFile.size() >= LOG_FILE_SIZE)
+         {
+            mutex.lock();
+            pruneLogFiles();
+            initLogFileName();
+            mutex.unlock();
+         }
+      }
+      doLog(lType, QString("%1, in %2").arg(message).arg(context.line));
+   } // End logMessageHandler
+
+   void pruneLogFiles()
+   {
+      //Need to close and reset the stream before deleting any files.
+      delete stream;
+      stream = nullptr;
+      if (logFile.isOpen())
+      {
+         logFile.close();
+      }
+
+      //if the logfile is closed and we're in testing mode where stderr is disabled, we need to enable is temporarily.
+      //saving old value to reset to after pruning.
+      bool old_isLoggingToStderr = isLoggingToStderr;
+      isLoggingToStderr = true;
+      //setting up som preniminaries.
+      QDir dir;
+      QStringList filters;
+      filters << "Brewtarget_Log_*.txt";
+
+      //configuring the file filters to only remove the log files as the directory also contains the database.
+      dir.setSorting(QDir::Reversed | QDir::Time);
+      dir.setFilter(QDir::Files | QDir::Hidden | QDir::NoSymLinks);
+      dir.setPath(logFilePath.canonicalPath());
+      dir.setNameFilters(filters);
+      QFileInfoList fileList = dir.entryInfoList();
+      if (fileList.size() > LOG_FILE_COUNT)
+      {
+         for (int i = 0; i < (fileList.size() - LOG_FILE_COUNT); i++)
+         {
+            QFile f(QString(fileList.at(i).canonicalFilePath()));
+            f.remove();
+         }
+      }
+      isLoggingToStderr = old_isLoggingToStderr;
+   } // function pruneLogFiles
+
+   QFileInfoList getLogFileList()
+   {
+      //testing the number of logfiles that exist under the logging directory, and also checking that neither is bigger than the specified size restriction.
+      QDir dir;
+      QStringList filters;
+      filters << "Brewtarget_Log_*.txt";
+
+      //configuring the file filters to only remove the log files as the directory also contains the database.
+      dir.setSorting(QDir::Reversed | QDir::Time);
+      dir.setFilter(QDir::Files | QDir::Hidden | QDir::NoSymLinks);
+      dir.setPath(Log::logFilePath.canonicalPath());
+      dir.setNameFilters(filters);
+      return dir.entryInfoList();
+   } // getLogFileList
 }

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -227,7 +227,8 @@ namespace Log
       */
 
       //Check if we're actually want to log and that we're set to log this level, this is set by the user options.
-      assert(loggingEnabled && qtLogLevelTranslateEnum[type] == logLevel);
+      if( ! loggingEnabled || ! (qtLogLevelTranslateEnum[type] <= logLevel) )
+         return;
 
       /* Check if there is a file actually set yet, in a rare case if the logfile was not created at initialization.
       * then we won't be logging to a file, the location may not yet have been loaded from the settings, thus only logging to the stderr.

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -32,7 +32,8 @@ namespace Log
    LogType logLevel = LogType_INFO;
    QDir logFilePath;
    bool logUseConfigDir = true;
-
+   const int logFileSize = 500 * 1024;
+   const int  logFileCount = 5;
    QString logFileName;
    QString timeFormat;
    QString tmpl;
@@ -246,7 +247,7 @@ namespace Log
          */
       if (stream)
       {
-         if (logFile.size() >= LOG_FILE_SIZE)
+         if (logFile.size() >= logFileSize)
          {
             mutex.lock();
             pruneLogFiles();
@@ -282,9 +283,9 @@ namespace Log
       dir.setPath(logFilePath.canonicalPath());
       dir.setNameFilters(filters);
       QFileInfoList fileList = dir.entryInfoList();
-      if (fileList.size() > LOG_FILE_COUNT)
+      if (fileList.size() > logFileCount)
       {
-         for (int i = 0; i < (fileList.size() - LOG_FILE_COUNT); i++)
+         for (int i = 0; i < (fileList.size() - logFileCount); i++)
          {
             QFile f(QString(fileList.at(i).canonicalFilePath()));
             f.remove();

--- a/src/Log.h
+++ b/src/Log.h
@@ -62,8 +62,8 @@ namespace Log
    extern LogType logLevel;
    extern QDir logFilePath;
    extern bool logUseConfigDir;
-   extern const int logFileSize;
-   extern const int logFileCount;
+   extern int const logFileSize;
+   extern int const logFileCount;
    extern QString logFileName;
    extern QString timeFormat;
    extern QString tmpl;

--- a/src/Log.h
+++ b/src/Log.h
@@ -21,9 +21,6 @@
 #ifndef _LOG_H
 #define _LOG_H
 
-#define LOG_FILE_SIZE 500 * 1024
-#define LOG_FILE_COUNT 5
-
 #include <QDir>
 #include <QObject>
 #include <QMutex>
@@ -64,7 +61,8 @@ namespace Log
    extern LogType logLevel;
    extern QDir logFilePath;
    extern bool logUseConfigDir;
-
+   extern const int logFileSize;
+   extern const int logFileCount;
    extern QString logFileName;
    extern QString timeFormat;
    extern QString tmpl;
@@ -98,7 +96,7 @@ namespace Log
     */
    extern bool initializeLog();
 
-   /* Prunes old log files from the directory, keeping only the specified number of files in LOG_FILE_COUNT,
+   /* Prunes old log files from the directory, keeping only the specified number of files in logFileCount,
     * purpose is to keep log files to a mininum while keeping the logs up-to-date and also not require manual pruning of files.
     */
    extern void pruneLogFiles();

--- a/src/Log.h
+++ b/src/Log.h
@@ -1,7 +1,8 @@
 /*
  * Log.h is part of Brewtarget, and is Copyright the following
- * authors 2009-2015
+ * authors 2009-2020
  * - Maxime Lavigne <duguigne@gmail.com>
+ * - Mattias Måhl <mattias@kejsarsten.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,34 +21,26 @@
 #ifndef _LOG_H
 #define _LOG_H
 
+#define LOG_FILE_SIZE 500 * 1024
+#define LOG_FILE_COUNT 5
+
 #include <QDir>
 #include <QObject>
 #include <QMutex>
 #include <QString>
 #include <QTextStream>
+#include <QDebug>
+#include <QStandardPaths>
+#include <QTime>
+#include <QApplication>
 
 /*!
- * \class Log
+ * \NameSpace Log
  *
  * \brief Provides a proxy to an OS agnostic Log file.
  */
-class Log : public QObject
+namespace Log
 {
-   Q_OBJECT
-   friend class Brewtarget;
-   friend class OptionDialog;
-public:
-   ~Log();
-
-   //! \brief Logs a debug message. (safe to remove on prod)
-   void debug(const QString message);
-   //! \brief Logs a informational message.
-   void info(const QString message);
-   //! \brief Logs a warning message.
-   void warn(const QString message);
-   //! \brief Logs a severe error. This is a potential fatal error.
-   void error(const QString message);
-
    //! \brief The log level of a message.
    enum LogType {
       //! Meant to express big actions one would want to find in the log file.
@@ -60,35 +53,58 @@ public:
       LogType_DEBUG
    };
 
-signals:
-   void wroteEntry(const QString entry);
-
-private:
-   QTextStream errStream;
-   QFile file;
-   bool isLoggingToStderr;
-   QTextStream* stream;
-   QMutex mutex;
+   extern QTextStream errStream;
+   extern QFile logFile;
+   extern bool isLoggingToStderr;
+   extern QTextStream* stream;
+   extern QMutex mutex;
 
    // options set by the end user.
-   bool LoggingEnabled = false;
-   Log::LogType LoggingLevel = LogType_INFO;
-   QDir LogFilePath;
-   bool LoggingUseConfigDir = true;
+   extern bool loggingEnabled;
+   extern LogType logLevel;
+   extern QDir logFilePath;
+   extern bool logUseConfigDir;
 
-   static const QString filename;
-   static const QString timeFormat;
-   static const QString tmpl;
-   Log(bool isLoggingToStderr);
+   extern QString logFileName;
+   extern QString timeFormat;
+   extern QString tmpl;
 
    //! \brief Sets the default directory of the log file
    //! \param defaultDir The directory which will host the log file.
-   void changeDirectory(const QDir defaultDir);
-   void changeDirectory();
-   void doLog(const LogType lt, const QString message);
-   QString getTypeName(const LogType type) const;
-   LogType getLogTypeFromString(QString type = QString("INFO"));
-   QString getOptionStringFromLogType(const LogType type = LogType_INFO);
+   extern void changeDirectory(const QDir defaultDir);
+   extern void changeDirectory();
+   extern void doLog(const LogType lt, const QString message);
+   extern QString getTypeName(const LogType type);
+   extern LogType getLogTypeFromString(QString type = QString("INFO"));
+   extern QString getOptionStringFromLogType(const LogType type = LogType_INFO);
+
+   /* initLogFileName initializes the log file and opens the stream for writing.
+    * This was moved to its own function as this has to be called everytime logs are being pruned.
+    */
+   extern bool initLogFileName();
+
+   /* logMessageHandler is going to handle all the logmessages.
+    * the old way of calling the Brewtarget::LogX functions will persist, but will use this way of writing logs as well.
+    * Usage after this version will be:
+    * qDebug << "message" << some_variable; //for a debug message!
+    * There is also, qWarning, qCritical, qFatal, qInfo that could be used.
+    */
+   extern void logMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &message);
+
+   /* Initialize logging to utilize the built in logging funxtionality in QT5
+    * this has to be called before any logging is done. should be self contained and not depend on anything being loaded.
+    * although user settings may alter location of files, this module will always start logging at the default application data path.
+    * i.e. on linux: ~/.config/brewtarget or on Windows %APPDATA% path.
+    */
+   extern bool initializeLog();
+
+   /* Prunes old log files from the directory, keeping only the specified number of files in LOG_FILE_COUNT,
+    * purpose is to keep log files to a mininum while keeping the logs up-to-date and also not require manual pruning of files.
+    */
+   extern void pruneLogFiles();
+
+   /* Get the list of Logfiles present in the directory currently logging in and returns a FileInfoList containing the files.*/
+   extern QFileInfoList getLogFileList();
 };
 
 #endif /* _LOG_H */

--- a/src/Log.h
+++ b/src/Log.h
@@ -56,6 +56,9 @@ namespace Log
    extern bool isLoggingToStderr;
    extern QTextStream* stream;
    extern QMutex mutex;
+   extern char const* logLevelNames[];
+   extern char const* qtLogLevelTranslate[];
+   extern LogType const qtLogLevelTranslateEnum[];
 
    // options set by the end user.
    extern bool loggingEnabled;
@@ -75,7 +78,6 @@ namespace Log
    extern void doLog(const LogType lt, const QString message);
    extern QString getTypeName(const LogType type);
    extern LogType getLogTypeFromString(QString type = QString("INFO"));
-   extern QString getOptionStringFromLogType(const LogType type = LogType_INFO);
 
    /* initLogFileName initializes the log file and opens the stream for writing.
     * This was moved to its own function as this has to be called everytime logs are being pruned.

--- a/src/Log.h
+++ b/src/Log.h
@@ -30,6 +30,7 @@
 #include <QStandardPaths>
 #include <QTime>
 #include <QApplication>
+#include <QMutexLocker>
 
 /*!
  * \NameSpace Log

--- a/src/Log.h
+++ b/src/Log.h
@@ -68,6 +68,7 @@ namespace Log
    extern int const logFileSize;
    extern int const logFileCount;
    extern QString logFileName;
+   extern QString logFileNameSuffix;
    extern QString timeFormat;
    extern QString tmpl;
 
@@ -78,6 +79,12 @@ namespace Log
    extern void doLog(const LogType lt, const QString message);
    extern QString getTypeName(const LogType type);
    extern LogType getLogTypeFromString(QString type = QString("INFO"));
+
+   /*
+   * Generates a Logfilename based on the settings above.
+   * prepared for user settings if need be.
+   */
+   extern QString logFileFullName();
 
    /* initLogFileName initializes the log file and opens the stream for writing.
     * This was moved to its own function as this has to be called everytime logs are being pruned.
@@ -103,6 +110,11 @@ namespace Log
     * purpose is to keep log files to a mininum while keeping the logs up-to-date and also not require manual pruning of files.
     */
    extern void pruneLogFiles();
+
+   /*
+   * \brief Closes the log file stream and the file handle.
+   */
+   extern void closeLogFile();
 
    /* Get the list of Logfiles present in the directory currently logging in and returns a FileInfoList containing the files.*/
    extern QFileInfoList getLogFileList();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -223,15 +223,15 @@ void MainWindow::setSizesInPixelsBasedOnDpi()
    //
    auto dpiX = this->logicalDpiX();
    auto dpiY = this->logicalDpiY();
-   Brewtarget::logD(QString("Logical DPI: %1,%2.  Physical DPI: %3,%4")
+   qDebug() << QString("Logical DPI: %1,%2.  Physical DPI: %3,%4")
       .arg(dpiX)
       .arg(dpiY)
       .arg(this->physicalDpiX())
-      .arg(this->physicalDpiY()));
+      .arg(this->physicalDpiY());
    auto defaultToolBarIconSize = this->toolBar->iconSize();
-   Brewtarget::logD(QString("Default toolbar icon size: %1,%2")
+   qDebug() << QString("Default toolbar icon size: %1,%2")
       .arg(defaultToolBarIconSize.width())
-      .arg(defaultToolBarIconSize.height()));
+      .arg(defaultToolBarIconSize.height());
    this->toolBar->setIconSize(QSize(dpiX/4,dpiY/4));
 
    //
@@ -239,9 +239,9 @@ void MainWindow::setSizesInPixelsBasedOnDpi()
    // size as the toolbar ones.
    //
    auto defaultTabIconSize = this->tabWidget_Trees->iconSize();
-   Brewtarget::logD(QString("Default tab icon size: %1,%2")
+   qDebug() << QString("Default tab icon size: %1,%2")
       .arg(defaultTabIconSize.width())
-      .arg(defaultTabIconSize.height()));
+      .arg(defaultTabIconSize.height());
    this->tabWidget_Trees->setIconSize(QSize(dpiX/4,dpiY/4));
 
    //
@@ -254,11 +254,11 @@ void MainWindow::setSizesInPixelsBasedOnDpi()
    //
    // This is a bit more work to implement because its a PNG image in a QLabel object
    //
-   Brewtarget::logD(QString("Logo default size: %1,%2").arg(this->label_Brewtarget->width()).arg(this->label_Brewtarget->height()));
+   qDebug() << QString("Logo default size: %1,%2").arg(this->label_Brewtarget->width()).arg(this->label_Brewtarget->height());
    this->label_Brewtarget->setScaledContents(true);
    this->label_Brewtarget->setFixedSize((265.0/66.0) * dpiX/2,  // width = 265/66 × height = 265/66 × half an inch = (265/66) × (dpiX/2)
                                         dpiY/2);                // height = half an inch = dpiY/2
-   Brewtarget::logD(QString("Logo new size: %1,%2").arg(this->label_Brewtarget->width()).arg(this->label_Brewtarget->height()));
+   qDebug() << QString("Logo new size: %1,%2").arg(this->label_Brewtarget->width()).arg(this->label_Brewtarget->height());
 
    return;
 }
@@ -864,7 +864,7 @@ void MainWindow::treeActivated(const QModelIndex &index)
          }
          break;
       default:
-         Brewtarget::logW(QString("MainWindow::treeActivated Unknown type %1.").arg(treeView_recipe->type(index)));
+         qWarning() << QString("MainWindow::treeActivated Unknown type %1.").arg(treeView_recipe->type(index));
    }
    treeView_recipe->setCurrentIndex(index);
 }
@@ -1290,12 +1290,12 @@ void MainWindow::droppedRecipeEquipment(Equipment *kit)
 // This isn't called when we think it is...!
 void MainWindow::droppedRecipeStyle(Style* style)
 {
-   Brewtarget::logD("MainWindow::droppedRecipeStyle");
+   qDebug() << "MainWindow::droppedRecipeStyle";
 
    if ( ! recipeObs )
       return;
    // When the style is changed, we also need to update what is shown on the Style button
-   Brewtarget::logD("MainWindow::droppedRecipeStyle - do or redo");
+   qDebug() << "MainWindow::droppedRecipeStyle - do or redo";
    this->doOrRedoUpdate(
       newRelationalUndoableUpdate(*this->recipeObs,
                                   &Recipe::setStyle,
@@ -1546,7 +1546,7 @@ void MainWindow::editUndo()
 {
    Q_ASSERT(this->undoStack != 0);
    if ( !this->undoStack->canUndo() ) {
-      Brewtarget::logD("Undo called but nothing to undo");
+      qDebug() << "Undo called but nothing to undo";
    } else {
       this->undoStack->undo();
    }
@@ -1559,7 +1559,7 @@ void MainWindow::editRedo()
 {
    Q_ASSERT(this->undoStack != 0);
    if ( !this->undoStack->canRedo() ) {
-      Brewtarget::logD("Redo called but nothing to redo");
+      qDebug() << "Redo called but nothing to redo";
    } else {
       this->undoStack->redo();
    }
@@ -1704,7 +1704,7 @@ void MainWindow::removeSelectedFermentable()
 
    size = selected.size();
 
-   Brewtarget::logD(QString("MainWindow::removeSelectedFermentable() %1 items selected to remove").arg(size));
+   qDebug() << QString("MainWindow::removeSelectedFermentable() %1 items selected to remove").arg(size);
 
    if( size == 0 )
       return;
@@ -2204,7 +2204,7 @@ void MainWindow::backup()
    // NB: QDir does all the necessary magic of translating '/' to whatever current platform's directory separator is
    QString defaultBackupFileName = QDir::currentPath() + "/" + Database::getDefaultBackupFileName();
    QString backupFileName = QFileDialog::getSaveFileName(this, tr("Backup Database"), defaultBackupFileName);
-   Brewtarget::logD( QString("Database backup filename \"%1\"").arg(backupFileName) );
+   qDebug() << QString("Database backup filename \"%1\"").arg(backupFileName);
 
    // If the filename returned from the dialog is empty, it means the user clicked cancel, so we should stop trying to do the backup
    if (!backupFileName.isEmpty())
@@ -2498,7 +2498,7 @@ void MainWindow::print(std::function<void(QPrinter* printer)> functor)
 {
    if (!functor)
    {
-      Brewtarget::logE("The print function is called with an empty functor");
+      qCritical() << "The print function is called with an empty functor";
    }
 
    QPrintDialog dialogue(printer, this);
@@ -2513,8 +2513,7 @@ void MainWindow::exportHTML(std::function<void(QFile* file)> functor)
 {
    if (!functor)
    {
-      Brewtarget::logE(
-            "The export HTML function is called with an empty functor");
+      qCritical() << "The export HTML function is called with an empty functor";
    }
 
    std::unique_ptr<QFile> file{
@@ -2615,7 +2614,7 @@ QFile* MainWindow::openForWrite( QString filterStr, QString defaultSuff)
 
       if( ! outFile->open(QIODevice::WriteOnly | QIODevice::Truncate) )
       {
-         Brewtarget::logW(QString("MainWindow::openForWrite Could not open %1 for writing.").arg(filename));
+         qWarning() << QString("MainWindow::openForWrite Could not open %1 for writing.").arg(filename);
          outFile = nullptr;
       }
    }

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -618,7 +618,7 @@ double MashDesigner::getDecoctionAmount_l()
    if( prevStep == nullptr )
    {
       QMessageBox::critical(this, tr("Decoction error"), tr("The first mash step cannot be a decoction."));
-      Brewtarget::logE(QString("MashDesigner: First step not a decoction."));
+      qCritical() << "MashDesigner: First step not a decoction.";
       return 0;
    }
    tf = stepTemp_c();

--- a/src/MashStepTableModel.cpp
+++ b/src/MashStepTableModel.cpp
@@ -53,7 +53,7 @@ MashStepTableModel::MashStepTableModel(QTableView* parent)
 
 void MashStepTableModel::addMashStep(MashStep * mashStep)
 {
-   Brewtarget::logD(QString("%1").arg(Q_FUNC_INFO));
+   qDebug() << QString("%1").arg(Q_FUNC_INFO);
 
    if (mashStep == nullptr || this->steps.contains(mashStep)) {
       return;
@@ -70,7 +70,7 @@ void MashStepTableModel::addMashStep(MashStep * mashStep)
 
 bool MashStepTableModel::removeMashStep(MashStep * mashStep)
 {
-   Brewtarget::logD(QString("%1").arg(Q_FUNC_INFO));
+   qDebug() << QString("%1").arg(Q_FUNC_INFO);
 
    int i {this->steps.indexOf(mashStep)};
    if( i >= 0 )
@@ -223,7 +223,7 @@ QVariant MashStepTableModel::data( const QModelIndex& index, int role ) const
    // Ensure the row is ok.
    if( index.row() >= static_cast<int>(steps.size()) )
    {
-      Brewtarget::logW(tr("Bad model index. row = %1").arg(index.row()));
+      qWarning() << tr("Bad model index. row = %1").arg(index.row());
       return QVariant();
    }
    else
@@ -259,7 +259,7 @@ QVariant MashStepTableModel::data( const QModelIndex& index, int role ) const
          scale = displayScale(col);
          return QVariant( Brewtarget::displayAmount(row->stepTime_min(), Units::minutes,3,Unit::noUnit,scale) );
       default :
-         Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
+         qWarning() << tr("Bad column: %1").arg(index.column());
          return QVariant();
    }
 }

--- a/src/MashWizard.cpp
+++ b/src/MashWizard.cpp
@@ -144,7 +144,7 @@ double MashWizard::calcDecoctionAmount( MashStep* step, Mash* mash, double water
    if( r < 0 || r > 1 )
    {
       QMessageBox::critical(this, tr("Decoction error"), tr("Something went wrong in decoction calculation.") );
-      Brewtarget::logE(QString("%1: r=%2").arg(Q_FUNC_INFO).arg(r));
+      qCritical() << Q_FUNC_INFO << "r=" << r;
       return -1;
    }
    return r * (waterMass + grainMass/grainDensity);
@@ -182,7 +182,7 @@ void MashWizard::wizardry()
    // We ensured that there was at least one mash step when we displayed the thickness dialog in show().
    mashStep = steps.at(0);
    if ( mashStep == nullptr ) {
-      Brewtarget::logE( "MashWizard::wizardry(): first mash step was null." );
+      qCritical() << "MashWizard::wizardry(): first mash step was null.";
       return;
    }
 
@@ -278,7 +278,7 @@ void MashWizard::wizardry()
          r = ((m_w*c_w + m_g*c_g + m_e*c_e)*(tf-t1)) / ((m_w*c_w + m_g*c_g)*(boilingPoint_c-tf) + (m_w*c_w + m_g*c_g)*(tf-t1));
          if( r < 0 || r > 1 ) {
             QMessageBox::critical(this, tr("Decoction error"), tr("Something went wrong in decoction calculation.") );
-            Brewtarget::logE(QString("Decoction: r=%1").arg(r));
+            qCritical().nospace() << "Decoction: r=" << r;
             return;
          }
 
@@ -347,7 +347,7 @@ void MashWizard::wizardry()
          t1 = steps[lastMashStep]->stepTemp_c() - 10.0; // You will lose about 10C from last step.
       else
       {
-         Brewtarget::logE( "MashWizard::wizardry(): Should have had at least one mash step before getting to sparging." );
+         qCritical() << "MashWizard::wizardry(): Should have had at least one mash step before getting to sparging.";
          return;
       }
       MC = recObs->grainsInMash_kg() * HeatCalculations::Cgrain_calGC

--- a/src/MiscTableModel.cpp
+++ b/src/MiscTableModel.cpp
@@ -186,7 +186,7 @@ QVariant MiscTableModel::data( const QModelIndex& index, int role ) const
    // Ensure the row is ok.
    if( index.row() >= static_cast<int>(miscObs.size() ))
    {
-      Brewtarget::logW(QString("Bad model index. row = %1").arg(index.row()));
+      qWarning() << QString("Bad model index. row = %1").arg(index.row());
       return QVariant();
    }
    else
@@ -242,7 +242,7 @@ QVariant MiscTableModel::data( const QModelIndex& index, int role ) const
          else
             return QVariant();
       default:
-         Brewtarget::logW(QString("Bad model index. column = %1").arg(index.column()));
+         qWarning() << QString("Bad model index. column = %1").arg(index.column());
    }
    return QVariant();
 }

--- a/src/OptionDialog.cpp
+++ b/src/OptionDialog.cpp
@@ -486,7 +486,7 @@ void OptionDialog::saveAndClose()
       Log::logFilePath = Brewtarget::getConfigDir();
    }
    Brewtarget::setOption("LoggingEnabled", Log::loggingEnabled);
-   Brewtarget::setOption("LoggingLevel", Log::getOptionStringFromLogType(Log::logLevel));
+   Brewtarget::setOption("LoggingLevel", Log::getTypeName(Log::logLevel));
    Brewtarget::setOption("LogFilePath", Log::logFilePath.absolutePath());
    Brewtarget::setOption("LoggingUseConfigDir", Log::logUseConfigDir);
    Log::changeDirectory();

--- a/src/OptionDialog.cpp
+++ b/src/OptionDialog.cpp
@@ -157,11 +157,11 @@ OptionDialog::OptionDialog(QWidget* parent)
    loggingLevelComboBox->addItem(tr("Warning"), QVariant(Log::LogType_WARNING));
    loggingLevelComboBox->addItem(tr("Error"), QVariant(Log::LogType_ERROR));
    loggingLevelComboBox->addItem(tr("Debug"), QVariant(Log::LogType_DEBUG));
-   checkBox_enableLogging->setChecked(Brewtarget::log.LoggingEnabled);
-   checkBox_LogFileLocationUseDefault->setChecked(Brewtarget::log.LoggingUseConfigDir);
-   lineEdit_LogFileLocation->setText(Brewtarget::log.LogFilePath.absolutePath());
-   setLoggingControlsState(Brewtarget::log.LoggingEnabled);
-   setFileLocationState(Brewtarget::log.LoggingUseConfigDir);
+   checkBox_enableLogging->setChecked(Log::loggingEnabled);
+   checkBox_LogFileLocationUseDefault->setChecked(Log::logUseConfigDir);
+   lineEdit_LogFileLocation->setText(Log::logFilePath.absolutePath());
+   setLoggingControlsState(Log::loggingEnabled);
+   setFileLocationState(Log::logUseConfigDir);
 
    // database panel stuff
    comboBox_engine->addItem( tr("SQLite (default)"), QVariant(Brewtarget::SQLITE));
@@ -477,19 +477,19 @@ void OptionDialog::saveAndClose()
    Brewtarget::setOption("firstWortHopAdjustment", ibuAdjustmentFirstWortDoubleSpinBox->value() / 100);
 
    // Saving Logging Options to the Log object
-   Brewtarget::log.LoggingEnabled = checkBox_enableLogging->isChecked();
-   Brewtarget::log.LoggingLevel = static_cast<Log::LogType>(loggingLevelComboBox->currentData().toInt());
-   Brewtarget::log.LogFilePath = QDir(lineEdit_LogFileLocation->text());
-   Brewtarget::log.LoggingUseConfigDir = checkBox_LogFileLocationUseDefault->isChecked();
-   if ( Brewtarget::log.LoggingUseConfigDir )
+   Log::loggingEnabled = checkBox_enableLogging->isChecked();
+   Log::logLevel = static_cast<Log::LogType>(loggingLevelComboBox->currentData().toInt());
+   Log::logFilePath = QDir(lineEdit_LogFileLocation->text());
+   Log::logUseConfigDir = checkBox_LogFileLocationUseDefault->isChecked();
+   if ( Log::logUseConfigDir )
    {
-      Brewtarget::log.LogFilePath = Brewtarget::getConfigDir();
+      Log::logFilePath = Brewtarget::getConfigDir();
    }
-   Brewtarget::setOption("LoggingEnabled", Brewtarget::log.LoggingEnabled);
-   Brewtarget::setOption("LoggingLevel", Brewtarget::log.getOptionStringFromLogType(Brewtarget::log.LoggingLevel));
-   Brewtarget::setOption("LogFilePath", Brewtarget::log.LogFilePath.absolutePath());
-   Brewtarget::setOption("LoggingUseConfigDir", Brewtarget::log.LoggingUseConfigDir);
-   Brewtarget::log.changeDirectory();
+   Brewtarget::setOption("LoggingEnabled", Log::loggingEnabled);
+   Brewtarget::setOption("LoggingLevel", Log::getOptionStringFromLogType(Log::logLevel));
+   Brewtarget::setOption("LogFilePath", Log::logFilePath.absolutePath());
+   Brewtarget::setOption("LoggingUseConfigDir", Log::logUseConfigDir);
+   Log::changeDirectory();
    // Make sure the main window updates.
    if( Brewtarget::mainWindow() )
       Brewtarget::mainWindow()->showChanges();

--- a/src/OptionDialog.cpp
+++ b/src/OptionDialog.cpp
@@ -318,7 +318,7 @@ void OptionDialog::saveAndClose()
          QMessageBox::information(this, tr("Restart"), tr("Please restart brewtarget to connect to the new database"));
       }
       catch (QString e) {
-         Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+         qCritical() << Q_FUNC_INFO << e;
          saveDbConfig = false;
       }
    }

--- a/src/SaltTableModel.cpp
+++ b/src/SaltTableModel.cpp
@@ -412,7 +412,7 @@ QVariant SaltTableModel::data( const QModelIndex& index, int role ) const
 
    // Ensure the row is ok.
    if( index.row() >= static_cast<int>(saltObs.size()) ) {
-      Brewtarget::logW(tr("Bad model index. row = %1").arg(index.row()));
+      qWarning() << tr("Bad model index. row = %1").arg(index.row());
       return QVariant();
    }
    else
@@ -446,7 +446,7 @@ QVariant SaltTableModel::data( const QModelIndex& index, int role ) const
          }
          return QVariant();
       default :
-         Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
+         qWarning() << tr("Bad column: %1").arg(index.column());
          return QVariant();
    }
 }
@@ -464,7 +464,7 @@ QVariant SaltTableModel::headerData( int section, Qt::Orientation orientation, i
          case SALTPCTACIDCOL:
                return  QVariant(tr("% Acid"));
          default:
-            Brewtarget::logW(tr("Bad column: %1").arg(section));
+            qWarning() << tr("Bad column: %1").arg(section);
             return QVariant();
       }
    }
@@ -539,7 +539,7 @@ bool SaltTableModel::setData( const QModelIndex& index, const QVariant& value, i
          break;
       default:
          retval = false;
-         Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
+         qWarning() << tr("Bad column: %1").arg(index.column());
    }
 
    if ( retval && row->addTo() != Salt::NEVER )

--- a/src/SimpleUndoableUpdate.cpp
+++ b/src/SimpleUndoableUpdate.cpp
@@ -68,7 +68,7 @@ bool SimpleUndoableUpdate::undoOrRedo(bool const isUndo)
    bool success = this->metaProperty.write(&updatee, isUndo ? this->oldValue : this->newValue);
    if (!success)
    {
-      Brewtarget::logE(QString("Could not %1 update of %2 property %3").arg(isUndo ? "undo" : "redo").arg(this->updatee.metaObject()->className()).arg(propertyName));
+      qCritical() << QString("Could not %1 update of %2 property %3").arg(isUndo ? "undo" : "redo").arg(this->updatee.metaObject()->className()).arg(propertyName);
    }
    return success;
 }

--- a/src/Testing.cpp
+++ b/src/Testing.cpp
@@ -279,8 +279,7 @@ void Testing::testLogRotation()
 void Testing::cleanupTestCase()
 {
    Brewtarget::cleanup();
-
-   Log::mutex.lock();
+   QMutexLocker locker(&Log::mutex);
    //Clean up the jibberich logs from disk by removing the
    QFileInfoList fileList = Log::getLogFileList();
    for (int i = 0; i < fileList.size(); i++)
@@ -288,7 +287,6 @@ void Testing::cleanupTestCase()
       QFile(QString(fileList.at(i).canonicalFilePath())).remove();
    }
    Log::logFilePath.rmdir(Log::logFilePath.canonicalPath());
-   Log::mutex.unlock();
 
    // Clear all persistent properties linked with this test suite.
    // It will clear all settings that are application specific, user-scoped, and in the brewtarget namespace.

--- a/src/Testing.cpp
+++ b/src/Testing.cpp
@@ -265,14 +265,14 @@ void Testing::testLogRotation()
    }
 
    QFileInfoList fileList = Log::getLogFileList();
-   //There is always a "LOG_FILE_COUNT" number of old files + 1 current file
-   QCOMPARE(fileList.size(), LOG_FILE_COUNT + 1);
+   //There is always a "logFileCount" number of old files + 1 current file
+   QCOMPARE(fileList.size(), Log::logFileCount + 1);
 
    for (int i = 0; i < fileList.size(); i++)
    {
       QFile f(QString(fileList.at(i).canonicalFilePath()));
-      //Here we test if the file is more than 10% bigger than the specified LOG_FILE_SIZE", if so, fail.
-      QVERIFY2(f.size() <= (LOG_FILE_SIZE * 1.1), "Wrong Sized file");
+      //Here we test if the file is more than 10% bigger than the specified logFileSize", if so, fail.
+      QVERIFY2(f.size() <= (Log::logFileSize * 1.1), "Wrong Sized file");
    }
 }
 

--- a/src/Testing.cpp
+++ b/src/Testing.cpp
@@ -94,6 +94,7 @@ void Testing::initTestCase()
    Log::loggingEnabled = true;
    //turning off logging to stderr console, this is so you won't have to watch 100k rows generate in the console.
    Log::isLoggingToStderr = false;
+   Log::logLevel = Log::LogType_DEBUG;
    qDebug() << "logging initialized";
 }
 

--- a/src/Testing.cpp
+++ b/src/Testing.cpp
@@ -257,7 +257,7 @@ void Testing::testLogRotation()
 
    //generate 40 000 log rows giving roughly 10 files with dummy/random logs
    // This should have to log rotate a few times leaving 5 log files in the directory which we can test for size and number of files.
-   for (int i=0; i < 10000; i++)
+   for (int i=0; i < 8000; i++)
    {
       qDebug() << QString("iteration %1-1; (%2)").arg(i).arg(randomStringGenerator());
       qWarning() << QString("iteration %1-2; (%2)").arg(i).arg(randomStringGenerator());
@@ -281,6 +281,8 @@ void Testing::cleanupTestCase()
 {
    Brewtarget::cleanup();
    QMutexLocker locker(&Log::mutex);
+   //Close the log file to avoind leaving hanging connections when removing all the files.
+   Log::closeLogFile();
    //Clean up the jibberich logs from disk by removing the
    QFileInfoList fileList = Log::getLogFileList();
    for (int i = 0; i < fileList.size(); i++)

--- a/src/Testing.h
+++ b/src/Testing.h
@@ -1,4 +1,4 @@
-b/*
+/*
  * Testing.h is part of Brewtarget, and is Copyright the following
  * authors 2009-2020
  * - Philip G. Lee <rocketman768@gmail.com>

--- a/src/Testing.h
+++ b/src/Testing.h
@@ -27,6 +27,7 @@
 #include <QString>
 #include <QDir>
 #include <QDebug>
+#include <QMutexLocker>
 
 class Equipment;
 class Hop;

--- a/src/Testing.h
+++ b/src/Testing.h
@@ -1,7 +1,8 @@
-/*
+b/*
  * Testing.h is part of Brewtarget, and is Copyright the following
- * authors 2009-2015
+ * authors 2009-2020
  * - Philip G. Lee <rocketman768@gmail.com>
+ * - Mattias Måhl <mattias@kejsarsten.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,6 +34,7 @@ class Fermentable;
 
 #include "brewtarget.h"
 #include "pstdint.h"
+#include "Log.h"
 
 class Testing : public QObject
 {
@@ -53,6 +55,22 @@ public:
       if( !ret )
          qDebug() << QString("a: %1, b: %2, tol: %3").arg(a).arg(b).arg(tol);
       return ret;
+   }
+
+   // method to fill dummy logs with content to build size
+   static QString randomStringGenerator()
+   {
+      QString posChars = "ABCDEFGHIJKLMNOPQRSTUVWXYabcdefghijklmnopqrstuvwwxyz";
+      int randomcharLength = 64;
+
+      QString randSTR;
+      for (int i = 0; i < randomcharLength; i++)
+      {
+         int index = QRandomGenerator().generate64() % posChars.length();
+         QChar nChar = posChars.at(index);
+         randSTR.append(nChar);
+      }
+      return randSTR;
    }
 
 private:
@@ -103,6 +121,9 @@ private slots:
 
    //! \brief Verify post-boil losses do not affect OG
    void postBoilLossOgTest();
+
+   //! \brief Verify Log rotation is working
+   void testLogRotation();
 };
 
 #endif /*TESTING_H*/

--- a/src/TimerWidget.cpp
+++ b/src/TimerWidget.cpp
@@ -202,9 +202,9 @@ void TimerWidget::setSound(QString s)
     //Taken from old brewtarget timers
 #ifndef NO_QTMULTIMEDIA
    if( !playlist->clear() )
-      Brewtarget::logW(playlist->errorString());
+      qWarning() << playlist->errorString();
    if( !playlist->addMedia(QUrl::fromLocalFile(s)) )
-      Brewtarget::logW(playlist->errorString());
+      qWarning() << playlist->errorString();
    playlist->setCurrentIndex(0);
 #endif
 }

--- a/src/UndoableAddOrRemove.h
+++ b/src/UndoableAddOrRemove.h
@@ -123,11 +123,11 @@ private:
       // will cause it to be stored in the DB with a new ID.
       //
       if (!isUndo) {
-         Brewtarget::logD(QString("%1: %2 \"%3\" for #%4").arg(Q_FUNC_INFO).arg(this->everDone ? "Redo" : "Do" ).arg(this->text()).arg(this->whatToAddOrRemove->key()));
+         qDebug() << QString("%1: %2 \"%3\" for #%4").arg(Q_FUNC_INFO).arg(this->everDone ? "Redo" : "Do" ).arg(this->text()).arg(this->whatToAddOrRemove->key());
 
          this->whatToAddOrRemove = (this->updatee.*(this->doer))(this->whatToAddOrRemove);
 
-         Brewtarget::logD(QString("%1: %2 Returned #%3").arg(Q_FUNC_INFO).arg(this->everDone ? "Redo" : "Do" ).arg(this->whatToAddOrRemove->key()));
+         qDebug() << QString("%1: %2 Returned #%3").arg(Q_FUNC_INFO).arg(this->everDone ? "Redo" : "Do" ).arg(this->whatToAddOrRemove->key());
          if (this->doCallback != nullptr) {
             (Brewtarget::mainWindow()->*(this->doCallback))(this->whatToAddOrRemove);
          }
@@ -136,11 +136,11 @@ private:
          // be able to distinguish the two cases.
          this->everDone = true;
       } else {
-         Brewtarget::logD(QString("%1: Undo \"%2\" for #%3").arg(Q_FUNC_INFO).arg(this->text()).arg(this->whatToAddOrRemove->key()));
+         qDebug() << QString("%1: Undo \"%2\" for #%3").arg(Q_FUNC_INFO).arg(this->text()).arg(this->whatToAddOrRemove->key());
 
          this->whatToAddOrRemove = (this->updatee.*(this->undoer))(this->whatToAddOrRemove);
 
-         Brewtarget::logD(QString("%1: Undo Returned #%2").arg(Q_FUNC_INFO).arg(this->whatToAddOrRemove->key()));
+         qDebug() << QString("%1: Undo Returned #%2").arg(Q_FUNC_INFO).arg(this->whatToAddOrRemove->key());
          if (this->undoCallback != nullptr) {
             (Brewtarget::mainWindow()->*(this->undoCallback))(this->whatToAddOrRemove);
          }

--- a/src/WaterDialog.cpp
+++ b/src/WaterDialog.cpp
@@ -181,7 +181,7 @@ void WaterDialog::setRecipe(Recipe *rec)
    m_salt_delegate->observeRecipe(m_rec);
 
    if ( mash == nullptr || mash->mashSteps().size() == 0 ) {
-      Brewtarget::logW(QString("Can not set water chemistry without a mash"));
+      qWarning() << QString("Can not set water chemistry without a mash");
       return;
    }
 
@@ -280,7 +280,7 @@ void WaterDialog::newTotals()
    double allTheWaters = mash->totalMashWater_l();
 
    if ( qFuzzyCompare(allTheWaters,0.0) ) {
-      Brewtarget::logW(QString("Can not set strike water chemistry without a mash"));
+      qWarning() << QString("Can not set strike water chemistry without a mash");
       return;
    }
    // Two major things need to happen here:

--- a/src/WaterTableModel.cpp
+++ b/src/WaterTableModel.cpp
@@ -199,7 +199,7 @@ QVariant WaterTableModel::data( const QModelIndex& index, int role ) const
    // Ensure the row is ok.
    if( index.row() >= waterObs.size() )
    {
-      Brewtarget::logW(tr("Bad model index. row = %1").arg(index.row()));
+      qWarning() << tr("Bad model index. row = %1").arg(index.row());
       return QVariant();
    }
    else
@@ -228,7 +228,7 @@ QVariant WaterTableModel::data( const QModelIndex& index, int role ) const
       case WATERMAGNESIUMCOL:
          return QVariant( Brewtarget::displayAmount(row->magnesium_ppm(), nullptr) );
       default :
-         Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
+         qWarning() << tr("Bad column: %1").arg(index.column());
          return QVariant();
    }
 }
@@ -256,7 +256,7 @@ QVariant WaterTableModel::headerData( int section, Qt::Orientation orientation, 
          case WATERMAGNESIUMCOL:
             return QVariant(tr("Magnesium (ppm)"));
          default:
-            Brewtarget::logW(tr("Bad column: %1").arg(section));
+            qWarning() << tr("Bad column: %1").arg(section);
             return QVariant();
       }
    }
@@ -322,7 +322,7 @@ bool WaterTableModel::setData( const QModelIndex& index, const QVariant& value, 
          break;
       default:
          retval = false;
-         Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
+         qWarning() << tr("Bad column: %1").arg(index.column());
    }
 
    return retval;

--- a/src/YeastTableModel.cpp
+++ b/src/YeastTableModel.cpp
@@ -238,7 +238,7 @@ QVariant YeastTableModel::data( const QModelIndex& index, int role ) const
    // Ensure the row is ok.
    if( index.row() >= static_cast<int>(yeastObs.size() ))
    {
-      Brewtarget::logW(tr("Bad model index. row = %1").arg(index.row()));
+      qWarning() << tr("Bad model index. row = %1").arg(index.row());
       return QVariant();
    }
    else
@@ -295,7 +295,7 @@ QVariant YeastTableModel::data( const QModelIndex& index, int role ) const
                         );
 
       default :
-         Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
+         qWarning() << tr("Bad column: %1").arg(index.column());
          return QVariant();
    }
 }
@@ -321,7 +321,7 @@ QVariant YeastTableModel::headerData( int section, Qt::Orientation orientation, 
          case YEASTPRODIDCOL:
              return QVariant(tr("Product ID"));
          default:
-            Brewtarget::logW(tr("Bad column: %1").arg(section));
+            qWarning() << tr("Bad column: %1").arg(section);
             return QVariant();
       }
    }
@@ -420,7 +420,7 @@ bool YeastTableModel::setData( const QModelIndex& index, const QVariant& value, 
          break;
 
       default:
-         Brewtarget::logW(tr("Bad column: %1").arg(index.column()));
+         qWarning() << tr("Bad column: %1").arg(index.column());
          return false;
    }
    return true;

--- a/src/beerxml.cpp
+++ b/src/beerxml.cpp
@@ -490,7 +490,7 @@ void BeerXML::fromXml(Ingredient* element, QHash<QString,QString> const& xmlTags
    {
       if( ! node.isElement() )
       {
-         Brewtarget::logW( QString("Node at line %1 is not an element.").arg(textNode.lineNumber()) );
+         qWarning() << QString("Node at line %1 is not an element.").arg(textNode.lineNumber());
          continue;
       }
 
@@ -533,11 +533,11 @@ void BeerXML::fromXml(Ingredient* element, QHash<QString,QString> const& xmlTags
                element->setProperty(xmlTagsToProperties[xmlTag].toStdString().c_str(), stringVal);
                break;
             default:
-               Brewtarget::logW(QString("%1: don't understand property type.").arg(Q_FUNC_INFO));
+               qWarning() << QString("%1: don't understand property type.").arg(Q_FUNC_INFO);
          }
          // Not sure if we should keep processing or just dump?
          if ( ! element->isValid() ) {
-            Brewtarget::logE( QString("%1 could not populate %2 from XML").arg(Q_FUNC_INFO).arg(xmlTag));
+            qCritical() << QString("%1 could not populate %2 from XML").arg(Q_FUNC_INFO).arg(xmlTag);
             return;
          }
       }
@@ -562,7 +562,7 @@ void BeerXML::fromXml(Ingredient* element, QDomNode const& elementNode)
    {
       if( ! node.isElement() )
       {
-         Brewtarget::logW( QString("Node at line %1 is not an element.").arg(textNode.lineNumber()) );
+         qWarning() << QString("Node at line %1 is not an element.").arg(textNode.lineNumber());
          continue;
       }
 
@@ -605,14 +605,14 @@ void BeerXML::fromXml(Ingredient* element, QDomNode const& elementNode)
                element->setProperty(pTag.toStdString().c_str(), stringVal);
                break;
             default:
-               Brewtarget::logW(QString("%1: don't understand property type. xmlTag=%2")
+               qWarning() << QString("%1: don't understand property type. xmlTag=%2")
                      .arg(Q_FUNC_INFO)
-                     .arg(xmlTag));
+                     .arg(xmlTag);
                break;
          }
          // Not sure if we should keep processing or just dump?
          if ( ! element->isValid() ) {
-            Brewtarget::logE( QString("%1 could not populate %2 from XML").arg(Q_FUNC_INFO).arg(xmlTag));
+            qCritical() << QString("%1 could not populate %2 from XML").arg(Q_FUNC_INFO).arg(xmlTag);
             return;
          }
       }
@@ -636,7 +636,7 @@ BrewNote* BeerXML::brewNoteFromXml( QDomNode const& node, Recipe* parent )
 
       if ( ! ret ) {
          QString error = "Could not create new brewnote.";
-         Brewtarget::logE(QString(error));
+         qCritical() << QString(error);
          QMessageBox::critical(nullptr, tr("Import error."),
                error.append("\nUnable to create brew note."));
          return ret;
@@ -650,7 +650,7 @@ BrewNote* BeerXML::brewNoteFromXml( QDomNode const& node, Recipe* parent )
       ret->insertInDatabase();
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
    }
    return ret;
 }
@@ -708,7 +708,7 @@ Equipment* BeerXML::equipmentFromXml( QDomNode const& node, Recipe* parent )
       }
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       blockSignals(false);
       throw;
    }
@@ -778,7 +778,7 @@ Fermentable* BeerXML::fermentableFromXml( QDomNode const& node, Recipe* parent )
          }
 
          if ( ! ret->isValid() ) {
-            Brewtarget::logW( QString("BeerXML::fermentableFromXml: Could convert a recognized type") );
+            qWarning() << QString("BeerXML::fermentableFromXml: Could convert a recognized type");
          }
          ret->insertInDatabase();
 
@@ -793,7 +793,7 @@ Fermentable* BeerXML::fermentableFromXml( QDomNode const& node, Recipe* parent )
       if ( parent == nullptr ) {
          db.sqlDatabase().rollback();
       }
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical () << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
    }
 
    if ( parent == nullptr ) {
@@ -962,7 +962,7 @@ Hop* BeerXML::hopFromXml( QDomNode const& node, Recipe* parent )
          }
 
          if ( ! ret->isValid() ) {
-            Brewtarget::logW(QString("BeerXML::hopFromXml: Could convert %1 to a recognized type"));
+            qWarning() << QString("BeerXML::hopFromXml: Could convert %1 to a recognized type");
          }
          ret->insertInDatabase();
       }
@@ -971,7 +971,7 @@ Hop* BeerXML::hopFromXml( QDomNode const& node, Recipe* parent )
          db.addToRecipe( parent, ret, true );
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e) );
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       blockSignals(false);
       if ( ! parent )
          db.sqlDatabase().rollback();
@@ -1016,7 +1016,7 @@ Instruction* BeerXML::instructionFromXml( QDomNode const& node, Recipe* parent )
 
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e) );
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       blockSignals(false);
       throw;
    }
@@ -1070,7 +1070,7 @@ Mash* BeerXML::mashFromXml( QDomNode const& node, Recipe* parent )
             MashStep* temp = mashStepFromXml( n, ret );
             if ( ! temp->isValid() ) {
                QString error = QString("Error importing mash step %1. Importing as infusion").arg(temp->name());
-               Brewtarget::logE(error);
+               qCritical() << error;
             }
          }
       }
@@ -1081,7 +1081,7 @@ Mash* BeerXML::mashFromXml( QDomNode const& node, Recipe* parent )
 
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       blockSignals(false);
       db.sqlDatabase().rollback();
       abort();
@@ -1140,7 +1140,7 @@ MashStep* BeerXML::mashStepFromXml( QDomNode const& node, Mash* parent )
       return ret;
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << Q_FUNC_INFO << e;
       abort();
    }
 
@@ -1272,7 +1272,7 @@ Misc* BeerXML::miscFromXml( QDomNode const& node, Recipe* parent )
          }
 
          if ( ! ret->isValid() ) {
-            Brewtarget::logW(QString("BeerXML::miscFromXml: Could convert %1 to a recognized type"));
+            qWarning() << QString("BeerXML::miscFromXml: Could convert %1 to a recognized type");
          }
          ret->insertInDatabase();
       }
@@ -1281,7 +1281,7 @@ Misc* BeerXML::miscFromXml( QDomNode const& node, Recipe* parent )
          db.addToRecipe( parent, ret, true );
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( ! parent )
          db.sqlDatabase().rollback();
       blockSignals(false);
@@ -1409,7 +1409,7 @@ Recipe* BeerXML::recipeFromXml( QDomNode const& node )
       blockSignals(false);
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       db.sqlDatabase().rollback();
       blockSignals(false);
       abort();
@@ -1474,7 +1474,7 @@ Style* BeerXML::styleFromXml( QDomNode const& node, Recipe* parent )
 
          // If translating the enums craps out, give a warning
          if (! ret->isValid() ) {
-            Brewtarget::logW(QString("BeerXML::styleFromXml: Could convert %1 to a recognized type"));
+            qWarning() << QString("BeerXML::styleFromXml: Could convert %1 to a recognized type");
          }
          // we need to poke this into the database
          ret->insertInDatabase();
@@ -1484,7 +1484,7 @@ Style* BeerXML::styleFromXml( QDomNode const& node, Recipe* parent )
       }
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( ! parent )
          db.sqlDatabase().rollback();
       blockSignals(false);
@@ -1539,7 +1539,7 @@ Water* BeerXML::waterFromXml( QDomNode const& node, Recipe* parent )
       }
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << Q_FUNC_INFO << e;
       if ( parent == nullptr )
          db.sqlDatabase().rollback();
       blockSignals(false);
@@ -1594,9 +1594,7 @@ Yeast* BeerXML::yeastFromXml( QDomNode const& node, Recipe* parent )
          // Handle type enums separately.
          n = node.firstChildElement("TYPE");
          if ( n.firstChild().isNull() ) {
-            Brewtarget::logE(
-                  QString("Could not find TYPE in %1.  Please select an appropriate value once the yeast is imported").arg(name)
-                  );
+            qCritical() << QString("Could not find TYPE in %1.  Please select an appropriate value once the yeast is imported").arg(name);
          }
          else {
             QString tname = n.firstChild().toText().nodeValue();
@@ -1606,18 +1604,16 @@ Yeast* BeerXML::yeastFromXml( QDomNode const& node, Recipe* parent )
             }
             else {
                ret->setType(static_cast<Yeast::Type>(0));
-               Brewtarget::logE(
+               qCritical() <<
                      QString("Could not translate the type %1 in %2.  Please select an appropriate value once the yeast is imported")
                      .arg(tname)
-                     .arg(name));
+                     .arg(name);
             }
          }
          // Handle form enums separately.
          n = node.firstChildElement("FORM");
          if ( n.firstChild().isNull() ) {
-            Brewtarget::logE(
-                  QString("Could not find FORM in %1.  Please select an appropriate value once the yeast is imported").arg(name)
-                  );
+            qCritical() << QString("Could not find FORM in %1.  Please select an appropriate value once the yeast is imported").arg(name);
          }
          else {
             QString tname = n.firstChild().toText().nodeValue();
@@ -1627,18 +1623,16 @@ Yeast* BeerXML::yeastFromXml( QDomNode const& node, Recipe* parent )
             }
             else {
                ret->setForm( static_cast<Yeast::Form>(0) );
-               Brewtarget::logE(
+               qCritical() <<
                      QString("Could not translate the form %1 in %2.  Please select an appropriate value once the yeast is imported")
                      .arg(tname)
-                     .arg(name));
+                     .arg(name);
             }
          }
          // Handle flocc enums separately.
          n = node.firstChildElement("FLOCCULATION");
          if ( n.firstChild().isNull() ) {
-            Brewtarget::logE(
-                  QString("Could not find FLOCCULATION in %1.  Please select an appropriate value once the yeast is imported").arg(name)
-                  );
+            qCritical() << QString("Could not find FLOCCULATION in %1.  Please select an appropriate value once the yeast is imported").arg(name);
          }
          else {
             QString tname = n.firstChild().toText().nodeValue();
@@ -1648,10 +1642,10 @@ Yeast* BeerXML::yeastFromXml( QDomNode const& node, Recipe* parent )
             }
             else {
                ret->setFlocculation( static_cast<Yeast::Flocculation>(0) );
-               Brewtarget::logE(
+               qCritical() <<
                      QString("Could not translate the flocculation %1 in %2.  Please select an appropriate value once the yeast is imported")
                      .arg(tname)
-                     .arg(name));
+                     .arg(name);
             }
          }
 
@@ -1667,7 +1661,7 @@ Yeast* BeerXML::yeastFromXml( QDomNode const& node, Recipe* parent )
       }
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << Q_FUNC_INFO<< e;
       if ( ! parent )
          db.sqlDatabase().rollback();
       blockSignals(false);

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -171,7 +171,7 @@ bool Brewtarget::createDir(QDir dir, QString errText)
   {
     // Write a message to the log, the usablity check below will alert the user
     QString errText(QObject::tr("Error attempting to create directory \"%1\""));
-    logE(errText.arg(dir.path()));
+    qCritical() << errText.arg(dir.path());
   }
 
   // It's possible that the path exists, but is useless to us
@@ -182,7 +182,7 @@ bool Brewtarget::createDir(QDir dir, QString errText)
     if( errText == nullptr)
       errText = QString(QObject::tr("\"%1\" cannot be read."));
 
-    logW(errText.arg(dir.path()));
+    qWarning() << errText.arg(dir.path());
 
     if (Brewtarget::isInteractive()) {
        QMessageBox::information(
@@ -209,7 +209,7 @@ bool Brewtarget::ensureDirectoriesExist()
   {
     dataDirSuccess = false;
     QString errMsg = QString(QObject::tr("Data directory \"%1\" is missing.  Some features will be unavaliable.")).arg(dataDir.path());
-    logE(errMsg);
+    qCritical() << errMsg;
 
     if (Brewtarget::isInteractive()) {
        QMessageBox::critical(
@@ -396,12 +396,12 @@ const QDir Brewtarget::getConfigDir()
    char* xdg_config_home = getenv("XDG_CONFIG_HOME");
 
    if (xdg_config_home) {
-     logI(QString("XDG_CONFIG_HOME directory is %1").arg(xdg_config_home));
+     qInfo() << QString("XDG_CONFIG_HOME directory is %1").arg(xdg_config_home);
      dir.setPath(QString(xdg_config_home).append("/brewtarget"));
    }
    else {
      // If XDG_CONFIG_HOME doesn't exist, config goes in ~/.config/brewtarget
-     logI(QString("XDG_CONFIG_HOME not set.  HOME directory is %1").arg(QDir::homePath()));
+      qInfo() << QString("XDG_CONFIG_HOME not set.  HOME directory is %1").arg(QDir::homePath());
      QString dirPath = QDir::homePath().append("/.config/brewtarget");
      dir = QDir(dirPath);
    }
@@ -437,11 +437,11 @@ QDir Brewtarget::getDefaultUserDataDir()
 #elif defined(Q_OS_WIN) // Windows OS.
    // On Windows the Programs directory is normally not writable so we need to get the appData path from the environment instead.
    userDataDir.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
-   logD(QString("userDataDir=%1").arg(userDataDir.path()));
+   qDebug() << QString("userDataDir=%1").arg(userDataDir.path());
    if (!userDataDir.exists()) {
-      logD(QString("User data dir \"%1\" does not exist, trying to create").arg(userDataDir.path()));
+      qDebug() << QString("User data dir \"%1\" does not exist, trying to create").arg(userDataDir.path());
       createDir(userDataDir);
-      logD("UserDatadit Created");
+      qDebug() << "UserDatadit Created";
    }
    return userDataDir;
 #else
@@ -480,7 +480,7 @@ bool Brewtarget::initialize(const QString &userDirectory)
    }
    // Guess where to put it.
    else {
-      logW(QString("User data directory not specified or doesn't exist - using default."));
+      qWarning() << QString("User data directory not specified or doesn't exist - using default.");
       userDataDir = getDefaultUserDataDir();
    }
 
@@ -512,7 +512,7 @@ bool Brewtarget::initialize(const QString &userDirectory)
 
    // Check if the database was successfully loaded before
    // loading the main window.
-   logD("Loading Database...");
+   qDebug() << "Loading Database...";
    if (Database::instance().loadSuccessful())
    {
       if ( ! QSettings().contains("converted") )
@@ -660,13 +660,13 @@ void Brewtarget::convertPersistentOptions()
    if( ! xmlFile.open(QIODevice::ReadOnly) )
    {
       // Now we know we can't open it.
-      logW(QString("Could not open %1 for reading.").arg(xmlFile.fileName()));
+      qWarning() << QString("Could not open %1 for reading.").arg(xmlFile.fileName());
       // Try changing the permissions
       return;
    }
 
    if( ! optionsDoc->setContent(&xmlFile, false, &err, &line, &col) )
-      logW(QString("Bad document formatting in %1 %2:%3").arg(xmlFile.fileName()).arg(line).arg(col));
+      qWarning() << QString("Bad document formatting in %1 %2:%3").arg(xmlFile.fileName()).arg(line).arg(col);
 
    root = optionsDoc->documentElement();
 
@@ -761,7 +761,7 @@ void Brewtarget::convertPersistentOptions()
          ibuFormula = NOONAN;
       else
       {
-         Brewtarget::logE(QString("Bad ibu_formula type: %1").arg(text));
+         qCritical() << QString("Bad ibu_formula type: %1").arg(text);
       }
    }
 
@@ -777,7 +777,7 @@ void Brewtarget::convertPersistentOptions()
          colorFormula = MOSHER;
       else
       {
-         Brewtarget::logE(QString("Bad color_formula type: %1").arg(text));
+         qCritical() << QString("Bad color_formula type: %1").arg(text);
       }
    }
 
@@ -797,7 +797,7 @@ void Brewtarget::convertPersistentOptions()
       }
       else
       {
-         logW(QString("Bad use_plato type: %1").arg(text));
+         qWarning() << QString("Bad use_plato type: %1").arg(text);
       }
    }
 
@@ -816,7 +816,7 @@ void Brewtarget::convertPersistentOptions()
          thingToUnitSystem.insert(Unit::Color,UnitSystems::ebcColorUnitSystem());
       }
       else
-         logW(QString("Bad color_unit type: %1").arg(text));
+         qWarning() << QString("Bad color_unit type: %1").arg(text);
    }
 
    //=======================Diastatic power unit===================
@@ -835,7 +835,7 @@ void Brewtarget::convertPersistentOptions()
       }
       else
       {
-         logW(QString("Bad diastatic_power_unit type: %1").arg(text));
+         qWarning() << QString("Bad diastatic_power_unit type: %1").arg(text);
       }
    }
 
@@ -868,7 +868,7 @@ QString Brewtarget::getOptionValue(const QDomDocument& optionsDoc, const QString
 
    list = optionsDoc.elementsByTagName(option);
    if(list.length() <= 0) {
-      logW(QString("Could not find the <%1> tag in the option file.").arg(option));
+      qWarning() << QString("Could not find the <%1> tag in the option file.").arg(option);
       if( hasOption != nullptr )
          *hasOption = false;
       return "";
@@ -983,7 +983,7 @@ void Brewtarget::readSystemOptions()
        ibuFormula = NOONAN;
    else
    {
-      Brewtarget::logE(QString("Bad ibu_formula type: %1").arg(text));
+      qCritical() << QString("Bad ibu_formula type: %1").arg(text);
    }
 
    //========================Color Formula======================
@@ -996,7 +996,7 @@ void Brewtarget::readSystemOptions()
       colorFormula = MOSHER;
    else
    {
-      Brewtarget::logE(QString("Bad color_formula type: %1").arg(text));
+      qCritical() << QString("Bad color_formula type: %1").arg(text);
    }
 
    //========================Density==================
@@ -1025,7 +1025,7 @@ void Brewtarget::readSystemOptions()
       thingToUnitSystem.insert(Unit::Color,UnitSystems::ebcColorUnitSystem());
    }
    else
-      logW(QString("Bad color_unit type: %1").arg(text));
+      qWarning() << QString("Bad color_unit type: %1").arg(text);
 
    //=======================Diastatic power unit===================
    text = option("diastatic_power_unit", "Lintner").toString();
@@ -1041,7 +1041,7 @@ void Brewtarget::readSystemOptions()
    }
    else
    {
-      logW(QString("Bad diastatic_power_unit type: %1").arg(text));
+      qWarning() << QString("Bad diastatic_power_unit type: %1").arg(text);
    }
 
    //=======================Date format===================
@@ -1162,30 +1162,6 @@ void Brewtarget::loadMap()
    thingToUnitSystem.insert(Unit::DiastaticPower | Unit::displayWK,UnitSystems::wkDiastaticPowerUnitSystem() );
 }
 
-void Brewtarget::logE( QString message )
-{
-   if ( Log::loggingEnabled && Log::logLevel <= Log::LogType_ERROR)
-      qCritical() << message;
-}
-
-void Brewtarget::logW( QString message )
-{
-   if ( Log::loggingEnabled && Log::logLevel <= Log::LogType_WARNING)
-      qWarning() << message;
-}
-
-void Brewtarget::logI( QString message )
-{
-   if ( Log::loggingEnabled && Log::logLevel <= Log::LogType_INFO)
-      qInfo() << message;
-}
-
-void Brewtarget::logD( QString message )
-{
-   if ( Log::loggingEnabled && Log::logLevel <= Log::LogType_DEBUG)
-      qDebug() << message;
-}
-
 /* Qt5 changed how QString::toDouble() works in that it will always convert
    in the C locale. We are instructed to use QLocale::toDouble instead, except
    that will never fall back to the C locale. This doesn't really work for us,
@@ -1223,8 +1199,8 @@ double Brewtarget::toDouble(const Ingredient* element, QString attribute, QStrin
       // Get the amount
       value = element->property(attribute.toLatin1().constData()).toString();
       amount = toDouble( value, &ok );
-      if ( ! ok )
-         logW( QString("%1 could not convert %2 to double").arg(caller).arg(value));
+      if (!ok)
+         qWarning() << QString("%1 could not convert %2 to double").arg(caller).arg(value);
       // Get the display units and scale
    }
    return amount;
@@ -1238,7 +1214,7 @@ double Brewtarget::toDouble(QString text, QString caller)
    ret = toDouble(text,&success);
 
    if ( ! success )
-      logW( QString("%1 could not convert %2 to double").arg(caller).arg(text));
+      QString("%1 could not convert %2 to double").arg(caller).arg(text);
 
    return ret;
 }
@@ -1289,9 +1265,9 @@ QString Brewtarget::displayAmount(Ingredient* element, QObject* object, QString 
       value = element->property(attribute.toLatin1().constData()).toString();
       amount = toDouble( value, &ok );
       if ( ! ok )
-         logW( QString("%1 could not convert %2 to double")
+         qWarning() << QString("%1 could not convert %2 to double")
                .arg(Q_FUNC_INFO)
-               .arg(value));
+               .arg(value);
       // Get the display units and scale
       dispUnit  = static_cast<Unit::unitDisplay>(option(attribute, Unit::noUnit,  object->objectName(), UNIT).toInt());
       dispScale = static_cast<Unit::unitScale>(option(  attribute, Unit::noScale, object->objectName(), SCALE).toInt());
@@ -1357,7 +1333,7 @@ double Brewtarget::amountDisplay(Ingredient* element, QObject* object, QString a
       value = element->property(attribute.toLatin1().constData()).toString();
       amount = toDouble( value, &ok );
       if ( ! ok )
-         logW( QString("Brewtarget::amountDisplay(Ingredient*,QObject*,QString,Unit*,int) could not convert %1 to double").arg(value));
+         qWarning() << QString("Brewtarget::amountDisplay(Ingredient*,QObject*,QString,Unit*,int) could not convert %1 to double").arg(value);
       // Get the display units and scale
       dispUnit  = static_cast<Unit::unitDisplay>(option(attribute, Unit::noUnit,  object->objectName(), UNIT).toInt());
       dispScale = static_cast<Unit::unitScale>(option(  attribute, Unit::noScale, object->objectName(), SCALE).toInt());

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -1124,7 +1124,7 @@ void Brewtarget::saveSystemOptions()
    }
 
    setOption("LoggingEnabled", Log::loggingEnabled);
-   setOption("LoggingLevel", Log::getOptionStringFromLogType(Log::logLevel));
+   setOption("LoggingLevel", Log::getTypeName(Log::logLevel));
    setOption("LogFilePath", Log::logFilePath.absolutePath());
    setOption("LoggingUseConfigDir", Log::logUseConfigDir);
 }

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -46,6 +46,7 @@ extern void qt_set_sequence_auto_mnemonic(bool b);
 #include <QMenu>
 #include <QMetaProperty>
 #include <QList>
+#include <QDebug>
 #include "UnitSystem.h"
 #include "Log.h"
 
@@ -190,15 +191,6 @@ public:
    static double toDouble(QString text, bool* ok = nullptr);
    static double toDouble(const Ingredient* element, QString attribute, QString caller);
    static double toDouble(QString text, QString caller);
-
-   //! \brief Log an error message.
-   static void logE( QString message );
-   //! \brief Log a warning message.
-   static void logW( QString message );
-   //! \brief Log an info message.
-   static void logI( QString message );
-   //! \brief Log a debug message.
-   static void logD( QString message );
 
    /*!
     *  \brief Displays an amount in the appropriate units.

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -360,8 +360,6 @@ private:
    static QDomDocument* optionsDoc;
    static QTranslator* defaultTrans;
    static QTranslator* btTrans;
-   //! \brief OS-Agnostic RAII style Thread-safe Log file.
-   static Log log;
    static QString currentLanguage;
    static QSettings btSettings;
    static bool userDatabaseDidNotExist;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -142,14 +142,14 @@ Database::~Database()
 
 bool Database::loadSQLite()
 {
-   Brewtarget::logD("Loading SQLITE...");
+   qDebug() << "Loading SQLITE...";
    bool dbIsOpen;
    QSqlDatabase sqldb;
 
    // Set file names.
    dbFileName = Brewtarget::getUserDataDir().filePath("database.sqlite");
    dataDbFileName = Brewtarget::getDataDir().filePath("default_db.sqlite");
-   Brewtarget::logD(QString("Database::loadSQLite() - dbFileName = \"%1\"\nDatabase::loadSQLite() - dataDbFileName=\"%2\"").arg(dbFileName).arg(dataDbFileName));
+   qDebug() << QString("Database::loadSQLite() - dbFileName = \"%1\"\nDatabase::loadSQLite() - dataDbFileName=\"%2\"").arg(dbFileName).arg(dataDbFileName);
    // Set the files.
    dbFile.setFileName(dbFileName);
    dataDbFile.setFileName(dataDbFileName);
@@ -192,7 +192,7 @@ bool Database::loadSQLite()
 
    if( ! dbIsOpen )
    {
-      Brewtarget::logE(QString("Could not open %1 for reading.\n%2").arg(dbFileName).arg(sqldb.lastError().text()));
+      qCritical() << QString("Could not open %1 for reading.\n%2").arg(dbFileName).arg(sqldb.lastError().text());
       if (Brewtarget::isInteractive()) {
          QMessageBox::critical(
             nullptr,
@@ -223,7 +223,7 @@ bool Database::loadSQLite()
          _threadToConnection.insert(QThread::currentThread(), dbConName);
       }
       catch(QString e) {
-         Brewtarget::logE( QString("%1: %2 (%3)").arg(Q_FUNC_INFO).arg(e).arg(pragma.lastError().text()));
+         qCritical() << QString("%1: %2 (%3)").arg(Q_FUNC_INFO).arg(e).arg(pragma.lastError().text());
          dbIsOpen = false;
       }
    }
@@ -273,7 +273,7 @@ bool Database::loadPgSQL()
    dbConName = sqldb.connectionName();
 
    if( ! dbIsOpen ) {
-      Brewtarget::logE(QString("Could not open %1 for reading.\n%2").arg(dbFileName).arg(sqldb.lastError().text()));
+      qCritical() << QString("Could not open %1 for reading.\n%2").arg(dbFileName).arg(sqldb.lastError().text());
       QMessageBox::critical(nullptr,
                             QObject::tr("Database Failure"),
                             QString(QObject::tr("Failed to open the database '%1'.").arg(dbHostname))
@@ -315,7 +315,7 @@ bool Database::load()
    if( createFromScratch ) {
       bool success = DatabaseSchemaHelper::create(sqldb,dbDefn,Brewtarget::dbType());
       if( !success ) {
-         Brewtarget::logE("DatabaseSchemaHelper::create() failed");
+         qCritical() << "DatabaseSchemaHelper::create() failed";
          return success;
       }
    }
@@ -436,7 +436,7 @@ bool Database::createBlank(QString const& filename)
       bool dbIsOpen = sqldb.open();
       if( ! dbIsOpen )
       {
-         Brewtarget::logW(QString("Database::createBlank(): could not open '%1'").arg(filename));
+         qWarning() << QString("Database::createBlank(): could not open '%1'").arg(filename);
          return false;
       }
 
@@ -543,7 +543,7 @@ QSqlDatabase Database::sqlDatabase()
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       _threadToConnectionMutex.unlock();
       throw;
    }
@@ -568,7 +568,7 @@ template <class T> void Database::populateElements( QHash<int,T*>& hash, Brewtar
          throw QString("%1 %2").arg(q.lastQuery()).arg(q.lastError().text());
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       q.finish();
       throw;
    }
@@ -607,14 +607,14 @@ template <class T> bool Database::getElements(QList<T*>& list,
       queryString = QString("SELECT %1 as id FROM %2").arg(id).arg(tbl->tableName());
    }
 
-   Brewtarget::logD(QString("%1 SQL: %2").arg(Q_FUNC_INFO).arg(queryString));
+   qDebug() << QString("%1 SQL: %2").arg(Q_FUNC_INFO).arg(queryString);
 
    try {
       if ( ! q.exec(queryString) )
          throw QString("could not execute query: %2 : %3").arg(queryString).arg(q.lastError().text());
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       q.finish();
       throw;
    }
@@ -689,7 +689,7 @@ void Database::automaticBackup()
       foobar++;
       newName = QString("%1_%2").arg(halfName).arg(foobar,4,10,QChar('0'));
       if ( foobar > 9999 ) {
-         Brewtarget::logW( QString("%1 : could not find a unique name in 10000 tries. Overwriting %2").arg(Q_FUNC_INFO).arg(halfName));
+         qWarning() << QString("%1 : could not find a unique name in 10000 tries. Overwriting %2").arg(Q_FUNC_INFO).arg(halfName);
          newName = halfName;
       }
    }
@@ -719,7 +719,7 @@ void Database::automaticBackup()
       if ( fileThing->exists() && fileThing->isFile() ) {
          // If we can't remove it, give a warning.
          if (! file->remove() ) {
-            Brewtarget::logW( QString("%1 : could not remove %2 (%3).").arg(Q_FUNC_INFO).arg(victim).arg(file->error()));
+            qWarning() << QString("%1 : could not remove %2 (%3).").arg(Q_FUNC_INFO).arg(victim).arg(file->error());
          }
       }
    }
@@ -791,7 +791,7 @@ bool Database::backupToFile(QString newDbFileName)
 
    success = dbFile.copy( newDbFileName );
 
-   Brewtarget::logD( QString("Database backup to \"%1\" %2").arg(newDbFileName, success ? "succeeded" : "failed") );
+   qDebug() << QString("Database backup to \"%1\" %2").arg(newDbFileName, success ? "succeeded" : "failed");
 
    return success;
 }
@@ -845,7 +845,7 @@ int Database::getParentIngredientKey(Ingredient const & ingredient) {
                                                  .arg(parentToChildTable->tableName())
                                                  .arg(parentToChildTable->childIndexName())
                                                  .arg(ingredient.key());
-      Brewtarget::logD(QString("%1 Find Parent Ingredient SQL: %2").arg(Q_FUNC_INFO).arg(findParentIngredient));
+      qDebug() << QString("%1 Find Parent Ingredient SQL: %2").arg(Q_FUNC_INFO).arg(findParentIngredient);
 
       QSqlQuery query(this->sqlDatabase());
       if (!query.exec(findParentIngredient)) {
@@ -854,7 +854,7 @@ int Database::getParentIngredientKey(Ingredient const & ingredient) {
 
       if (query.next()) {
          parentKey = query.record().value(parentToChildTable->parentIndexName()).toInt();
-         Brewtarget::logD(QString("Found Parent with Key: %1").arg(parentKey));
+         qDebug() << QString("Found Parent with Key: %1").arg(parentKey);
       }
    }
    return parentKey;
@@ -878,7 +878,7 @@ bool Database::isStored(Ingredient const & ingredient) {
                                                                        .arg(idColumnName)
                                                                        .arg(ingredient.key());
 
-   Brewtarget::logD(QString("%1 SQL: %2").arg(Q_FUNC_INFO).arg(queryString));
+   qDebug() << QString("%1 SQL: %2").arg(Q_FUNC_INFO).arg(queryString);
 
    QSqlQuery query(this->sqlDatabase());
 
@@ -887,7 +887,7 @@ bool Database::isStored(Ingredient const & ingredient) {
          throw QString("could not execute query: %2 : %3").arg(queryString).arg(query.lastError().text());
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       query.finish();
       throw;
    }
@@ -915,7 +915,7 @@ Ingredient * Database::removeIngredientFromRecipe( Recipe* rec, Ingredient* ing 
    sqlDatabase().transaction();
    QSqlQuery q(sqlDatabase());
 
-   Brewtarget::logD(QString("%1 Deleting Ingredient %2 #%3").arg(Q_FUNC_INFO).arg(meta->className()).arg(ing->_key));
+   qDebug() << QString("%1 Deleting Ingredient %2 #%3").arg(Q_FUNC_INFO).arg(meta->className()).arg(ing->_key);
 
    try {
       if ( ndx != -1 ) {
@@ -938,14 +938,14 @@ Ingredient * Database::removeIngredientFromRecipe( Recipe* rec, Ingredient* ing 
                                  .arg(ing->_key)
                                  .arg(inrec->recipeIndexName())
                                  .arg(rec->_key);
-      Brewtarget::logD(QString("Delete From In Recipe SQL: %1").arg(deleteFromInRecipe));
+      qDebug() << QString("Delete From In Recipe SQL: %1").arg(deleteFromInRecipe);
 
       // delete from misc where id = [misc key]
       QString deleteIngredient = QString("DELETE FROM %1 where %2=%3")
                                  .arg(table->tableName())
                                  .arg(table->keyName())
                                  .arg(ing->_key);
-      Brewtarget::logD(QString("Delete Ingredient SQL: %1").arg(deleteIngredient));
+      qDebug() << QString("Delete Ingredient SQL: %1").arg(deleteIngredient);
 
       q.setForwardOnly(true);
 
@@ -956,7 +956,7 @@ Ingredient * Database::removeIngredientFromRecipe( Recipe* rec, Ingredient* ing 
                                     .arg(child->tableName())
                                     .arg( child->childIndexName() )
                                     .arg(ing->_key);
-         Brewtarget::logD(QString("Delete From Children SQL: %1").arg(deleteFromChildren));
+         qDebug() << QString("Delete From Children SQL: %1").arg(deleteFromChildren);
          if ( ! q.exec( deleteFromChildren ) ) {
             throw QString("failed to delete children.");
          }
@@ -970,11 +970,11 @@ Ingredient * Database::removeIngredientFromRecipe( Recipe* rec, Ingredient* ing 
 
    }
    catch ( QString e ) {
-      Brewtarget::logE(QString("%1 %2 %3 %4")
+      qCritical() << QString("%1 %2 %3 %4")
                            .arg(Q_FUNC_INFO)
                            .arg(e)
                            .arg(q.lastQuery())
-                           .arg(q.lastError().text()));
+                           .arg(q.lastError().text());
       sqlDatabase().rollback();
       q.finish();
       abort();
@@ -991,7 +991,7 @@ Ingredient * Database::removeIngredientFromRecipe( Recipe* rec, Ingredient* ing 
 
 void Database::removeFromRecipe( Recipe* rec, Instruction* ins )
 {
-   Brewtarget::logD(QString("%1").arg(Q_FUNC_INFO));
+   qDebug() << QString("%1").arg(Q_FUNC_INFO);
 
    try {
       removeIngredientFromRecipe( rec, ins);
@@ -1016,7 +1016,7 @@ void Database::removeFrom( Mash* mash, MashStep* step )
                QString("%1 = %2").arg(tbl->keyName()).arg(step->_key));
    }
    catch ( QString e ) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 
@@ -1041,11 +1041,11 @@ Recipe* Database::getParentRecipe( BrewNote const* note )
          throw QString("could not find recipe id");
    }
    catch ( QString e ) {
-      Brewtarget::logE(QString("%1 %2 %3 %4")
+      qCritical() << QString("%1 %2 %3 %4")
                            .arg(Q_FUNC_INFO)
                            .arg(e)
                            .arg(q.lastQuery())
-                           .arg(q.lastError().text()));
+                           .arg(q.lastError().text());
       q.finish();
       throw;
    }
@@ -1096,11 +1096,11 @@ void Database::swapMashStepOrder(MashStep* m1, MashStep* m2)
          throw QString("failed to swap steps");
    }
    catch ( QString e ) {
-      Brewtarget::logE(QString("%1 %2 %3 %4")
+      qCritical() << QString("%1 %2 %3 %4")
                            .arg(Q_FUNC_INFO)
                            .arg(e)
                            .arg(q.lastQuery())
-                           .arg(q.lastError().text()));
+                           .arg(q.lastError().text());
       q.finish();
       throw;
    }
@@ -1141,11 +1141,11 @@ void Database::swapInstructionOrder(Instruction* in1, Instruction* in2)
          throw QString("failed to swap steps");
    }
    catch ( QString e ) {
-      Brewtarget::logE(QString("%1 %2 %3 %4")
+      qCritical() << QString("%1 %2 %3 %4")
                            .arg(Q_FUNC_INFO)
                            .arg(e)
                            .arg(q.lastQuery())
-                           .arg(q.lastError().text()));
+                           .arg(q.lastError().text());
       q.finish();
       throw;
    }
@@ -1230,11 +1230,11 @@ void Database::insertInstruction(Instruction* in, int pos)
          throw QString("failed to insert new instruction recipe");
    }
    catch ( QString e ) {
-      Brewtarget::logE(QString("%1 %2 %3 %4")
+      qCritical() << QString("%1 %2 %3 %4")
                            .arg(Q_FUNC_INFO)
                            .arg(e)
                            .arg(q.lastQuery())
-                           .arg(q.lastError().text()));
+                           .arg(q.lastError().text());
       q.finish();
       sqlDatabase().rollback();
       throw;
@@ -1434,7 +1434,7 @@ BrewNote* Database::newBrewNote(Recipe* parent, bool signal)
 
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1464,7 +1464,7 @@ Equipment* Database::newEquipment(Equipment* other)
       emit newEquipmentSignal(tmp);
    }
    else {
-      Brewtarget::logE( QString("%1 couldn't copy %2").arg(Q_FUNC_INFO).arg(other->name()));
+      qCritical() << QString("%1 couldn't copy %2").arg(Q_FUNC_INFO).arg(other->name());
    }
 
    return tmp;
@@ -1491,7 +1491,7 @@ Fermentable* Database::newFermentable(Fermentable* other)
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact ) sqlDatabase().rollback();
       throw;
    }
@@ -1504,7 +1504,7 @@ Fermentable* Database::newFermentable(Fermentable* other)
       emit newFermentableSignal(tmp);
    }
    else {
-      Brewtarget::logE( QString("%1 couldn't copy %2").arg(Q_FUNC_INFO).arg(other->name()));
+      qCritical() << QString("%1 couldn't copy %2").arg(Q_FUNC_INFO).arg(other->name());
    }
 
    return tmp;
@@ -1528,7 +1528,7 @@ Hop* Database::newHop(Hop* other)
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact ) sqlDatabase().rollback();
       throw;
    }
@@ -1542,9 +1542,9 @@ Hop* Database::newHop(Hop* other)
       emit newHopSignal(tmp);
    }
    else {
-      Brewtarget::logE( QString("%1 could not %2 hop")
+      qCritical() << QString("%1 could not %2 hop")
             .arg(Q_FUNC_INFO)
-            .arg( other ? "copy" : "create"));
+            .arg( other ? "copy" : "create");
    }
 
    return tmp;
@@ -1564,7 +1564,7 @@ Instruction* Database::newInstruction(Recipe* rec)
       tmp = addIngredientToRecipe<Instruction>(rec,tmp,true,nullptr,false,false);
    }
    catch ( QString e ) {
-      Brewtarget::logE( QString("%1 %2").arg( Q_FUNC_INFO ).arg(e));
+      qCritical() << QString("%1 %2").arg( Q_FUNC_INFO ).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1658,7 +1658,7 @@ Mash* Database::newMash(Recipe* parent, bool transact)
                  QString("%1=%2").arg(tbl->keyName()).arg(parent->_key));
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact )
          sqlDatabase().rollback();
       throw;
@@ -1718,7 +1718,7 @@ MashStep* Database::newMashStep(Mash* mash, bool connected)
                  QString("%1=%2").arg(tbl->keyName()).arg(tmp->_key));
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1751,7 +1751,7 @@ Misc* Database::newMisc(Misc* other)
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact ) sqlDatabase().rollback();
       throw;
    }
@@ -1765,9 +1765,9 @@ Misc* Database::newMisc(Misc* other)
       emit newMiscSignal(tmp);
    }
    else {
-      Brewtarget::logE( QString("%1 could not %2 misc")
+      qCritical() << QString("%1 could not %2 misc")
             .arg(Q_FUNC_INFO)
-            .arg( other ? "copy" : "create"));
+            .arg( other ? "copy" : "create");
    }
 
    return tmp;
@@ -1785,7 +1785,7 @@ Recipe* Database::newRecipe(QString name)
       newMash(tmp,false);
    }
    catch (QString e ) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1798,7 +1798,7 @@ Recipe* Database::newRecipe(QString name)
       tmp->setDeleted(false);
    }
    catch (QString e ) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 
@@ -1832,7 +1832,7 @@ Recipe* Database::newRecipe(Recipe* other)
       addToRecipe( tmp, other->style(), false, false);
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1852,7 +1852,7 @@ Style* Database::newStyle(Style* other)
       tmp = copy(other, &allStyles);
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1871,7 +1871,7 @@ Style* Database::newStyle(QString name)
       tmp = newIngredient(name, &allStyles);
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1885,7 +1885,7 @@ Style* Database::newStyle(QString name)
    }
 
    catch (QString e ) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 
@@ -1906,7 +1906,7 @@ Water* Database::newWater(Water* other)
          tmp = newIngredient(&allWaters);
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1928,7 +1928,7 @@ Salt* Database::newSalt(Salt* other)
          tmp = newIngredient(&allSalts);
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1957,7 +1957,7 @@ Yeast* Database::newYeast(Yeast* other)
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -1986,7 +1986,7 @@ int Database::insertElement(Ingredient* ins)
    QStringList allProps = schema->allPropertyNames(Brewtarget::dbType());
 
    ///qDebug() << Q_FUNC_INFO << "SQL:" << insertQ;
-   Brewtarget::logD(QString("%1 SQL: %2").arg(Q_FUNC_INFO).arg(insertQ));
+   qDebug() << QString("%1 SQL: %2").arg(Q_FUNC_INFO).arg(insertQ);
    q.prepare(insertQ);
 
    QString sqlParameters;
@@ -2000,7 +2000,7 @@ int Database::insertElement(Ingredient* ins)
       q.bindValue( QString(":%1").arg(prop), val_to_ins);
       sqlParametersConcat << prop << " = " << val_to_ins.toString() << " || ";
    }
-   Brewtarget::logD(QString("%1 SQL Parameters: %2").arg(Q_FUNC_INFO).arg(*sqlParametersConcat.string()));
+   qDebug() << QString("%1 SQL Parameters: %2").arg(Q_FUNC_INFO).arg(*sqlParametersConcat.string());
 
    try {
       if ( ! q.exec() ) {
@@ -2014,7 +2014,7 @@ int Database::insertElement(Ingredient* ins)
    }
    catch (QString e) {
       sqlDatabase().rollback();
-      Brewtarget::logE(QString("%1 %2 %3").arg(Q_FUNC_INFO).arg(e).arg( q.lastError().text()));
+      qCritical() << QString("%1 %2 %3").arg(Q_FUNC_INFO).arg(e).arg( q.lastError().text());
       abort();
    }
    ins->_key = key;
@@ -2065,7 +2065,7 @@ int Database::insertFermentable(Fermentable* ins)
       ins->setInventoryId(invKey);
    }
    catch( QString e ) {
-      Brewtarget::logE(e);
+      qCritical() << e;
       throw;
    }
 
@@ -2088,7 +2088,7 @@ int Database::insertHop(Hop* ins)
       ins->setInventoryId(invKey);
    }
    catch( QString e ) {
-      Brewtarget::logE(e);
+      qCritical() << e;
       throw;
    }
 
@@ -2113,7 +2113,7 @@ int Database::insertInstruction(Instruction* ins, Recipe* parent)
 
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -2172,7 +2172,7 @@ int Database::insertMashStep(MashStep* ins, Mash* parent)
                  QString("%1=%2").arg(tbl->keyName()).arg(ins->_key));
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -2202,7 +2202,7 @@ int Database::insertMisc(Misc* ins)
       ins->setInventoryId(invKey);
    }
    catch( QString e ) {
-      Brewtarget::logE(e);
+      qCritical() << e;
       throw;
    }
 
@@ -2238,7 +2238,7 @@ int Database::insertYeast(Yeast* ins)
       ins->setInventoryId(invKey);
    }
    catch( QString e ) {
-      Brewtarget::logE(e);
+      qCritical() << e;
       throw;
    }
 
@@ -2291,7 +2291,7 @@ int Database::insertBrewNote(BrewNote* ins, Recipe* parent)
 
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -2319,7 +2319,7 @@ void Database::deleteRecord( Ingredient* object )
       updateEntry( object, kpropDeleted, Brewtarget::dbTrue(), true);
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e) );
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 
@@ -2372,7 +2372,7 @@ template<class T> T* Database::addIngredientToRecipe(
                            .arg(ing->_key)
                            .arg(reinterpret_cast<Ingredient*>(rec)->_key)
                            .arg(inrec->recipeIndexName());
-      Brewtarget::logD(QString("%1 Ingredient in recipe search: %2").arg(Q_FUNC_INFO).arg(select));
+      qDebug() << QString("%1 Ingredient in recipe search: %2").arg(Q_FUNC_INFO).arg(select);
       if (! q.exec(select) ) {
          throw QString("Couldn't execute ingredient in recipe search: Query: %1 error: %2")
             .arg(q.lastQuery()).arg(q.lastError().text());
@@ -2401,7 +2401,7 @@ template<class T> T* Database::addIngredientToRecipe(
          if ( newIng == nullptr ) {
             throw QString("error copying ingredient");
          }
-         Brewtarget::logD(QString("%1 Copy %2 #%3 to %2 #%4").arg(Q_FUNC_INFO).arg(meta->className()).arg(ing->key()).arg(newIng->key()));
+         qDebug() << QString("%1 Copy %2 #%3 to %2 #%4").arg(Q_FUNC_INFO).arg(meta->className()).arg(ing->key()).arg(newIng->key());
          newIng->setParent(*ing);
       }
 
@@ -2419,7 +2419,7 @@ template<class T> T* Database::addIngredientToRecipe(
       q.bindValue(":ingredient", newIng->key());
       q.bindValue(":recipe", rec->_key);
 
-      Brewtarget::logD(QString("%1 Link ingredient to recipe: %2 with args %3, %4").arg(Q_FUNC_INFO).arg(insert).arg(newIng->key()).arg(rec->_key));
+      qDebug() << QString("%1 Link ingredient to recipe: %2 with args %3, %4").arg(Q_FUNC_INFO).arg(insert).arg(newIng->key()).arg(rec->_key);
 
       if ( ! q.exec() ) {
          throw QString("%2 : %1.").arg(q.lastQuery()).arg(q.lastError().text());
@@ -2448,7 +2448,7 @@ template<class T> T* Database::addIngredientToRecipe(
                .arg(child->childIndexName())
                .arg(key);
          q.prepare(parentChildSql);
-         Brewtarget::logD(QString("%1 Parent-Child find: %2").arg(Q_FUNC_INFO).arg(parentChildSql));
+         qDebug() << QString("%1 Parent-Child find: %2").arg(Q_FUNC_INFO).arg(parentChildSql);
          if (q.exec() && q.next()) {
             key = q.record().value(child->parentIndexName()).toInt();
          }
@@ -2463,7 +2463,7 @@ template<class T> T* Database::addIngredientToRecipe(
          q.bindValue(":parent", key);
          q.bindValue(":child", newIng->key());
 
-         Brewtarget::logD(QString("%1 Parent-Child Insert: %2 with args %3, %4").arg(Q_FUNC_INFO).arg(insert).arg(key).arg(newIng->key()));
+         qDebug() << QString("%1 Parent-Child Insert: %2 with args %3, %4").arg(Q_FUNC_INFO).arg(insert).arg(key).arg(newIng->key());
 
          if ( ! q.exec() ) {
             throw QString("%1 %2.").arg(q.lastQuery()).arg(q.lastError().text());
@@ -2473,7 +2473,7 @@ template<class T> T* Database::addIngredientToRecipe(
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(QString("Q_FUNC_INFO")).arg(e));
+      qCritical() << QString("%1 %2").arg(QString("Q_FUNC_INFO")).arg(e);
       q.finish();
       if ( transact )
          sqlDatabase().rollback();
@@ -2514,7 +2514,7 @@ void Database::duplicateMashSteps(Mash *oldMash, Mash *newMash)
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 
@@ -2592,7 +2592,7 @@ void Database::setInventory(Ingredient* ins, QVariant value, int invKey, bool no
 
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e) );
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 
@@ -2614,7 +2614,7 @@ void Database::updateEntry( Ingredient* object, QString propName, QVariant value
    }
 
    if ( colName.isEmpty() ) {
-      Brewtarget::logE(QString("Could not translate %1 to a column name").arg(propName));
+      qCritical() << QString("Could not translate %1 to a column name").arg(propName);
       throw  QString("Could not translate %1 to a column name").arg(propName);
    }
    if ( transact )
@@ -2640,7 +2640,7 @@ void Database::updateEntry( Ingredient* object, QString propName, QVariant value
 
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e) );
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact )
          sqlDatabase().rollback();
       throw;
@@ -2701,7 +2701,7 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table)
 {
    TableSchema* tbl = dbDefn->table(table);
    TableSchema* cld = dbDefn->childTable( table );
-   Brewtarget::logI( QString("Populating Children Ingredient Links (%1)").arg(tbl->tableName()));
+   qInfo() << QString("Populating Children Ingredient Links (%1)").arg(tbl->tableName());
 
    try {
       // "SELECT DISTINCT name FROM [tablename]"
@@ -2768,7 +2768,7 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table)
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
    }
 }
@@ -2788,7 +2788,7 @@ void Database::populateChildTablesByName()
       populateChildTablesByName(Brewtarget::YEASTTABLE);
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 }
@@ -3000,7 +3000,7 @@ void Database::addToRecipe( Recipe* rec, QList<Hop*>hops, bool transact )
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact ) {
          sqlDatabase().rollback();
       }
@@ -3035,7 +3035,7 @@ Mash * Database::addToRecipe( Recipe* rec, Mash* m, bool noCopy, bool transact )
                QString("%1=%2").arg(tbl->keyName()).arg(rec->_key));
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact )
          sqlDatabase().rollback();
       throw;
@@ -3081,7 +3081,7 @@ void Database::addToRecipe( Recipe* rec, QList<Misc*>miscs, bool transact )
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact ) {
          sqlDatabase().rollback();
       }
@@ -3135,7 +3135,7 @@ Style * Database::addToRecipe( Recipe* rec, Style* s, bool noCopy, bool transact
                 QString("%1=%2").arg(tbl->keyName()).arg(rec->_key));
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact )
          sqlDatabase().rollback();
       throw;
@@ -3183,7 +3183,7 @@ void Database::addToRecipe( Recipe* rec, QList<Yeast*>yeasts, bool transact )
       }
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact )
          sqlDatabase().rollback();
       throw;
@@ -3215,7 +3215,7 @@ template<class T> T* Database::copy( Ingredient const* object, QHash<int,T*>* ke
       QString select = QString("SELECT * FROM %1 WHERE id = %2").arg(tName).arg(object->_key);
 
       ///qDebug() << Q_FUNC_INFO << "SELECT SQL:" << select;
-      Brewtarget::logD(QString("%1 SELECT SQL: %2").arg(Q_FUNC_INFO).arg(select));
+      qDebug() << QString("%1 SELECT SQL: %2").arg(Q_FUNC_INFO).arg(select);
 
       if( !q.exec(select) )
          throw QString("%1 %2").arg(q.lastQuery()).arg(q.lastError().text());
@@ -3242,7 +3242,7 @@ template<class T> T* Database::copy( Ingredient const* object, QHash<int,T*>* ke
                            .arg(holder);
 
       ///qDebug() << Q_FUNC_INFO << "INSERT SQL:" << prepString;
-      Brewtarget::logD(QString("%1 INSERT SQL: %2").arg(Q_FUNC_INFO).arg(prepString));
+      qDebug() << QString("%1 INSERT SQL: %2").arg(Q_FUNC_INFO).arg(prepString);
 
       QSqlQuery insert = QSqlQuery( sqlDatabase() );
       insert.prepare(prepString);
@@ -3271,7 +3271,7 @@ template<class T> T* Database::copy( Ingredient const* object, QHash<int,T*>* ke
       keyHash->insert( newKey, newOne );
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       q.finish();
       throw;
    }
@@ -3296,7 +3296,7 @@ void Database::sqlUpdate( Brewtarget::DBTable table, QString const& setClause, Q
    }
    catch (QString e) {
       q.finish();
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
    }
 
@@ -3316,7 +3316,7 @@ void Database::sqlDelete( Brewtarget::DBTable table, QString const& whereClause 
    }
    catch (QString e) {
       q.finish();
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
    }
 
@@ -3456,7 +3456,7 @@ bool Database::updateSchema(bool* err)
       bool success = DatabaseSchemaHelper::migrate( currentVersion, newVersion, sqlDatabase() );
       if( !success )
       {
-         Brewtarget::logE(QString("Database migration %1->%2 failed").arg(currentVersion).arg(newVersion));
+         qCritical() << QString("Database migration %1->%2 failed").arg(currentVersion).arg(newVersion);
          if( err )
             *err = true;
          return false;
@@ -3484,7 +3484,7 @@ bool Database::updateSchema(bool* err)
       }
    }
    catch (QString e ) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       throw;
    }
@@ -3509,12 +3509,12 @@ bool Database::importFromXML(const QString& filename)
 
    if( ! inFile.open(QIODevice::ReadOnly) )
    {
-      Brewtarget::logW(QString("Database::importFromXML: Could not open %1 for reading.").arg(filename));
+      qWarning() << QString("Database::importFromXML: Could not open %1 for reading.").arg(filename);
       return false;
    }
 
    if( ! xmlDoc.setContent(&inFile, false, &err, &line, &col) )
-      Brewtarget::logW(QString("Database::importFromXML: Bad document formatting in %1 %2:%3. %4").arg(filename).arg(line).arg(col).arg(err) );
+      qWarning() << QString("Database::importFromXML: Bad document formatting in %1 %2:%3. %4").arg(filename).arg(line).arg(col).arg(err);
 
    list = xmlDoc.elementsByTagName("RECIPE");
    if ( list.count() )
@@ -3777,7 +3777,7 @@ void Database::updateDatabase(QString const& filename)
       // I think
    }
    catch (QString e) {
-      Brewtarget::logE(QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       sqlDatabase().rollback();
       abort();
    }
@@ -3842,7 +3842,7 @@ QSqlDatabase Database::openSQLite()
          throw QString("Could not open %1 : %2").arg(filePath).arg(newDb.lastError().text());
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 
@@ -3866,7 +3866,7 @@ QSqlDatabase Database::openPostgres(QString const& Hostname, QString const& DbNa
          throw QString("Could not open %1 : %2").arg(Hostname).arg(newDb.lastError().text());
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
    return newDb;
@@ -3903,7 +3903,7 @@ void Database::convertDatabase(QString const& Hostname, QString const& DbName,
 
       // this is to prevent us from over-writing or doing heavens knows what to an existing db
       if( newDb.tables().contains(QLatin1String("settings")) ) {
-         Brewtarget::logW( QString("It appears the database is already configured."));
+         qWarning() << QString("It appears the database is already configured.");
          return;
       }
 
@@ -3922,7 +3922,7 @@ void Database::convertDatabase(QString const& Hostname, QString const& DbName,
       copyDatabase(oldType,newType,newDb);
    }
    catch (QString e) {
-      Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+      qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       throw;
    }
 }
@@ -4019,13 +4019,13 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
          if ( table->dbTable() == Brewtarget::INSTINRECTABLE ) {
             QString trigger = table->generateIncrementTrigger(newType);
             if ( trigger.isEmpty() ) {
-               Brewtarget::logE(QString("No increment triggers found for %1").arg(table->tableName()));
+               qCritical() << QString("No increment triggers found for %1").arg(table->tableName());
             }
             else {
                upsertNew.exec(trigger);
                trigger =  table->generateDecrementTrigger(newType);
                if ( trigger.isEmpty() ) {
-                  Brewtarget::logE(QString("No decrement triggers found for %1").arg(table->tableName()));
+                  qCritical() << QString("No decrement triggers found for %1").arg(table->tableName());
                }
                else {
                   if ( ! upsertNew.exec(trigger) ) {
@@ -4048,7 +4048,7 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
          }
       }
       catch (QString e) {
-         Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+         qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
          newDb.rollback();
          throw;
       }

--- a/src/database.h
+++ b/src/database.h
@@ -150,7 +150,7 @@ public:
          q.finish();
       }
       catch (QString e) {
-         Brewtarget::logE(QString("%1 %2 %3").arg(Q_FUNC_INFO).arg(e).arg( q.lastError().text()));
+         qCritical() << Q_FUNC_INFO << e << q.lastError().text();
          throw; // rethrow the error until somebody cares
       }
 
@@ -183,7 +183,7 @@ public:
          q.finish();
       }
       catch (QString e) {
-         Brewtarget::logE(QString("%1 %2 %3").arg(Q_FUNC_INFO).arg(e).arg( q.lastError().text()));
+         qCritical() << Q_FUNC_INFO << e << q.lastError().text();
          throw; // rethrow the error until somebody cares
       }
 
@@ -595,7 +595,7 @@ private:
             throw QString("could not execute query: %2 : %3").arg(queryString).arg(q.lastError().text());
       }
       catch (QString e) {
-         Brewtarget::logE( QString("%1 %2").arg(Q_FUNC_INFO).arg(e));
+         qCritical() << Q_FUNC_INFO << e;
          q.finish();
          throw;
       }

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -147,7 +147,7 @@ void Equipment::setBoilSize_l( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: boil size negative: %1").arg(var) );
+      qWarning() << QString("Equipment: boil size negative: %1").arg(var);
       return;
    }
    else
@@ -164,7 +164,7 @@ void Equipment::setBatchSize_l( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: batch size negative: %1").arg(var) );
+      qWarning() << QString("Equipment: batch size negative: %1").arg(var);
       return;
    }
    else
@@ -181,7 +181,7 @@ void Equipment::setTunVolume_l( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: tun volume negative: %1").arg(var) );
+      qWarning() << QString("Equipment: tun volume negative: %1").arg(var);
       return;
    }
    else
@@ -197,7 +197,7 @@ void Equipment::setTunWeight_kg( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: tun weight negative: %1").arg(var) );
+      qWarning() << QString("Equipment: tun weight negative: %1").arg(var);
       return;
    }
    else
@@ -213,7 +213,7 @@ void Equipment::setTunSpecificHeat_calGC( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: tun sp heat negative: %1").arg(var) );
+      qWarning() << QString("Equipment: tun sp heat negative: %1").arg(var);
       return;
    }
    else
@@ -229,7 +229,7 @@ void Equipment::setTopUpWater_l( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: top up water negative: %1").arg(var) );
+      qWarning() << QString("Equipment: top up water negative: %1").arg(var);
       return;
    }
    else
@@ -246,7 +246,7 @@ void Equipment::setTrubChillerLoss_l( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: trub chiller loss negative: %1").arg(var) );
+      qWarning() << QString("Equipment: trub chiller loss negative: %1").arg(var);
       return;
    }
    else
@@ -263,7 +263,7 @@ void Equipment::setEvapRate_pctHr( double var )
 {
    if( var < 0.0 || var > 100.0)
    {
-      Brewtarget::logW( QString("Equipment: 0 < evap rate < 100: %1").arg(var) );
+      qWarning() << QString("Equipment: 0 < evap rate < 100: %1").arg(var);
       return;
    }
    else
@@ -285,7 +285,7 @@ void Equipment::setEvapRate_lHr( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: evap rate negative: %1").arg(var) );
+      qWarning() << QString("Equipment: evap rate negative: %1").arg(var);
       return;
    }
    else
@@ -304,7 +304,7 @@ void Equipment::setBoilTime_min( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: boil time negative: %1").arg(var) );
+      qWarning() << QString("Equipment: boil time negative: %1").arg(var);
       return;
    }
    else
@@ -333,7 +333,7 @@ void Equipment::setLauterDeadspace_l( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: deadspace negative: %1").arg(var) );
+      qWarning() << QString("Equipment: deadspace negative: %1").arg(var);
       return;
    }
    else
@@ -349,7 +349,7 @@ void Equipment::setTopUpKettle_l( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: top up kettle negative: %1").arg(var) );
+      qWarning() << QString("Equipment: top up kettle negative: %1").arg(var);
       return;
    }
    else
@@ -365,7 +365,7 @@ void Equipment::setHopUtilization_pct( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: 0 < hop utilization: %1").arg(var) );
+      qWarning() << QString("Equipment: 0 < hop utilization: %1").arg(var);
       return;
    }
    else
@@ -389,7 +389,7 @@ void Equipment::setGrainAbsorption_LKg(double var)
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: absorption < 0: %1").arg(var) );
+      qWarning() << QString("Equipment: absorption < 0: %1").arg(var);
       return;
    }
    else
@@ -405,7 +405,7 @@ void Equipment::setBoilingPoint_c(double var)
 {
    if ( var < 0.0 )
    {
-      Brewtarget::logW( QString("Equipment: boiling point of water < 0: %1").arg(var));
+      qWarning() << QString("Equipment: boiling point of water < 0: %1").arg(var);
       return;
    }
    else

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -369,7 +369,7 @@ void Fermentable::setAmount_kg( double num )
 {
    if( num < 0.0 )
    {
-      Brewtarget::logW( QString("Fermentable: negative amount: %1").arg(num) );
+      qWarning() << QString("Fermentable: negative amount: %1").arg(num);
       return;
    }
    else
@@ -384,7 +384,7 @@ void Fermentable::setAmount_kg( double num )
 void Fermentable::setInventoryAmount( double num )
 {
    if( num < 0.0 ) {
-      Brewtarget::logW( QString("Fermentable: negative inventory: %1").arg(num) );
+      qWarning() << QString("Fermentable: negative inventory: %1").arg(num);
       return;
    }
    else
@@ -398,7 +398,7 @@ void Fermentable::setInventoryAmount( double num )
 void Fermentable::setInventoryId( int key )
 {
    if( key < 1 ) {
-      Brewtarget::logW( QString("Fermentable: bad inventory id: %1").arg(key) );
+      qWarning() << QString("Fermentable: bad inventory id: %1").arg(key);
       return;
    }
    else
@@ -433,7 +433,7 @@ void Fermentable::setYield_pct( double num )
    }
    else
    {
-      Brewtarget::logW( QString("Fermentable: 0 < yield < 100: %1").arg(num) );
+      qWarning() << QString("Fermentable: 0 < yield < 100: %1").arg(num);
    }
 }
 
@@ -441,7 +441,7 @@ void Fermentable::setColor_srm( double num )
 {
    if( num < 0.0 )
    {
-      Brewtarget::logW( QString("Fermentable: negative color: %1").arg(num) );
+      qWarning() << QString("Fermentable: negative color: %1").arg(num);
       return;
    }
    else
@@ -464,7 +464,7 @@ void Fermentable::setCoarseFineDiff_pct( double num )
    }
    else
    {
-      Brewtarget::logW( QString("Fermentable: 0 < coarsefinediff < 100: %1").arg(num) );
+      qWarning() << QString("Fermentable: 0 < coarsefinediff < 100: %1").arg(num);
    }
 }
 
@@ -479,7 +479,7 @@ void Fermentable::setMoisture_pct( double num )
    }
    else
    {
-      Brewtarget::logW( QString("Fermentable: 0 < moisture < 100: %1").arg(num) );
+      qWarning() << QString("Fermentable: 0 < moisture < 100: %1").arg(num);
    }
 }
 
@@ -487,7 +487,7 @@ void Fermentable::setDiastaticPower_lintner( double num )
 {
    if( num < 0.0 )
    {
-      Brewtarget::logW( QString("Fermentable: negative DP: %1").arg(num) );
+      qWarning() << QString("Fermentable: negative DP: %1").arg(num);
       return;
    }
    else
@@ -510,7 +510,7 @@ void Fermentable::setProtein_pct( double num )
    }
    else
    {
-      Brewtarget::logW( QString("Fermentable: 0 < protein < 100: %1").arg(num) );
+      qWarning() << QString("Fermentable: 0 < protein < 100: %1").arg(num);
    }
 }
 
@@ -525,7 +525,7 @@ void Fermentable::setMaxInBatch_pct( double num )
    }
    else
    {
-      Brewtarget::logW( QString("Fermentable: 0 < maxinbatch < 100: %1").arg(num) );
+      qWarning() << QString("Fermentable: 0 < maxinbatch < 100: %1").arg(num);
    }
 }
 

--- a/src/hop.cpp
+++ b/src/hop.cpp
@@ -176,7 +176,7 @@ void Hop::setAlpha_pct( double num )
 {
    if( num < 0.0 || num > 100.0 )
    {
-      Brewtarget::logW( QString("Hop: 0 < alpha < 100: %1").arg(num) );
+      qWarning() << QString("Hop: 0 < alpha < 100: %1").arg(num);
       return;
    }
    else
@@ -192,7 +192,7 @@ void Hop::setAmount_kg( double num )
 {
    if( num < 0.0 )
    {
-      Brewtarget::logW( QString("Hop: amount < 0: %1").arg(num) );
+      qWarning() << QString("Hop: amount < 0: %1").arg(num);
       return;
    }
    else
@@ -208,7 +208,7 @@ void Hop::setInventoryAmount( double num )
 {
    if( num < 0.0 )
    {
-      Brewtarget::logW( QString("Hop: inventory < 0: %1").arg(num) );
+      qWarning() << QString("Hop: inventory < 0: %1").arg(num);
       return;
    }
    else
@@ -243,7 +243,7 @@ void Hop::setTime_min( double num )
 {
    if( num < 0.0 )
    {
-      Brewtarget::logW( QString("Hop: time < 0: %1").arg(num) );
+      qWarning() << QString("Hop: time < 0: %1").arg(num);
       return;
    }
    else
@@ -289,7 +289,7 @@ void Hop::setBeta_pct( double num )
 {
    if( num < 0.0 || num > 100.0 )
    {
-      Brewtarget::logW( QString("Hop: 0 < beta < 100: %1").arg(num) );
+      qWarning() << QString("Hop: 0 < beta < 100: %1").arg(num);
       return;
    }
    else
@@ -305,7 +305,7 @@ void Hop::setHsi_pct( double num )
 {
    if( num < 0.0 || num > 100.0 )
    {
-      Brewtarget::logW( QString("Hop: 0 < hsi < 100: %1").arg(num) );
+      qWarning() << QString("Hop: 0 < hsi < 100: %1").arg(num);
       return;
    }
    else
@@ -337,7 +337,7 @@ void Hop::setHumulene_pct( double num )
 {
    if( num < 0.0 || num > 100.0 )
    {
-      Brewtarget::logW( QString("Hop: 0 < humulene < 100: %1").arg(num) );
+      qWarning() << QString("Hop: 0 < humulene < 100: %1").arg(num);
       return;
    }
    else
@@ -353,7 +353,7 @@ void Hop::setCaryophyllene_pct( double num )
 {
    if( num < 0.0 || num > 100.0 )
    {
-      Brewtarget::logW( QString("Hop: 0 < cary < 100: %1").arg(num) );
+      qWarning() << QString("Hop: 0 < cary < 100: %1").arg(num);
       return;
    }
    else
@@ -369,7 +369,7 @@ void Hop::setCohumulone_pct( double num )
 {
    if( num < 0.0 || num > 100.0 )
    {
-      Brewtarget::logW( QString("Hop: 0 < cohumulone < 100: %1").arg(num) );
+      qWarning() << QString("Hop: 0 < cohumulone < 100: %1").arg(num);
       return;
    }
    else
@@ -385,7 +385,7 @@ void Hop::setMyrcene_pct( double num )
 {
    if( num < 0.0 || num > 100.0 )
    {
-      Brewtarget::logW( QString("Hop: 0 < myrcene < 100: %1").arg(num) );
+      qWarning() << QString("Hop: 0 < myrcene < 100: %1").arg(num);
       return;
    }
    else

--- a/src/ingredient.cpp
+++ b/src/ingredient.cpp
@@ -148,7 +148,7 @@ double Ingredient::getDouble(const QDomText& textNode)
    // ret = text.toDouble(&ok);
    ret = Brewtarget::toDouble(text,&ok);
    if( !ok )
-      Brewtarget::logE(QString("Ingredient::getDouble: %1 is not a number. Line %2").arg(text).arg(textNode.lineNumber()) );
+      qCritical() << QString("Ingredient::getDouble: %1 is not a number. Line %2").arg(text).arg(textNode.lineNumber());
 
    return ret;
 }
@@ -162,7 +162,7 @@ bool Ingredient::getBool(const QDomText& textNode)
    else if( text == "FALSE" )
       return false;
    else
-      Brewtarget::logE(QString("Ingredient::getBool: %1 is not a boolean value. Line %2").arg(text).arg(textNode.lineNumber()) );
+      qCritical() << QString("Ingredient::getBool: %1 is not a boolean value. Line %2").arg(text).arg(textNode.lineNumber());
 
    return false;
 }
@@ -175,7 +175,7 @@ int Ingredient::getInt(const QDomText& textNode)
 
    ret = text.toInt(&ok);
    if( !ok )
-      Brewtarget::logE(QString("Ingredient::getInt: %1 is not an integer. Line %2").arg(text).arg(textNode.lineNumber()) );
+      qCritical() << QString("Ingredient::getInt: %1 is not an integer. Line %2").arg(text).arg(textNode.lineNumber());
 
    return ret;
 }
@@ -194,7 +194,7 @@ QDateTime Ingredient::getDateTime( QDomText const& textNode )
    ret = QDateTime::fromString(text, Qt::ISODate);
    ok = ret.isValid();
    if( !ok )
-      Brewtarget::logE(QString("Ingredient::getDateTime: %1 is not a date. Line %2").arg(text).arg(textNode.lineNumber()) );
+      qCritical() << QString("Ingredient::getDateTime: %1 is not a date. Line %2").arg(text).arg(textNode.lineNumber());
 
    return ret;
 }
@@ -215,7 +215,7 @@ QDate Ingredient::getDate( QDomText const& textNode )
    }
 
    if ( !ok )
-      Brewtarget::logE(QString("Ingredient::getDate: %1 is not an ISO date-time. Line %2").arg(text).arg(textNode.lineNumber()) );
+      qCritical() << QString("Ingredient::getDate: %1 is not an ISO date-time. Line %2").arg(text).arg(textNode.lineNumber());
 
    return ret;
 }

--- a/src/mash.cpp
+++ b/src/mash.cpp
@@ -135,7 +135,7 @@ void Mash::setPh( double var )
 {
    if( var < 0.0 || var > 14.0 )
    {
-      Brewtarget::logW( QString("Mash: 0 < pH < 14: %1").arg(var) );
+      qWarning() << QString("Mash: 0 < pH < 14: %1").arg(var);
       return;
    }
    else
@@ -151,7 +151,7 @@ void Mash::setTunWeight_kg( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Mash: tun weight < 0: %1").arg(var) );
+      qWarning() << QString("Mash: tun weight < 0: %1").arg(var);
       return;
    }
    else
@@ -167,7 +167,7 @@ void Mash::setTunSpecificHeat_calGC( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Mash: sp heat < 0: %1").arg(var) );
+      qWarning() << QString("Mash: sp heat < 0: %1").arg(var);
       return;
    }
    else

--- a/src/mashstep.cpp
+++ b/src/mashstep.cpp
@@ -116,7 +116,7 @@ void MashStep::setInfuseAmount_l( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("%1 number cannot be negative: %2").arg(Q_FUNC_INFO).arg(var) );
+      qWarning() << QString("%1 number cannot be negative: %2").arg(Q_FUNC_INFO).arg(var);
       return;
    }
    else
@@ -132,7 +132,7 @@ void MashStep::setStepTemp_c( double var )
 {
    if( var < -273.15 )
    {
-      Brewtarget::logW( QString("%1: temp below absolute zero: %2").arg(Q_FUNC_INFO).arg(var) );
+      qWarning() << QString("%1: temp below absolute zero: %2").arg(Q_FUNC_INFO).arg(var);
       return;
    }
    else
@@ -148,7 +148,7 @@ void MashStep::setStepTime_min( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("%1: step time cannot be negative: %2").arg(Q_FUNC_INFO).arg(var) );
+      qWarning() << QString("%1: step time cannot be negative: %2").arg(Q_FUNC_INFO).arg(var);
       return;
    }
    else
@@ -164,7 +164,7 @@ void MashStep::setRampTime_min( double var )
 {
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("%1: ramp time cannot be negative: %2").arg(Q_FUNC_INFO).arg(var) );
+      qWarning() << QString("%1: ramp time cannot be negative: %2").arg(Q_FUNC_INFO).arg(var);
 
       return;
    }
@@ -181,7 +181,7 @@ void MashStep::setEndTemp_c( double var )
 {
    if( var < -273.15 )
    {
-      Brewtarget::logW( QString("%1: temp below absolute zero: %2").arg(Q_FUNC_INFO).arg(var) );
+      qWarning() << QString("%1: temp below absolute zero: %2").arg(Q_FUNC_INFO).arg(var);
       return;
    }
    else

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -235,7 +235,7 @@ void Misc::setAmountIsWeight( bool var )
 void Misc::setAmount( double var )
 {
    if( var < 0.0 )
-      Brewtarget::logW( QString("Misc: amount < 0: %1").arg(var) );
+      qWarning() << QString("Misc: amount < 0: %1").arg(var);
    else {
       m_amount = var;
       if ( ! m_cacheOnly ) {
@@ -247,7 +247,7 @@ void Misc::setAmount( double var )
 void Misc::setInventoryAmount( double var )
 {
    if( var < 0.0 )
-      Brewtarget::logW( QString("Misc: inventory < 0: %1").arg(var) );
+      qWarning() << QString("Misc: inventory < 0: %1").arg(var);
    else {
       m_inventory = var;
       if ( ! m_cacheOnly )
@@ -265,7 +265,7 @@ void Misc::setInventoryId( int key )
 void Misc::setTime( double var )
 {
    if( var < 0.0 )
-      Brewtarget::logW( QString("Misc: time < 0: %1").arg(var) );
+      qWarning() << QString("Misc: time < 0: %1").arg(var);
    else {
       m_time = var;
       if ( ! m_cacheOnly ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -412,7 +412,7 @@ QVector<PreInstruction> Recipe::hopSteps(Hop::Use type)
             str = tr("Steep %1 %2 in wort for %3.");
          else
          {
-            Brewtarget::logW("Recipe::hopSteps(): Unrecognized hop use.");
+            qWarning() << "Recipe::hopSteps(): Unrecognized hop use.";
             str = tr("Use %1 %2 for %3");
          }
 
@@ -453,7 +453,7 @@ QVector<PreInstruction> Recipe::miscSteps(Misc::Use type)
             str = tr("Put %1 %2 into secondary for %3.");
          else
          {
-            Brewtarget::logW("Recipe::getMiscSteps(): Unrecognized misc use.");
+            qWarning() << "Recipe::getMiscSteps(): Unrecognized misc use.";
             str = tr("Use %1 %2 for %3.");
          }
 
@@ -928,7 +928,7 @@ void Recipe::setType( const QString &var )
 {
    QString tmp;
    if ( ! isValidType(var) ) {
-      Brewtarget::logW( QString("Recipe: invalid type: %1").arg(var) );
+      qWarning() << QString("Recipe: invalid type: %1").arg(var);
       tmp = "All Grain";
    }
    else {
@@ -953,7 +953,7 @@ void Recipe::setBatchSize_l( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: batch size < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: batch size < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -977,7 +977,7 @@ void Recipe::setBoilSize_l( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: boil size < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: boil size < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1001,7 +1001,7 @@ void Recipe::setBoilTime_min( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: boil time < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: boil time < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1020,7 +1020,7 @@ void Recipe::setEfficiency_pct( double var )
    double tmp;
    if( var < 0.0  || var > 100.0 )
    {
-      Brewtarget::logW( QString("Recipe: 0 < efficiency < 100: %1").arg(var) );
+      qWarning() << QString("Recipe: 0 < efficiency < 100: %1").arg(var);
       tmp = 70;
    }
    else
@@ -1068,7 +1068,7 @@ void Recipe::setTasteRating( double var )
    double tmp;
    if( var < 0.0 || var > 50.0 )
    {
-      Brewtarget::logW( QString("Recipe: 0 < taste rating < 50: %1").arg(var) );
+      qWarning() << QString("Recipe: 0 < taste rating < 50: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1087,7 +1087,7 @@ void Recipe::setOg( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: og < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: og < 0: %1").arg(var);
       tmp = 1.0;
    }
    else
@@ -1106,7 +1106,7 @@ void Recipe::setFg( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: fg < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: fg < 0: %1").arg(var);
       tmp = 1.0;
    }
    else
@@ -1125,7 +1125,7 @@ void Recipe::setFermentationStages( int var )
    int tmp;
    if( var < 0 )
    {
-      Brewtarget::logW( QString("Recipe: stages < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: stages < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1144,7 +1144,7 @@ void Recipe::setPrimaryAge_days( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: primary age < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: primary age < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1171,7 +1171,7 @@ void Recipe::setSecondaryAge_days( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: secondary age < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: secondary age < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1198,7 +1198,7 @@ void Recipe::setTertiaryAge_days( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: tertiary age < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: tertiary age < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1225,7 +1225,7 @@ void Recipe::setAge_days( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: age < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: age < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1262,7 +1262,7 @@ void Recipe::setCarbonation_vols( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: carb < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: carb < 0: %1").arg(var);
       tmp = 0;
    }
    else
@@ -1305,7 +1305,7 @@ void Recipe::setPrimingSugarEquiv( double var )
    double tmp;
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: primingsugarequiv < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: primingsugarequiv < 0: %1").arg(var);
       tmp = 1;
    }
    else
@@ -1325,7 +1325,7 @@ void Recipe::setKegPrimingFactor( double var )
 
    if( var < 0.0 )
    {
-      Brewtarget::logW( QString("Recipe: keg priming factor < 0: %1").arg(var) );
+      qWarning() << QString("Recipe: keg priming factor < 0: %1").arg(var);
       tmp = 1;
    }
    else
@@ -1534,7 +1534,7 @@ template<class T> T * Recipe::add(T * var) {
 
 Ingredient * Recipe::removeIngredient( Ingredient *var )
 {
-//   Brewtarget::logD(QString("%1").arg(Q_FUNC_INFO));
+//   qDebug() << QString("%1").arg(Q_FUNC_INFO);
 
    // brewnotes a bit odd
    if ( dynamic_cast<BrewNote*>(var) ) {

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -235,7 +235,7 @@ public:
     * making add and remove more symmetric).
     */
    template<class T> T * remove(T * var) {
-//      Brewtarget::logD(QString("%1").arg(Q_FUNC_INFO));
+//      qDebug() << QString("%1").arg(Q_FUNC_INFO);
       return static_cast<T *>(this->removeIngredient(var));
    }
 

--- a/src/yeast.cpp
+++ b/src/yeast.cpp
@@ -271,7 +271,7 @@ void Yeast::setForm( Yeast::Form f )
 void Yeast::setAmount( double var )
 {
    if( var < 0.0 )
-      Brewtarget::logW( QString("Yeast: amount < 0: %1").arg(var) );
+      qWarning() << QString("Yeast: amount < 0: %1").arg(var);
    else {
       m_amount = var;
       if ( ! m_cacheOnly ) {
@@ -283,7 +283,7 @@ void Yeast::setAmount( double var )
 void Yeast::setInventoryQuanta( int var )
 {
    if( var < 0.0 ) {
-      Brewtarget::logW( QString("Yeast: inventory < 0: %1").arg(var) );
+      qWarning() << QString("Yeast: inventory < 0: %1").arg(var);
    }
    else {
       m_inventory = var;


### PR DESCRIPTION
This PR will add new functionality to the Logging in Brewtarget.
Short description of what's been updated:
 - Log-Class has been rewritten as a Log Namespace to better suit the Qt Framworks QDebug library.
 - Refined logging and file management
 - Build the log rotation functionality
 - Build a test in QtTest for the logging librarys log rotation functionality.
 - Fixing up Copyright on modified files.

After these changes you can use either Brewtarget:logX(....) functions or use the QDebug- functions directly, i.e. QDebug() << "some nifty debug message" << someVariable;

This is part 1 of Issue #504 to help with logging when importing BeerXML files into Brewtarget
