### PR TITLE
Bugs/constructors

### DIFF
--- a/src/BrewDayWidget.cpp
+++ b/src/BrewDayWidget.cpp
@@ -56,7 +56,11 @@ BrewDayWidget::BrewDayWidget(QWidget* parent) :
 
 
    // Set up the printer stuff
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
    printer->setPageSize(QPrinter::Letter);
+#else
+   printer->setPageSize(QPageSize(QPageSize::Letter));
+#endif
 
    // populate the drop down list
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -267,7 +267,11 @@ MainWindow::MainWindow(QWidget* parent)
 
    // Set up the printer
    printer = new QPrinter;
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
    printer->setPageSize(QPrinter::Letter);
+#else
+   printer->setPageSize(QPageSize(QPageSize::Letter));
+#endif
    return;
 }
 

--- a/src/TableSchema.h
+++ b/src/TableSchema.h
@@ -123,6 +123,7 @@ public:
    bool isBtTable();
    bool isMetaTable();
 
+   // convenience for the name of the key (eg, id) field in the db
    const QString keyName(Brewtarget::DBTypes type = Brewtarget::ALLDB) const;
 
 private:

--- a/src/TimerMainDialog.cpp
+++ b/src/TimerMainDialog.cpp
@@ -128,9 +128,11 @@ void TimerMainDialog::resetTimers()
     boilTime->setBoilTime(setBoilTimeBox->value() * 60);
     updateTime();
     // Reset all children timers
-    if (!timers->isEmpty())
-        foreach (TimerWidget* t, *timers)
+    if (!timers->isEmpty()) {
+        foreach (TimerWidget* t, *timers) {
             t->reset();
+        }
+    }
 }
 
 void TimerMainDialog::on_setBoilTimeBox_valueChanged(int t)

--- a/src/WaterEditor.cpp
+++ b/src/WaterEditor.cpp
@@ -142,7 +142,10 @@ void WaterEditor::showChanges(QMetaProperty* prop)
    }
    if (propName == PropertyNames::Water::alkalinityAsHCO3 || updateAll ) {
       bool typeless = this->obs->alkalinityAsHCO3();
-      comboBox_alk->setCurrentIndex(comboBox_alk->findText(typeless ? "HCO3" : "CO3"));
+      if ( this->obs->key() == 15 ) {
+         qInfo() << Q_FUNC_INFO << "typeless = " << typeless;
+      }
+      comboBox_alk->setCurrentIndex(comboBox_alk->findText(typeless ? "HCO3" : "CaCO3"));
       if ( ! updateAll ) return;
    }
    if (propName == PropertyNames::Water::notes || updateAll ) {

--- a/src/WaterEditor.cpp
+++ b/src/WaterEditor.cpp
@@ -142,9 +142,6 @@ void WaterEditor::showChanges(QMetaProperty* prop)
    }
    if (propName == PropertyNames::Water::alkalinityAsHCO3 || updateAll ) {
       bool typeless = this->obs->alkalinityAsHCO3();
-      if ( this->obs->key() == 15 ) {
-         qInfo() << Q_FUNC_INFO << "typeless = " << typeless;
-      }
       comboBox_alk->setCurrentIndex(comboBox_alk->findText(typeless ? "HCO3" : "CaCO3"));
       if ( ! updateAll ) return;
    }

--- a/src/brewnote.cpp
+++ b/src/brewnote.cpp
@@ -38,7 +38,7 @@
 #include "mash.h"
 #include "yeast.h"
 #include "database.h"
-#include "TableSchemaConst.h"
+#include "TableSchema.h"
 #include "BrewnoteSchema.h"
 
 // These belong here, because they really just are constant strings for
@@ -68,51 +68,10 @@ bool BrewNote::isEqualTo(NamedEntity const & other) const {
 }
 
 // Initializers
-BrewNote::BrewNote(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key),
+BrewNote::BrewNote(QString name, bool cache)
+   : NamedEntity(Brewtarget::BREWNOTETABLE,name,true),
      loading(false),
      m_brewDate(QDateTime()),
-     m_fermentDate(QDateTime()),
-     m_notes(QString()),
-     m_sg(0.0),
-     m_abv(0.0),
-     m_effIntoBK_pct(0.0),
-     m_brewhouseEff_pct(0.0),
-     m_volumeIntoBK_l(0.0),
-     m_strikeTemp_c(0.0),
-     m_mashFinTemp_c(0.0),
-     m_og(0.0),
-     m_postBoilVolume_l(0.0),
-     m_volumeIntoFerm_l(0.0),
-     m_pitchTemp_c(0.0),
-     m_fg(0.0),
-     m_attenuation(0.0),
-     m_finalVolume_l(0.0),
-     m_boilOff_l(0.0),
-     m_projBoilGrav(0.0),
-     m_projVolIntoBK_l(0.0),
-     m_projStrikeTemp_c(0.0),
-     m_projMashFinTemp_c(0.0),
-     m_projOg(0.0),
-     m_projVolIntoFerm_l(0.0),
-     m_projFg(0.0),
-     m_projEff_pct(0.0),
-     m_projABV_pct(0.0),
-     m_projPoints(0.0),
-     m_projFermPoints(0.0),
-     m_projAtten(0.0),
-     m_cacheOnly(false)
-{
-}
-
-BrewNote::BrewNote(QString name, bool cache) : BrewNote(QDateTime(), cache, name) {
-   return;
-}
-
-BrewNote::BrewNote(QDateTime dateNow, bool cache, QString const & name)
-   : NamedEntity(Brewtarget::BREWNOTETABLE,-1,name,true),
-     loading(false),
-     m_brewDate(dateNow),
      m_fermentDate(QDateTime()),
      m_notes(QString()),
      m_sg(0.0),
@@ -146,40 +105,40 @@ BrewNote::BrewNote(QDateTime dateNow, bool cache, QString const & name)
 {
 }
 
-BrewNote::BrewNote(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolBNoteFermDate).toString(), rec.value(kcolDisplay).toBool()),
-     m_brewDate(QDateTime::fromString(rec.value(kcolBNoteBrewDate).toString(), Qt::ISODate)),
-     m_fermentDate(QDateTime::fromString(rec.value(kcolBNoteFermDate).toString(), Qt::ISODate)),
-     m_notes(rec.value(kcolBNoteNotes).toString()),
-     m_sg(rec.value(kcolBNoteSG).toDouble()),
-     m_abv(rec.value(kcolBNoteABV).toDouble()),
-     m_effIntoBK_pct(rec.value(kcolBNoteEffIntoBoil).toDouble()),
-     m_brewhouseEff_pct(rec.value(kcolBNoteBrewhsEff).toDouble()),
-     m_volumeIntoBK_l(rec.value(kcolBNoteVolIntoBoil).toDouble()),
-     m_strikeTemp_c(rec.value(kcolBNoteStrikeTemp).toDouble()),
-     m_mashFinTemp_c(rec.value(kcolBNoteMashFinTemp).toDouble()),
-     m_og(rec.value(kcolBNoteOG).toDouble()),
-     m_postBoilVolume_l(rec.value(kcolBNotePostBoilVol).toDouble()),
-     m_volumeIntoFerm_l(rec.value(kcolBNoteVolIntoFerm).toDouble()),
-     m_pitchTemp_c(rec.value(kcolBNotePitchTemp).toDouble()),
-     m_fg(rec.value(kcolBNoteFG).toDouble()),
-     m_attenuation(rec.value(kcolBNoteAtten).toDouble()),
-     m_finalVolume_l(rec.value(kcolBNoteFinVol).toDouble()),
-     m_boilOff_l(rec.value(kcolBNoteBoilOff).toDouble()),
-     m_projBoilGrav(rec.value(kcolBNoteProjBoilGrav).toDouble()),
-     m_projVolIntoBK_l(rec.value(kcolBNoteProjVolIntoBoil).toDouble()),
-     m_projStrikeTemp_c(rec.value(kcolBNoteProjStrikeTemp).toDouble()),
-     m_projMashFinTemp_c(rec.value(kcolBNoteProjMashFinTemp).toDouble()),
-     m_projOg(rec.value(kcolBNoteProjOG).toDouble()),
-     m_projVolIntoFerm_l(rec.value(kcolBNoteProjVolIntoFerm).toDouble()),
-     m_projFg(rec.value(kcolBNoteProjFG).toDouble()),
-     m_projEff_pct(rec.value(kcolBNoteProjEff).toDouble()),
-     m_projABV_pct(rec.value(kcolBNoteProjABV).toDouble()),
-     m_projPoints(rec.value(kcolBNoteProjPnts).toDouble()),
-     m_projFermPoints(rec.value(kcolBNoteProjFermPnts).toDouble()),
-     m_projAtten(rec.value(kcolBNoteProjAtten).toDouble()),
+BrewNote::BrewNote(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
      m_cacheOnly(false)
 {
+     m_brewDate = QDateTime::fromString( rec.value( table->propertyToColumn( PropertyNames::BrewNote::brewDate )).toString(), Qt::ISODate);
+     m_fermentDate = QDateTime::fromString(rec.value( table->propertyToColumn(PropertyNames::BrewNote::fermentDate)).toString(), Qt::ISODate);
+     m_notes = rec.value( table->propertyToColumn(PropertyNames::BrewNote::notes)).toString();
+     m_sg = rec.value( table->propertyToColumn(PropertyNames::BrewNote::sg)).toDouble();
+     m_abv = rec.value( table->propertyToColumn(PropertyNames::BrewNote::abv)).toDouble();
+     m_effIntoBK_pct = rec.value( table->propertyToColumn(PropertyNames::BrewNote::effIntoBK_pct)).toDouble();
+     m_brewhouseEff_pct = rec.value( table->propertyToColumn(PropertyNames::BrewNote::brewhouseEff_pct)).toDouble();
+     m_volumeIntoBK_l = rec.value( table->propertyToColumn(PropertyNames::BrewNote::volumeIntoBK_l)).toDouble();
+     m_strikeTemp_c = rec.value( table->propertyToColumn(PropertyNames::BrewNote::strikeTemp_c)).toDouble();
+     m_mashFinTemp_c = rec.value( table->propertyToColumn(PropertyNames::BrewNote::mashFinTemp_c)).toDouble();
+     m_og = rec.value( table->propertyToColumn(PropertyNames::BrewNote::og)).toDouble();
+     m_postBoilVolume_l = rec.value( table->propertyToColumn(PropertyNames::BrewNote::postBoilVolume_l)).toDouble();
+     m_volumeIntoFerm_l = rec.value( table->propertyToColumn(PropertyNames::BrewNote::volumeIntoFerm_l)).toDouble();
+     m_pitchTemp_c = rec.value( table->propertyToColumn(PropertyNames::BrewNote::pitchTemp_c)).toDouble();
+     m_fg = rec.value( table->propertyToColumn(PropertyNames::BrewNote::fg)).toDouble();
+     m_attenuation = rec.value( table->propertyToColumn(PropertyNames::BrewNote::attenuation)).toDouble();
+     m_finalVolume_l = rec.value( table->propertyToColumn(PropertyNames::BrewNote::finalVolume_l)).toDouble();
+     m_boilOff_l = rec.value( table->propertyToColumn(PropertyNames::BrewNote::boilOff_l)).toDouble();
+     m_projBoilGrav = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projBoilGrav)).toDouble();
+     m_projVolIntoBK_l = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projVolIntoBK_l)).toDouble();
+     m_projStrikeTemp_c = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projStrikeTemp_c)).toDouble();
+     m_projMashFinTemp_c = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projMashFinTemp_c)).toDouble();
+     m_projOg = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projOg)).toDouble();
+     m_projVolIntoFerm_l = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projVolIntoFerm_l)).toDouble();
+     m_projFg = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projFg)).toDouble();
+     m_projEff_pct = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projEff_pct)).toDouble();
+     m_projABV_pct = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projABV_pct)).toDouble();
+     m_projPoints = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projPoints)).toDouble();
+     m_projFermPoints = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projFermPoints)).toDouble();
+     m_projAtten = rec.value( table->propertyToColumn(PropertyNames::BrewNote::projAtten)).toDouble();
 }
 
 void BrewNote::populateNote(Recipe* parent)

--- a/src/brewnote.cpp
+++ b/src/brewnote.cpp
@@ -105,8 +105,8 @@ BrewNote::BrewNote(QString name, bool cache)
 {
 }
 
