### PR TITLE
Declaration of getTypeName was incorrectly declared in Log.cpp. fixed.

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -187,7 +187,7 @@ namespace Log
       //emit wroteEntry(logEntry);
    }
 
-   QString Log::getTypeName(const LogType type) {
+   QString getTypeName(const LogType type) {
       return QString(logLevelNames[type]);
    }
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -118,6 +118,6 @@ namespace Log
 
    /* Get the list of Logfiles present in the directory currently logging in and returns a FileInfoList containing the files.*/
    extern QFileInfoList getLogFileList();
-};
+}
 
 #endif /* _LOG_H */


### PR DESCRIPTION
As jimdbr so correctly found is that the getTypeName was incorrectly defined in Log.cpp.
This PR fixes that issue.

Built and testes on both windows and Linux.
