### PR TITLE
Closes #507 - adding equipment to new recipe

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1259,6 +1259,8 @@ void MainWindow::droppedRecipeEquipment(Equipment *kit)
    {
       m->setTunWeight_kg( kit->tunWeight_kg() );
       m->setTunSpecificHeat_calGC( kit->tunSpecificHeat_calGC() );
+      new SimpleUndoableUpdate(*m, "tunWeight_kg", m->tunWeight_kg(), tr("Change Tun Weight"), equipmentUpdate);
+      new SimpleUndoableUpdate(*m, "tunSpecificHeat_calGC", m->tunSpecificHeat_calGC(), tr("Change Tun Specific Heat"), equipmentUpdate);
    }
 
    if( QMessageBox::question(this,
@@ -1278,9 +1280,6 @@ void MainWindow::droppedRecipeEquipment(Equipment *kit)
       new SimpleUndoableUpdate(*this->recipeObs, "batchSize_l", kit->batchSize_l(), tr("Change Batch Size"), equipmentUpdate);
       new SimpleUndoableUpdate(*this->recipeObs, "boilSize_l", kit->boilSize_l(), tr("Change Boil Size"), equipmentUpdate);
       new SimpleUndoableUpdate(*this->recipeObs, "boilTime_min", kit->boilTime_min(), tr("Change Boil Time"), equipmentUpdate);
-      Mash * mash = this->recipeObs->mash();
-      new SimpleUndoableUpdate(*mash, "tunWeight_kg", mash->tunWeight_kg(), tr("Change Tun Weight"), equipmentUpdate);
-      new SimpleUndoableUpdate(*mash, "tunSpecificHeat_calGC", mash->tunSpecificHeat_calGC(), tr("Change Tun Specific Heat"), equipmentUpdate);
    }
 
    // This will do the equipment update and any related updates - see above

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1257,10 +1257,8 @@ void MainWindow::droppedRecipeEquipment(Equipment *kit)
    Mash* m = recipeObs->mash();
    if( m )
    {
-      m->setTunWeight_kg( kit->tunWeight_kg() );
-      m->setTunSpecificHeat_calGC( kit->tunSpecificHeat_calGC() );
-      new SimpleUndoableUpdate(*m, "tunWeight_kg", m->tunWeight_kg(), tr("Change Tun Weight"), equipmentUpdate);
-      new SimpleUndoableUpdate(*m, "tunSpecificHeat_calGC", m->tunSpecificHeat_calGC(), tr("Change Tun Specific Heat"), equipmentUpdate);
+      new SimpleUndoableUpdate(*m, "tunWeight_kg", kit->tunWeight_kg(), tr("Change Tun Weight"), equipmentUpdate);
+      new SimpleUndoableUpdate(*m, "tunSpecificHeat_calGC", kit->tunSpecificHeat_calGC(), tr("Change Tun Specific Heat"), equipmentUpdate);
    }
 
    if( QMessageBox::question(this,


### PR DESCRIPTION
My usual process in creating a new recipe is to create the recipe; set the style and equipment; add fermentables, hops and yeast; and then define the mash.

The undo code missed this possible path and assumed there would always be a mash. In my path, mash was null and we sigsegv'd.

The fix was to move the creation of the undo objects for the tunWeight and tunSpecificGravity properties to earlier in the code, where we had already checked to make sure we had a mash. We also modified those two properties regardless of how the user responds to the dialog we prompt, so moving the undo made that work a bit better.