-BrewNote::BrewNote(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+BrewNote::BrewNote(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
      m_cacheOnly(false)
 {
      m_brewDate = QDateTime::fromString( rec.value( table->propertyToColumn( PropertyNames::BrewNote::brewDate )).toString(), Qt::ISODate);

--- a/src/brewnote.h
+++ b/src/brewnote.h
@@ -77,6 +77,7 @@ class BrewNote : public NamedEntity
    friend class BeerXML;
 
 public:
+   BrewNote(QString name, bool cache = true);
    virtual ~BrewNote() = default;
 
    bool operator<(BrewNote const & other) const;
@@ -224,12 +225,11 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
+   BrewNote(TableSchema* table, QSqlRecord rec);
+   /*
    BrewNote(Brewtarget::DBTable table, int key);
-   BrewNote(Brewtarget::DBTable table, int key, QSqlRecord rec);
-public:
-   BrewNote(QString name, bool cache = true);
-private:
    BrewNote(QDateTime dateNow, bool cache = true, QString const & name = "");
+   */
    BrewNote(BrewNote const& other);
    bool loading;
 

--- a/src/brewnote.h
+++ b/src/brewnote.h
@@ -225,7 +225,7 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   BrewNote(TableSchema* table, QSqlRecord rec);
+   BrewNote(TableSchema* table, QSqlRecord rec, int t_key = -1);
    /*
    BrewNote(Brewtarget::DBTable table, int key);
    BrewNote(QDateTime dateNow, bool cache = true, QString const & name = "");

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -2431,7 +2431,7 @@ template<class T> T* Database::addNamedEntityToRecipe(
       }
 
       // Put this (ing,rec) pair in the <ing_type>_in_recipe table.
-      // q.setForwardOnly(true);
+      q.setForwardOnly(true);
 
       // Link the ingredient to the recipe in the DB
       // Eg, for a fermentable, this is INSERT INTO fermentable_in_recipe (fermentable_id, recipe_id) VALUES (:ingredient, :recipe)
@@ -3301,13 +3301,13 @@ template<class T> T* Database::copy( NamedEntity const* object, QHash<int,T*>* k
          throw QString("could not execute %1 : %2").arg(insert.lastQuery()).arg(insert.lastError().text());
 
       newKey = insert.lastInsertId().toInt();
-      newOne = new T(tbl, oldRecord);
+      newOne = new T(tbl, oldRecord, newKey);
       keyHash->insert( newKey, newOne );
    }
    catch (QString e) {
       qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       q.finish();
-      throw;
+      abort();
    }
 
    q.finish();

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -77,8 +77,8 @@ Equipment::Equipment(QString t_name, bool cacheOnly)
 {
 }
 
-Equipment::Equipment(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec ),
+Equipment::Equipment(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key ),
    m_cacheOnly(false)
 {
    m_boilSize_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::boilSize_l)).toDouble();

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -55,7 +55,7 @@ bool Equipment::isEqualTo(NamedEntity const & other) const {
 
 //=============================CONSTRUCTORS=====================================
 Equipment::Equipment(QString t_name, bool cacheOnly)
-   : NamedEntity(Brewtarget::EQUIPTABLE, -1, t_name, true),
+   : NamedEntity(Brewtarget::EQUIPTABLE, t_name, true),
    m_boilSize_l(22.927),
    m_batchSize_l(18.927),
    m_tunVolume_l(0.0),
@@ -77,50 +77,28 @@ Equipment::Equipment(QString t_name, bool cacheOnly)
 {
 }
 
-Equipment::Equipment(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key, QString(), true ),
-   m_boilSize_l(22.927),
-   m_batchSize_l(18.927),
-   m_tunVolume_l(0.0),
-   m_tunWeight_kg(0.0),
-   m_tunSpecificHeat_calGC(0.0),
-   m_topUpWater_l(0.0),
-   m_trubChillerLoss_l(1.0),
-   m_evapRate_pctHr(0.0),
-   m_evapRate_lHr(4.0),
-   m_boilTime_min(60.0),
-   m_calcBoilVolume(true),
-   m_lauterDeadspace_l(0.0),
-   m_topUpKettle_l(0.0),
-   m_hopUtilization_pct(100.0),
-   m_notes(QString()),
-   m_grainAbsorption_LKg(1.086),
-   m_boilingPoint_c(100.0),
+Equipment::Equipment(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec ),
    m_cacheOnly(false)
 {
-}
+   m_boilSize_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::boilSize_l)).toDouble();
+   m_batchSize_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::batchSize_l)).toDouble();
+   m_tunVolume_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::tunVolume_l)).toDouble();
+   m_tunWeight_kg = rec.value( table->propertyToColumn( PropertyNames::Equipment::tunWeight_kg)).toDouble();
+   m_tunSpecificHeat_calGC = rec.value( table->propertyToColumn( PropertyNames::Equipment::tunSpecificHeat_calGC)).toDouble();
+   m_topUpWater_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::topUpWater_l)).toDouble();
+   m_trubChillerLoss_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::trubChillerLoss_l)).toDouble();
+   m_evapRate_pctHr = rec.value( table->propertyToColumn( PropertyNames::Equipment::evapRate_pctHr)).toDouble();
+   m_evapRate_lHr = rec.value( table->propertyToColumn( PropertyNames::Equipment::evapRate_lHr)).toDouble();
+   m_boilTime_min = rec.value( table->propertyToColumn( PropertyNames::Equipment::boilTime_min)).toDouble();
+   m_calcBoilVolume = rec.value( table->propertyToColumn( PropertyNames::Equipment::calcBoilVolume)).toBool();
+   m_lauterDeadspace_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::lauterDeadspace_l)).toDouble();
+   m_topUpKettle_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::topUpKettle_l)).toDouble();
+   m_hopUtilization_pct = rec.value( table->propertyToColumn( PropertyNames::Equipment::hopUtilization_pct)).toDouble();
+   m_notes = rec.value( table->propertyToColumn(PropertyNames::Equipment::notes)).toString();
+   m_grainAbsorption_LKg = rec.value( table->propertyToColumn( PropertyNames::Equipment::grainAbsorption_LKg)).toDouble();
+   m_boilingPoint_c = rec.value( table->propertyToColumn( PropertyNames::Equipment::boilingPoint_c)).toDouble();
 
-Equipment::Equipment(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool(), rec.value(kcolFolder).toString()),
-   m_boilSize_l(rec.value(kcolEquipBoilSize).toDouble()),
-   m_batchSize_l(rec.value(kcolEquipBatchSize).toDouble()),
-   m_tunVolume_l(rec.value(kcolEquipTunVolume).toDouble()),
-   m_tunWeight_kg(rec.value(kcolEquipTunWeight).toDouble()),
-   m_tunSpecificHeat_calGC(rec.value(kcolEquipTunSpecHeat).toDouble()),
-   m_topUpWater_l(rec.value(kcolEquipTopUpWater).toDouble()),
-   m_trubChillerLoss_l(rec.value(kcolEquipTrubChillLoss).toDouble()),
-   m_evapRate_pctHr(rec.value(kcolEquipEvapRate).toDouble()),
-   m_evapRate_lHr(rec.value(kcolEquipRealEvapRate).toDouble()),
-   m_boilTime_min(rec.value(kcolEquipBoilTime).toDouble()),
-   m_calcBoilVolume(rec.value(kcolEquipCalcBoilVol).toBool()),
-   m_lauterDeadspace_l(rec.value(kcolEquipLauterSpace).toDouble()),
-   m_topUpKettle_l(rec.value(kcolEquipTopUpKettle).toDouble()),
-   m_hopUtilization_pct(rec.value(kcolEquipHopUtil).toDouble()),
-   m_notes(rec.value(kcolNotes).toString()),
-   m_grainAbsorption_LKg(rec.value(kcolEquipAbsorption).toDouble()),
-   m_boilingPoint_c(rec.value(kcolEquipBoilingPoint).toDouble()),
-   m_cacheOnly(false)
-{
 }
 
 Equipment::Equipment( Equipment const& other )

--- a/src/equipment.h
+++ b/src/equipment.h
@@ -169,7 +169,7 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Equipment(TableSchema* table, QSqlRecord rec);
+   Equipment(TableSchema* table, QSqlRecord rec, int t_key = -1);
    // Equipment(Brewtarget::DBTable table, int key);
    Equipment( Equipment const& other);
 

--- a/src/equipment.h
+++ b/src/equipment.h
@@ -59,6 +59,7 @@ class Equipment : public NamedEntity
 
 public:
 
+   Equipment(QString t_name, bool cacheOnly = true);
    virtual ~Equipment() {}
 
    //! \brief The boil size in liters.
@@ -168,11 +169,8 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Equipment(Brewtarget::DBTable table, int key);
-public:
-   Equipment(QString t_name, bool cacheOnly = true);
-private:
-   Equipment(Brewtarget::DBTable table, int key, QSqlRecord rec);
+   Equipment(TableSchema* table, QSqlRecord rec);
+   // Equipment(Brewtarget::DBTable table, int key);
    Equipment( Equipment const& other);
 
    double m_boilSize_l;

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -62,7 +62,7 @@ QString Fermentable::classNameStr()
 }
 
 Fermentable::Fermentable(QString name, bool cache)
-   : NamedEntity(Brewtarget::FERMTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::FERMTABLE, name, true),
      m_typeStr(QString()),
      m_type(static_cast<Fermentable::Type>(0)),
      m_amountKg(0.0),
@@ -86,54 +86,33 @@ Fermentable::Fermentable(QString name, bool cache)
 {
 }
 
-Fermentable::Fermentable(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key, QString(), true),
-     m_typeStr(QString()),
-     m_type(static_cast<Fermentable::Type>(0)),
-     m_amountKg(0.0),
-     m_yieldPct(0.0),
-     m_colorSrm(0.0),
-     m_isAfterBoil(false),
-     m_origin(QString()),
-     m_supplier(QString()),
-     m_notes(QString()),
-     m_coarseFineDiff(0.0),
-     m_moisturePct(0.0),
-     m_diastaticPower(0.0),
-     m_proteinPct(0.0),
-     m_maxInBatchPct(0.0),
-     m_recommendMash(true),
-     m_ibuGalPerLb(0.0),
+Fermentable::Fermentable(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
      m_inventory(-1.0),
-     m_inventory_id(0),
-     m_isMashed(true),
      m_cacheOnly(false)
 {
-}
+     m_typeStr = rec.value( table->propertyToColumn( PropertyNames::Fermentable::type)).toString();
+     m_amountKg = rec.value( table->propertyToColumn( PropertyNames::Fermentable::amount_kg)).toDouble();
+     m_yieldPct = rec.value( table->propertyToColumn( PropertyNames::Fermentable::yield_pct)).toDouble();
+     m_colorSrm = rec.value( table->propertyToColumn( PropertyNames::Fermentable::color_srm)).toDouble();
+     m_isAfterBoil = rec.value( table->propertyToColumn( PropertyNames::Fermentable::addAfterBoil)).toBool();
+     m_origin = rec.value( table->propertyToColumn( PropertyNames::Fermentable::origin)).toString();
+     m_supplier = rec.value( table->propertyToColumn( PropertyNames::Fermentable::supplier)).toString();
+     m_notes = rec.value(table->propertyToColumn( PropertyNames::Fermentable::notes)).toString();
+     m_coarseFineDiff = rec.value( table->propertyToColumn( PropertyNames::Fermentable::coarseFineDiff_pct)).toDouble();
+     m_moisturePct = rec.value( table->propertyToColumn( PropertyNames::Fermentable::moisture_pct)).toDouble();
+     m_diastaticPower = rec.value( table->propertyToColumn( PropertyNames::Fermentable::diastaticPower_lintner)).toDouble();
+     m_proteinPct = rec.value( table->propertyToColumn( PropertyNames::Fermentable::protein_pct)).toDouble();
+     m_maxInBatchPct = rec.value( table->propertyToColumn( PropertyNames::Fermentable::maxInBatch_pct)).toDouble();
+     m_recommendMash = rec.value( table->propertyToColumn( PropertyNames::Fermentable::recommendMash)).toBool();
+     m_ibuGalPerLb = rec.value( table->propertyToColumn( PropertyNames::Fermentable::ibuGalPerLb)).toDouble();
+     m_isMashed = rec.value( table->propertyToColumn( PropertyNames::Fermentable::isMashed)).toBool();
 
-Fermentable::Fermentable(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool(), rec.value(kcolFolder).toString()),
-     m_typeStr(rec.value(kcolFermType).toString()),
-     m_type(static_cast<Fermentable::Type>(types.indexOf(m_typeStr))),
-     m_amountKg(rec.value(kcolFermAmount).toDouble()),
-     m_yieldPct(rec.value(kcolFermYield).toDouble()),
-     m_colorSrm(rec.value(kcolFermColor).toDouble()),
-     m_isAfterBoil(rec.value(kcolFermAddAfterBoil).toBool()),
-     m_origin(rec.value(kcolFermOrigin).toString()),
-     m_supplier(rec.value(kcolFermSupplier).toString()),
-     m_notes(rec.value(kcolNotes).toString()),
-     m_coarseFineDiff(rec.value(kcolFermCoarseFineDiff).toDouble()),
-     m_moisturePct(rec.value(kcolFermMoisture).toDouble()),
-     m_diastaticPower(rec.value(kcolFermDiastaticPower).toDouble()),
-     m_proteinPct(rec.value(kcolFermProtein).toDouble()),
-     m_maxInBatchPct(rec.value(kcolFermMaxInBatch).toDouble()),
-     m_recommendMash(rec.value(kcolFermRecommendMash).toBool()),
-     m_ibuGalPerLb(rec.value(kcolFermIBUGalPerLb).toDouble()),
-     m_inventory(-1.0),
-     m_inventory_id(rec.value(kcolInventoryId).toInt()),
-     m_isMashed(rec.value(kcolFermIsMashed).toBool()),
-     m_cacheOnly(false)
-{
+     // keys is different critters
+     m_inventory_id = rec.value( table->foreignKeyToColumn(PropertyNames::Fermentable::inventory_id)).toInt();
+
+     // calculated, not retrieved from the db
+     m_type = static_cast<Fermentable::Type>(types.indexOf(m_typeStr));
 }
 
 Fermentable::Fermentable( Fermentable &other )
@@ -399,8 +378,9 @@ void Fermentable::setInventoryAmount( double num )
    else
    {
       m_inventory = num;
-      if ( ! m_cacheOnly )
+      if ( ! m_cacheOnly ) {
          setInventory(num,m_inventory_id);
+      }
    }
 }
 
@@ -413,15 +393,16 @@ void Fermentable::setInventoryId( int key )
    else
    {
       m_inventory_id = key;
-      if ( ! m_cacheOnly )
+      if ( ! m_cacheOnly ) {
          setEasy(kpropInventoryId,key);
+      }
    }
 }
 
 double Fermentable::inventory()
 {
    if ( m_inventory < 0 ) {
-      m_inventory = getInventory(PropertyNames::Fermentable::inventory).toDouble();
+      m_inventory = getInventory().toDouble();
    }
    return m_inventory;
 }

--- a/src/fermentable.cpp
+++ b/src/fermentable.cpp
@@ -86,8 +86,8 @@ Fermentable::Fermentable(QString name, bool cache)
 {
 }
 
-Fermentable::Fermentable(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+Fermentable::Fermentable(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
      m_inventory(-1.0),
      m_cacheOnly(false)
 {

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -29,6 +29,7 @@
 #include "model/NamedEntity.h"
 #include "unit.h"
 namespace PropertyNames::Fermentable { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
+namespace PropertyNames::Fermentable { static char const * const inventory_id = "inventory_id"; /* previously kpropInventoryId */ }
 namespace PropertyNames::Fermentable { static char const * const origin = "origin"; /* previously kpropOrigin */ }
 namespace PropertyNames::Fermentable { static char const * const amount_kg = "amount_kg"; /* previously kpropAmountKg */ }
 namespace PropertyNames::Fermentable { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
@@ -72,6 +73,7 @@ public:
    enum AdditionTime {Normal, Late};
    Q_ENUMS( Type AdditionMethod AdditionTime )
 
+   Fermentable( QString name, bool cache = true );
    virtual ~Fermentable() {}
 
    //! \brief The \c Type.
@@ -200,12 +202,10 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Fermentable(Brewtarget::DBTable table, int key);
-   Fermentable(Brewtarget::DBTable table, int key, QSqlRecord rec);
+//   Fermentable(Brewtarget::DBTable table, int key);
+   Fermentable(TableSchema* table, QSqlRecord rec);
+
    Fermentable( Fermentable &other );
-public:
-   Fermentable( QString name, bool cache = true );
-private:
 
    static bool isValidType( const QString& str );
    static QStringList types;

--- a/src/fermentable.h
+++ b/src/fermentable.h
@@ -203,7 +203,7 @@ protected:
 
 private:
 //   Fermentable(Brewtarget::DBTable table, int key);
-   Fermentable(TableSchema* table, QSqlRecord rec);
+   Fermentable(TableSchema* table, QSqlRecord rec, int t_key = -1);
 
    Fermentable( Fermentable &other );
 

--- a/src/hop.cpp
+++ b/src/hop.cpp
@@ -76,34 +76,8 @@ QString Hop::classNameStr()
    return name;
 }
 
-Hop::Hop(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key, QString()),
-     m_useStr(QString()),
-     m_use(static_cast<Hop::Use>(0)),
-     m_typeStr(QString()),
-     m_type(static_cast<Hop::Type>(0)),
-     m_formStr(QString()),
-     m_form(static_cast<Hop::Form>(0)),
-     m_alpha_pct(0.0),
-     m_amount_kg(0.0),
-     m_time_min(0.0),
-     m_notes(QString()),
-     m_beta_pct(0.0),
-     m_hsi_pct(0.0),
-     m_origin(QString()),
-     m_substitutes(QString()),
-     m_humulene_pct(0.0),
-     m_caryophyllene_pct(0.0),
-     m_cohumulone_pct(0.0),
-     m_myrcene_pct(0.0),
-     m_inventory(-1.0),
-     m_inventory_id(0),
-     m_cacheOnly(false)
-{
-}
-
 Hop::Hop(QString name, bool cache)
-   : NamedEntity(Brewtarget::HOPTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::HOPTABLE, name, true),
      m_useStr(QString()),
      m_use(static_cast<Hop::Use>(0)),
      m_typeStr(QString()),
@@ -128,30 +102,34 @@ Hop::Hop(QString name, bool cache)
 {
 }
 
-Hop::Hop(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool(), rec.value(kcolFolder).toString()),
-     m_useStr(rec.value(kcolUse).toString()),
-     m_use(static_cast<Hop::Use>(uses.indexOf(m_useStr))),
-     m_typeStr(rec.value(kcolHopType).toString()),
-     m_type(static_cast<Hop::Type>(types.indexOf(m_typeStr))),
-     m_formStr(rec.value(kcolHopForm).toString()),
-     m_form(static_cast<Hop::Form>(forms.indexOf(m_formStr))),
-     m_alpha_pct(rec.value(kcolHopAlpha).toDouble()),
-     m_amount_kg(rec.value(kcolHopAmount).toDouble()),
-     m_time_min(rec.value(kcolTime).toDouble()),
-     m_notes(rec.value(kcolNotes).toString()),
-     m_beta_pct(rec.value(kcolHopBeta).toDouble()),
-     m_hsi_pct(rec.value(kcolHopHSI).toDouble()),
-     m_origin(rec.value(kcolOrigin).toString()),
-     m_substitutes(rec.value(kcolSubstitutes).toString()),
-     m_humulene_pct(rec.value(kcolHopHumulene).toDouble()),
-     m_caryophyllene_pct(rec.value(kcolHopCaryophyllene).toDouble()),
-     m_cohumulone_pct(rec.value(kcolHopCohumulone).toDouble()),
-     m_myrcene_pct(rec.value(kcolHopMyrcene).toDouble()),
+Hop::Hop(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
      m_inventory(-1.0),
-     m_inventory_id(rec.value(kcolInventoryId).toInt()),
      m_cacheOnly(false)
 {
+     m_useStr = rec.value(table->propertyToColumn(PropertyNames::Hop::use)).toString();
+     m_typeStr = rec.value(table->propertyToColumn(PropertyNames::Hop::type)).toString();
+     m_formStr = rec.value(table->propertyToColumn(PropertyNames::Hop::form)).toString();
+     m_alpha_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::alpha_pct)).toDouble();
+     m_amount_kg = rec.value(table->propertyToColumn(PropertyNames::Hop::amount_kg)).toDouble();
+     m_time_min = rec.value(table->propertyToColumn(PropertyNames::Hop::time_min)).toDouble();
+     m_notes = rec.value(table->propertyToColumn(PropertyNames::Hop::notes)).toString();
+     m_beta_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::beta_pct)).toDouble();
+     m_hsi_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::hsi_pct)).toDouble();
+     m_origin = rec.value(table->propertyToColumn(PropertyNames::Hop::origin)).toString();
+     m_substitutes = rec.value(table->propertyToColumn(PropertyNames::Hop::substitutes)).toString();
+     m_humulene_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::humulene_pct)).toDouble();
+     m_caryophyllene_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::caryophyllene_pct)).toDouble();
+     m_cohumulone_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::cohumulone_pct)).toDouble();
+     m_myrcene_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::myrcene_pct)).toDouble();
+
+     // keys need special handling
+     m_inventory_id = rec.value(table->foreignKeyToColumn(PropertyNames::Hop::inventory_id)).toInt();
+
+     // these are not taken directly from the SQL record
+     m_use  = static_cast<Hop::Use>(uses.indexOf(m_useStr));
+     m_type = static_cast<Hop::Type>(types.indexOf(m_typeStr));
+     m_form = static_cast<Hop::Form>(forms.indexOf(m_formStr));
 }
 
 Hop::Hop( Hop & other )
