### PR TITLE
Extra define needed for pi constant for RadarChart on Windows

### DIFF
--- a/src/RadarChart.cpp
+++ b/src/RadarChart.cpp
@@ -27,6 +27,11 @@
 #include <QDebug>
 #include <QHash>
 
+// We need an extra define on Windows to access the M_PI constant in cmath.  (More details in comment below.)
+#ifdef Q_OS_WIN
+#define _USE_MATH_DEFINES
+#endif
+
 // Internal constants
 namespace {
    struct ColorAndObject{
@@ -40,7 +45,9 @@ namespace {
    // starting from 3 o'clock as 0rad.  There are 2π radians in a circle.
    //
    // When we switch to C++20, we should replace M_PI (non-standard but usually defined in cmath) with std::numbers::pi
-   // (standard as of C++20).
+   // (standard as of C++20).  Note that, on Windows,
+   // per https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-160, we also have to
+   // #define _USE_MATH_DEFINES to use M_PI.
    double const RadiansInACircle = 2 * M_PI;
 
    double const StartingAngleInRadians = RadiansInACircle / 4;


### PR DESCRIPTION
Fix for https://github.com/Brewtarget/brewtarget/issues/538

I don't have a Windows build set up on my machine, so it would be great if someone who has could quickly check this compiles as expected.