### PR TITLE
Fixing Log initialization.

### DIFF
--- a/src/BtTreeItem.cpp
+++ b/src/BtTreeItem.cpp
@@ -314,7 +314,7 @@ QVariant BtTreeItem::dataMisc(int column)
             return QVariant(misc->useStringTr());
          break;
       default :
-         QString("BtTreeItem::dataMisc Bad column: %1").arg(column);
+         qWarning() << QString("BtTreeItem::dataMisc Bad column: %1").arg(column);
    }
    return QVariant();
 }

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -53,11 +53,17 @@ namespace Log
    };
 
    // options set by the end user.
+   // Default logging set to enable to get the first logs out.
    bool loggingEnabled(true);
-   LogType logLevel = LogType_DEBUG;
+   // Default logging level set to INFO, to get only status logs.
+   LogType logLevel = LogType_INFO;
+   // Stores the path to the logfiles
    QDir logFilePath;
+   // Set to true if you want brewtarget to figure out where to put the logs.
    bool logUseConfigDir = true;
+   // Set the log file size for the rotation.
    int const logFileSize = 500 * 1024;
+   // set the number of files to keep when rotating.
    int const logFileCount = 5;
    // \brief this is the file we're always logging to.
    QString logFileName("brewtarget_log");

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -60,7 +60,7 @@ namespace Log
    int const logFileSize = 500 * 1024;
    int const logFileCount = 5;
    // \brief this is the file we're always logging to.
-   QString logFileName("Brewtarget_Log");
+   QString logFileName("brewtarget_log");
    // \brief what file ending to use for the file.
    QString logFileNameSuffix("txt");
    QString timeFormat;

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -53,8 +53,8 @@ namespace Log
    };
 
    // options set by the end user.
-   bool loggingEnabled = false;
-   LogType logLevel = LogType_INFO;
+   bool loggingEnabled(true);
+   LogType logLevel = LogType_DEBUG;
    QDir logFilePath;
    bool logUseConfigDir = true;
    int const logFileSize = 500 * 1024;
@@ -71,6 +71,7 @@ namespace Log
          .arg(logFileName)
          .arg(logFileNameSuffix);
    }
+
    bool initializeLog()
    {
       timeFormat = "hh:mm:ss.zzz";
@@ -80,22 +81,8 @@ namespace Log
       {
          logFilePath.setPath(QDir::tempPath());
       }
-      else
-      {
-         logFilePath.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
-      }
-      //check if Logging directory exists and if not create it.
-      if (!QDir(logFilePath).exists())
-      {
-         QDir().mkpath(logFilePath.canonicalPath());
-      }
-      //Delete old files
-      pruneLogFiles();
-      //Generate a new logfile and open a stream for writing
-      initLogFileName();
-      //Register the Message handler with QT framwork to enable the qDebug macro
       qInstallMessageHandler(Log::logMessageHandler);
-
+      qDebug() << Q_FUNC_INFO << "Logging initialized ";
       return true;
    }
 
