### PR TITLE
Add a Brew It button to recipe

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -708,6 +708,8 @@ void MainWindow::setupClicks()
    connect( pushButton_mashUp, &QAbstractButton::clicked, this, &MainWindow::moveSelectedMashStepUp );
    connect( pushButton_mashDown, &QAbstractButton::clicked, this, &MainWindow::moveSelectedMashStepDown );
    connect( pushButton_mashRemove, &QAbstractButton::clicked, this, &MainWindow::removeMash );
+   connect( pushButton_brewIt, &QAbstractButton::clicked, this, &MainWindow::brewItHelper );
+   return;
 }
 
 // anything with a SIGNAL of activated() should go in here.

--- a/ui/mainWindow.ui
+++ b/ui/mainWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1050</width>
-    <height>829</height>
+    <width>1200</width>
+    <height>900</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -744,6 +744,16 @@
                      </layout>
                     </item>
                    </layout>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="pushButton_brewIt">
+                    <property name="text">
+                     <string>Brew It!</string>
+                    </property>
+                    <property name="toolTip">
+                     <string>Record what happened on brew day</string>
+                    </property>
+                   </widget>
                   </item>
                   <item>
                    <spacer name="verticalSpacer_7">


### PR DESCRIPTION
This is a fix for https://github.com/Brewtarget/brewtarget/issues/403 to make the "brew notes" functionality more visible (ie not just accessible from a right-click on the tree of recipes).