@@ -233,7 +211,7 @@ void Hop::setInventoryId( int key )
 {
    m_inventory_id = key;
    if ( ! m_cacheOnly ) {
-      setEasy(kpropInventoryId, key);
+      setEasy(PropertyNames::Hop::inventory_id, key);
    }
 }
 
@@ -434,7 +412,7 @@ bool   Hop::cacheOnly() const { return m_cacheOnly; }
 double Hop::inventory()
 {
    if ( m_inventory < 0 ) {
-      m_inventory = getInventory(PropertyNames::Hop::inventory).toDouble();
+      m_inventory = getInventory().toDouble();
    }
    return m_inventory;
 }

--- a/src/hop.cpp
+++ b/src/hop.cpp
@@ -102,8 +102,8 @@ Hop::Hop(QString name, bool cache)
 {
 }
 
-Hop::Hop(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+Hop::Hop(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
      m_inventory(-1.0),
      m_cacheOnly(false)
 {

--- a/src/hop.h
+++ b/src/hop.h
@@ -26,10 +26,14 @@
 
 #include <QString>
 #include <QStringList>
+
+#include "TableSchema.h"
 #include "model/NamedEntity.h"
+
 namespace PropertyNames::Hop { static char const * const form = "form"; /* previously kpropForm */ }
 namespace PropertyNames::Hop { static char const * const time_min = "time_min"; /* previously kpropTime */ }
 namespace PropertyNames::Hop { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
+namespace PropertyNames::Hop { static char const * const inventory_id = "inventory_id"; /* previously kpropInventoryId */ }
 namespace PropertyNames::Hop { static char const * const useString = "useString"; /* previously kpropUseString */ }
 namespace PropertyNames::Hop { static char const * const use = "use"; /* previously kpropUse */ }
 namespace PropertyNames::Hop { static char const * const origin = "origin"; /* previously kpropOrigin */ }
@@ -71,9 +75,12 @@ public:
    //! \brief The way the hop is used.
    // .:TBD:. (MY 2021-01-01) Shall we perhaps change "UseAroma" to "PostBoil", since this is what BeerXML means by
    // Aroma in this context?
+   //         (MF 2021-04-09) Nope. These fields MUST remain as they are until we are certain that we have converted 
+   //                         all existing bt v1.0 XML databases. You know.  Forever.
    enum Use {Mash, First_Wort, Boil, UseAroma, Dry_Hop }; // NOTE: way bad. We have a duplicate enum (Aroma)
    Q_ENUMS( Type Form Use )
 
+   Hop(QString name, bool cache = true);
    virtual ~Hop() {}
 
    //! \brief The percent alpha.
@@ -182,11 +189,8 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Hop(Brewtarget::DBTable table, int key);
-   Hop(Brewtarget::DBTable table, int key, QSqlRecord rec);
-public:
-   Hop(QString name, bool cache = true);
-private:
+   // Hop(Brewtarget::DBTable table, int key);
+   Hop(TableSchema* table, QSqlRecord rec);
    Hop( Hop & other );
 
    QString m_useStr;

--- a/src/hop.h
+++ b/src/hop.h
@@ -190,7 +190,7 @@ protected:
 
 private:
    // Hop(Brewtarget::DBTable table, int key);
-   Hop(TableSchema* table, QSqlRecord rec);
+   Hop(TableSchema* table, QSqlRecord rec, int t_key = -1);
    Hop( Hop & other );
 
    QString m_useStr;

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -55,8 +55,8 @@ Instruction::Instruction(QString name, bool cache)
 {
 }
 
-Instruction::Instruction(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+Instruction::Instruction(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
      m_cacheOnly(false),
      m_recipe   (nullptr)
 {

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -43,20 +43,8 @@ QString Instruction::classNameStr()
    return name;
 }
 
-Instruction::Instruction(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key, QString(), true),
-     m_directions(QString()),
-     m_hasTimer  (false),
-     m_timerValue(QString()),
-     m_completed (false),
-     m_interval  (0.0),
-     m_cacheOnly(false),
-     m_recipe   (nullptr)
-{
-}
-
 Instruction::Instruction(QString name, bool cache)
-   : NamedEntity(Brewtarget::INSTRUCTIONTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::INSTRUCTIONTABLE, name, true),
      m_directions(QString()),
      m_hasTimer  (false),
      m_timerValue(QString()),
@@ -67,16 +55,16 @@ Instruction::Instruction(QString name, bool cache)
 {
 }
 
-Instruction::Instruction(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool() ),
-     m_directions(rec.value(kcolInstructionDirections).toString()),
-     m_hasTimer  (rec.value(kcolInstructionHasTimer).toBool()),
-     m_timerValue(rec.value(kcolInstructionTimerValue).toString()),
-     m_completed (rec.value(kcolInstructionCompleted).toBool()),
-     m_interval  (rec.value(kcolInstructionInterval).toDouble()),
+Instruction::Instruction(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
      m_cacheOnly(false),
      m_recipe   (nullptr)
 {
+     m_directions = rec.value( table->propertyToColumn( PropertyNames::Instruction::directions)).toString();
+     m_hasTimer   = rec.value( table->propertyToColumn( PropertyNames::Instruction::hasTimer)).toBool();
+     m_timerValue = rec.value( table->propertyToColumn( PropertyNames::Instruction::timerValue)).toString();
+     m_completed  = rec.value( table->propertyToColumn( PropertyNames::Instruction::completed)).toBool();
+     m_interval   = rec.value( table->propertyToColumn( PropertyNames::Instruction::interval)).toDouble();
 }
 
 // Setters ====================================================================

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -97,7 +97,7 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Instruction(TableSchema* table, QSqlRecord rec);
+   Instruction(TableSchema* table, QSqlRecord rec,int t_key = -1);
    Instruction( Instruction const& other );
 
    QString m_directions;

--- a/src/instruction.h
+++ b/src/instruction.h
@@ -27,6 +27,7 @@
 #include <QString>
 #include <QVector>
 #include <QDomNode>
+#include "TableSchema.h"
 #include "model/NamedEntity.h"
 #include "recipe.h"
 namespace PropertyNames::Instruction { static char const * const interval = "interval"; /* previously kpropInterval */ }
@@ -46,8 +47,10 @@ class Instruction : public NamedEntity
    Q_CLASSINFO("signal", "instructions")
    friend class Database;
    friend class BeerXML;
+
 public:
 
+   Instruction( QString name, bool cache = true );
    virtual ~Instruction() {}
 
    Q_PROPERTY( QString directions READ directions WRITE setDirections /*NOTIFY changed*/ /*changedDirections*/ )
@@ -94,11 +97,7 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Instruction(Brewtarget::DBTable table, int key);
-   Instruction(Brewtarget::DBTable table, int key, QSqlRecord rec);
-public:
-   Instruction( QString name, bool cache = true );
-private:
+   Instruction(TableSchema* table, QSqlRecord rec);
    Instruction( Instruction const& other );
 
    QString m_directions;

--- a/src/mash.cpp
+++ b/src/mash.cpp
@@ -54,22 +54,8 @@ QString Mash::classNameStr()
    return name;
 }
 
-Mash::Mash(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key, QString(), true),
-     m_grainTemp_c(0.0),
-     m_notes(QString()),
-     m_tunTemp_c(0.0),
-     m_spargeTemp_c(0.0),
-     m_ph(0.0),
-     m_tunWeight_kg(0.0),
-     m_tunSpecificHeat_calGC(0.0),
-     m_equipAdjust(true),
-     m_cacheOnly(false)
-{
-}
-
 Mash::Mash(QString name, bool cache)
-   : NamedEntity(Brewtarget::MASHTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::MASHTABLE, name, true),
      m_grainTemp_c(0.0),
      m_notes(QString()),
      m_tunTemp_c(0.0),
@@ -82,18 +68,19 @@ Mash::Mash(QString name, bool cache)
 {
 }
 
-Mash::Mash(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool()),
-     m_grainTemp_c(rec.value(kcolMashGrainTemp).toDouble()),
-     m_notes(rec.value(kcolNotes).toString()),
-     m_tunTemp_c(rec.value(kcolMashTunTemp).toDouble()),
-     m_spargeTemp_c(rec.value(kcolMashSpargeTemp).toDouble()),
-     m_ph(rec.value(kcolPH).toDouble()),
-     m_tunWeight_kg(rec.value(kcolMashTunWeight).toDouble()),
-     m_tunSpecificHeat_calGC(rec.value(kcolMashTunSpecHeat).toDouble()),
-     m_equipAdjust(rec.value(kcolMashEquipAdjust).toBool()),
+Mash::Mash(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
      m_cacheOnly(false)
 {
+     m_grainTemp_c = rec.value( table->propertyToColumn(PropertyNames::Mash::grainTemp_c)).toDouble();
+     m_notes = rec.value( table->propertyToColumn(PropertyNames::Mash::notes)).toString();
+     m_tunTemp_c = rec.value( table->propertyToColumn(PropertyNames::Mash::tunTemp_c)).toDouble();
+     m_spargeTemp_c = rec.value( table->propertyToColumn(PropertyNames::Mash::spargeTemp_c)).toDouble();
+     m_ph = rec.value( table->propertyToColumn(PropertyNames::Mash::ph)).toDouble();
+     m_tunWeight_kg = rec.value( table->propertyToColumn(PropertyNames::Mash::tunWeight_kg)).toDouble();
+     m_tunSpecificHeat_calGC = rec.value( table->propertyToColumn(PropertyNames::Mash::tunSpecificHeat_calGC)).toDouble();
+     m_equipAdjust = rec.value( table->propertyToColumn(PropertyNames::Mash::equipAdjust)).toBool();
+
 }
 
 void Mash::setGrainTemp_c( double var )

--- a/src/mash.cpp
+++ b/src/mash.cpp
@@ -68,8 +68,8 @@ Mash::Mash(QString name, bool cache)
 {
 }
 
-Mash::Mash(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+Mash::Mash(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
      m_cacheOnly(false)
 {
      m_grainTemp_c = rec.value( table->propertyToColumn(PropertyNames::Mash::grainTemp_c)).toDouble();

--- a/src/mash.h
+++ b/src/mash.h
@@ -143,10 +143,9 @@ protected:
 
 private:
 // Mash(Brewtarget::DBTable table, int key);
-   Mash( TableSchema* table, QSqlRecord rec );
+   Mash( TableSchema* table, QSqlRecord rec, int t_key = -1 );
    Mash( Mash const& other );
 
-private:
    double m_grainTemp_c;
    QString m_notes;
    double m_tunTemp_c;

--- a/src/mash.h
+++ b/src/mash.h
@@ -52,8 +52,10 @@ class Mash : public NamedEntity
    friend class BeerXML;
    friend class MashDesigner;
    friend class MashEditor;
+
 public:
 
+   Mash( QString name, bool cache = true );
    virtual ~Mash() {}
 
    //! \brief The initial grain temp in Celsius.
@@ -140,11 +142,9 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Mash(Brewtarget::DBTable table, int key);
-   Mash(Brewtarget::DBTable table, int key, QSqlRecord rec);
+// Mash(Brewtarget::DBTable table, int key);
+   Mash( TableSchema* table, QSqlRecord rec );
    Mash( Mash const& other );
-public:
-   Mash( QString name, bool cache = true );
 
 private:
    double m_grainTemp_c;

--- a/src/mashstep.cpp
+++ b/src/mashstep.cpp
@@ -71,8 +71,8 @@ MashStep::MashStep(QString name, bool cache)
 {
 }
 
-MashStep::MashStep(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+MashStep::MashStep(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
      m_cacheOnly(false)
 {
      m_typeStr = rec.value( table->propertyToColumn( PropertyNames::MashStep::type)).toString();

--- a/src/mashstep.cpp
+++ b/src/mashstep.cpp
@@ -25,6 +25,7 @@
 #include "database.h"
 #include "TableSchemaConst.h"
 #include "MashStepSchema.h"
+#include "mash.h"
 
 QStringList MashStep::types = QStringList() << "Infusion" << "Temperature" << "Decoction" << "Fly Sparge" << "Batch Sparge";
 QStringList MashStep::typesTr = QStringList() << QObject::tr("Infusion") << QObject::tr("Temperature") << QObject::tr("Decoction") << QObject::tr("Fly Sparge") << QObject::tr("Batch Sparge");
@@ -54,24 +55,8 @@ QString MashStep::classNameStr()
 
 //==============================CONSTRUCTORS====================================
 
-MashStep::MashStep(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key, QString(), true),
-     m_typeStr(QString()),
-     m_type(static_cast<MashStep::Type>(0)),
-     m_infuseAmount_l(0.0),
-     m_stepTemp_c(0.0),
-     m_stepTime_min(0.0),
-     m_rampTime_min(0.0),
-     m_endTemp_c(0.0),
-     m_infuseTemp_c(0.0),
-     m_decoctionAmount_l(0.0),
-     m_stepNumber(0.0),
-     m_cacheOnly(false)
-{
-}
-
 MashStep::MashStep(QString name, bool cache)
-   : NamedEntity(Brewtarget::MASHSTEPTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::MASHSTEPTABLE, name, true),
      m_typeStr(QString()),
      m_type(static_cast<MashStep::Type>(0)),
      m_infuseAmount_l(0.0),
@@ -86,20 +71,21 @@ MashStep::MashStep(QString name, bool cache)
 {
 }
 
-MashStep::MashStep(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool()),
-     m_typeStr(rec.value(kcolMashstepType).toString()),
-     m_type(static_cast<MashStep::Type>(types.indexOf(m_typeStr))),
-     m_infuseAmount_l(rec.value(kcolMashstepInfuseAmt).toDouble()),
-     m_stepTemp_c(rec.value(kcolMashstepStepTemp).toDouble()),
-     m_stepTime_min(rec.value(kcolMashstepStepTime).toDouble()),
-     m_rampTime_min(rec.value(kcolMashstepRampTime).toDouble()),
-     m_endTemp_c(rec.value(kcolMashstepEndTemp).toDouble()),
-     m_infuseTemp_c(rec.value(kcolMashstepInfuseTemp).toDouble()),
-     m_decoctionAmount_l(rec.value(kcolMashstepDecoctAmt).toDouble()),
-     m_stepNumber(rec.value(kcolMashstepStepNumber).toInt()),
+MashStep::MashStep(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
      m_cacheOnly(false)
 {
+     m_typeStr = rec.value( table->propertyToColumn( PropertyNames::MashStep::type)).toString();
+     m_infuseAmount_l = rec.value( table->propertyToColumn( PropertyNames::MashStep::infuseAmount_l)).toDouble();
+     m_stepTemp_c = rec.value( table->propertyToColumn( PropertyNames::MashStep::stepTemp_c)).toDouble();
+     m_stepTime_min = rec.value( table->propertyToColumn( PropertyNames::MashStep::stepTime_min)).toDouble();
+     m_rampTime_min = rec.value( table->propertyToColumn( PropertyNames::MashStep::rampTime_min)).toDouble();
+     m_endTemp_c = rec.value( table->propertyToColumn( PropertyNames::MashStep::endTemp_c)).toDouble();
+     m_infuseTemp_c = rec.value( table->propertyToColumn( PropertyNames::MashStep::infuseTemp_c)).toDouble();
+     m_decoctionAmount_l = rec.value( table->propertyToColumn( PropertyNames::MashStep::decoctionAmount_l)).toDouble();
+     m_stepNumber = rec.value( table->propertyToColumn( PropertyNames::MashStep::stepNumber)).toInt();
+
+     m_type = static_cast<MashStep::Type>(types.indexOf(m_typeStr));
 }
 
 //================================"SET" METHODS=================================

--- a/src/mashstep.h
+++ b/src/mashstep.h
@@ -57,6 +57,7 @@ public:
    enum Type { Infusion, Temperature, Decoction, flySparge, batchSparge };
    Q_ENUMS( Type )
 
+   MashStep( QString name, bool cache = true );
    virtual ~MashStep() {}
 
    //! \brief The \c Type.
@@ -128,13 +129,10 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   MashStep(Brewtarget::DBTable table, int key);
-   MashStep(Brewtarget::DBTable table, int key, QSqlRecord rec);
+//   MashStep(Brewtarget::DBTable table, int key);
+   MashStep( TableSchema* table, QSqlRecord rec );
    MashStep( MashStep const& other );
-public:
-   MashStep(QString name, bool cache = true);
 
-private:
    QString m_typeStr;
    Type m_type;
    double m_infuseAmount_l;

--- a/src/mashstep.h
+++ b/src/mashstep.h
@@ -130,7 +130,7 @@ protected:
 
 private:
 //   MashStep(Brewtarget::DBTable table, int key);
-   MashStep( TableSchema* table, QSqlRecord rec );
+   MashStep( TableSchema* table, QSqlRecord rec, int t_key = -1 );
    MashStep( MashStep const& other );
 
    QString m_typeStr;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -56,38 +56,25 @@ bool Misc::isEqualTo(NamedEntity const & other) const {
 }
 
 //============================CONSTRUCTORS======================================
-Misc::Misc(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key),
-   m_typeString(QString()),
-   m_type(static_cast<Misc::Type>(0)),
-   m_useString(QString()),
-   m_use(static_cast<Misc::Use>(0)),
-   m_time(0.0),
-   m_amount(0.0),
-   m_amountIsWeight(false),
-   m_useFor(QString()),
-   m_notes(QString()),
-   m_inventory(-1.0),
-   m_inventory_id(0),
-   m_cacheOnly(false)
-{
-}
 
-Misc::Misc(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool(), rec.value(kcolFolder).toString()),
-   m_typeString(rec.value(kcolMiscType).toString()),
-   m_type(static_cast<Misc::Type>(types.indexOf(m_typeString))),
-   m_useString(rec.value(kcolUse).toString()),
-   m_use(static_cast<Misc::Use>(uses.indexOf(m_useString))),
-   m_time(rec.value(kcolTime).toDouble()),
-   m_amount(rec.value(kcolAmount).toDouble()),
-   m_amountIsWeight(rec.value(kcolMiscAmtIsWgt).toBool()),
-   m_useFor(rec.value(kcolMiscUseFor).toString()),
-   m_notes(rec.value(kcolNotes).toString()),
+Misc::Misc(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
    m_inventory(-1.0),
-   m_inventory_id(rec.value(kcolInventoryId).toInt()),
    m_cacheOnly(false)
 {
+   m_typeString = rec.value( table->propertyToColumn( PropertyNames::Misc::type)).toString();
+   m_useString = rec.value( table->propertyToColumn( PropertyNames::Misc::use)).toString();
+   m_time = rec.value( table->propertyToColumn( PropertyNames::Misc::time)).toDouble();
+   m_amount = rec.value( table->propertyToColumn( PropertyNames::Misc::amount)).toDouble();
+   m_amountIsWeight = rec.value( table->propertyToColumn( PropertyNames::Misc::amountIsWeight)).toBool();
+   m_useFor = rec.value( table->propertyToColumn( PropertyNames::Misc::useFor)).toString();
+   m_notes = rec.value( table->propertyToColumn( PropertyNames::Misc::notes)).toString();
+
+   // handle foreign keys properly
+   m_inventory_id = rec.value( table->foreignKeyToColumn( PropertyNames::Misc::inventory_id)).toInt();
+   // not read from the db
+   m_type = static_cast<Misc::Type>(types.indexOf(m_typeString));
+   m_use = static_cast<Misc::Use>(uses.indexOf(m_useString));
 }
 
 Misc::Misc(Misc & other) : NamedEntity(other),
@@ -107,7 +94,7 @@ Misc::Misc(Misc & other) : NamedEntity(other),
 }
 
 Misc::Misc(QString name, bool cache)
-   : NamedEntity(Brewtarget::MISCTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::MISCTABLE, name, true),
    m_typeString(QString()),
    m_type(static_cast<Misc::Type>(0)),
    m_useString(QString()),
@@ -145,7 +132,7 @@ QString Misc::notes() const { return m_notes; }
 double Misc::inventory()
 {
    if ( m_inventory < 0.0 ) {
-      m_inventory = getInventory(PropertyNames::Misc::inventory).toDouble();
+      m_inventory = getInventory().toDouble();
    }
    return m_inventory;
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -57,8 +57,8 @@ bool Misc::isEqualTo(NamedEntity const & other) const {
 
 //============================CONSTRUCTORS======================================
 
-Misc::Misc(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+Misc::Misc(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
    m_inventory(-1.0),
    m_cacheOnly(false)
 {

--- a/src/misc.h
+++ b/src/misc.h
@@ -28,6 +28,7 @@
 namespace PropertyNames::Misc { static char const * const amount = "amount"; /* previously kpropAmount */ }
 namespace PropertyNames::Misc { static char const * const amountIsWeight = "amountIsWeight"; /* previously kpropAmtIsWgt */ }
 namespace PropertyNames::Misc { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
+namespace PropertyNames::Misc { static char const * const inventory_id = "inventory_id"; /* previously kpropInventoryId */ }
 namespace PropertyNames::Misc { static char const * const useString = "useString"; /* previously kpropUseString */ }
 namespace PropertyNames::Misc { static char const * const use = "use"; /* previously kpropUse */ }
 namespace PropertyNames::Misc { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
@@ -59,6 +60,7 @@ public:
    enum AmountType { AmountType_Weight, AmountType_Volume };
    Q_ENUMS( Type Use AmountType )
 
+   Misc(QString name, bool cache = true);
    virtual ~Misc() {}
 
    //! \brief The \c Type.
@@ -144,11 +146,7 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Misc(Brewtarget::DBTable table, int key);
-   Misc(Brewtarget::DBTable table, int key, QSqlRecord rec);
-public:
-   Misc(QString name, bool cache = true);
-private:
+   Misc(TableSchema* table, QSqlRecord rec);
    Misc(Misc & other);
 
    QString m_typeString;

--- a/src/misc.h
+++ b/src/misc.h
@@ -146,7 +146,7 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Misc(TableSchema* table, QSqlRecord rec);
+   Misc(TableSchema* table, QSqlRecord rec, int t_key = -1);
    Misc(Misc & other);
 
    QString m_typeString;

--- a/src/model/NamedEntity.cpp
+++ b/src/model/NamedEntity.cpp
@@ -48,12 +48,18 @@ NamedEntity::NamedEntity(Brewtarget::DBTable table, QString t_name, bool t_displ
 }
 
 // othertimes, we creating a thing from a record in the db
-NamedEntity::NamedEntity(TableSchema* table, QSqlRecord rec )
+NamedEntity::NamedEntity(TableSchema* table, QSqlRecord rec, int t_key )
    : QObject(nullptr),
      parentKey(0),
      _deleted(QVariant())
 {
-   _key     = rec.value( table->keyName()                                             ).toInt();
+   if ( t_key == -1 ) {
+      _key = rec.value( table->keyName() ).toInt();
+   }
+   else {
+      _key = t_key;
+   }
+      
    _folder  = rec.value( table->propertyToColumn(PropertyNames::NamedEntity::folder)  ).toString();
    _name    = rec.value( table->propertyToColumn(PropertyNames::NamedEntity::name)    ).toString();
    _display = rec.value( table->propertyToColumn(PropertyNames::NamedEntity::display) ).toBool();

--- a/src/model/NamedEntity.cpp
+++ b/src/model/NamedEntity.cpp
@@ -34,19 +34,33 @@
 
 static const char* kVersion = "version";
 
-NamedEntity::NamedEntity(Brewtarget::DBTable table, int key, QString t_name, bool t_display, QString folder)
+// sometimes I just want to create a thing with a name and nothing else
+NamedEntity::NamedEntity(Brewtarget::DBTable table, QString t_name, bool t_display)
    : QObject(nullptr),
-     _key(key),
+     _key(-1),
      _table(table),
      parentKey(0),
-     _folder(folder),
+     _folder(QString()),
      _name(t_name),
      _display(t_display),
      _deleted(QVariant())
 {
-   return;
 }
 
+// othertimes, we creating a thing from a record in the db
+NamedEntity::NamedEntity(TableSchema* table, QSqlRecord rec )
+   : QObject(nullptr),
+     parentKey(0),
+     _deleted(QVariant())
+{
+   _key     = rec.value( table->keyName()                                             ).toInt();
+   _folder  = rec.value( table->propertyToColumn(PropertyNames::NamedEntity::folder)  ).toString();
+   _name    = rec.value( table->propertyToColumn(PropertyNames::NamedEntity::name)    ).toString();
+   _display = rec.value( table->propertyToColumn(PropertyNames::NamedEntity::display) ).toBool();
+   _table   = table->dbTable();
+}
+
+// and finally sometimes we create a thing from other things
 NamedEntity::NamedEntity(NamedEntity const& other)
    : QObject(nullptr),
      _key(other._key),
@@ -342,10 +356,10 @@ void NamedEntity::setInventory( const QVariant& value, int invKey, bool notify )
    Database::instance().setInventory( this, value, invKey, notify );
 }
 
-QVariant NamedEntity::getInventory( const QString& col_name ) const
+QVariant NamedEntity::getInventory() const
 {
    QVariant val = 0.0;
-   val = Database::instance().getInventoryAmt(col_name, _table, _key);
+   val = Database::instance().getInventoryAmt(_table, _key);
    return val;
 }
 

--- a/src/model/NamedEntity.h
+++ b/src/model/NamedEntity.h
@@ -36,6 +36,8 @@
 #include <QDateTime>
 #include <QSqlRecord>
 #include "brewtarget.h"
+#include "TableSchema.h"
+
 namespace PropertyNames::NamedEntity { static char const * const folder = "folder"; /* previously kpropFolder */ }
 namespace PropertyNames::NamedEntity { static char const * const display = "display"; /* previously kpropDisplay */ }
 namespace PropertyNames::NamedEntity { static char const * const deleted = "deleted"; /* previously kpropDeleted */ }
@@ -84,8 +86,14 @@ class NamedEntity : public QObject
    friend class Database;
    friend class BeerXML;
 public:
+/*
    NamedEntity(Brewtarget::DBTable table, int key, QString t_name = QString(),
                   bool t_display = false, QString folder = QString());
+*/
+   NamedEntity(Brewtarget::DBTable table, QString t_name = QString(), bool t_display = false);
+
+   NamedEntity(TableSchema* table, QSqlRecord rec);
+
    NamedEntity( NamedEntity const& other );
 
    // Our destructor needs to be virtual because we sometimes point to an instance of a derived class through a pointer
@@ -261,7 +269,7 @@ protected:
    QVariant get( const QString& col_name ) const;
 
    void setInventory( const QVariant& value, int invKey = 0, bool notify=true );
-   QVariant getInventory( const QString& col_name ) const;
+   QVariant getInventory() const;
 
    QVariantMap getColumnValueMap() const;
 

--- a/src/model/NamedEntity.h
+++ b/src/model/NamedEntity.h
@@ -92,7 +92,7 @@ public:
 */
    NamedEntity(Brewtarget::DBTable table, QString t_name = QString(), bool t_display = false);
 
-   NamedEntity(TableSchema* table, QSqlRecord rec);
+   NamedEntity(TableSchema* table, QSqlRecord rec, int t_key );
 
    NamedEntity( NamedEntity const& other );
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -147,8 +147,8 @@ Recipe::Recipe(QString name, bool cache)
 {
 }
 
-Recipe::Recipe(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec ),
+Recipe::Recipe(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
    m_cacheOnly(false)
 {
    m_type = rec.value( table->propertyToColumn( PropertyNames::Recipe::type)).toString();

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -112,43 +112,8 @@ QString Recipe::classNameStr()
    return name;
 }
 
-Recipe::Recipe(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key),
-   m_type(QString("All Grain")),
-   m_brewer(QString("")),
-   m_asstBrewer(QString("Brewtarget: free beer software")),
-   m_batchSize_l(0.0),
-   m_boilSize_l(0.0),
-   m_boilTime_min(0.0),
-   m_efficiency_pct(0.0),
-   m_fermentationStages(1),
-   m_primaryAge_days(0.0),
-   m_primaryTemp_c(0.0),
-   m_secondaryAge_days(0.0),
-   m_secondaryTemp_c(0.0),
-   m_tertiaryAge_days(0.0),
-   m_tertiaryTemp_c(0.0),
-   m_age(0.0),
-   m_ageTemp_c(0.0),
-   m_date(QDate::currentDate()),
-   m_carbonation_vols(0.0),
-   m_forcedCarbonation(false),
-   m_primingSugarName(QString("")),
-   m_carbonationTemp_c(0.0),
-   m_primingSugarEquiv(0.0),
-   m_kegPrimingFactor(0.0),
-   m_notes(QString("")),
-   m_tasteNotes(QString("")),
-   m_tasteRating(0.0),
-   m_style_id(0),
-   m_og(1.0),
-   m_fg(1.0),
-   m_cacheOnly(false)
-{
-}
-
 Recipe::Recipe(QString name, bool cache)
-   : NamedEntity(Brewtarget::RECTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::RECTABLE, name, true),
    m_type(QString("All Grain")),
    m_brewer(QString("")),
    m_asstBrewer(QString("Brewtarget: free beer software")),
@@ -182,39 +147,39 @@ Recipe::Recipe(QString name, bool cache)
 {
 }
 
-Recipe::Recipe(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool(), rec.value(kcolFolder).toString()),
-   m_type(rec.value(kcolRecipeType).toString()),
-   m_brewer(rec.value(kcolRecipeBrewer).toString()),
-   m_asstBrewer(rec.value(kcolRecipeAsstBrewer).toString()),
-   m_batchSize_l(rec.value(kcolRecipeBatchSize).toDouble()),
-   m_boilSize_l(rec.value(kcolRecipeBoilSize).toDouble()),
-   m_boilTime_min(rec.value(kcolRecipeBoilTime).toDouble()),
-   m_efficiency_pct(rec.value(kcolRecipeEff).toDouble()),
-   m_fermentationStages(rec.value(kcolRecipeFermStages).toInt()),
-   m_primaryAge_days(rec.value(kcolRecipePrimAgeDays).toDouble()),
-   m_primaryTemp_c(rec.value(kcolRecipePrimTemp).toDouble()),
-   m_secondaryAge_days(rec.value(kcolRecipeSecAgeDays).toDouble()),
-   m_secondaryTemp_c(rec.value(kcolRecipeSecTemp).toDouble()),
-   m_tertiaryAge_days(rec.value(kcolRecipeTertAgeDays).toDouble()),
-   m_tertiaryTemp_c(rec.value(kcolRecipeTertTemp).toDouble()),
-   m_age(rec.value(kcolRecipeAge).toDouble()),
-   m_ageTemp_c(rec.value(kcolRecipeAgeTemp).toDouble()),
-   m_date(QDate::fromString(rec.value(kcolRecipeDate).toString(), QString("d/M/yyyy"))),
-   m_carbonation_vols(rec.value(kcolRecipeCarbVols).toDouble()),
-   m_forcedCarbonation(rec.value(kcolRecipeForcedCarb).toBool()),
-   m_primingSugarName(rec.value(kcolRecipePrimSugName).toString()),
-   m_carbonationTemp_c(rec.value(kcolRecipeCarbTemp).toDouble()),
-   m_primingSugarEquiv(rec.value(kcolRecipePrimSugEquiv).toDouble()),
-   m_kegPrimingFactor(rec.value(kcolRecipeKegPrimFact).toDouble()),
-   m_notes(rec.value(kcolNotes).toString()),
-   m_tasteNotes(rec.value(kcolRecipeTasteNotes).toString()),
-   m_tasteRating(rec.value(kcolRecipeTasteRating).toDouble()),
-   m_style_id(rec.value(kcolRecipeStyleId).toInt()),
-   m_og(rec.value(kcolRecipeOG).toDouble()),
-   m_fg(rec.value(kcolRecipeFG).toDouble()),
+Recipe::Recipe(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec ),
    m_cacheOnly(false)
 {
+   m_type = rec.value( table->propertyToColumn( PropertyNames::Recipe::type)).toString();
+   m_brewer = rec.value( table->propertyToColumn( PropertyNames::Recipe::brewer)).toString();
+   m_asstBrewer = rec.value( table->propertyToColumn( PropertyNames::Recipe::asstBrewer)).toString();
+   m_batchSize_l = rec.value( table->propertyToColumn( PropertyNames::Recipe::batchSize_l)).toDouble();
+   m_boilSize_l = rec.value( table->propertyToColumn( PropertyNames::Recipe::boilSize_l)).toDouble();
+   m_boilTime_min = rec.value( table->propertyToColumn( PropertyNames::Recipe::boilTime_min)).toDouble();
+   m_efficiency_pct = rec.value( table->propertyToColumn( PropertyNames::Recipe::efficiency_pct)).toDouble();
+   m_fermentationStages = rec.value( table->propertyToColumn( PropertyNames::Recipe::fermentationStages)).toInt();
+   m_primaryAge_days = rec.value( table->propertyToColumn( PropertyNames::Recipe::primaryAge_days)).toDouble();
+   m_primaryTemp_c = rec.value( table->propertyToColumn( PropertyNames::Recipe::primaryTemp_c)).toDouble();
+   m_secondaryAge_days = rec.value( table->propertyToColumn( PropertyNames::Recipe::secondaryAge_days)).toDouble();
+   m_secondaryTemp_c = rec.value( table->propertyToColumn( PropertyNames::Recipe::secondaryTemp_c)).toDouble();
+   m_tertiaryAge_days = rec.value( table->propertyToColumn( PropertyNames::Recipe::tertiaryAge_days)).toDouble();
+   m_tertiaryTemp_c = rec.value( table->propertyToColumn( PropertyNames::Recipe::tertiaryTemp_c)).toDouble();
+   m_age = rec.value( table->propertyToColumn( PropertyNames::Recipe::age)).toDouble();
+   m_ageTemp_c = rec.value( table->propertyToColumn( PropertyNames::Recipe::ageTemp_c)).toDouble();
+   m_date = QDate::fromString(rec.value( table->propertyToColumn( PropertyNames::Recipe::date)).toString(), QString("d/M/yyyy"));
+   m_carbonation_vols = rec.value( table->propertyToColumn( PropertyNames::Recipe::carbonation_vols)).toDouble();
+   m_forcedCarbonation = rec.value( table->propertyToColumn( PropertyNames::Recipe::forcedCarbonation)).toBool();
+   m_primingSugarName = rec.value( table->propertyToColumn( PropertyNames::Recipe::primingSugarName)).toString();
+   m_carbonationTemp_c = rec.value( table->propertyToColumn( PropertyNames::Recipe::carbonationTemp_c)).toDouble();
+   m_primingSugarEquiv = rec.value( table->propertyToColumn( PropertyNames::Recipe::primingSugarEquiv)).toDouble();
+   m_kegPrimingFactor = rec.value( table->propertyToColumn( PropertyNames::Recipe::kegPrimingFactor)).toDouble();
+   m_notes = rec.value( table->propertyToColumn(PropertyNames::Recipe::notes) ).toString();
+   m_tasteNotes = rec.value( table->propertyToColumn( PropertyNames::Recipe::tasteNotes)).toString();
+   m_tasteRating = rec.value( table->propertyToColumn( PropertyNames::Recipe::tasteRating)).toDouble();
+   m_style_id = rec.value( table->propertyToColumn( PropertyNames::Recipe::style_id)).toInt();
+   m_og = rec.value( table->propertyToColumn( PropertyNames::Recipe::og)).toDouble();
+   m_fg = rec.value( table->propertyToColumn( PropertyNames::Recipe::fg)).toDouble();
 }
 
 Recipe::Recipe( Recipe const& other ) : NamedEntity(other),

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -468,7 +468,7 @@ protected:
 
 private:
 //   Recipe(Brewtarget::DBTable table, int key);
-   Recipe(TableSchema* table, QSqlRecord rec);
+   Recipe(TableSchema* table, QSqlRecord rec, int t_key = -1);
    Recipe(Recipe const& other);
 
    // Cached properties that are written directly to db

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -81,6 +81,7 @@ namespace PropertyNames::Recipe { static char const * const calories = "calories
 namespace PropertyNames::Recipe { static char const * const grainsInMash_kg = "grainsInMash_kg"; /* not stored */ }
 namespace PropertyNames::Recipe { static char const * const grains_kg = "grains_kg"; /* not stored */ }
 namespace PropertyNames::Recipe { static char const * const SRMColor = "SRMColor"; /* not stored */ }
+namespace PropertyNames::Recipe { static char const * const style_id = "styleId"; /* not stored */ }
 
 
 // Forward declarations.
@@ -112,8 +113,10 @@ class Recipe : public NamedEntity
    friend class RecipeFormatter;
    friend class MainWindow;
    friend class WaterDialog;
+
 public:
 
+   Recipe(QString name, bool cache = true);
    virtual ~Recipe() {}
 
    // NOTE: move to database?
@@ -258,13 +261,7 @@ public:
    //         #include "database.h" and database.h already needs to #include "recipe.h", so we'd be trapped in circular
    //         dependencies.  Fortunately there is a trick that allows us to declare the function in the header and
    //         define it in the cpp file, even though it's templated.
-private:
-   /*!
-    * \brief Remove \c var from the recipe and return what was removed - ie \c var
-    */
-   NamedEntity * removeNamedEntity( NamedEntity *var);
 
-public:
    /*!
     * \brief Remove \c var from the recipe and return what was removed - ie \c var
     *
@@ -272,7 +269,6 @@ public:
     * making add and remove more symmetric).
     */
    template<class T> T * remove(T * var) {
-//      qDebug() << QString("%1").arg(Q_FUNC_INFO);
       return static_cast<T *>(this->removeNamedEntity(var));
    }
 
@@ -471,11 +467,8 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Recipe(Brewtarget::DBTable table, int key);
-   Recipe(Brewtarget::DBTable table, int key, QSqlRecord rec);
-public:
-   Recipe(QString name, bool cache = true);
-private:
+//   Recipe(Brewtarget::DBTable table, int key);
+   Recipe(TableSchema* table, QSqlRecord rec);
    Recipe(Recipe const& other);
 
    // Cached properties that are written directly to db
@@ -540,6 +533,11 @@ private:
    double batchSizeNoLosses_l();
 
    // Some recalculators for calculated properties.
+
+   /*!
+    * \brief Remove \c var from the recipe and return what was removed - ie \c var
+    */
+   NamedEntity * removeNamedEntity( NamedEntity *var);
 
    /* Recalculates all the calculated properties.
     *

--- a/src/salt.cpp
+++ b/src/salt.cpp
@@ -81,8 +81,8 @@ Salt::Salt(Salt & other)
 {
 }
 
-Salt::Salt(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+Salt::Salt(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
    m_cacheOnly(false)
 {
    m_amount = rec.value(table->propertyToColumn( PropertyNames::Salt::amount)).toDouble();

--- a/src/salt.cpp
+++ b/src/salt.cpp
@@ -31,10 +31,13 @@
 #include "database.h"
 
 // TBD Not clear why we use this ordering for salts.  Let's see what happens if we let it use the default ordering (name) of NamedEntity
-//bool operator<(const Salt &s1, const Salt &s2)
-//{
-//   return s1.m_add_to < s2.m_add_to;
-//}
+// MF (2021-04-09): Using this ordering makes the salts display properly in
+//                  the editor -- grouped around when they are added and not
+//                  the name. I'm putting this back 
+bool operator<(const Salt &s1, const Salt &s2)
+{
+   return s1.addTo() < s2.addTo();
+}
 
 bool Salt::isEqualTo(NamedEntity const & other) const {
    // Base class (NamedEntity) will have ensured this cast is valid
@@ -52,21 +55,8 @@ QString Salt::classNameStr()
    return name;
 }
 
-Salt::Salt(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key),
-   m_amount(0.0),
-   m_add_to(NEVER),
-   m_type(NONE),
-   m_amount_is_weight(true),
-   m_percent_acid(0.0),
-   m_is_acid(false),
-   m_misc_id(-1),
-   m_cacheOnly(false)
-{
-}
-
 Salt::Salt(QString name, bool cache)
-   : NamedEntity(Brewtarget::SALTTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::SALTTABLE, name, true),
    m_amount(0.0),
    m_add_to(NEVER),
    m_type(NONE),
@@ -79,7 +69,7 @@ Salt::Salt(QString name, bool cache)
 }
 
 Salt::Salt(Salt & other)
-   : NamedEntity(Brewtarget::SALTTABLE, -1, other.name(), true),
+   : NamedEntity(Brewtarget::SALTTABLE, other.name(), true),
    m_amount(other.m_amount),
    m_add_to(other.m_add_to),
    m_type(other.m_type),
@@ -91,17 +81,19 @@ Salt::Salt(Salt & other)
 {
 }
 
-Salt::Salt(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool()),
-   m_amount(rec.value(kcolAmount).toDouble()),
-   m_add_to(static_cast<Salt::WhenToAdd>(rec.value(kcolSaltAddTo).toInt())),
-   m_type(static_cast<Salt::Types>(rec.value(kcolSaltType).toInt())),
-   m_amount_is_weight(rec.value(kcolSaltAmtIsWgt).toBool()),
-   m_percent_acid(rec.value(kcolSaltPctAcid).toDouble()),
-   m_is_acid(rec.value(kcolSaltIsAcid).toBool()),
-   m_misc_id(rec.value(kcolMiscId).toInt()),
+Salt::Salt(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
    m_cacheOnly(false)
 {
+   m_amount = rec.value(table->propertyToColumn( PropertyNames::Salt::amount)).toDouble();
+   m_amount_is_weight = rec.value( table->propertyToColumn( PropertyNames::Salt::amountIsWeight)).toBool();
+   m_percent_acid = rec.value( table->propertyToColumn( PropertyNames::Salt::percentAcid)).toDouble();
+   m_is_acid = rec.value( table->propertyToColumn( PropertyNames::Salt::isAcid)).toBool();
+   // foreign keys suck
+   m_misc_id = rec.value(table->foreignKeyToColumn( PropertyNames::Salt::misc_id)).toInt();
+
+   m_add_to = static_cast<Salt::WhenToAdd>(rec.value( table->propertyToColumn( PropertyNames::Salt::addTo)).toInt());
+   m_type = static_cast<Salt::Types>(rec.value( table->propertyToColumn( PropertyNames::Salt::type)).toInt());
 }
 
 //================================"SET" METHODS=================================

--- a/src/salt.h
+++ b/src/salt.h
@@ -134,7 +134,7 @@ protected:
 
 private:
 //   Salt(Brewtarget::DBTable table, int key);
-   Salt(TableSchema* table, QSqlRecord rec);
+   Salt(TableSchema* table, QSqlRecord rec, int t_key = -1);
    Salt(Salt & other );
 
    double m_amount;

--- a/src/salt.h
+++ b/src/salt.h
@@ -31,6 +31,7 @@ namespace PropertyNames::Salt { static char const * const isAcid = "isAcid"; /* 
 namespace PropertyNames::Salt { static char const * const percentAcid = "percentAcid"; /* previously kpropPctAcid */ }
 namespace PropertyNames::Salt { static char const * const addTo = "addTo"; /* previously kpropAddTo */ }
 
+namespace PropertyNames::Salt { static char const * const misc_id = "misc_id"; /* previously kcolMiscId */ }
 
 /*!
  * \class Salt
@@ -73,6 +74,7 @@ public:
 
    Q_ENUMS(WhenToAdd Types)
 
+   Salt(QString name, bool cache = true);
    virtual ~Salt() {}
 
    // On a base or target profile, bicarbonate and alkalinity cannot both be used. I'm gonna have fun figuring that out
@@ -131,10 +133,9 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Salt(Brewtarget::DBTable table, int key);
-   Salt(Brewtarget::DBTable table, int key, QSqlRecord rec);
+//   Salt(Brewtarget::DBTable table, int key);
+   Salt(TableSchema* table, QSqlRecord rec);
    Salt(Salt & other );
-   Salt(QString name, bool cache = true);
 
    double m_amount;
    Salt::WhenToAdd m_add_to;

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -52,7 +52,7 @@ QString Style::classNameStr()
 
 // suitable for something that will be written to the db later
 Style::Style(QString t_name, bool cacheOnly)
-   : NamedEntity(Brewtarget::STYLETABLE, -1, t_name, true),
+   : NamedEntity(Brewtarget::STYLETABLE, t_name, true),
      m_category(QString()),
      m_categoryNumber(QString()),
      m_styleLetter(QString()),
@@ -79,63 +79,34 @@ Style::Style(QString t_name, bool cacheOnly)
 {
 }
 
-// suitable for something that needs to be created in the db when the object is, but all the other
-// fields will be filled in later (shouldn't be used that much)
-Style::Style(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key, QString(), true),
-     m_category(QString()),
-     m_categoryNumber(QString()),
-     m_styleLetter(QString()),
-     m_styleGuide(QString()),
-     m_typeStr(QString()),
-     m_type(static_cast<Style::Type>(0)),
-     m_ogMin(0.0),
-     m_ogMax(0.0),
-     m_fgMin(0.0),
-     m_fgMax(0.0),
-     m_ibuMin(0.0),
-     m_ibuMax(0.0),
-     m_colorMin_srm(0.0),
-     m_colorMax_srm(0.0),
-     m_carbMin_vol(0.0),
-     m_carbMax_vol(0.0),
-     m_abvMin_pct(0.0),
-     m_abvMax_pct(0.0),
-     m_notes(QString()),
-     m_profile(QString()),
-     m_ingredients(QString()),
-     m_examples(QString()),
-     m_cacheOnly(false)
-{
-}
-
 // suitable for creating a Style from a database record
-Style::Style(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool(), rec.value(kcolFolder).toString()),
-     m_category(rec.value(kcolStyleCat).toString()),
-     m_categoryNumber(rec.value(kcolStyleCatNum).toString()),
-     m_styleLetter(rec.value(kcolStyleLetter).toString()),
-     m_styleGuide(rec.value(kcolStyleGuide).toString()),
-     m_typeStr(rec.value(kcolStyleType).toString()),
-     m_type(static_cast<Style::Type>(m_types.indexOf(m_typeStr))),
-     m_ogMin(rec.value(kcolStyleOGMin).toDouble()),
-     m_ogMax(rec.value(kcolStyleOGMax).toDouble()),
-     m_fgMin(rec.value(kcolStyleFGMin).toDouble()),
-     m_fgMax(rec.value(kcolStyleFGMax).toDouble()),
-     m_ibuMin(rec.value(kcolStyleIBUMin).toDouble()),
-     m_ibuMax(rec.value(kcolStyleIBUMax).toDouble()),
-     m_colorMin_srm(rec.value(kcolStyleColorMin).toDouble()),
-     m_colorMax_srm(rec.value(kcolStyleColorMax).toDouble()),
-     m_carbMin_vol(rec.value(kcolStyleCarbMin).toDouble()),
-     m_carbMax_vol(rec.value(kcolStyleCarbMax).toDouble()),
-     m_abvMin_pct(rec.value(kcolStyleABVMin).toDouble()),
-     m_abvMax_pct(rec.value(kcolStyleABVMax).toDouble()),
-     m_notes(rec.value(kcolNotes).toString()),
-     m_profile(rec.value(kcolStyleProfile).toString()),
-     m_ingredients(rec.value(kcolStyleIngreds).toString()),
-     m_examples(rec.value(kcolStyleExamples).toString()),
+Style::Style(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
      m_cacheOnly(false)
 {
+     m_category = rec.value( table->propertyToColumn( PropertyNames::Style::category)).toString();
+     m_categoryNumber = rec.value( table->propertyToColumn( PropertyNames::Style::categoryNumber)).toString();
+     m_styleLetter = rec.value( table->propertyToColumn( PropertyNames::Style::styleLetter)).toString();
+     m_styleGuide = rec.value( table->propertyToColumn( PropertyNames::Style::styleGuide)).toString();
+     m_typeStr = rec.value( table->propertyToColumn( PropertyNames::Style::type)).toString();
+     m_ogMin = rec.value( table->propertyToColumn( PropertyNames::Style::ogMin)).toDouble();
+     m_ogMax = rec.value( table->propertyToColumn( PropertyNames::Style::ogMax)).toDouble();
+     m_fgMin = rec.value( table->propertyToColumn( PropertyNames::Style::fgMin)).toDouble();
+     m_fgMax = rec.value( table->propertyToColumn( PropertyNames::Style::fgMax)).toDouble();
+     m_ibuMin = rec.value( table->propertyToColumn( PropertyNames::Style::ibuMin)).toDouble();
+     m_ibuMax = rec.value( table->propertyToColumn( PropertyNames::Style::ibuMax)).toDouble();
+     m_colorMin_srm = rec.value( table->propertyToColumn( PropertyNames::Style::colorMin_srm)).toDouble();
+     m_colorMax_srm = rec.value( table->propertyToColumn( PropertyNames::Style::colorMax_srm)).toDouble();
+     m_carbMin_vol = rec.value( table->propertyToColumn( PropertyNames::Style::carbMin_vol)).toDouble();
+     m_carbMax_vol = rec.value( table->propertyToColumn( PropertyNames::Style::carbMax_vol)).toDouble();
+     m_abvMin_pct = rec.value( table->propertyToColumn( PropertyNames::Style::abvMin_pct)).toDouble();
+     m_abvMax_pct = rec.value( table->propertyToColumn( PropertyNames::Style::abvMax_pct)).toDouble();
+     m_notes = rec.value( table->propertyToColumn( PropertyNames::Style::notes)).toString();
+     m_profile = rec.value( table->propertyToColumn( PropertyNames::Style::profile)).toString();
+     m_ingredients = rec.value( table->propertyToColumn( PropertyNames::Style::ingredients)).toString();
+     m_examples = rec.value( table->propertyToColumn( PropertyNames::Style::examples)).toString();
+
+     m_type = static_cast<Style::Type>(m_types.indexOf(m_typeStr));
 }
 
 //==============================="SET" METHODS==================================
@@ -173,8 +144,17 @@ void Style::setStyleGuide( const QString& var )
 
 void Style::setType( Type t )
 {
-   m_type = t;
+
+   if ( t < Type::Lager || t > Type::Cider ) {
+      qCritical() << t << " cannot be converted to a type";
+      m_type = Type::Cider;
+   }
+   else {
+      m_type = t;
+   }
+
    m_typeStr = m_types.at(t);
+
    if ( ! m_cacheOnly ) {
       setEasy( PropertyNames::Style::type, m_typeStr);
    }

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -80,8 +80,8 @@ Style::Style(QString t_name, bool cacheOnly)
 }
 
 // suitable for creating a Style from a database record
-Style::Style(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+Style::Style(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
      m_cacheOnly(false)
 {
      m_category = rec.value( table->propertyToColumn( PropertyNames::Style::category)).toString();

--- a/src/style.h
+++ b/src/style.h
@@ -62,8 +62,10 @@ class Style : public NamedEntity
    friend class Database;
    friend class BeerXML;
    friend class StyleEditor;
+
 public:
 
+   Style( QString t_name, bool cacheOnly = true);
    virtual ~Style() {}
 
    //! \brief The type of beverage.
@@ -174,12 +176,10 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Style(Brewtarget::DBTable table, int key);
-public:
-   Style(QString t_name, bool cacheOnly = true);
-private:
-   Style(Brewtarget::DBTable table, int key, QSqlRecord rec);
-   Style( Style const& other );
+
+//   Style(Brewtarget::DBTable table, int key);
+   Style( TableSchema* table, QSqlRecord rec);
+   Style( Style const& other);
 
    QString m_category;
    QString m_categoryNumber;

--- a/src/style.h
+++ b/src/style.h
@@ -178,7 +178,7 @@ protected:
 private:
 
 //   Style(Brewtarget::DBTable table, int key);
-   Style( TableSchema* table, QSqlRecord rec);
+   Style( TableSchema* table, QSqlRecord rec, int t_key = -1);
    Style( Style const& other);
 
    QString m_category;

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -49,28 +49,8 @@ QString Water::classNameStr()
    return name;
 }
 
-Water::Water(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key),
-   m_amount(0.0),
-   m_calcium_ppm(0.0),
-   m_bicarbonate_ppm(0.0),
-   m_sulfate_ppm(0.0),
-   m_chloride_ppm(0.0),
-   m_sodium_ppm(0.0),
-   m_magnesium_ppm(0.0),
-   m_ph(0.0),
-   m_alkalinity(0.0),
-   m_notes(QString()),
-   m_cacheOnly(false),
-   m_type(NONE),
-   m_mash_ro(0.0),
-   m_sparge_ro(0.0),
-   m_alkalinity_as_hco3(true)
-{
-}
-
 Water::Water(QString name, bool cache)
-   : NamedEntity(Brewtarget::WATERTABLE, -1, name, true),
+   : NamedEntity(Brewtarget::WATERTABLE, name, true),
    m_amount(0.0),
    m_calcium_ppm(0.0),
    m_bicarbonate_ppm(0.0),
@@ -90,7 +70,7 @@ Water::Water(QString name, bool cache)
 }
 
 Water::Water(Water const& other, bool cache)
-   : NamedEntity(Brewtarget::WATERTABLE, -1, other.name(), true),
+   : NamedEntity(Brewtarget::WATERTABLE, other.name(), true),
    m_amount(other.m_amount),
    m_calcium_ppm(other.m_calcium_ppm),
    m_bicarbonate_ppm(other.m_bicarbonate_ppm),
@@ -109,24 +89,26 @@ Water::Water(Water const& other, bool cache)
 {
 }
 
-Water::Water(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool(), rec.value(kcolFolder).toString()),
-   m_amount(rec.value(kcolAmount).toDouble()),
-   m_calcium_ppm(rec.value(kcolWaterCalcium).toDouble()),
-   m_bicarbonate_ppm(rec.value(kcolWaterBiCarbonate).toDouble()),
-   m_sulfate_ppm(rec.value(kcolWaterSulfate).toDouble()),
-   m_chloride_ppm(rec.value(kcolWaterChloride).toDouble()),
-   m_sodium_ppm(rec.value(kcolWaterSodium).toDouble()),
-   m_magnesium_ppm(rec.value(kcolWaterMagnesium).toDouble()),
-   m_ph(rec.value(kcolPH).toDouble()),
-   m_alkalinity(rec.value(kcolWaterAlkalinity).toDouble()),
-   m_notes(rec.value(kcolNotes).toString()),
-   m_cacheOnly(false),
-   m_type(static_cast<Water::Types>(rec.value(kcolWaterType).toInt())),
-   m_mash_ro(rec.value(kcolWaterMashRO).toDouble()),
-   m_sparge_ro(rec.value(kcolWaterSpargeRO).toDouble()),
-   m_alkalinity_as_hco3(rec.value(kcolWaterAsHCO3).toBool())
+Water::Water(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec ),
+   m_cacheOnly(false)
 {
+   m_amount = rec.value( table->propertyToColumn( PropertyNames::Water::amount)).toDouble();
+   m_calcium_ppm = rec.value( table->propertyToColumn( PropertyNames::Water::calcium_ppm)).toDouble();
+   m_bicarbonate_ppm = rec.value( table->propertyToColumn( PropertyNames::Water::bicarbonate_ppm)).toDouble();
+   m_sulfate_ppm = rec.value( table->propertyToColumn( PropertyNames::Water::sulfate_ppm)).toDouble();
+   m_chloride_ppm = rec.value( table->propertyToColumn( PropertyNames::Water::chloride_ppm)).toDouble();
+   m_sodium_ppm = rec.value( table->propertyToColumn( PropertyNames::Water::sodium_ppm)).toDouble();
+   m_magnesium_ppm = rec.value( table->propertyToColumn( PropertyNames::Water::magnesium_ppm)).toDouble();
+   m_ph = rec.value( table->propertyToColumn( PropertyNames::Water::ph)).toDouble();
+   m_alkalinity = rec.value( table->propertyToColumn( PropertyNames::Water::alkalinity)).toDouble();
+   m_notes = rec.value( table->propertyToColumn( PropertyNames::Water::notes)).toString();
+   m_type = static_cast<Water::Types>(rec.value( table->propertyToColumn( PropertyNames::Water::type)).toInt());
+   m_mash_ro = rec.value( table->propertyToColumn( PropertyNames::Water::mashRO)).toDouble();
+   m_sparge_ro = rec.value( table->propertyToColumn( PropertyNames::Water::spargeRO)).toDouble();
+
+   m_alkalinity_as_hco3 = rec.value( table->propertyToColumn( PropertyNames::Water::alkalinityAsHCO3)).toBool();
+
 }
 
 //================================"SET" METHODS=================================

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -89,8 +89,8 @@ Water::Water(Water const& other, bool cache)
 {
 }
 
-Water::Water(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec ),
+Water::Water(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
    m_cacheOnly(false)
 {
    m_amount = rec.value( table->propertyToColumn( PropertyNames::Water::amount)).toDouble();

--- a/src/water.h
+++ b/src/water.h
@@ -156,7 +156,7 @@ protected:
 
 private:
 //   Water(Brewtarget::DBTable table, int key);
-   Water( TableSchema* table, QSqlRecord rec);
+   Water( TableSchema* table, QSqlRecord rec, int t_key = -1);
    Water( Water const& other, bool cache = true);
 
    double m_amount;

--- a/src/water.h
+++ b/src/water.h
@@ -24,6 +24,8 @@
 
 #include <QString>
 #include "model/NamedEntity.h"
+#include "TableSchema.h"
+
 namespace PropertyNames::Water { static char const * const ph = "ph"; /* previously kpropPH */ }
 namespace PropertyNames::Water { static char const * const amount = "amount"; /* previously kpropAmount */ }
 namespace PropertyNames::Water { static char const * const type = "type"; /* previously kpropType */ }
@@ -53,6 +55,7 @@ class Water : public NamedEntity
    friend class BeerXML;
    friend class WaterDialog;
    friend class WaterEditor;
+
 public:
 
    enum Types {
@@ -73,6 +76,7 @@ public:
 
    Q_ENUM(Types Ions)
 
+   Water( QString name, bool cache = true);
    virtual ~Water() {}
 
    // On a base or target profile, bicarbonate and alkalinity cannot both be used. I'm gonna have fun figuring that out
@@ -151,13 +155,10 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Water(Brewtarget::DBTable table, int key);
-   Water(Brewtarget::DBTable table, int key, QSqlRecord rec);
-   Water(Water const& other, bool cache = true);
-public:
-   Water(QString name, bool cache = true);
+//   Water(Brewtarget::DBTable table, int key);
+   Water( TableSchema* table, QSqlRecord rec);
+   Water( Water const& other, bool cache = true);
 
-private:
    double m_amount;
    double m_calcium_ppm;
    double m_bicarbonate_ppm;

--- a/src/yeast.cpp
+++ b/src/yeast.cpp
@@ -82,8 +82,8 @@ Yeast::Yeast(QString name, bool cache )
 {
 }
 
-Yeast::Yeast(TableSchema* table, QSqlRecord rec)
-   : NamedEntity(table, rec),
+Yeast::Yeast(TableSchema* table, QSqlRecord rec, int t_key)
+   : NamedEntity(table, rec, t_key),
      m_inventory(-1),
      m_cacheOnly(false)
 {

--- a/src/yeast.cpp
+++ b/src/yeast.cpp
@@ -55,34 +55,9 @@ QString Yeast::classNameStr()
 }
 
 //============================CONSTRUCTORS======================================
-Yeast::Yeast(Brewtarget::DBTable table, int key)
-   : NamedEntity(table, key, QString(), true ),
-     m_typeString(QString()),
-     m_type(static_cast<Yeast::Type>(0)),
-     m_formString(QString()),
-     m_form(static_cast<Yeast::Form>(0)),
-     m_flocculationString(QString()),
-     m_flocculation(static_cast<Yeast::Flocculation>(0)),
-     m_amount(0.0),
-     m_amountIsWeight(false),
-     m_laboratory(QString()),
-     m_productID(QString()),
-     m_minTemperature_c(0.0),
-     m_maxTemperature_c(0.0),
-     m_attenuation_pct(0.0),
-     m_notes(QString()),
-     m_bestFor(QString()),
-     m_timesCultured(0),
-     m_maxReuse(0),
-     m_addToSecondary(false),
-     m_inventory(-1.0),
-     m_inventory_id(0),
-     m_cacheOnly(false)
-{
-}
 
 Yeast::Yeast(QString name, bool cache )
-   : NamedEntity(Brewtarget::YEASTTABLE, -1, name, true ),
+   : NamedEntity(Brewtarget::YEASTTABLE, name, true ),
      m_typeString(QString()),
      m_type(static_cast<Yeast::Type>(0)),
      m_formString(QString()),
@@ -107,30 +82,33 @@ Yeast::Yeast(QString name, bool cache )
 {
 }
 
-Yeast::Yeast(Brewtarget::DBTable table, int key, QSqlRecord rec)
-   : NamedEntity(table, key, rec.value(kcolName).toString(), rec.value(kcolDisplay).toBool(), rec.value(kcolFolder).toString()),
-     m_typeString(rec.value(kcolYeastType).toString()),
-     m_type(static_cast<Yeast::Type>(types.indexOf(m_typeString))),
-     m_formString(rec.value(kcolYeastForm).toString()),
-     m_form(static_cast<Yeast::Form>(forms.indexOf(m_formString))),
-     m_flocculationString(rec.value(kcolYeastFloc).toString()),
-     m_flocculation(static_cast<Yeast::Flocculation>(flocculations.indexOf(m_flocculationString))),
-     m_amount(rec.value(kcolYeastAmount).toDouble()),
-     m_amountIsWeight(rec.value(kcolYeastAmtIsWgt).toBool()),
-     m_laboratory(rec.value(kcolYeastLab).toString()),
-     m_productID(rec.value(kcolYeastProductID).toString()),
-     m_minTemperature_c(rec.value(kcolYeastMinTemp).toDouble()),
-     m_maxTemperature_c(rec.value(kcolYeastMaxTemp).toDouble()),
-     m_attenuation_pct(rec.value(kcolYeastAtten).toDouble()),
-     m_notes(rec.value(kcolNotes).toString()),
-     m_bestFor(rec.value(kcolYeastBestFor).toString()),
-     m_timesCultured(rec.value(kcolYeastTimesCultd).toInt()),
-     m_maxReuse(rec.value(kcolYeastMaxReuse).toInt()),
-     m_addToSecondary(rec.value(kcolYeastAddToSec).toBool()),
+Yeast::Yeast(TableSchema* table, QSqlRecord rec)
+   : NamedEntity(table, rec),
      m_inventory(-1),
-     m_inventory_id(rec.value(kcolInventoryId).toInt()),
      m_cacheOnly(false)
 {
+     m_typeString = rec.value( table->propertyToColumn( PropertyNames::Yeast::type)).toString();
+     m_formString = rec.value( table->propertyToColumn( PropertyNames::Yeast::form)).toString();
+     m_flocculationString = rec.value( table->propertyToColumn( PropertyNames::Yeast::flocculation)).toString();
+     m_amount = rec.value( table->propertyToColumn( PropertyNames::Yeast::amount)).toDouble();
+     m_amountIsWeight = rec.value( table->propertyToColumn( PropertyNames::Yeast::amountIsWeight)).toBool();
+     m_laboratory = rec.value( table->propertyToColumn( PropertyNames::Yeast::laboratory)).toString();
+     m_productID = rec.value( table->propertyToColumn( PropertyNames::Yeast::productID)).toString();
+     m_minTemperature_c = rec.value( table->propertyToColumn( PropertyNames::Yeast::minTemperature_c)).toDouble();
+     m_maxTemperature_c = rec.value( table->propertyToColumn( PropertyNames::Yeast::maxTemperature_c)).toDouble();
+     m_attenuation_pct = rec.value( table->propertyToColumn( PropertyNames::Yeast::attenuation_pct)).toDouble();
+     m_notes = rec.value( table->propertyToColumn( PropertyNames::Yeast::notes)).toString();
+     m_bestFor = rec.value( table->propertyToColumn( PropertyNames::Yeast::bestFor)).toString();
+     m_timesCultured = rec.value( table->propertyToColumn( PropertyNames::Yeast::timesCultured)).toInt();
+     m_maxReuse = rec.value( table->propertyToColumn( PropertyNames::Yeast::maxReuse)).toInt();
+     m_addToSecondary = rec.value( table->propertyToColumn( PropertyNames::Yeast::addToSecondary)).toBool();
+
+     // foreign keys blow
+     m_inventory_id = rec.value( table->foreignKeyToColumn( PropertyNames::Yeast::inventory_id)).toInt();
+
+     m_type = static_cast<Yeast::Type>(types.indexOf(m_typeString));
+     m_form = static_cast<Yeast::Form>(forms.indexOf(m_formString));
+     m_flocculation = static_cast<Yeast::Flocculation>(flocculations.indexOf(m_flocculationString));
 }
 
 Yeast::Yeast(Yeast & other) : NamedEntity(other),
@@ -183,7 +161,7 @@ double Yeast::attenuation_pct() const { return m_attenuation_pct; }
 
 int Yeast::inventory() {
    if ( m_inventory < 0 ) {
-      m_inventory = getInventory(PropertyNames::Yeast::inventory).toInt();
+      m_inventory = getInventory().toInt();
    }
    return m_inventory;
 }

--- a/src/yeast.h
+++ b/src/yeast.h
@@ -30,6 +30,7 @@ namespace PropertyNames::Yeast { static char const * const amount = "amount"; /*
 namespace PropertyNames::Yeast { static char const * const form = "form"; /* previously kpropForm */ }
 namespace PropertyNames::Yeast { static char const * const amountIsWeight = "amountIsWeight"; /* previously kpropAmtIsWgt */ }
 namespace PropertyNames::Yeast { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
+namespace PropertyNames::Yeast { static char const * const inventory_id = "inventory_id"; /* previously kpropInventoryId */ }
 namespace PropertyNames::Yeast { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
 namespace PropertyNames::Yeast { static char const * const type = "type"; /* previously kpropType */ }
 namespace PropertyNames::Yeast { static char const * const notes = "notes"; /* previously kpropNotes */ }
@@ -59,6 +60,7 @@ class Yeast : public NamedEntity
    friend class Database;
    friend class BeerXML;
    friend class YeastDialog;
+
 public:
    //! \brief What beverage the yeast is for.
    enum Type {Ale, Lager, Wheat, Wine, Champagne};
@@ -68,6 +70,7 @@ public:
    enum Flocculation {Low, Medium, High, Very_High}; // NOTE: BeerXML expects a space in "Very High", but not possible with enum. What to do?
    Q_ENUMS( Type Form Flocculation )
 
+   Yeast(QString name, bool cache = true);
    virtual ~Yeast() {}
 
    //! \brief The \c Type.
@@ -175,11 +178,8 @@ protected:
    virtual bool isEqualTo(NamedEntity const & other) const;
 
 private:
-   Yeast(Brewtarget::DBTable table, int key);
-   Yeast(Brewtarget::DBTable table, int key, QSqlRecord rec);
-public:
-   Yeast(QString name, bool cache = true);
-private:
+//   Yeast(Brewtarget::DBTable table, int key);
+   Yeast(TableSchema* table, QSqlRecord rec);
    Yeast(Yeast & other);
 
    QString m_typeString;

--- a/src/yeast.h
+++ b/src/yeast.h
@@ -179,7 +179,7 @@ protected:
 
 private:
 //   Yeast(Brewtarget::DBTable table, int key);
-   Yeast(TableSchema* table, QSqlRecord rec);
+   Yeast(TableSchema* table, QSqlRecord rec, int t_key = -1);
    Yeast(Yeast & other);
 
    QString m_typeString;


### PR DESCRIPTION
Side discussions made me aware that I had horribly broken the model in the primitive constructors by making each of them aware of the database column names. This is my first pass at fixing it.

I was able to remove a lot of unused constructors, one slightly redundant template method and generally clean the code up. It comes with a price tag of a slightly more complex NamedEntity constructor, and that one of the newNamedEntity methods has to search for the record it just created.