@@ -123,6 +110,7 @@ namespace Log
    }
 
    void changeDirectory() {
+      qDebug() << Q_FUNC_INFO;
       //If it's the same, just return, no need to do anything.
       if (logFilePath.filePath(logFileFullName()) == logFile.fileName()) {
          return;
@@ -131,6 +119,7 @@ namespace Log
       //Check if the new directory exists, if not create it.
       if (!logFilePath.exists())
       {
+         qDebug() << Q_FUNC_INFO << logFilePath.canonicalPath() << "does not exist, creating";
          if (!logFilePath.mkpath(logFilePath.canonicalPath()))
          {
             qCritical() << QString("Could not create directory as location '%1'").arg(logFilePath.canonicalPath());

--- a/src/Log.h
+++ b/src/Log.h
@@ -118,6 +118,7 @@ namespace Log
 
    /* Get the list of Logfiles present in the directory currently logging in and returns a FileInfoList containing the files.*/
    extern QFileInfoList getLogFileList();
+
 }
 
 #endif /* _LOG_H */

--- a/src/OptionDialog.cpp
+++ b/src/OptionDialog.cpp
@@ -157,6 +157,7 @@ OptionDialog::OptionDialog(QWidget* parent)
    loggingLevelComboBox->addItem(tr("Warning"), QVariant(Log::LogType_WARNING));
    loggingLevelComboBox->addItem(tr("Error"), QVariant(Log::LogType_ERROR));
    loggingLevelComboBox->addItem(tr("Debug"), QVariant(Log::LogType_DEBUG));
+   loggingLevelComboBox->setCurrentIndex(Log::logLevel);
    checkBox_enableLogging->setChecked(Log::loggingEnabled);
    checkBox_LogFileLocationUseDefault->setChecked(Log::logUseConfigDir);
    lineEdit_LogFileLocation->setText(Log::logFilePath.absolutePath());

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -1214,7 +1214,7 @@ double Brewtarget::toDouble(QString text, QString caller)
    ret = toDouble(text,&success);
 
    if ( ! success )
-      QString("%1 could not convert %2 to double").arg(caller).arg(text);
+      qWarning() << QString("%1 could not convert %2 to double").arg(caller).arg(text);
 
    return ret;
 }

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -467,6 +467,10 @@ bool Brewtarget::initialize(const QString &userDirectory)
    qRegisterMetaType< QList<Water*> >();
    qRegisterMetaType< QList<Salt*> >();
 
+   /* Here we initialize the logging to log to stderr to start with.
+    * this is to get the really early logging out put to the console.
+    * further down we read in the users settings and then update the settings in the logging library
+    */
    Log::initializeLog();
 
    // Use overwride if present.
@@ -492,7 +496,10 @@ bool Brewtarget::initialize(const QString &userDirectory)
 
    readSystemOptions();
    loadMap();
-    Log::changeDirectory();
+   /* Here we update the settings opening the file at the location specified in the Application settings and users settings.
+    * the readSystemOptions(); will update the the logFilePath in the Log library, then we run the changeDirectory to apply the settings.
+    */
+   Log::changeDirectory();
 
    // Make sure all the necessary directories and files we need exist before starting.
    ensureDirectoriesExist();
@@ -1051,16 +1058,18 @@ void Brewtarget::readSystemOptions()
    _dbType = static_cast<Brewtarget::DBTypes>(option("dbType",Brewtarget::SQLITE).toInt());
 
    //======================Logging options =======================
-    Log::loggingEnabled = option("LoggingEnabled", false).toBool();
-    Log::logLevel = Log::getLogTypeFromString(QString(option("LoggingLevel", "INFO").toString()));
-    Log::logFilePath = QDir(option("LogFilePath", getUserDataDir().canonicalPath()).toString());
-    Log::logUseConfigDir = option("LoggingUseConfigDir", true).toBool();
+   Log::loggingEnabled = option("LoggingEnabled", false).toBool();
+   Log::logLevel = Log::getLogTypeFromString(QString(option("LoggingLevel", "INFO").toString()));
+   Log::logFilePath = QDir(option("LogFilePath", getUserDataDir().canonicalPath()).toString());
+   Log::logUseConfigDir = option("LoggingUseConfigDir", true).toBool();
    if( Log::logUseConfigDir )
+   {
 #if QT_VERSION < QT_VERSION_CHECK(5,15,0)
-        Log::logFilePath = getUserDataDir().canonicalPath();
+      Log::logFilePath = getUserDataDir().canonicalPath();
 #else
       Log::logFilePath.setPath(getUserDataDir().canonicalPath());
 #endif
+   }
 }
 
 void Brewtarget::saveSystemOptions()

--- a/src/brewtarget.cpp
+++ b/src/brewtarget.cpp
@@ -467,7 +467,7 @@ bool Brewtarget::initialize(const QString &userDirectory)
    qRegisterMetaType< QList<Water*> >();
    qRegisterMetaType< QList<Salt*> >();
 
-    Log::initializeLog();
+   Log::initializeLog();
 
    // Use overwride if present.
    if (!userDirectory.isEmpty() && QDir(userDirectory).exists()) {


### PR DESCRIPTION
Now it starts to log to file after options has been read.
Early logging is sent to stderr, and Logging is enabled by default.

Error was thrown when Linux did not supply a valid path for log file at initialization, this was changed to only log to stderr at startup.
On windows there was a path supplied on my machine at least, but not on my linux laptop.
