### PR TITLE
Fixing annoying windows icon build location

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,13 +387,13 @@ ADD_CUSTOM_TARGET(translations DEPENDS ${QM_FILES})
 SET(brewtarget_ICON "")
 
 IF( WIN32 AND MINGW )
-  ADD_CUSTOM_COMMAND(OUTPUT ${WINDIR}/icon.o
+  ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_BINARY_DIR}/src/icon.o
                      COMMAND windres.exe -I${CMAKE_CURRENT_SOURCE_DIR}
                      -i${RCFILE}
-                     -o${WINDIR}/icon.o
+                     -o${CMAKE_BINARY_DIR}/src/icon.o
                      DEPENDS ${RCFILE}
   )
-  SET(brewtarget_ICON ${WINDIR}/icon.o)
+  SET(brewtarget_ICON ${CMAKE_BINARY_DIR}/src/icon.o)
 ELSEIF(WIN32)
   SET(brewtarget_ICON ${RCFILE})
 ENDIF()


### PR DESCRIPTION
When Compiling on Windows the icon was compiled in the source tree making git believe there is a new file to add to the source!
This has nagged me for awhile, finally got around to fixing it.