### PR TITLE
Bugs/btstringedit

### DIFF
--- a/src/BtHorizontalTabs.h
+++ b/src/BtHorizontalTabs.h
@@ -1,0 +1,57 @@
+/*
+ * BtHorizontalTabs.h is part of Brewtarget, and is Copyright the following
+ * authors 2021-2025
+ * - Mik Firestone <mikfire@gmail.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BTHORIZONTALTABS_H
+#define BTHORIZONTALTABS_H
+
+#include <QProxyStyle>
+#include <QStyleOption>
+#include <QStyleOptionTab>
+#include <QSize>
+
+/* A quick little bit to handle a tab bar with the tabs on the west. 
+ */
+class BtHorizontalTabs : public QProxyStyle
+{
+public:
+   QSize sizeFromContents( ContentsType type, const QStyleOption* option,
+                           const QSize& size, const QWidget* widget ) const
+   {
+      QSize s = QProxyStyle::sizeFromContents(type,option,size,widget);
+      if ( type == QStyle::CT_TabBarTab ) {
+         s.transpose();
+      }
+      return s;
+   }
+
+   void drawControl( ControlElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget ) const
+   {
+      if ( element == CE_TabBarTabLabel ) {
+         if ( const QStyleOptionTab* tab = qstyleoption_cast<const QStyleOptionTab*>(option)) {
+            QStyleOptionTab opt(*tab);
+            // this looks wrong, but it isn't. No idea why.
+            opt.shape = QTabBar::RoundedNorth;
+            QProxyStyle::drawControl(element,&opt,painter,widget);
+            return;
+         }
+      }
+      QProxyStyle::drawControl(element,option,painter,widget);
+   }
+};
+#endif

--- a/src/BtLineEdit.h
+++ b/src/BtLineEdit.h
@@ -109,7 +109,7 @@ signals:
 
 private:
    void calculateDisplaySize(QString const & maximalDisplayString);
-   void setDisplaySize();
+   void setDisplaySize(bool recalculate = false);
    int desiredWidthInPixels;
 
 protected:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,6 +206,7 @@ SET( brewtarget_UIS
     ${UIDIR}/mainWindow.ui
     ${UIDIR}/mashStepEditor.ui
     ${UIDIR}/miscEditor.ui
+    ${UIDIR}/equipmentEditor.ui
     ${UIDIR}/fermentableEditor.ui
     ${UIDIR}/hopEditor.ui
     ${UIDIR}/instructionWidget.ui
@@ -250,6 +251,7 @@ SET( brewtarget_MOC_HEADERS
     ${SRCDIR}/BtDigitWidget.h
     ${SRCDIR}/BtDatePopup.h
     ${SRCDIR}/BtFolder.h
+    ${SRCDIR}/BtHorizontalTabs.h
     ${SRCDIR}/BtLabel.h
     ${SRCDIR}/BtLineEdit.h
     ${SRCDIR}/BtTextEdit.h

--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -39,11 +39,12 @@
 #include "HeatCalculations.h"
 #include "PhysicalConstants.h"
 #include "NamedEntitySortProxyModel.h"
+#include "BtHorizontalTabs.h"
 
 EquipmentEditor::EquipmentEditor(QWidget* parent, bool singleEquipEditor)
    : QDialog(parent)
 {
-   doLayout();
+   setupUi(this);
 
    if( singleEquipEditor )
    {
@@ -58,6 +59,7 @@ EquipmentEditor::EquipmentEditor(QWidget* parent, bool singleEquipEditor)
       pushButton_new->setVisible(false);
    }
 
+   this->tabWidget_editor->tabBar()->setStyle( new BtHorizontalTabs );
    // Set grain absorption label based on units.
    Unit* weightUnit = nullptr;
    Unit* volumeUnit = nullptr;
@@ -89,432 +91,12 @@ EquipmentEditor::EquipmentEditor(QWidget* parent, bool singleEquipEditor)
    connect(checkBox_calcBoilVolume, &QCheckBox::stateChanged, this, &EquipmentEditor::updateCheckboxRecord);
    connect(checkBox_defaultEquipment, &QCheckBox::stateChanged, this, &EquipmentEditor::updateDefaultEquipment);
 
-   // Labels
-   connect(label_boilSize, &BtLabel::labelChanged, lineEdit_boilSize, &BtLineEdit::lineChanged);
-   connect(label_batchSize, &BtLabel::labelChanged, lineEdit_batchSize, &BtLineEdit::lineChanged);
-   connect(label_evaporationRate, &BtLabel::labelChanged, lineEdit_evaporationRate, &BtLineEdit::lineChanged);
-   connect(label_topUpWater, &BtLabel::labelChanged, lineEdit_topUpWater, &BtLineEdit::lineChanged);
-   connect(label_boilingPoint, &BtLabel::labelChanged, lineEdit_boilingPoint, &BtLineEdit::lineChanged);
-   connect(label_tunVolume, &BtLabel::labelChanged, lineEdit_tunVolume, &BtLineEdit::lineChanged);
-   connect(label_tunWeight, &BtLabel::labelChanged, lineEdit_tunWeight, &BtLineEdit::lineChanged);
-   connect(label_lauterDeadspace, &BtLabel::labelChanged, lineEdit_lauterDeadspace, &BtLineEdit::lineChanged);
-   connect(label_trubChillerLoss, &BtLabel::labelChanged, lineEdit_trubChillerLoss, &BtLineEdit::lineChanged);
-   connect(label_topUpKettle, &BtLabel::labelChanged, lineEdit_topUpKettle, &BtLineEdit::lineChanged);
-   connect(label_boilTime, &BtLabel::labelChanged, lineEdit_boilTime, &BtLineEdit::lineChanged);
-
-   QMetaObject::connectSlotsByName(this);
+   // QMetaObject::connectSlotsByName(this);
 
    // make sure the dialog gets populated the first time it's opened from the menu
    equipmentSelected();
    // Ensure correct state of Boil Volume edit box.
    updateCheckboxRecord();
-}
-
-void EquipmentEditor::doLayout()
-{
-   resize(0,0);
-   topVLayout = new QVBoxLayout(this);
-      horizontalLayout_equipments = new QHBoxLayout();
-         label = new QLabel(this);
-         equipmentComboBox = new QComboBox(this);
-            equipmentComboBox->setObjectName(QStringLiteral("equipmentComboBox"));
-            equipmentComboBox->setMinimumSize(QSize(200, 0));
-            equipmentComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-         pushButton_remove = new QPushButton(this);
-            pushButton_remove->setObjectName(QStringLiteral("pushButton_remove"));
-            QIcon icon;
-            icon.addFile(QStringLiteral(":/images/smallMinus.svg"), QSize(), QIcon::Normal, QIcon::Off);
-            pushButton_remove->setIcon(icon);
-            pushButton_remove->setAutoDefault(false);
-         horizontalSpacer = new QSpacerItem(40, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);
-         checkBox_defaultEquipment = new QCheckBox(this);
-            checkBox_defaultEquipment->setObjectName(QStringLiteral("checkBox_defaultEquipment"));
-         horizontalLayout_equipments->addWidget(label);
-         horizontalLayout_equipments->addWidget(equipmentComboBox);
-         horizontalLayout_equipments->addWidget(pushButton_remove);
-         horizontalLayout_equipments->addItem(horizontalSpacer);
-         horizontalLayout_equipments->addWidget(checkBox_defaultEquipment);
-      horizontalLayout = new QHBoxLayout();
-         vLayout_left = new QVBoxLayout();
-            groupBox_required = new QGroupBox(this);
-               groupBox_required->setProperty("configSection", QVariant(QStringLiteral("equipmentEditor")));
-               formLayout = new QFormLayout(groupBox_required);
-                  label_name = new QLabel(groupBox_required);
-                     label_name->setObjectName(QStringLiteral("label_name"));
-                     QSizePolicy sizePolicy1(QSizePolicy::Expanding, QSizePolicy::Preferred);
-                     sizePolicy1.setHorizontalStretch(0);
-                     sizePolicy1.setVerticalStretch(0);
-                     sizePolicy1.setHeightForWidth(label_name->sizePolicy().hasHeightForWidth());
-                     label_name->setSizePolicy(sizePolicy1);
-                  lineEdit_name = new QLineEdit(groupBox_required);
-                     lineEdit_name->setObjectName(QStringLiteral("lineEdit_name"));
-                     QSizePolicy sizePolicy2(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                     sizePolicy2.setHorizontalStretch(100);
-                     sizePolicy2.setVerticalStretch(0);
-                     sizePolicy2.setHeightForWidth(lineEdit_name->sizePolicy().hasHeightForWidth());
-                     lineEdit_name->setSizePolicy(sizePolicy2);
-                     lineEdit_name->setMinimumSize(QSize(100, 0));
-                     lineEdit_name->setMaximumSize(QSize(100, 16777215));
-                  label_boilSize = new BtVolumeLabel(groupBox_required);
-                     label_boilSize->setObjectName(QStringLiteral("label_boilSize"));
-                     sizePolicy1.setHeightForWidth(label_boilSize->sizePolicy().hasHeightForWidth());
-                     label_boilSize->setSizePolicy(sizePolicy1);
-                     label_boilSize->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_boilSize = new BtVolumeEdit(groupBox_required);
-                     lineEdit_boilSize->setObjectName(QStringLiteral("lineEdit_boilSize"));
-                     sizePolicy2.setHeightForWidth(lineEdit_boilSize->sizePolicy().hasHeightForWidth());
-                     lineEdit_boilSize->setSizePolicy(sizePolicy2);
-                     lineEdit_boilSize->setMinimumSize(QSize(100, 0));
-                     lineEdit_boilSize->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_boilSize->setProperty("editField", QVariant(QStringLiteral("boilSize_l")));
-                  label_batchSize = new BtVolumeLabel(groupBox_required);
-                     label_batchSize->setObjectName(QStringLiteral("label_batchSize"));
-                     sizePolicy1.setHeightForWidth(label_batchSize->sizePolicy().hasHeightForWidth());
-                     label_batchSize->setSizePolicy(sizePolicy1);
-                     label_batchSize->setContextMenuPolicy(Qt::CustomContextMenu);
-                  checkBox_calcBoilVolume = new QCheckBox(groupBox_required);
-                     checkBox_calcBoilVolume->setObjectName(QStringLiteral("checkBox_calcBoilVolume"));
-                  label_calcBoilVolume = new QLabel(groupBox_required);
-                     label_calcBoilVolume->setObjectName(QStringLiteral("label_calcBoilVolume"));
-                     sizePolicy1.setHeightForWidth(label_calcBoilVolume->sizePolicy().hasHeightForWidth());
-                     label_calcBoilVolume->setSizePolicy(sizePolicy1);
-
-
-                  lineEdit_batchSize = new BtVolumeEdit(groupBox_required);
-                     lineEdit_batchSize->setObjectName(QStringLiteral("lineEdit_batchSize"));
-                     sizePolicy2.setHeightForWidth(lineEdit_batchSize->sizePolicy().hasHeightForWidth());
-                     lineEdit_batchSize->setSizePolicy(sizePolicy2);
-                     lineEdit_batchSize->setMinimumSize(QSize(100, 0));
-                     lineEdit_batchSize->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_batchSize->setProperty("editField", QVariant(QStringLiteral("batchSize_l")));
-
-                  formLayout->setWidget(0, QFormLayout::LabelRole, label_name);
-                  formLayout->setWidget(0, QFormLayout::FieldRole, lineEdit_name);
-                  formLayout->setWidget(1, QFormLayout::LabelRole, label_batchSize);
-                  formLayout->setWidget(1, QFormLayout::FieldRole, lineEdit_batchSize);
-                  formLayout->setWidget(2, QFormLayout::LabelRole, label_boilSize);
-                  formLayout->setWidget(2, QFormLayout::FieldRole, lineEdit_boilSize);
-                  formLayout->setWidget(3, QFormLayout::LabelRole, label_calcBoilVolume);
-                  formLayout->setWidget(3, QFormLayout::FieldRole, checkBox_calcBoilVolume);
-
-            groupBox_water = new QGroupBox(this);
-               groupBox_water->setProperty("configSection", QVariant(QStringLiteral("equipmentEditor")));
-               formLayout_water = new QFormLayout(groupBox_water);
-                  formLayout_water->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
-                  label_boilTime = new BtTimeLabel(groupBox_water);
-                     label_boilTime->setObjectName(QStringLiteral("label_boilTime"));
-                     sizePolicy1.setHeightForWidth(label_boilTime->sizePolicy().hasHeightForWidth());
-                     label_boilTime->setSizePolicy(sizePolicy1);
-                     label_boilTime->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_boilTime = new BtTimeEdit(groupBox_water);
-                     lineEdit_boilTime->setObjectName(QStringLiteral("lineEdit_boilTime"));
-                     sizePolicy2.setHeightForWidth(lineEdit_boilTime->sizePolicy().hasHeightForWidth());
-                     lineEdit_boilTime->setSizePolicy(sizePolicy2);
-                     lineEdit_boilTime->setMinimumSize(QSize(100, 0));
-                     lineEdit_boilTime->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_boilTime->setProperty("editField", QVariant(QStringLiteral("boilTime_min")));
-                  label_evaporationRate = new BtVolumeLabel(groupBox_water);
-                     label_evaporationRate->setObjectName(QStringLiteral("label_evaporationRate"));
-                     sizePolicy1.setHeightForWidth(label_evaporationRate->sizePolicy().hasHeightForWidth());
-                     label_evaporationRate->setSizePolicy(sizePolicy1);
-                     label_evaporationRate->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_evaporationRate = new BtVolumeEdit(groupBox_water);
-                     lineEdit_evaporationRate->setObjectName(QStringLiteral("lineEdit_evaporationRate"));
-                     sizePolicy2.setHeightForWidth(lineEdit_evaporationRate->sizePolicy().hasHeightForWidth());
-                     lineEdit_evaporationRate->setSizePolicy(sizePolicy2);
-                     lineEdit_evaporationRate->setMinimumSize(QSize(100, 0));
-                     lineEdit_evaporationRate->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_evaporationRate->setProperty("editField", QVariant(QString(PropertyNames::Equipment::evapRate_lHr)));
-                  label_topUpKettle = new BtVolumeLabel(groupBox_water);
-                     label_topUpKettle->setObjectName(QStringLiteral("label_topUpKettle"));
-                     sizePolicy1.setHeightForWidth(label_topUpKettle->sizePolicy().hasHeightForWidth());
-                     label_topUpKettle->setSizePolicy(sizePolicy1);
-                     label_topUpKettle->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_topUpKettle = new BtVolumeEdit(groupBox_water);
-                     lineEdit_topUpKettle->setObjectName(QStringLiteral("lineEdit_topUpKettle"));
-                     sizePolicy2.setHeightForWidth(lineEdit_topUpKettle->sizePolicy().hasHeightForWidth());
-                     lineEdit_topUpKettle->setSizePolicy(sizePolicy2);
-                     lineEdit_topUpKettle->setMinimumSize(QSize(100, 0));
-                     lineEdit_topUpKettle->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_topUpKettle->setProperty("editField", QVariant(QString(PropertyNames::Equipment::topUpKettle_l)));
-                  label_topUpWater = new BtVolumeLabel(groupBox_water);
-                     label_topUpWater->setObjectName(QStringLiteral("label_topUpWater"));
-                     sizePolicy1.setHeightForWidth(label_topUpWater->sizePolicy().hasHeightForWidth());
-                     label_topUpWater->setSizePolicy(sizePolicy1);
-                     label_topUpWater->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_topUpWater = new BtVolumeEdit(groupBox_water);
-                     lineEdit_topUpWater->setObjectName(QStringLiteral("lineEdit_topUpWater"));
-                     sizePolicy2.setHeightForWidth(lineEdit_topUpWater->sizePolicy().hasHeightForWidth());
-                     lineEdit_topUpWater->setSizePolicy(sizePolicy2);
-                     lineEdit_topUpWater->setMinimumSize(QSize(100, 0));
-                     lineEdit_topUpWater->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_topUpWater->setProperty("editField", QVariant(QString(PropertyNames::Equipment::topUpWater_l)));
-                  label_absorption = new QLabel(groupBox_water);
-                     label_absorption->setObjectName(QStringLiteral("label_absorption"));
-                  lineEdit_grainAbsorption = new BtGenericEdit(groupBox_water);
-                     lineEdit_grainAbsorption->setObjectName(QStringLiteral("lineEdit_grainAbsorption"));
-                     QSizePolicy sizePolicy3(QSizePolicy::Preferred, QSizePolicy::Fixed);
-                     sizePolicy3.setHorizontalStretch(0);
-                     sizePolicy3.setVerticalStretch(0);
-                     sizePolicy3.setHeightForWidth(lineEdit_grainAbsorption->sizePolicy().hasHeightForWidth());
-                     lineEdit_grainAbsorption->setSizePolicy(sizePolicy3);
-                     lineEdit_grainAbsorption->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_grainAbsorption->setProperty("editField", QVariant(QString(PropertyNames::Equipment::grainAbsorption_LKg)));
-                  pushButton_absorption = new QPushButton(groupBox_water);
-                     pushButton_absorption->setObjectName(QStringLiteral("pushButton_absorption"));
-                  label_boilingPoint = new BtTemperatureLabel(groupBox_water);
-                     label_boilingPoint->setObjectName(QStringLiteral("label_boilingPoint"));
-                     label_boilingPoint->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_boilingPoint = new BtTemperatureEdit(groupBox_water);
-                     lineEdit_boilingPoint->setObjectName(QStringLiteral("lineEdit_boilingPoint"));
-                     sizePolicy3.setHeightForWidth(lineEdit_boilingPoint->sizePolicy().hasHeightForWidth());
-                     lineEdit_boilingPoint->setSizePolicy(sizePolicy3);
-                     lineEdit_boilingPoint->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_boilingPoint->setProperty("editField", QVariant(QString(PropertyNames::Equipment::boilingPoint_c)));
-                  label_hopUtilization = new QLabel(groupBox_water);
-                     label_hopUtilization->setObjectName(QStringLiteral("label_hopUtilization"));
-                  lineEdit_hopUtilization = new BtGenericEdit(groupBox_water);
-                     lineEdit_hopUtilization->setObjectName(QStringLiteral("lineEdit_hopUtilization"));
-                     sizePolicy3.setHeightForWidth(lineEdit_hopUtilization->sizePolicy().hasHeightForWidth());
-                     lineEdit_hopUtilization->setSizePolicy(sizePolicy3);
-                     lineEdit_hopUtilization->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_hopUtilization->setProperty("editField", QVariant(QString(PropertyNames::Equipment::hopUtilization_pct)));
-                  formLayout_water->setWidget(0, QFormLayout::LabelRole, label_boilTime);
-                  formLayout_water->setWidget(0, QFormLayout::FieldRole, lineEdit_boilTime);
-                  formLayout_water->setWidget(1, QFormLayout::LabelRole, label_evaporationRate);
-                  formLayout_water->setWidget(1, QFormLayout::FieldRole, lineEdit_evaporationRate);
-                  formLayout_water->setWidget(2, QFormLayout::LabelRole, label_topUpKettle);
-                  formLayout_water->setWidget(2, QFormLayout::FieldRole, lineEdit_topUpKettle);
-                  formLayout_water->setWidget(3, QFormLayout::LabelRole, label_topUpWater);
-                  formLayout_water->setWidget(3, QFormLayout::FieldRole, lineEdit_topUpWater);
-                  formLayout_water->setWidget(4, QFormLayout::LabelRole, label_absorption);
-                  formLayout_water->setWidget(4, QFormLayout::FieldRole, lineEdit_grainAbsorption);
-                  formLayout_water->setWidget(5, QFormLayout::LabelRole, pushButton_absorption);
-                  formLayout_water->setWidget(6, QFormLayout::LabelRole, label_boilingPoint);
-                  formLayout_water->setWidget(6, QFormLayout::FieldRole, lineEdit_boilingPoint);
-                  formLayout_water->setWidget(7, QFormLayout::LabelRole, label_hopUtilization);
-                  formLayout_water->setWidget(7, QFormLayout::FieldRole, lineEdit_hopUtilization);
-            verticalSpacer_2 = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
-            vLayout_left->addWidget(groupBox_required);
-            vLayout_left->addWidget(groupBox_water);
-            vLayout_left->addItem(verticalSpacer_2);
-         vLayout_right = new QVBoxLayout();
-            groupBox_mashTun = new QGroupBox(this);
-               groupBox_mashTun->setObjectName(QStringLiteral("groupBox_mashTun"));
-               groupBox_mashTun->setProperty("configSection", QVariant(QStringLiteral("equipmentEditor")));
-               formLayout_mashTun = new QFormLayout(groupBox_mashTun);
-                  formLayout_mashTun->setObjectName(QStringLiteral("formLayout_mashTun"));
-                  label_tunVolume = new BtVolumeLabel(groupBox_mashTun);
-                     label_tunVolume->setObjectName(QStringLiteral("label_tunVolume"));
-                     sizePolicy1.setHeightForWidth(label_tunVolume->sizePolicy().hasHeightForWidth());
-                     label_tunVolume->setSizePolicy(sizePolicy1);
-                     label_tunVolume->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_tunVolume = new BtVolumeEdit(groupBox_mashTun);
-                     lineEdit_tunVolume->setObjectName(QStringLiteral("lineEdit_tunVolume"));
-                     sizePolicy2.setHeightForWidth(lineEdit_tunVolume->sizePolicy().hasHeightForWidth());
-                     lineEdit_tunVolume->setSizePolicy(sizePolicy2);
-                     lineEdit_tunVolume->setMinimumSize(QSize(100, 0));
-                     lineEdit_tunVolume->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_tunVolume->setProperty("editField", QVariant(QString(PropertyNames::Equipment::tunVolume_l)));
-                  label_tunWeight = new BtMassLabel(groupBox_mashTun);
-                     label_tunWeight->setObjectName(QStringLiteral("label_tunWeight"));
-                     sizePolicy1.setHeightForWidth(label_tunWeight->sizePolicy().hasHeightForWidth());
-                     label_tunWeight->setSizePolicy(sizePolicy1);
-                     label_tunWeight->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_tunWeight = new BtMassEdit(groupBox_mashTun);
-                     lineEdit_tunWeight->setObjectName(QStringLiteral("lineEdit_tunWeight"));
-                     sizePolicy2.setHeightForWidth(lineEdit_tunWeight->sizePolicy().hasHeightForWidth());
-                     lineEdit_tunWeight->setSizePolicy(sizePolicy2);
-                     lineEdit_tunWeight->setMinimumSize(QSize(100, 0));
-                     lineEdit_tunWeight->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_tunWeight->setProperty("editField", QVariant(QStringLiteral("tunWeight_kg")));
-                  label_tunSpecificHeat = new QLabel(groupBox_mashTun);
-                     label_tunSpecificHeat->setObjectName(QStringLiteral("label_tunSpecificHeat"));
-                     sizePolicy1.setHeightForWidth(label_tunSpecificHeat->sizePolicy().hasHeightForWidth());
-                     label_tunSpecificHeat->setSizePolicy(sizePolicy1);
-                  lineEdit_tunSpecificHeat = new BtGenericEdit(groupBox_mashTun);
-                     lineEdit_tunSpecificHeat->setObjectName(QStringLiteral("lineEdit_tunSpecificHeat"));
-                     sizePolicy2.setHeightForWidth(lineEdit_tunSpecificHeat->sizePolicy().hasHeightForWidth());
-                     lineEdit_tunSpecificHeat->setSizePolicy(sizePolicy2);
-                     lineEdit_tunSpecificHeat->setMinimumSize(QSize(100, 0));
-                     lineEdit_tunSpecificHeat->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_tunSpecificHeat->setProperty("editField", QVariant(QStringLiteral("tunSpecificHeat_calGC")));
-                  formLayout_mashTun->setWidget(0, QFormLayout::LabelRole, label_tunVolume);
-                  formLayout_mashTun->setWidget(0, QFormLayout::FieldRole, lineEdit_tunVolume);
-                  formLayout_mashTun->setWidget(1, QFormLayout::LabelRole, label_tunWeight);
-                  formLayout_mashTun->setWidget(1, QFormLayout::FieldRole, lineEdit_tunWeight);
-                  formLayout_mashTun->setWidget(2, QFormLayout::LabelRole, label_tunSpecificHeat);
-                  formLayout_mashTun->setWidget(2, QFormLayout::FieldRole, lineEdit_tunSpecificHeat);
-            groupBox_losses = new QGroupBox(this);
-               groupBox_losses->setProperty("configSection", QVariant(QStringLiteral("equipmentEditor")));
-               formLayout_losses = new QFormLayout(groupBox_losses);
-                  label_trubChillerLoss = new BtVolumeLabel(groupBox_losses);
-                     label_trubChillerLoss->setObjectName(QStringLiteral("label_trubChillerLoss"));
-                     sizePolicy1.setHeightForWidth(label_trubChillerLoss->sizePolicy().hasHeightForWidth());
-                     label_trubChillerLoss->setSizePolicy(sizePolicy1);
-                     label_trubChillerLoss->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_trubChillerLoss = new BtVolumeEdit(groupBox_losses);
-                     lineEdit_trubChillerLoss->setObjectName(QStringLiteral("lineEdit_trubChillerLoss"));
-                     sizePolicy2.setHeightForWidth(lineEdit_trubChillerLoss->sizePolicy().hasHeightForWidth());
-                     lineEdit_trubChillerLoss->setSizePolicy(sizePolicy2);
-                     lineEdit_trubChillerLoss->setMinimumSize(QSize(100, 0));
-                     lineEdit_trubChillerLoss->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_trubChillerLoss->setProperty("editField", QVariant(QString(PropertyNames::Equipment::trubChillerLoss_l)));
-                  label_lauterDeadspace = new BtVolumeLabel(groupBox_losses);
-                     label_lauterDeadspace->setObjectName(QStringLiteral("label_lauterDeadspace"));
-                     sizePolicy1.setHeightForWidth(label_lauterDeadspace->sizePolicy().hasHeightForWidth());
-                     label_lauterDeadspace->setSizePolicy(sizePolicy1);
-                     label_lauterDeadspace->setContextMenuPolicy(Qt::CustomContextMenu);
-                  lineEdit_lauterDeadspace = new BtVolumeEdit(groupBox_losses);
-                     lineEdit_lauterDeadspace->setObjectName(QStringLiteral("lineEdit_lauterDeadspace"));
-                     sizePolicy2.setHeightForWidth(lineEdit_lauterDeadspace->sizePolicy().hasHeightForWidth());
-                     lineEdit_lauterDeadspace->setSizePolicy(sizePolicy2);
-                     lineEdit_lauterDeadspace->setMinimumSize(QSize(100, 0));
-                     lineEdit_lauterDeadspace->setMaximumSize(QSize(100, 16777215));
-                     lineEdit_lauterDeadspace->setProperty("editField", QVariant(QString(PropertyNames::Equipment::lauterDeadspace_l)));
-                  formLayout_losses->setWidget(0, QFormLayout::LabelRole, label_trubChillerLoss);
-                  formLayout_losses->setWidget(0, QFormLayout::FieldRole, lineEdit_trubChillerLoss);
-                  formLayout_losses->setWidget(1, QFormLayout::LabelRole, label_lauterDeadspace);
-                  formLayout_losses->setWidget(1, QFormLayout::FieldRole, lineEdit_lauterDeadspace);
-            groupBox_notes = new QGroupBox(this);
-               verticalLayout_notes = new QVBoxLayout(groupBox_notes);
-                  verticalLayout_notes->setObjectName(QStringLiteral("verticalLayout_notes"));
-                  textEdit_notes = new QTextEdit(groupBox_notes);
-                     textEdit_notes->setObjectName(QStringLiteral("textEdit_notes"));
-                  verticalLayout_notes->addWidget(textEdit_notes);
-            verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
-            vLayout_right->addWidget(groupBox_mashTun);
-            vLayout_right->addWidget(groupBox_losses);
-            vLayout_right->addWidget(groupBox_notes);
-            vLayout_right->addItem(verticalSpacer);
-         horizontalLayout->addLayout(vLayout_left);
-         horizontalLayout->addLayout(vLayout_right);
-      hLayout_buttons = new QHBoxLayout();
-         horizontalSpacer_2 = new QSpacerItem(40, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);
-         pushButton_new = new QPushButton(this);
-            pushButton_new->setObjectName(QStringLiteral("pushButton_new"));
-            QIcon icon1;
-            icon1.addFile(QStringLiteral(":/images/smallPlus.svg"), QSize(), QIcon::Normal, QIcon::Off);
-            pushButton_new->setIcon(icon1);
-            pushButton_new->setAutoDefault(false);
-         pushButton_save = new QPushButton(this);
-            pushButton_save->setObjectName(QStringLiteral("pushButton_save"));
-            QIcon icon2;
-            icon2.addFile(QStringLiteral(":/images/filesave.svg"), QSize(), QIcon::Normal, QIcon::Off);
-            pushButton_save->setIcon(icon2);
-            pushButton_save->setAutoDefault(false);
-            pushButton_save->setDefault(true);
-         pushButton_cancel = new QPushButton(this);
-            pushButton_cancel->setObjectName(QStringLiteral("pushButton_cancel"));
-            QIcon icon3;
-            icon3.addFile(QStringLiteral(":/images/exit.svg"), QSize(), QIcon::Normal, QIcon::Off);
-            pushButton_cancel->setIcon(icon3);
-            pushButton_cancel->setAutoDefault(false);
-         hLayout_buttons->addItem(horizontalSpacer_2);
-         hLayout_buttons->addWidget(pushButton_new);
-         hLayout_buttons->addWidget(pushButton_save);
-         hLayout_buttons->addWidget(pushButton_cancel);
-   topVLayout->addLayout(horizontalLayout_equipments);
-   topVLayout->addLayout(horizontalLayout);
-   topVLayout->addLayout(hLayout_buttons);
-
-#ifndef QT_NO_SHORTCUT
-   label_name->setBuddy(lineEdit_name);
-   label_boilSize->setBuddy(lineEdit_boilSize);
-   label_calcBoilVolume->setBuddy(checkBox_calcBoilVolume);
-   label_batchSize->setBuddy(lineEdit_batchSize);
-   label_boilTime->setBuddy(lineEdit_boilTime);
-   label_evaporationRate->setBuddy(lineEdit_evaporationRate);
-   label_topUpKettle->setBuddy(lineEdit_topUpKettle);
-   label_topUpWater->setBuddy(lineEdit_topUpWater);
-   label_absorption->setBuddy(lineEdit_grainAbsorption);
-   label_hopUtilization->setBuddy(lineEdit_hopUtilization);
-   label_boilingPoint->setBuddy(lineEdit_boilingPoint);
-   label_tunVolume->setBuddy(lineEdit_tunVolume);
-   label_tunWeight->setBuddy(lineEdit_tunWeight);
-   label_tunSpecificHeat->setBuddy(lineEdit_tunSpecificHeat);
-   label_trubChillerLoss->setBuddy(lineEdit_trubChillerLoss);
-   label_lauterDeadspace->setBuddy(lineEdit_lauterDeadspace);
-#endif // QT_NO_SHORTCUT
-
-   QWidget::setTabOrder(equipmentComboBox, pushButton_remove);
-   QWidget::setTabOrder(pushButton_remove, checkBox_defaultEquipment);
-   QWidget::setTabOrder(checkBox_defaultEquipment, lineEdit_name);
-   QWidget::setTabOrder(checkBox_calcBoilVolume, lineEdit_batchSize);
-   QWidget::setTabOrder(lineEdit_boilSize, checkBox_calcBoilVolume);
-   QWidget::setTabOrder(lineEdit_name, lineEdit_boilSize);
-   QWidget::setTabOrder(lineEdit_batchSize, lineEdit_boilTime);
-   QWidget::setTabOrder(lineEdit_boilTime, lineEdit_evaporationRate);
-   QWidget::setTabOrder(lineEdit_evaporationRate, lineEdit_topUpKettle);
-   QWidget::setTabOrder(lineEdit_topUpKettle, lineEdit_topUpWater);
-   QWidget::setTabOrder(lineEdit_topUpWater, lineEdit_grainAbsorption);
-   QWidget::setTabOrder(lineEdit_grainAbsorption, pushButton_absorption);
-   QWidget::setTabOrder(pushButton_absorption, lineEdit_boilingPoint);
-   QWidget::setTabOrder(lineEdit_boilingPoint, lineEdit_hopUtilization);
-   QWidget::setTabOrder(lineEdit_hopUtilization, lineEdit_tunVolume);
-   QWidget::setTabOrder(lineEdit_tunVolume, lineEdit_tunWeight);
-   QWidget::setTabOrder(lineEdit_tunWeight, lineEdit_tunSpecificHeat);
-   QWidget::setTabOrder(lineEdit_tunSpecificHeat, lineEdit_trubChillerLoss);
-   QWidget::setTabOrder(lineEdit_trubChillerLoss, lineEdit_lauterDeadspace);
-   QWidget::setTabOrder(lineEdit_lauterDeadspace, textEdit_notes);
-   QWidget::setTabOrder(textEdit_notes, pushButton_new);
-   QWidget::setTabOrder(pushButton_new, pushButton_save);
-   QWidget::setTabOrder(pushButton_save, pushButton_cancel);
-
-   retranslateUi();
-}
-
-void EquipmentEditor::retranslateUi()
-{
-   setWindowTitle(tr("Equipment Editor"));
-   label->setText(tr("Equipment"));
-   pushButton_remove->setText(QString());
-   checkBox_defaultEquipment->setText(tr("Set as Default"));
-   groupBox_required->setTitle(tr("Required Fields"));
-   label_name->setText(tr("Name"));
-   label_boilSize->setText(tr("Pre-boil volume"));
-   label_calcBoilVolume->setText(tr("Calculate pre-boil volume"));
-   checkBox_calcBoilVolume->setText(QString());
-   label_batchSize->setText(tr("Batch size"));
-   groupBox_water->setTitle(tr("Boiling && Water"));
-   label_boilTime->setText(tr("Boil time"));
-   label_evaporationRate->setText(tr("Evaporation rate (per hr)"));
-   label_topUpKettle->setText(tr("Kettle top-up water"));
-   label_topUpWater->setText(tr("Final top-up water"));
-   label_absorption->setText(tr("Grain Absorption (L/kg)"));
-   pushButton_absorption->setText(tr("Default Absorption"));
-   label_hopUtilization->setText(tr("Hop Utilization "));
-   label_boilingPoint->setText(tr("Boiling Point of Water"));
-   groupBox_mashTun->setTitle(tr("Mash Tun"));
-   label_tunVolume->setText(tr("Volume"));
-   label_tunWeight->setText(tr("Mass"));
-   label_tunSpecificHeat->setText(QApplication::translate("equipmentEditor", "Specific heat (Cal/(g*C))", nullptr));
-   groupBox_losses->setTitle(QApplication::translate("equipmentEditor", "Losses", nullptr));
-   groupBox_losses->setProperty("configSection", QVariant(QApplication::translate("equipmentEditor", "equipmentEditor", nullptr)));
-   label_trubChillerLoss->setText(QApplication::translate("equipmentEditor", "Kettle to fermenter", nullptr));
-   label_lauterDeadspace->setText(QApplication::translate("equipmentEditor", "Lauter deadspace", nullptr));
-   pushButton_new->setText(QString());
-   pushButton_save->setText(QString());
-   pushButton_cancel->setText(QString());
-#ifndef QT_NO_TOOLTIP
-   pushButton_remove->setToolTip(tr("Remove equipment"));
-   lineEdit_name->setToolTip(tr("Name"));
-   lineEdit_boilSize->setToolTip(tr("Pre-boil volume"));
-   label_calcBoilVolume->setToolTip(tr("If checked, we will calculate your pre-boil volume based on your desired batch size, boil time, evaporation rate, losses, etc."));
-   checkBox_calcBoilVolume->setToolTip(tr("Automatically fill in pre-boil volume"));
-   lineEdit_batchSize->setToolTip(tr("Batch size"));
-   lineEdit_boilTime->setToolTip(tr("Boil time"));
-   lineEdit_evaporationRate->setToolTip(tr("How much water boils off per hour"));
-   lineEdit_topUpKettle->setToolTip(tr("How much water is added to kettle immediately pre-boil"));
-   lineEdit_topUpWater->setToolTip(tr("Water added to fermenter"));
-   lineEdit_tunVolume->setToolTip(tr("Volume of mash tun"));
-   lineEdit_tunWeight->setToolTip(tr("Mass or weight of mash tun"));
-   lineEdit_trubChillerLoss->setToolTip(tr("Wort lost between kettle and fermenter"));
-   lineEdit_lauterDeadspace->setToolTip(tr("Volume of wort lost to lauter deadspace"));
-   pushButton_new->setToolTip(tr("New equipment"));
-   pushButton_save->setToolTip(tr("Save"));
-   pushButton_cancel->setToolTip(tr("Cancel"));
-#endif // QT_NO_TOOLTIP
 }
 
 void EquipmentEditor::setEquipment( Equipment* e )
@@ -709,6 +291,7 @@ void EquipmentEditor::resetAbsorption()
    double gaCustomUnits = PhysicalConstants::grainAbsorption_Lkg * volumeUnit->fromSI(1.0) * weightUnit->toSI(1.0);
 
    lineEdit_grainAbsorption->displayAmount(gaCustomUnits);
+   showChanges();
 }
 
 void EquipmentEditor::changed(QMetaProperty /*prop*/, QVariant /*val*/)
@@ -720,8 +303,7 @@ void EquipmentEditor::changed(QMetaProperty /*prop*/, QVariant /*val*/)
 void EquipmentEditor::showChanges()
 {
    Equipment *e = obsEquip;
-   if( e == nullptr )
-   {
+   if( e == nullptr ) {
       clear();
       return;
    }
@@ -736,12 +318,14 @@ void EquipmentEditor::showChanges()
 
    lineEdit_name->setText(e->name());
    lineEdit_name->setCursorPosition(0);
+   tabWidget_editor->setTabText(0, e->name() );
    lineEdit_boilSize->setText(e);
+
    checkBox_calcBoilVolume->blockSignals(true); // Keep next line from emitting a signal and changing e.
    checkBox_calcBoilVolume->setCheckState( (e->calcBoilVolume())? Qt::Checked : Qt::Unchecked );
    checkBox_calcBoilVolume->blockSignals(false);
-   lineEdit_batchSize->setText(e);
 
+   lineEdit_batchSize->setText(e);
    lineEdit_tunVolume->setText(e);
    lineEdit_tunWeight->setText(e);
    lineEdit_tunSpecificHeat->setText(e);

--- a/src/EquipmentEditor.h
+++ b/src/EquipmentEditor.h
@@ -23,32 +23,12 @@
 #ifndef _EQUIPMENTEDITOR_H
 #define _EQUIPMENTEDITOR_H
 
-#include <QDialog>
+class EquipmentEditor;
+
+#include "ui_equipmentEditor.h"
 #include <QMetaProperty>
 #include <QVariant>
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QComboBox>
-#include <QPushButton>
-#include <QSpacerItem>
-#include <QCheckBox>
-#include <QGroupBox>
-#include <QFormLayout>
-#include <QLineEdit>
-#include <QTextEdit>
-#include <QEvent>
 
-#include "BtLabel.h"
-// Forward declarations
-class BtGenericEdit;
-class BtMassEdit;
-class BtMassLabel;
-class BtTemperatureEdit;
-class BtTimeLabel;
-class BtTimeEdit;
-class BtVolumeLabel;
-class BtVolumeEdit;
 class Equipment;
 class EquipmentListModel;
 class NamedEntitySortProxyModel;
@@ -59,7 +39,7 @@ class NamedEntitySortProxyModel;
  *
  * \brief This is a dialog that edits an equipment record.
  */
-class EquipmentEditor : public QDialog
+class EquipmentEditor : public QDialog, private Ui::equipmentEditor
 {
    Q_OBJECT
 
@@ -67,75 +47,6 @@ public:
    //! \param singleEquipEditor true if you do not want the necessary elements for viewing all the database elements.
    EquipmentEditor( QWidget *parent=nullptr, bool singleEquipEditor=false );
    virtual ~EquipmentEditor() {}
-
-   //! \name Public UI Variables
-   //! @{
-   QVBoxLayout *verticalLayout_6;
-   QVBoxLayout *topVLayout;
-   QHBoxLayout *horizontalLayout_equipments;
-   QLabel *label;
-   QComboBox *equipmentComboBox;
-   QPushButton *pushButton_remove;
-   QSpacerItem *horizontalSpacer;
-   QCheckBox *checkBox_defaultEquipment;
-   QHBoxLayout *horizontalLayout;
-   QVBoxLayout *vLayout_left;
-   QGroupBox *groupBox_required;
-   QVBoxLayout *verticalLayout;
-   QFormLayout *formLayout;
-   QLabel *label_name;
-   QLineEdit *lineEdit_name;
-   BtVolumeLabel *label_boilSize;
-   BtVolumeEdit *lineEdit_boilSize;
-   QLabel *label_calcBoilVolume;
-   QCheckBox *checkBox_calcBoilVolume;
-   BtVolumeLabel *label_batchSize;
-   BtVolumeEdit *lineEdit_batchSize;
-   QGroupBox *groupBox_water;
-   QVBoxLayout *verticalLayout_3;
-   QFormLayout *formLayout_water;
-   BtTimeLabel *label_boilTime;
-   BtTimeEdit *lineEdit_boilTime;
-   BtVolumeLabel *label_evaporationRate;
-   BtVolumeEdit *lineEdit_evaporationRate;
-   BtVolumeLabel *label_topUpKettle;
-   BtVolumeEdit *lineEdit_topUpKettle;
-   BtVolumeLabel *label_topUpWater;
-   BtVolumeEdit *lineEdit_topUpWater;
-   QLabel *label_absorption;
-   BtGenericEdit *lineEdit_grainAbsorption;
-   QPushButton *pushButton_absorption;
-   BtTemperatureEdit *lineEdit_boilingPoint;
-   QLabel *label_hopUtilization;
-   BtGenericEdit *lineEdit_hopUtilization;
-   BtTemperatureLabel *label_boilingPoint;
-   QSpacerItem *verticalSpacer_2;
-   QVBoxLayout *vLayout_right;
-   QGroupBox *groupBox_mashTun;
-   QFormLayout *formLayout_mashTun;
-   BtVolumeLabel *label_tunVolume;
-   BtVolumeEdit *lineEdit_tunVolume;
-   BtMassLabel *label_tunWeight;
-   BtMassEdit *lineEdit_tunWeight;
-   QLabel *label_tunSpecificHeat;
-   BtGenericEdit *lineEdit_tunSpecificHeat;
-   QGroupBox *groupBox_losses;
-   QVBoxLayout *verticalLayout_4;
-   QFormLayout *formLayout_losses;
-   BtVolumeLabel *label_trubChillerLoss;
-   BtVolumeEdit *lineEdit_trubChillerLoss;
-   BtVolumeLabel *label_lauterDeadspace;
-   BtVolumeEdit *lineEdit_lauterDeadspace;
-   QGroupBox *groupBox_notes;
-   QVBoxLayout *verticalLayout_notes;
-   QTextEdit *textEdit_notes;
-   QSpacerItem *verticalSpacer;
-   QHBoxLayout *hLayout_buttons;
-   QSpacerItem *horizontalSpacer_2;
-   QPushButton *pushButton_new;
-   QPushButton *pushButton_save;
-   QPushButton *pushButton_cancel;
-   //! @}
 
    //! Edit the given equipment.
    void setEquipment( Equipment* e );
@@ -168,15 +79,7 @@ public slots:
    double calcBatchSize();
 
 protected:
-   //! User closed the dialog
    void closeEvent(QCloseEvent *event);
-
-   virtual void changeEvent(QEvent* event)
-   {
-      if(event->type() == QEvent::LanguageChange)
-         retranslateUi();
-      QDialog::changeEvent(event);
-   }
 
 private:
    Equipment* obsEquip;
@@ -185,8 +88,6 @@ private:
 
    void showChanges();
 
-   void doLayout();
-   void retranslateUi();
 };
 
 #endif   /* _EQUIPMENTEDITOR_H */

--- a/src/FermentableEditor.cpp
+++ b/src/FermentableEditor.cpp
@@ -22,6 +22,7 @@
 
 #include <QIcon>
 #include "FermentableEditor.h"
+#include "BtHorizontalTabs.h"
 #include "fermentable.h"
 #include "database.h"
 #include "config.h"
@@ -33,6 +34,7 @@ FermentableEditor::FermentableEditor( QWidget* parent )
 {
    setupUi(this);
 
+   this->tabWidget_editor->tabBar()->setStyle( new BtHorizontalTabs );
    connect( this, &QDialog::accepted, this, &FermentableEditor::save);
    connect( this, &QDialog::rejected, this, &FermentableEditor::clearAndClose);
 
@@ -100,8 +102,10 @@ void FermentableEditor::showChanges(QMetaProperty* metaProp)
 
    QString propName;
    bool updateAll = false;
-   if( metaProp == nullptr )
+
+   if( metaProp == nullptr ) {
       updateAll = true;
+   }
    else
    {
       propName = metaProp->name();
@@ -111,6 +115,8 @@ void FermentableEditor::showChanges(QMetaProperty* metaProp)
    {
       lineEdit_name->setText(obsFerm->name());
       lineEdit_name->setCursorPosition(0);
+
+      tabWidget_editor->setTabText(0, obsFerm->name() );
       if( ! updateAll )
          return;
    }

--- a/src/FermentableEditor.cpp
+++ b/src/FermentableEditor.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <QIcon>
+#include <QInputDialog>
 #include "FermentableEditor.h"
 #include "BtHorizontalTabs.h"
 #include "fermentable.h"
@@ -35,9 +36,10 @@ FermentableEditor::FermentableEditor( QWidget* parent )
    setupUi(this);
 
    this->tabWidget_editor->tabBar()->setStyle( new BtHorizontalTabs );
-   connect( this, &QDialog::accepted, this, &FermentableEditor::save);
-   connect( this, &QDialog::rejected, this, &FermentableEditor::clearAndClose);
 
+   connect( pushButton_new,    SIGNAL( clicked() ),       this, SLOT( newFermentable() ) );
+   connect( pushButton_save,   &QAbstractButton::clicked, this, &FermentableEditor::save );
+   connect( pushButton_cancel, &QAbstractButton::clicked, this, &FermentableEditor::clearAndClose );
 }
 
 void FermentableEditor::setFermentable( Fermentable* newFerm )
@@ -211,4 +213,24 @@ void FermentableEditor::showChanges(QMetaProperty* metaProp)
       if( ! updateAll )
          return;
    }
+}
+
+void FermentableEditor::newFermentable(QString folder) 
+{
+   QString name = QInputDialog::getText(this, tr("Fermentable name"),
+                                          tr("Fermentable name:"));
+   if( name.isEmpty() )
+      return;
+
+   Fermentable* f = new Fermentable(name,true);
+
+   if ( ! folder.isEmpty() )
+      f->setFolder(folder);
+
+   setFermentable(f);
+   show();
+}
+void FermentableEditor::newFermentable()
+{
+   newFermentable(QString());
 }

--- a/src/FermentableEditor.h
+++ b/src/FermentableEditor.h
@@ -46,10 +46,12 @@ public:
    FermentableEditor( QWidget *parent=nullptr );
    virtual ~FermentableEditor() {}
    void setFermentable( Fermentable* f );
+   void newFermentable( QString folder );
 
 public slots:
    void save();
    void clearAndClose();
+   void newFermentable();
 
 private:
    Fermentable* obsFerm;

--- a/src/HopEditor.cpp
+++ b/src/HopEditor.cpp
@@ -24,6 +24,7 @@
 #include <QIcon>
 #include "hop.h"
 #include "HopEditor.h"
+#include "BtHorizontalTabs.h"
 #include "database.h"
 #include "config.h"
 #include "unit.h"
@@ -34,6 +35,7 @@ HopEditor::HopEditor( QWidget* parent )
 {
    setupUi(this);
 
+   this->tabWidget_editor->tabBar()->setStyle( new BtHorizontalTabs );
    connect( buttonBox, &QDialogButtonBox::accepted, this, &HopEditor::save);
    connect( buttonBox, &QDialogButtonBox::rejected, this, &HopEditor::clearAndClose);
 }
@@ -107,10 +109,10 @@ void HopEditor::showChanges(QMetaProperty* prop)
    if( obsHop == nullptr )
       return;
 
-   if( prop == nullptr )
+   if( prop == nullptr ) {
       updateAll = true;
-   else
-   {
+   }
+   else {
       propName = prop->name();
    }
 
@@ -118,6 +120,7 @@ void HopEditor::showChanges(QMetaProperty* prop)
    {
       lineEdit_name->setText(obsHop->name());
       lineEdit_name->setCursorPosition(0);
+      tabWidget_editor->setTabText(0, obsHop->name() );
       if( ! updateAll )
          return;
    }

--- a/src/HopEditor.cpp
+++ b/src/HopEditor.cpp
@@ -22,6 +22,7 @@
 
 #include <QtGui>
 #include <QIcon>
+#include <QInputDialog>
 #include "hop.h"
 #include "HopEditor.h"
 #include "BtHorizontalTabs.h"
@@ -36,8 +37,10 @@ HopEditor::HopEditor( QWidget* parent )
    setupUi(this);
 
    this->tabWidget_editor->tabBar()->setStyle( new BtHorizontalTabs );
-   connect( buttonBox, &QDialogButtonBox::accepted, this, &HopEditor::save);
-   connect( buttonBox, &QDialogButtonBox::rejected, this, &HopEditor::clearAndClose);
+
+   connect( pushButton_new, SIGNAL( clicked() ), this, SLOT( newHop() ) );
+   connect( pushButton_save,   &QAbstractButton::clicked, this, &HopEditor::save );
+   connect( pushButton_cancel, &QAbstractButton::clicked, this, &HopEditor::clearAndClose );
 }
 
 void HopEditor::setHop( Hop* h )
@@ -207,3 +210,25 @@ void HopEditor::showChanges(QMetaProperty* prop)
          return;
    }
 }
+
+void HopEditor::newHop(QString folder)
+{
+   QString name = QInputDialog::getText(this, tr("Hop name"),
+                                          tr("Hop name:"));
+   if( name.isEmpty() )
+      return;
+
+   Hop* h = new Hop(name,true);
+
+   if ( ! folder.isEmpty() )
+      h->setFolder(folder);
+
+   setHop(h);
+   show();
+}
+
+void HopEditor::newHop()
+{
+   newHop(QString());
+}
+

--- a/src/HopEditor.h
+++ b/src/HopEditor.h
@@ -46,6 +46,8 @@ public:
    virtual ~HopEditor() {}
    //! Edit the given hop.
    void setHop( Hop* h );
+   //! Create a new hop
+   void newHop(QString folder);
 
 public slots:
    //! Save the changes.
@@ -53,6 +55,7 @@ public slots:
    //! Clear the dialog and close it.
    void clearAndClose();
    void changed(QMetaProperty,QVariant);
+   void newHop();
 
 private:
    Hop* obsHop;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -58,6 +58,7 @@
 #include <QDesktopWidget>
 
 #include "Algorithms.h"
+#include "BtTabWidget.h"
 #include "MashStepEditor.h"
 #include "MashStepTableModel.h"
 #include "mash.h"
@@ -123,6 +124,7 @@
 #include "beerxml.h"
 #include "RelationalUndoableUpdate.h"
 #include "UndoableAddOrRemove.h"
+#include "BtHorizontalTabs.h"
 
 #if defined(Q_OS_WIN)
    #include <windows.h>
@@ -245,6 +247,9 @@ MainWindow::MainWindow(QWidget* parent)
 
    // Stop things looking ridiculously tiny on high DPI displays
    this->setSizesInPixelsBasedOnDpi();
+
+   // Horizontal tabs, please
+   tabWidget_Trees->tabBar()->setStyle(new BtHorizontalTabs);
 
    /* PLEASE DO NOT REMOVE.
     This code is left here, commented out, intentionally. The only way I can

--- a/src/MiscEditor.h
+++ b/src/MiscEditor.h
@@ -45,14 +45,17 @@ public:
    virtual ~MiscEditor() {}
    //! Set the misc we wish to view/edit.
    void setMisc( Misc* m );
+   //! Create a misc with folders
+   void newMisc(QString folder);
 
 public slots:
    //! Save changes.
    void save();
    //! Clear dialog and close.
    void clearAndClose();
+   //! Add a new misc
+   void newMisc();
    void changed(QMetaProperty,QVariant);
-//   void updateField();
 
 private:
    Misc* obsMisc;

--- a/src/OptionDialog.cpp
+++ b/src/OptionDialog.cpp
@@ -39,6 +39,8 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include "MainWindow.h"
+#include "qsizepolicy.h"
+#include "qwidget.h"
 
 OptionDialog::OptionDialog(QWidget* parent)
 {
@@ -623,19 +625,26 @@ void OptionDialog::setDbDialog(Brewtarget::DBTypes db)
       postgresVisible(false);
       sqliteVisible(true);
 
-      gridLayout->addWidget(label_dataDir,0,0);
+      gridLayout->addWidget(label_dataDir,0,0,1,1);
       gridLayout->addWidget(btStringEdit_dataDir,0,1,1,2);
-      gridLayout->addWidget(pushButton_browseDataDir,0,3);
+      gridLayout->addWidget(pushButton_browseDataDir,0,3,1,1);
 
-      gridLayout->addWidget(label_backupDir,1,0);
+      gridLayout->addWidget(label_backupDir,1,0,1,1);
       gridLayout->addWidget(btStringEdit_backupDir,1,1,1,2);
-      gridLayout->addWidget(pushButton_browseBackupDir,1,3);
+      gridLayout->addWidget(pushButton_browseBackupDir,1,3,1,1);
 
-      gridLayout->addWidget(label_numBackups,3,0);
-      gridLayout->addWidget(spinBox_numBackups,3,1);
+      gridLayout->addWidget(label_numBackups,3,0,1,1);
+      gridLayout->addWidget(spinBox_numBackups,3,1,1,1);
 
-      gridLayout->addWidget(label_frequency,4,0);
-      gridLayout->addWidget(spinBox_frequency,4,1);
+      gridLayout->addWidget(label_frequency,4,0,1,1);
+      gridLayout->addWidget(spinBox_frequency,4,1,1,1);
+
+      /*
+      gridLayout->setColumnStretch(0,0);
+      gridLayout->setColumnStretch(1,2);
+      gridLayout->setColumnStretch(2,0);
+      gridLayout->setColumnStretch(3,0);
+      */
    }
    groupBox_dbConfig->setVisible(true);
 }

--- a/src/StyleEditor.cpp
+++ b/src/StyleEditor.cpp
@@ -20,6 +20,7 @@
 
 #include "database.h"
 #include "StyleEditor.h"
+#include "BtHorizontalTabs.h"
 #include <QInputDialog>
 #include "style.h"
 #include "StyleListModel.h"
@@ -42,6 +43,8 @@ StyleEditor::StyleEditor(QWidget* parent, bool singleStyleEditor)
 
       pushButton_new->setVisible(false);
    }
+
+   this->tabWidget_profile->tabBar()->setStyle(new BtHorizontalTabs);
 
    styleListModel = new StyleListModel(styleComboBox);
    styleProxyModel = new StyleSortFilterProxyModel(styleComboBox);

--- a/src/StyleEditor.cpp
+++ b/src/StyleEditor.cpp
@@ -209,6 +209,7 @@ void StyleEditor::showChanges(QMetaProperty* metaProp)
    if( updateAll )
    {
       lineEdit_name->setText(s->name());
+      tabWidget_profile->setTabText(0, s->name() );
       lineEdit_category->setText(s->category());
       lineEdit_categoryNumber->setText(s->categoryNumber());
       lineEdit_styleLetter->setText(s->styleLetter());
@@ -234,48 +235,71 @@ void StyleEditor::showChanges(QMetaProperty* metaProp)
       return;
    }
 
-   if( propName == PropertyNames::NamedEntity::name )
+   if( propName == PropertyNames::NamedEntity::name ) {
       lineEdit_name->setText(val.toString());
-   else if( propName == PropertyNames::Style::category )
+      tabWidget_profile->setTabText(0, s->name() );
+   }
+   else if( propName == PropertyNames::Style::category ) {
       lineEdit_category->setText(val.toString());
-   else if( propName == PropertyNames::Style::categoryNumber )
+   }
+   else if( propName == PropertyNames::Style::categoryNumber ) {
       lineEdit_categoryNumber->setText(val.toString());
-   else if( propName == PropertyNames::Style::styleLetter )
+   }
+   else if( propName == PropertyNames::Style::styleLetter ) {
       lineEdit_styleLetter->setText(val.toString());
-   else if( propName == PropertyNames::Style::styleGuide )
+   }
+   else if( propName == PropertyNames::Style::styleGuide ) {
       lineEdit_styleGuide->setText(val.toString());
-   else if( propName == "type" )
+   }
+   else if( propName == "type" ) {
       comboBox_type->setCurrentIndex(val.toInt());
-   else if( propName == PropertyNames::Style::ogMin )
+   }
+   else if( propName == PropertyNames::Style::ogMin ) {
       lineEdit_ogMin->setText(val);
-   else if( propName == PropertyNames::Style::ogMax )
+   }
+   else if( propName == PropertyNames::Style::ogMax ) {
       lineEdit_ogMax->setText(val);
-   else if( propName == PropertyNames::Style::fgMin )
+   }
+   else if( propName == PropertyNames::Style::fgMin ) {
       lineEdit_fgMin->setText(val);
-   else if( propName == PropertyNames::Style::fgMax )
+   }
+   else if( propName == PropertyNames::Style::fgMax ) {
       lineEdit_fgMax->setText(val);
-   else if( propName == PropertyNames::Style::ibuMin )
+   }
+   else if( propName == PropertyNames::Style::ibuMin ) {
       lineEdit_ibuMin->setText(val);
-   else if( propName == PropertyNames::Style::ibuMax )
+   }
+   else if( propName == PropertyNames::Style::ibuMax ) {
       lineEdit_ibuMax->setText(val);
-   else if( propName == PropertyNames::Style::colorMin_srm )
+   }
+   else if( propName == PropertyNames::Style::colorMin_srm ) {
       lineEdit_colorMin->setText(val);
-   else if( propName == PropertyNames::Style::colorMax_srm )
+   }
+   else if( propName == PropertyNames::Style::colorMax_srm ) {
       lineEdit_colorMax->setText(val);
-   else if( propName == PropertyNames::Style::carbMin_vol )
+   }
+   else if( propName == PropertyNames::Style::carbMin_vol ) {
       lineEdit_carbMin->setText(val);
-   else if( propName == PropertyNames::Style::carbMax_vol )
+   }
+   else if( propName == PropertyNames::Style::carbMax_vol ) {
       lineEdit_carbMax->setText(val);
-   else if( propName == PropertyNames::Style::abvMin_pct )
+   }
+   else if( propName == PropertyNames::Style::abvMin_pct ) {
       lineEdit_abvMin->setText(val);
-   else if( propName == PropertyNames::Style::abvMax_pct )
+   }
+   else if( propName == PropertyNames::Style::abvMax_pct ) {
       lineEdit_abvMax->setText(val);
-   else if( propName == PropertyNames::Style::profile )
+   }
+   else if( propName == PropertyNames::Style::profile ) {
       textEdit_profile->setText(val.toString());
-   else if( propName == PropertyNames::Style::ingredients )
+   }
+   else if( propName == PropertyNames::Style::ingredients ) {
       textEdit_ingredients->setText(val.toString());
-   else if( propName == PropertyNames::Style::examples )
+   }
+   else if( propName == PropertyNames::Style::examples ) {
       textEdit_examples->setText(val.toString());
-   else if( propName == "notes" )
+   }
+   else if( propName == "notes" ) {
       textEdit_notes->setText(val.toString());
+   }
 }

--- a/src/TableSchema.cpp
+++ b/src/TableSchema.cpp
@@ -1031,7 +1031,7 @@ void TableSchema::defineMiscTable()
    m_properties[PropertyNames::Misc::notes]    = new PropertySchema( PropertyNames::Misc::notes,      kcolNotes,        kxmlPropNotes,    QString("text"), QString("''"));
    m_properties[PropertyNames::Misc::amount]   = new PropertySchema( PropertyNames::Misc::amount,     kcolAmount,       kxmlPropAmount,   QString("real"), QVariant(0.0));
    m_properties[PropertyNames::Misc::use]      = new PropertySchema( PropertyNames::Misc::useString,  kcolUse,          kxmlPropUse,      QString("text"), QString("'Boil'"));
-   m_properties[PropertyNames::Hop::time_min]     = new PropertySchema( PropertyNames::Hop::time_min,       kcolTime,         kxmlPropTime,     QString("real"), QVariant(0.0));
+   m_properties[PropertyNames::Misc::time]     = new PropertySchema( PropertyNames::Misc::time, kcolTime,         kxmlPropTime,     QString("real"), QVariant(0.0));
    m_properties[PropertyNames::Misc::type]     = new PropertySchema( PropertyNames::Misc::typeString, kcolMiscType,     kxmlPropType,     QString("text"), QString("'Other'"));
    m_properties[PropertyNames::Misc::amountIsWeight] = new PropertySchema( PropertyNames::Misc::amountIsWeight,   kcolMiscAmtIsWgt, kxmlPropAmtIsWgt, QString("boolean"), QVariant(true));
    m_properties[PropertyNames::Misc::useFor]   = new PropertySchema( PropertyNames::Misc::useFor,     kcolMiscUseFor,   kxmlPropUseFor,   QString("text"), QString("''"));

--- a/src/YeastEditor.cpp
+++ b/src/YeastEditor.cpp
@@ -20,7 +20,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "math.h"
+#include <QInputDialog>
 #include "YeastEditor.h"
+#include "BtHorizontalTabs.h"
 #include "database.h"
 #include "config.h"
 #include "unit.h"
@@ -32,8 +35,10 @@ YeastEditor::YeastEditor( QWidget* parent )
 {
    setupUi(this);
 
-   connect( buttonBox, &QDialogButtonBox::accepted, this, &YeastEditor::save);
-   connect( buttonBox, &QDialogButtonBox::rejected, this, &YeastEditor::clearAndClose);
+   tabWidget_editor->tabBar()->setStyle( new BtHorizontalTabs );
+   connect( pushButton_new, SIGNAL( clicked() ), this, SLOT( newYeast() ) );
+   connect( pushButton_save,   &QAbstractButton::clicked, this, &YeastEditor::save );
+   connect( pushButton_cancel, &QAbstractButton::clicked, this, &YeastEditor::clearAndClose );
 }
 
 void YeastEditor::setYeast( Yeast* y )
@@ -71,6 +76,7 @@ void YeastEditor::save()
    y->setMaxTemperature_c( lineEdit_maxTemperature->toSI());
    y->setFlocculation( static_cast<Yeast::Flocculation>(comboBox_flocculation->currentIndex()) );
    y->setAttenuation_pct(lineEdit_attenuation->toSI());
+
    y->setTimesCultured(lineEdit_timesCultured->text().toInt());
    y->setMaxReuse(lineEdit_maxReuse->text().toInt());
    y->setAddToSecondary( (checkBox_addToSecondary->checkState() == Qt::Checked)? true : false );
@@ -118,6 +124,8 @@ void YeastEditor::showChanges(QMetaProperty* metaProp)
    {
       lineEdit_name->setText(obsYeast->name());
       lineEdit_name->setCursorPosition(0);
+
+      tabWidget_editor->setTabText(0, obsYeast->name());
       if( ! updateAll )
          return;
    }
@@ -137,7 +145,7 @@ void YeastEditor::showChanges(QMetaProperty* metaProp)
          return;
    }
    if( propName == "inventory" || updateAll ) {
-      lineEdit_inventory->setText( QString::number(obsYeast->inventory()) );
+      lineEdit_inventory->setText( obsYeast->inventory(),0 );
       if( ! updateAll )
          return;
    }
@@ -179,12 +187,12 @@ void YeastEditor::showChanges(QMetaProperty* metaProp)
          return;
    }
    if( propName == PropertyNames::Yeast::timesCultured || updateAll ) {
-      lineEdit_timesCultured->setText(QString::number(obsYeast->timesCultured()));
+      lineEdit_timesCultured->setText(obsYeast->timesCultured(),0);
       if( ! updateAll )
          return;
    }
    if( propName == PropertyNames::Yeast::maxReuse || updateAll ) {
-      lineEdit_maxReuse->setText(QString::number(obsYeast->maxReuse()));
+      lineEdit_maxReuse->setText(obsYeast->maxReuse(),0);
       if( ! updateAll )
          return;
    }
@@ -203,4 +211,25 @@ void YeastEditor::showChanges(QMetaProperty* metaProp)
       if( ! updateAll )
          return;
    }
+}
+
+void YeastEditor::newYeast()
+{
+   newYeast(QString());
+}
+
+void YeastEditor::newYeast(QString folder)
+{
+   QString name = QInputDialog::getText(this, tr("Yeast name"),
+                                          tr("Yeast name:"));
+   if( name.isEmpty() )
+      return;
+
+   Yeast* y = new Yeast(name);
+
+   if ( ! folder.isEmpty() )
+      y->setFolder(folder);
+
+   setYeast(y);
+   show();
 }

--- a/src/YeastEditor.h
+++ b/src/YeastEditor.h
@@ -47,11 +47,13 @@ public:
    virtual ~YeastEditor() {}
    //! Set the yeast we want to modify.
    void setYeast( Yeast* y );
+   void newYeast(QString folder);
 
 public slots:
    void save();
    void clearAndClose();
    void changed(QMetaProperty,QVariant);
+   void newYeast();
 
 private:
    Yeast* obsYeast;

--- a/src/beerxml.cpp
+++ b/src/beerxml.cpp
@@ -723,10 +723,11 @@ void BeerXML::toXml( BrewNote* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -749,10 +750,11 @@ void BeerXML::toXml( Equipment* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -775,10 +777,11 @@ void BeerXML::toXml( Fermentable* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -803,10 +806,11 @@ void BeerXML::toXml( Hop* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -831,10 +835,11 @@ void BeerXML::toXml( Instruction* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -860,10 +865,11 @@ void BeerXML::toXml( Mash* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -895,8 +901,9 @@ void BeerXML::toXml( MashStep* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          QString val;
          // flySparge and batchSparge aren't part of the BeerXML spec.
          // This makes sure we give BeerXML something it understands.
@@ -909,7 +916,7 @@ void BeerXML::toXml( MashStep* a, QDomDocument& doc, QDomNode& parent )
             }
          }
          else {
-            val = textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element));
+            val = textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element));
          }
          tmpElement = doc.createElement(tbl->propertyToXml(element));
          tmpText    = doc.createTextNode(val);
@@ -936,10 +943,11 @@ void BeerXML::toXml( Misc* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -963,10 +971,11 @@ void BeerXML::toXml( Recipe* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -1043,10 +1052,11 @@ void BeerXML::toXml( Style* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -1069,10 +1079,11 @@ void BeerXML::toXml( Water* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -1096,10 +1107,11 @@ void BeerXML::toXml( Yeast* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -2012,7 +2012,7 @@ int Database::insertElement(NamedEntity * ins)
 
    TableSchema* schema = dbDefn->table(ins->table());
    QString insertQ = schema->generateInsertProperties(Brewtarget::dbType());
-   QStringList allProps = schema->allPropertyNames(Brewtarget::dbType());
+   QStringList allProps = schema->allProperties();
 
    qDebug() << Q_FUNC_INFO << "SQL:" << insertQ;
    q.prepare(insertQ);
@@ -2020,13 +2020,15 @@ int Database::insertElement(NamedEntity * ins)
    QString sqlParameters;
    QTextStream sqlParametersConcat(&sqlParameters);
    foreach (QString prop, allProps) {
-      QVariant val_to_ins = ins->property(prop.toUtf8().data());
+      // this is kind of a mess. I need all properties, because that's how the
+      // query is bound, but I need the property names to get the right value
+      QVariant val_to_ins = ins->property(schema->propertyName(prop).toUtf8().data());
       if ( ins->table() == Brewtarget::BREWNOTETABLE && prop == PropertyNames::BrewNote::brewDate ) {
          val_to_ins = val_to_ins.toString();
       }
       // I've arranged it such that the bindings are on the property names. It simplifies a lot
       q.bindValue( QString(":%1").arg(prop), val_to_ins);
-      sqlParametersConcat << prop << " = " << val_to_ins.toString() << " || ";
+      sqlParametersConcat << QString(":%1").arg(prop) << " = " << val_to_ins.toString() << "\n\t";
    }
    qDebug() << Q_FUNC_INFO << "SQL Parameters: " << *sqlParametersConcat.string();
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -266,7 +266,7 @@ void Misc::setTime( double var )
    else {
       m_time = var;
       if ( ! m_cacheOnly ) {
-         setEasy( PropertyNames::Hop::time_min, var );
+         setEasy( PropertyNames::Misc::time, var );
       }
    }
 }

--- a/ui/equipmentEditor.ui
+++ b/ui/equipmentEditor.ui
@@ -1,0 +1,884 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>equipmentEditor</class>
+ <widget class="QDialog" name="equipmentEditor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>510</width>
+    <height>387</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Equipment Editor</string>
+  </property>
+  <property name="configSection" stdset="0">
+   <string notr="true">equipmentEditor</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_equipments">
+     <item>
+      <widget class="QLabel" name="label_equipment">
+       <property name="text">
+        <string>Equipment</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="equipmentComboBox">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToContents</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_remove">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/smallMinus.svg</normaloff>:/images/smallMinus.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox_defaultEquipment">
+       <property name="text">
+        <string>Set as Default</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="tabWidget_editor">
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <property name="movable">
+      <bool>true</bool>
+     </property>
+     <property name="configSection" stdset="0">
+      <string>equipmentEditor</string>
+     </property>
+     <widget class="QWidget" name="tabWidget_editorPage1">
+      <attribute name="title">
+       <string>Main</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="1">
+        <widget class="BtStringEdit" name="lineEdit_name">
+         <property name="toolTip">
+          <string>Name</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="BtVolumeLabel" name="label_batchSize">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Batch Size&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_batchSize</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_calcBoilVolume">
+         <property name="text">
+          <string>Calculate pre-boil volume</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_name">
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="BtVolumeLabel" name="label_boilSize">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Pre-boil Volume&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_boilSize</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_batchSize">
+         <property name="editField" stdset="0">
+          <string>boilSize_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="checkBox_calcBoilVolume">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_boilSize">
+         <property name="editField" stdset="0">
+          <string>boilSize_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabWidget_editorPage2">
+      <attribute name="title">
+       <string>Boiling/Water</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_hopUtilization">
+         <property name="text">
+          <string>Hop Utilization</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_hopUtilization</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="label_absorption">
+         <property name="text">
+          <string>Grain absorption (L/kg)</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_grainAbsorption</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_topUpKettle">
+         <property name="editField" stdset="0">
+          <string>topUpKettle_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="BtTemperatureEdit" name="lineEdit_boilingPoint">
+         <property name="editField" stdset="0">
+          <string>boilingPoint_c</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="2">
+        <widget class="QPushButton" name="pushButton_absorption">
+         <property name="text">
+          <string>Default Absorption</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="BtTimeLabel" name="label_boilTime">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Boil time</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_boilTime</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="BtVolumeLabel" name="label_topUpWater">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Final top-up water</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_topUpWater</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="4" column="0">
+        <widget class="BtVolumeLabel" name="label_evaporationRate">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Evaporation rate (per hr)</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_evaporationRate</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_evaporationRate">
+         <property name="editField" stdset="0">
+          <string>evapRate_lHr</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="BtTimeEdit" name="lineEdit_boilTime">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Time</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">boilTime_min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="BtVolumeLabel" name="label_topUpKettle">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Kettle top-up water</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_topUpKettle</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_grainAbsorption">
+         <property name="editField" stdset="0">
+          <string>grainAbsorption_LKg</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_topUpWater">
+         <property name="editField" stdset="0">
+          <string>topUpWater_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_hopUtilization">
+         <property name="editField" stdset="0">
+          <string>hopUtilization_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="BtTemperatureLabel" name="label_boilingPoint">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Boiling Point of Water</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_boilingPoint</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="3">
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabWidget_editorPage3">
+      <attribute name="title">
+       <string>Mash Tun</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_tunVolume">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Volume of mash tun</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">tunVolume_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="BtVolumeLabel" name="label_trubChillerLoss">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Kettle to Fermenter</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_trubChillerLoss</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_trubChillerLoss">
+         <property name="editField" stdset="0">
+          <string>trubChillerLoss_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Losses</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_tunSpecificHeat">
+         <property name="editField" stdset="0">
+          <string>tunSpecificHeat_calGC</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="BtVolumeLabel" name="label_tunVolume">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Volume</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_tunVolume</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="BtMassEdit" name="lineEdit_tunWeight">
+         <property name="editField" stdset="0">
+          <string>tunWeight_kg</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_lauterDeadspace">
+         <property name="editField" stdset="0">
+          <string>lauterDeadspace_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_tunSpecificHeat">
+         <property name="text">
+          <string>Specific Heat (Cal/(g*C))</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="BtMassLabel" name="label_tunWeight">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Mass</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_tunWeight</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="5" column="0">
+        <widget class="BtVolumeLabel" name="label_lauterDeadspace">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Lauter deadspace</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_lauterDeadspace</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <spacer name="horizontalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabWidget_editorPage5">
+      <attribute name="title">
+       <string>Notes</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QTextEdit" name="textEdit_notes">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>1000</width>
+           <height>1000</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_new">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/smallPlus.svg</normaloff>:/images/smallPlus.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_save">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/filesave.svg</normaloff>:/images/filesave.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_cancel">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/exit.svg</normaloff>:/images/exit.svg</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>BtGenericEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BtStringEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BtMassEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <signal>textModified()</signal>
+    <slot>lineChanged()</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtMassLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+    <slot>popContextMenu(QPoint)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtTimeEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtTimeLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtVolumeLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtVolumeEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtTemperatureLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtTemperatureEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget_editor</tabstop>
+  <tabstop>lineEdit_name</tabstop>
+  <tabstop>lineEdit_boilTime</tabstop>
+  <tabstop>textEdit_notes</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../brewtarget.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>label_tunWeight</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_tunWeight</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>120</x>
+     <y>101</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>269</x>
+     <y>101</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_boilTime</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_boilTime</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>68</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>68</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_batchSize</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_batchSize</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>121</x>
+     <y>101</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>271</x>
+     <y>101</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_boilSize</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_boilSize</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>121</x>
+     <y>134</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>271</x>
+     <y>134</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_evaporationRate</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_evaporationRate</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>101</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>101</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_topUpKettle</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_topUpKettle</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>134</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>134</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_topUpWater</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_topUpWater</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>167</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>167</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_boilingPoint</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_boilingPoint</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>233</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>233</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_tunVolume</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_tunWeight</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>120</x>
+     <y>68</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>269</x>
+     <y>101</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_trubChillerLoss</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_trubChillerLoss</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>120</x>
+     <y>192</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>269</x>
+     <y>192</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>label_lauterDeadspace</sender>
+   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   <receiver>lineEdit_lauterDeadspace</receiver>
+   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>120</x>
+     <y>225</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>269</x>
+     <y>225</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/ui/equipmentEditor.ui
+++ b/ui/equipmentEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>510</width>
-    <height>387</height>
+    <width>626</width>
+    <height>315</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -81,7 +81,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="usesScrollButtons">
       <bool>false</bool>
@@ -97,6 +97,32 @@
        <string>Main</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
+       <item row="2" column="0">
+        <widget class="BtVolumeLabel" name="label_boilSize">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Pre-boil Volume</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_boilSize</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="BtVolumeLabel" name="label_batchSize">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Batch Size</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_batchSize</cstring>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="1">
         <widget class="BtStringEdit" name="lineEdit_name">
          <property name="toolTip">
@@ -107,75 +133,15 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="BtVolumeLabel" name="label_batchSize">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Batch Size&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_batchSize</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_calcBoilVolume">
-         <property name="text">
-          <string>Calculate pre-boil volume</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_name">
          <property name="toolTip">
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Name</string>
          </property>
         </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="BtVolumeLabel" name="label_boilSize">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Pre-boil Volume&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_boilSize</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="BtVolumeEdit" name="lineEdit_batchSize">
-         <property name="editField" stdset="0">
-          <string>boilSize_l</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QCheckBox" name="checkBox_calcBoilVolume">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item row="2" column="1">
         <widget class="BtVolumeEdit" name="lineEdit_boilSize">
@@ -184,127 +150,14 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tabWidget_editorPage2">
-      <attribute name="title">
-       <string>Boiling/Water</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_2">
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_hopUtilization">
-         <property name="text">
-          <string>Hop Utilization</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_hopUtilization</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="label_absorption">
-         <property name="text">
-          <string>Grain absorption (L/kg)</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_grainAbsorption</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="BtVolumeEdit" name="lineEdit_topUpKettle">
+       <item row="1" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_batchSize">
          <property name="editField" stdset="0">
-          <string>topUpKettle_l</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="BtTemperatureEdit" name="lineEdit_boilingPoint">
-         <property name="editField" stdset="0">
-          <string>boilingPoint_c</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="2">
-        <widget class="QPushButton" name="pushButton_absorption">
-         <property name="text">
-          <string>Default Absorption</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="BtTimeLabel" name="label_boilTime">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>Boil time</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_boilTime</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="BtVolumeLabel" name="label_topUpWater">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>Final top-up water</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_topUpWater</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="0">
-        <widget class="BtVolumeLabel" name="label_evaporationRate">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>Evaporation rate (per hr)</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_evaporationRate</cstring>
+          <string>batchSize_l</string>
          </property>
         </widget>
        </item>
        <item row="4" column="1">
-        <widget class="BtVolumeEdit" name="lineEdit_evaporationRate">
-         <property name="editField" stdset="0">
-          <string>evapRate_lHr</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
         <widget class="BtTimeEdit" name="lineEdit_boilTime">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -320,7 +173,87 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="2" column="2">
+        <widget class="QLabel" name="label_calcBoilVolume">
+         <property name="text">
+          <string>Calculate pre-boil volume</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="4" column="0">
+        <widget class="BtTimeLabel" name="label_boilTime">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Boil time</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_boilTime</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QCheckBox" name="checkBox_calcBoilVolume">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="BtVolumeLabel" name="label_evaporationRate">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Evaporation rate (per hr)</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_evaporationRate</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="3">
+        <widget class="BtVolumeEdit" name="lineEdit_evaporationRate">
+         <property name="editField" stdset="0">
+          <string>evapRate_lHr</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="BtVolumeLabel" name="label_topUpWater">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Final top-up water</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_topUpWater</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="BtVolumeEdit" name="lineEdit_topUpWater">
+         <property name="editField" stdset="0">
+          <string>topUpWater_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
         <widget class="BtVolumeLabel" name="label_topUpKettle">
          <property name="contextMenuPolicy">
           <enum>Qt::CustomContextMenu</enum>
@@ -333,28 +266,95 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="0" column="3">
+        <widget class="BtVolumeEdit" name="lineEdit_topUpKettle">
+         <property name="editField" stdset="0">
+          <string>topUpKettle_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="BtVolumeLabel" name="label_trubChillerLoss">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Kettle to Fermenter Loss</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_trubChillerLoss</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="BtVolumeEdit" name="lineEdit_trubChillerLoss">
+         <property name="editField" stdset="0">
+          <string>trubChillerLoss_l</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="2">
+        <widget class="BtVolumeLabel" name="label_lauterDeadspace">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Lauter deadspace</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_lauterDeadspace</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="3">
+        <widget class="BtVolumeEdit" name="lineEdit_lauterDeadspace">
+         <property name="editField" stdset="0">
+          <string>lauterDeadspace_l</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabWidget_editorPage2">
+      <attribute name="title">
+       <string>Physics</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="7" column="2">
+        <widget class="QPushButton" name="pushButton_absorption">
+         <property name="text">
+          <string>Default Absorption</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_absorption">
+         <property name="text">
+          <string>Grain absorption (L/kg)</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_grainAbsorption</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_hopUtilization">
+         <property name="text">
+          <string>Hop % Utilization</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_hopUtilization</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
         <widget class="BtGenericEdit" name="lineEdit_grainAbsorption">
          <property name="editField" stdset="0">
           <string>grainAbsorption_LKg</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
-        <widget class="BtVolumeEdit" name="lineEdit_topUpWater">
-         <property name="editField" stdset="0">
-          <string>topUpWater_l</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="BtGenericEdit" name="lineEdit_hopUtilization">
-         <property name="editField" stdset="0">
-          <string>hopUtilization_pct</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
+       <item row="6" column="0">
         <widget class="BtTemperatureLabel" name="label_boilingPoint">
          <property name="contextMenuPolicy">
           <enum>Qt::CustomContextMenu</enum>
@@ -367,27 +367,33 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="3">
-        <spacer name="horizontalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+       <item row="3" column="0">
+        <widget class="BtVolumeLabel" name="label_tunVolume">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
+         <property name="text">
+          <string>Mash tun Volume</string>
          </property>
-        </spacer>
+         <property name="buddy">
+          <cstring>lineEdit_tunVolume</cstring>
+         </property>
+        </widget>
        </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tabWidget_editorPage3">
-      <attribute name="title">
-       <string>Mash Tun</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_3">
-       <item row="0" column="1">
+       <item row="3" column="2">
+        <widget class="BtMassLabel" name="label_tunWeight">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Mash tun Weight</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_tunWeight</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
         <widget class="BtVolumeEdit" name="lineEdit_tunVolume">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -403,96 +409,35 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="Line" name="line">
+       <item row="5" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_hopUtilization">
+         <property name="editField" stdset="0">
+          <string>hopUtilization_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="3">
+        <spacer name="horizontalSpacer_4">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="BtVolumeLabel" name="label_trubChillerLoss">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
          </property>
-         <property name="text">
-          <string>Kettle to Fermenter</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_trubChillerLoss</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="BtVolumeEdit" name="lineEdit_trubChillerLoss">
-         <property name="editField" stdset="0">
-          <string>trubChillerLoss_l</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Losses</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="BtGenericEdit" name="lineEdit_tunSpecificHeat">
-         <property name="editField" stdset="0">
-          <string>tunSpecificHeat_calGC</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="BtVolumeLabel" name="label_tunVolume">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>Volume</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_tunVolume</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="BtMassEdit" name="lineEdit_tunWeight">
-         <property name="editField" stdset="0">
-          <string>tunWeight_kg</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="BtVolumeEdit" name="lineEdit_lauterDeadspace">
-         <property name="editField" stdset="0">
-          <string>lauterDeadspace_l</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_tunSpecificHeat">
-         <property name="text">
-          <string>Specific Heat (Cal/(g*C))</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="BtMassLabel" name="label_tunWeight">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>Mass</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_tunWeight</cstring>
-         </property>
-        </widget>
+        </spacer>
        </item>
        <item row="6" column="1">
-        <spacer name="verticalSpacer_3">
+        <widget class="BtTemperatureEdit" name="lineEdit_boilingPoint">
+         <property name="editField" stdset="0">
+          <string>boilingPoint_c</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -504,31 +449,26 @@
          </property>
         </spacer>
        </item>
-       <item row="5" column="0">
-        <widget class="BtVolumeLabel" name="label_lauterDeadspace">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>Lauter deadspace</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_lauterDeadspace</cstring>
+       <item row="3" column="3">
+        <widget class="BtMassEdit" name="lineEdit_tunWeight">
+         <property name="editField" stdset="0">
+          <string>tunWeight_kg</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="2">
-        <spacer name="horizontalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+       <item row="5" column="2">
+        <widget class="QLabel" name="label_tunSpecificHeat">
+         <property name="text">
+          <string>Specific Heat (Cal/(g*C))</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
+        </widget>
+       </item>
+       <item row="5" column="3">
+        <widget class="BtGenericEdit" name="lineEdit_tunSpecificHeat">
+         <property name="editField" stdset="0">
+          <string>tunSpecificHeat_calGC</string>
          </property>
-        </spacer>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -580,6 +520,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButton_new">
+       <property name="toolTip">
+        <string>New equipment</string>
+       </property>
        <property name="text">
         <string/>
        </property>
@@ -591,6 +534,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButton_save">
+       <property name="toolTip">
+        <string>Save and close</string>
+       </property>
        <property name="text">
         <string/>
        </property>
@@ -602,6 +548,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButton_cancel">
+       <property name="toolTip">
+        <string>Discard and close</string>
+       </property>
        <property name="text">
         <string/>
        </property>
@@ -622,9 +571,41 @@
    <header>BtLineEdit.h</header>
   </customwidget>
   <customwidget>
+   <class>BtTemperatureEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtTemperatureLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
+  </customwidget>
+  <customwidget>
    <class>BtStringEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BtTimeEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtTimeLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
   </customwidget>
   <customwidget>
    <class>BtMassEdit</class>
@@ -646,22 +627,6 @@
    </slots>
   </customwidget>
   <customwidget>
-   <class>BtTimeEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
-   <slots>
-    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtTimeLabel</class>
-   <extends>QLabel</extends>
-   <header>BtLabel.h</header>
-   <slots>
-    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   </slots>
-  </customwidget>
-  <customwidget>
    <class>BtVolumeLabel</class>
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
@@ -677,27 +642,32 @@
     <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
-  <customwidget>
-   <class>BtTemperatureLabel</class>
-   <extends>QLabel</extends>
-   <header>BtLabel.h</header>
-   <slots>
-    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtTemperatureEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
-   <slots>
-    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   </slots>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>tabWidget_editor</tabstop>
+  <tabstop>equipmentComboBox</tabstop>
+  <tabstop>pushButton_remove</tabstop>
+  <tabstop>checkBox_defaultEquipment</tabstop>
   <tabstop>lineEdit_name</tabstop>
+  <tabstop>lineEdit_batchSize</tabstop>
+  <tabstop>lineEdit_boilSize</tabstop>
+  <tabstop>checkBox_calcBoilVolume</tabstop>
   <tabstop>lineEdit_boilTime</tabstop>
+  <tabstop>lineEdit_trubChillerLoss</tabstop>
+  <tabstop>lineEdit_topUpKettle</tabstop>
+  <tabstop>lineEdit_topUpWater</tabstop>
+  <tabstop>lineEdit_evaporationRate</tabstop>
+  <tabstop>lineEdit_lauterDeadspace</tabstop>
+  <tabstop>lineEdit_tunVolume</tabstop>
+  <tabstop>lineEdit_hopUtilization</tabstop>
+  <tabstop>lineEdit_boilingPoint</tabstop>
+  <tabstop>lineEdit_grainAbsorption</tabstop>
+  <tabstop>pushButton_absorption</tabstop>
+  <tabstop>lineEdit_tunWeight</tabstop>
+  <tabstop>lineEdit_tunSpecificHeat</tabstop>
+  <tabstop>pushButton_new</tabstop>
+  <tabstop>pushButton_save</tabstop>
+  <tabstop>pushButton_cancel</tabstop>
   <tabstop>textEdit_notes</tabstop>
  </tabstops>
  <resources>

--- a/ui/fermentableEditor.ui
+++ b/ui/fermentableEditor.ui
@@ -25,6 +25,9 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
      <widget class="QWidget" name="tab_main">
       <attribute name="title">
        <string>Main</string>
@@ -46,7 +49,7 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Name</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_name</cstring>
@@ -78,22 +81,6 @@
           </size>
          </property>
         </spacer>
-       </item>
-       <item row="5" column="0">
-        <widget class="BtColorLabel" name="label_color">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="toolTip">
-          <string>Required</string>
-         </property>
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Color&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_color</cstring>
-         </property>
-        </widget>
        </item>
        <item row="2" column="1">
         <widget class="QComboBox" name="comboBox_type">
@@ -155,41 +142,6 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
-        <widget class="BtColorEdit" name="lineEdit_color">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Lovibond rating</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">color_srm</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_yield">
-         <property name="toolTip">
-          <string>Required</string>
-         </property>
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Yield %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_yield</cstring>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="3">
         <widget class="QLabel" name="label_addAfterBoil">
          <property name="sizePolicy">
@@ -222,28 +174,6 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
-        <widget class="BtGenericEdit" name="lineEdit_yield">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Yield as compared to glucose</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">yield_pct</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="1">
         <widget class="BtStringEdit" name="lineEdit_name">
          <property name="sizePolicy">
@@ -272,7 +202,7 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Type&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Type</string>
          </property>
          <property name="buddy">
           <cstring>comboBox_type</cstring>
@@ -344,6 +274,79 @@
         </widget>
        </item>
        <item row="3" column="0">
+        <widget class="BtColorLabel" name="label_color">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>Color</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_color</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="BtColorEdit" name="lineEdit_color">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Lovibond rating</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">color_srm</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_yield">
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>Yield %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_yield</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_yield">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Yield as compared to glucose</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">yield_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="3">
         <widget class="BtMassLabel" name="label_amount">
          <property name="contextMenuPolicy">
           <enum>Qt::CustomContextMenu</enum>
@@ -352,14 +355,14 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Default Amount&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Default Amount</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_amount</cstring>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="7" column="4">
         <widget class="BtMassEdit" name="lineEdit_amount">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -698,14 +701,63 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_new">
+       <property name="toolTip">
+        <string>New fermentable</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../brewtarget/mik/brewtarget.qrc">
+         <normaloff>:/images/smallPlus.svg</normaloff>:/images/smallPlus.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_save">
+       <property name="toolTip">
+        <string>Save and close</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../brewtarget/mik/brewtarget.qrc">
+         <normaloff>:/images/filesave.svg</normaloff>:/images/filesave.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_cancel">
+       <property name="toolTip">
+        <string>Discard and close</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../brewtarget/mik/brewtarget.qrc">
+         <normaloff>:/images/exit.svg</normaloff>:/images/exit.svg</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -773,56 +825,33 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>tabWidget_editor</tabstop>
   <tabstop>lineEdit_name</tabstop>
   <tabstop>comboBox_type</tabstop>
   <tabstop>lineEdit_color</tabstop>
+  <tabstop>lineEdit_yield</tabstop>
+  <tabstop>lineEdit_inventory</tabstop>
   <tabstop>checkBox_addAfterBoil</tabstop>
   <tabstop>checkBox_recommendMash</tabstop>
   <tabstop>checkBox_isMashed</tabstop>
+  <tabstop>lineEdit_amount</tabstop>
   <tabstop>lineEdit_origin</tabstop>
   <tabstop>lineEdit_supplier</tabstop>
   <tabstop>lineEdit_moisture</tabstop>
   <tabstop>lineEdit_diastaticPower</tabstop>
+  <tabstop>lineEdit_protein</tabstop>
   <tabstop>lineEdit_maxInBatch</tabstop>
   <tabstop>lineEdit_coarseFineDiff</tabstop>
   <tabstop>lineEdit_ibuGalPerLb</tabstop>
+  <tabstop>pushButton_new</tabstop>
+  <tabstop>pushButton_save</tabstop>
+  <tabstop>pushButton_cancel</tabstop>
   <tabstop>textEdit_notes</tabstop>
-  <tabstop>lineEdit_protein</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../../../brewtarget/mik/brewtarget.qrc"/>
+ </resources>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>fermentableEditor</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>487</x>
-     <y>345</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fermentableEditor</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>494</x>
-     <y>345</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>label_amount</sender>
    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>

--- a/ui/fermentableEditor.ui
+++ b/ui/fermentableEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>605</width>
-    <height>374</height>
+    <width>543</width>
+    <height>316</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,245 +16,181 @@
   <property name="configSection" stdset="0">
    <string notr="true">fermentableEditor</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_18">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <property name="spacing">
+    <widget class="QTabWidget" name="tabWidget_editor">
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
+     </property>
+     <property name="currentIndex">
       <number>0</number>
      </property>
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>Required Fields</string>
-       </property>
-       <property name="configSection" stdset="0">
-        <string notr="true">fermentableEditor</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>2</number>
-        </property>
-        <property name="bottomMargin">
-         <number>2</number>
-        </property>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Name</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_name</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="lineEdit_name">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Name</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <item>
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Type</string>
-            </property>
-            <property name="buddy">
-             <cstring>comboBox_type</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="comboBox_type">
-            <property name="toolTip">
-             <string>Type</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>Grain</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Sugar</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Extract</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Dry Extract</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Adjunct</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="BtMassLabel" name="label_amount">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="text">
-             <string>Default Amount</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_amount</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="BtMassEdit" name="lineEdit_amount">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Amount</string>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">amount_kg</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QLabel" name="label_yield">
-            <property name="text">
-             <string>Yield (%)</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_yield</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="BtGenericEdit" name="lineEdit_yield">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Yield as compared to glucose</string>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">yield_pct</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="BtColorLabel" name="label_color">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="text">
-             <string>Color</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_color</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="BtColorEdit" name="lineEdit_color">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Lovibond rating</string>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">color_srm</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>13</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_6">
-       <item>
+     <widget class="QWidget" name="tab_main">
+      <attribute name="title">
+       <string>Main</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="2" column="4">
+        <widget class="QCheckBox" name="checkBox_recommendMash">
+         <property name="toolTip">
+          <string>Recommend this be mashed</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label">
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_name</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="2">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="5" column="0">
+        <widget class="BtColorLabel" name="label_color">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Color&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_color</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="comboBox_type">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Type</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Grain</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Sugar</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Extract</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Dry Extract</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Adjunct</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QLabel" name="label_recommendMash">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Recommend Mash</string>
+         </property>
+         <property name="buddy">
+          <cstring>checkBox_recommendMash</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="BtColorEdit" name="lineEdit_color">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Lovibond rating</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">color_srm</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_yield">
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Yield %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_yield</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
         <widget class="QLabel" name="label_addAfterBoil">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -270,7 +206,7 @@
          </property>
         </widget>
        </item>
-       <item>
+       <item row="0" column="4">
         <widget class="QCheckBox" name="checkBox_addAfterBoil">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -286,11 +222,90 @@
          </property>
         </widget>
        </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_16">
-       <item>
+       <item row="6" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_yield">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Yield as compared to glucose</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">yield_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="BtStringEdit" name="lineEdit_name">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Name</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Type&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_type</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="QLabel" name="label_isMashed">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Is Mashed</string>
+         </property>
+         <property name="buddy">
+          <cstring>checkBox_isMashed</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="4">
+        <widget class="QCheckBox" name="checkBox_isMashed">
+         <property name="toolTip">
+          <string>Checked if it is present in mash</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
         <widget class="BtMassLabel" name="label_inventory">
          <property name="contextMenuPolicy">
           <enum>Qt::CustomContextMenu</enum>
@@ -306,7 +321,7 @@
          </property>
         </widget>
        </item>
-       <item>
+       <item row="7" column="1">
         <widget class="BtMassEdit" name="lineEdit_inventory">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -328,22 +343,24 @@
          </property>
         </widget>
        </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,0">
-       <item>
-        <widget class="QLabel" name="label_origin">
+       <item row="3" column="0">
+        <widget class="BtMassLabel" name="label_amount">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
          <property name="text">
-          <string>Origin</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Default Amount&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="buddy">
-          <cstring>lineEdit_origin</cstring>
+          <cstring>lineEdit_amount</cstring>
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QLineEdit" name="lineEdit_origin">
+       <item row="3" column="1">
+        <widget class="BtMassEdit" name="lineEdit_amount">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -357,104 +374,21 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Origin</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_8">
-       <item>
-        <widget class="QLabel" name="label_supplier">
-         <property name="text">
-          <string>Supplier</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_supplier</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="lineEdit_supplier">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Supplier</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_9">
-       <item>
-        <widget class="QLabel" name="label_coarseFineDiff">
-         <property name="text">
-          <string>Coarse/Fine Diff (%)</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_coarseFineDiff</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="BtGenericEdit" name="lineEdit_coarseFineDiff">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Yield difference between coarse and fine grind</string>
+          <string>Amount</string>
          </property>
          <property name="editField" stdset="0">
-          <string notr="true">coarseFineDiff_pct</string>
+          <string notr="true">amount_kg</string>
          </property>
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout_3">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_10">
-       <item>
-        <widget class="QLabel" name="label_moisture">
-         <property name="text">
-          <string>Moisture (%)</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_moisture</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
+     </widget>
+     <widget class="QWidget" name="tab_extras">
+      <attribute name="title">
+       <string>Extras</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="2" column="1">
         <widget class="BtGenericEdit" name="lineEdit_moisture">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -476,182 +410,7 @@
          </property>
         </widget>
        </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_11">
-       <item>
-        <widget class="BtDiastaticPowerLabel" name="label_diastaticPower">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>Diastatic power</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_diastaticPower</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="BtDiastaticPowerEdit" name="lineEdit_diastaticPower">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Diastatic power</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">diastaticPower_lintner</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_12">
-       <item>
-        <widget class="QLabel" name="label_protein">
-         <property name="text">
-          <string>Protein (%)</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_protein</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="BtGenericEdit" name="lineEdit_protein">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Protein percentage by mass</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">protein_pct</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_13">
-       <item>
-        <widget class="QLabel" name="label_maxInBatch">
-         <property name="text">
-          <string>Max In Batch (%)</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_maxInBatch</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="BtGenericEdit" name="lineEdit_maxInBatch">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Maximum recommended percentage of total grist</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">maxInBatch_pct</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_14">
-       <item>
-        <widget class="QLabel" name="label_recommendMash">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Recommend Mash</string>
-         </property>
-         <property name="buddy">
-          <cstring>checkBox_recommendMash</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_recommendMash">
-         <property name="toolTip">
-          <string>Recommend this be mashed</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_17">
-       <item>
-        <widget class="QLabel" name="label_isMashed">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Is Mashed</string>
-         </property>
-         <property name="buddy">
-          <cstring>checkBox_isMashed</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_isMashed">
-         <property name="toolTip">
-          <string>Checked if it is present in mash</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_15">
-       <item>
+       <item row="3" column="3">
         <widget class="QLabel" name="label_ibuGalPerLb">
          <property name="text">
           <string>Bitterness (IBU*gal/lb)</string>
@@ -661,7 +420,7 @@
          </property>
         </widget>
        </item>
-       <item>
+       <item row="3" column="4">
         <widget class="BtGenericEdit" name="lineEdit_ibuGalPerLb">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -683,55 +442,270 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_moisture">
+         <property name="text">
+          <string>Moisture (%)</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_moisture</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="BtStringEdit" name="lineEdit_origin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Origin</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>origin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_origin">
+         <property name="text">
+          <string>Origin</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_origin</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="label_protein">
+         <property name="text">
+          <string>Protein (%)</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_protein</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="BtDiastaticPowerLabel" name="label_diastaticPower">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Diastatic power</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_diastaticPower</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="BtDiastaticPowerEdit" name="lineEdit_diastaticPower">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Diastatic power</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">diastaticPower_lintner</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QLabel" name="label_coarseFineDiff">
+         <property name="text">
+          <string>Coarse/Fine Diff (%)</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_coarseFineDiff</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_supplier">
+         <property name="text">
+          <string>Supplier</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_supplier</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="BtStringEdit" name="lineEdit_supplier">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Supplier</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>supplier</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="BtGenericEdit" name="lineEdit_maxInBatch">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Maximum recommended percentage of total grist</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">maxInBatch_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="4">
+        <widget class="BtGenericEdit" name="lineEdit_protein">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Protein percentage by mass</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">protein_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QLabel" name="label_maxInBatch">
+         <property name="text">
+          <string>Max In Batch (%)</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_maxInBatch</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="4">
+        <widget class="BtGenericEdit" name="lineEdit_coarseFineDiff">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Yield difference between coarse and fine grind</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">coarseFineDiff_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_notes">
-       <property name="text">
-        <string>Notes:</string>
-       </property>
-       <property name="buddy">
-        <cstring>textEdit_notes</cstring>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QTextEdit" name="textEdit_notes">
-       <property name="maximumSize">
-        <size>
-         <width>1000</width>
-         <height>1000</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </widget>
+     <widget class="QWidget" name="tab_notes">
+      <attribute name="title">
+       <string>Notes</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QTextEdit" name="textEdit_notes">
+         <property name="maximumSize">
+          <size>
+           <width>1000</width>
+           <height>1000</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -740,6 +714,27 @@
    <class>BtGenericEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BtStringEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BtColorLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtColorEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
   </customwidget>
   <customwidget>
    <class>BtMassEdit</class>
@@ -752,28 +747,12 @@
    </slots>
   </customwidget>
   <customwidget>
-   <class>BtColorLabel</class>
-   <extends>QLabel</extends>
-   <header>BtLabel.h</header>
-   <slots>
-    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   </slots>
-  </customwidget>
-  <customwidget>
    <class>BtMassLabel</class>
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
     <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
     <slot>popContextMenu(QPoint)</slot>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtColorEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
-   <slots>
-    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
    </slots>
   </customwidget>
   <customwidget>
@@ -796,23 +775,19 @@
  <tabstops>
   <tabstop>lineEdit_name</tabstop>
   <tabstop>comboBox_type</tabstop>
-  <tabstop>lineEdit_amount</tabstop>
-  <tabstop>lineEdit_yield</tabstop>
   <tabstop>lineEdit_color</tabstop>
   <tabstop>checkBox_addAfterBoil</tabstop>
-  <tabstop>lineEdit_inventory</tabstop>
-  <tabstop>lineEdit_origin</tabstop>
-  <tabstop>lineEdit_supplier</tabstop>
-  <tabstop>lineEdit_coarseFineDiff</tabstop>
-  <tabstop>lineEdit_moisture</tabstop>
-  <tabstop>lineEdit_diastaticPower</tabstop>
-  <tabstop>lineEdit_protein</tabstop>
-  <tabstop>lineEdit_maxInBatch</tabstop>
   <tabstop>checkBox_recommendMash</tabstop>
   <tabstop>checkBox_isMashed</tabstop>
+  <tabstop>lineEdit_origin</tabstop>
+  <tabstop>lineEdit_supplier</tabstop>
+  <tabstop>lineEdit_moisture</tabstop>
+  <tabstop>lineEdit_diastaticPower</tabstop>
+  <tabstop>lineEdit_maxInBatch</tabstop>
+  <tabstop>lineEdit_coarseFineDiff</tabstop>
   <tabstop>lineEdit_ibuGalPerLb</tabstop>
   <tabstop>textEdit_notes</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>lineEdit_protein</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/ui/hopEditor.ui
+++ b/ui/hopEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>389</width>
-    <height>408</height>
+    <width>472</width>
+    <height>318</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -45,23 +45,29 @@
        <string>Main</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="2">
+        <widget class="QLabel" name="label_use">
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>Use</string>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_use</cstring>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_name">
          <property name="toolTip">
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Name</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_name</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="BtStringEdit" name="lineEdit_name">
-         <property name="toolTip">
-          <string>Name</string>
          </property>
         </widget>
        </item>
@@ -71,10 +77,23 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Alpha %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Alpha %</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_alpha</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="BtMassLabel" name="label_inventory">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Amount in Inventory</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_inventory</cstring>
          </property>
         </widget>
        </item>
@@ -88,22 +107,6 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="BtMassLabel" name="label_amount">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="toolTip">
-          <string>Required</string>
-         </property>
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Default Amount &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_amount</cstring>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="1">
         <widget class="BtMassEdit" name="lineEdit_amount">
          <property name="toolTip">
@@ -114,20 +117,59 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_use">
+       <item row="0" column="1">
+        <widget class="BtStringEdit" name="lineEdit_name">
+         <property name="toolTip">
+          <string>Name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="BtMassLabel" name="label_amount">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
          <property name="toolTip">
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Use&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Default Amount</string>
          </property>
          <property name="buddy">
-          <cstring>comboBox_use</cstring>
+          <cstring>lineEdit_amount</cstring>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
+        <widget class="BtMassEdit" name="lineEdit_inventory">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Amount in inventory</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">inventory</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="3">
         <widget class="QComboBox" name="comboBox_use">
          <property name="toolTip">
           <string>Use</string>
@@ -159,36 +201,7 @@
          </item>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="BtMassLabel" name="label_inventory">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="text">
-          <string>Amount in Inventory</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_inventory</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="BtMassEdit" name="lineEdit_inventory">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Amount in inventory</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">inventory</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
+       <item row="1" column="2">
         <widget class="QLabel" name="label_type">
          <property name="text">
           <string>Type</string>
@@ -198,7 +211,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="1" column="3">
         <widget class="QComboBox" name="comboBox_type">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -226,7 +239,7 @@
          </item>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="2" column="2">
         <widget class="QLabel" name="label_form">
          <property name="text">
           <string>Form</string>
@@ -236,7 +249,7 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="2" column="3">
         <widget class="QComboBox" name="comboBox_form">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -264,19 +277,6 @@
          </item>
         </widget>
        </item>
-       <item row="7" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabWidget_editorPage2">
@@ -284,7 +284,7 @@
        <string>Extras</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="0">
+       <item row="0" column="2">
         <widget class="BtTimeLabel" name="label_time">
          <property name="contextMenuPolicy">
           <enum>Qt::CustomContextMenu</enum>
@@ -294,177 +294,6 @@
          </property>
          <property name="buddy">
           <cstring>lineEdit_time</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="BtTimeEdit" name="lineEdit_time">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Time</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">time_min</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_HSI">
-         <property name="text">
-          <string>HSI</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_HSI</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="BtGenericEdit" name="lineEdit_HSI">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Hop Stability/Storage index</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">hsi_pct</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_origin">
-         <property name="text">
-          <string>Origin</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_origin</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="BtStringEdit" name="lineEdit_origin">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Origin</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_beta">
-         <property name="text">
-          <string>Beta %</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_beta</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="BtGenericEdit" name="lineEdit_beta">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Beta acids as percent by mass</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">beta_pct</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_humulene">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Humulene %</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_humulene</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="BtGenericEdit" name="lineEdit_humulene">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Humulene</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">humulene_pct</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_caryophyllene">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Caryophyllene %</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_caryophyllene</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="BtGenericEdit" name="lineEdit_caryophyllene">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Caryophyllene %</string>
-         </property>
-         <property name="editField" stdset="0">
-          <string notr="true">caryophyllene_pct</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_cohumulone">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Cohumulone %</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_cohumulone</cstring>
          </property>
         </widget>
        </item>
@@ -481,22 +310,6 @@
          </property>
          <property name="editField" stdset="0">
           <string notr="true">cohumulone_pct</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_myrcene">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Myrcene %</string>
-         </property>
-         <property name="buddy">
-          <cstring>lineEdit_myrcene</cstring>
          </property>
         </widget>
        </item>
@@ -528,6 +341,193 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_cohumulone">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Cohumulone %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_cohumulone</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_myrcene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Myrcene %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_myrcene</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="BtTimeEdit" name="lineEdit_time">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Time</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">time_min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLabel" name="label_HSI">
+         <property name="text">
+          <string>HSI</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_HSI</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="BtGenericEdit" name="lineEdit_HSI">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Hop Stability/Storage index</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">hsi_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QLabel" name="label_origin">
+         <property name="text">
+          <string>Origin</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_origin</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="BtStringEdit" name="lineEdit_origin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Origin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_beta">
+         <property name="text">
+          <string>Beta %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_beta</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_beta">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Beta acids as percent by mass</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">beta_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_humulene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Humulene %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_humulene</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_humulene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Humulene</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">humulene_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_caryophyllene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Caryophyllene %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_caryophyllene</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_caryophyllene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Caryophyllene %</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">caryophyllene_pct</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -592,18 +592,72 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_new">
+       <property name="toolTip">
+        <string>New hop</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../brewtarget/mik/brewtarget.qrc">
+         <normaloff>:/images/smallPlus.svg</normaloff>:/images/smallPlus.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_save">
+       <property name="toolTip">
+        <string>Save and close</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../brewtarget/mik/brewtarget.qrc">
+         <normaloff>:/images/filesave.svg</normaloff>:/images/filesave.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_cancel">
+       <property name="toolTip">
+        <string>Discard and close</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../brewtarget/mik/brewtarget.qrc">
+         <normaloff>:/images/exit.svg</normaloff>:/images/exit.svg</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>BtGenericEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+  </customwidget>
   <customwidget>
    <class>BtStringEdit</class>
    <extends>QLineEdit</extends>
@@ -624,11 +678,6 @@
    <slots>
     <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
    </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtGenericEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
   </customwidget>
   <customwidget>
    <class>BtMassEdit</class>
@@ -655,54 +704,26 @@
   <tabstop>lineEdit_name</tabstop>
   <tabstop>lineEdit_alpha</tabstop>
   <tabstop>lineEdit_amount</tabstop>
-  <tabstop>comboBox_use</tabstop>
   <tabstop>lineEdit_inventory</tabstop>
+  <tabstop>comboBox_use</tabstop>
   <tabstop>comboBox_type</tabstop>
   <tabstop>comboBox_form</tabstop>
-  <tabstop>lineEdit_time</tabstop>
-  <tabstop>lineEdit_HSI</tabstop>
-  <tabstop>lineEdit_origin</tabstop>
   <tabstop>lineEdit_beta</tabstop>
   <tabstop>lineEdit_humulene</tabstop>
   <tabstop>lineEdit_caryophyllene</tabstop>
   <tabstop>lineEdit_cohumulone</tabstop>
   <tabstop>lineEdit_myrcene</tabstop>
+  <tabstop>lineEdit_time</tabstop>
+  <tabstop>lineEdit_HSI</tabstop>
+  <tabstop>lineEdit_origin</tabstop>
+  <tabstop>pushButton_new</tabstop>
+  <tabstop>pushButton_save</tabstop>
+  <tabstop>pushButton_cancel</tabstop>
   <tabstop>textEdit_substitutes</tabstop>
   <tabstop>textEdit_notes</tabstop>
  </tabstops>
- <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>hopEditor</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>501</x>
-     <y>383</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>hopEditor</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>508</x>
-     <y>383</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <resources>
+  <include location="../../../../../brewtarget/mik/brewtarget.qrc"/>
+ </resources>
+ <connections/>
 </ui>

--- a/ui/hopEditor.ui
+++ b/ui/hopEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>515</width>
-    <height>390</height>
+    <width>389</width>
+    <height>408</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,777 +22,524 @@
   <property name="configSection" stdset="0">
    <string notr="true">hopEditor</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_17">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_15">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Required Fields</string>
+    <widget class="QTabWidget" name="tabWidget_editor">
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <property name="movable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="tabWidget_editorPage1">
+      <attribute name="title">
+       <string>Main</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_name">
+         <property name="toolTip">
+          <string>Required</string>
          </property>
-         <property name="configSection" stdset="0">
-          <string notr="true">hopEditor</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="sizeConstraint">
-           <enum>QLayout::SetMinimumSize</enum>
-          </property>
-          <property name="leftMargin">
-           <number>2</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>2</number>
-          </property>
-          <property name="bottomMargin">
-           <number>3</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="sizeConstraint">
-             <enum>QLayout::SetNoConstraint</enum>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="label_name">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Name</string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_name</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="lineEdit_name">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>100</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>100</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>1000</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Name</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLabel" name="label_alpha">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Alpha (%)</string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_alpha</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="BtGenericEdit" name="lineEdit_alpha">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>100</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>100</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Alpha acids as percent by mass</string>
-              </property>
-              <property name="editField" stdset="0">
-               <string notr="true">alpha_pct</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="BtMassLabel" name="label_amount">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="contextMenuPolicy">
-               <enum>Qt::CustomContextMenu</enum>
-              </property>
-              <property name="text">
-               <string>Default Amount </string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_amount</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="BtMassEdit" name="lineEdit_amount">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>100</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>100</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Amount</string>
-              </property>
-              <property name="editField" stdset="0">
-               <string notr="true">amount_kg</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
-             <widget class="QLabel" name="label_use">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Use</string>
-              </property>
-              <property name="buddy">
-               <cstring>comboBox_use</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="comboBox_use">
-              <property name="toolTip">
-               <string>Use</string>
-              </property>
-              <item>
-               <property name="text">
-                <string>Mash</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>First Wort</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Boil</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Aroma</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Dry Hop</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="BtTimeLabel" name="label_time">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="contextMenuPolicy">
-               <enum>Qt::CustomContextMenu</enum>
-              </property>
-              <property name="text">
-               <string>Time</string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_time</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="BtTimeEdit" name="lineEdit_time">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>100</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>100</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Time</string>
-              </property>
-              <property name="editField" stdset="0">
-               <string notr="true">time_min</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_16">
-         <item>
-          <widget class="BtMassLabel" name="label_inventory">
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="text">
-            <string>Amount in Inventory</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_inventory</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtMassEdit" name="lineEdit_inventory">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Amount in inventory</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">inventory</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <item>
-          <widget class="QLabel" name="label_type">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Type</string>
-           </property>
-           <property name="buddy">
-            <cstring>comboBox_type</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="comboBox_type">
-           <property name="toolTip">
-            <string>Type</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>Bittering</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Aroma</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Both</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
-         <item>
-          <widget class="QLabel" name="label_form">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Form</string>
-           </property>
-           <property name="buddy">
-            <cstring>comboBox_form</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="comboBox_form">
-           <property name="toolTip">
-            <string>Form</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>Leaf</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Pellet</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Plug</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_7">
-         <item>
-          <widget class="QLabel" name="label_beta">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Beta (%)</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_beta</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtGenericEdit" name="lineEdit_beta">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Beta acids as percent by mass</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">beta_pct</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_9">
-         <item>
-          <widget class="QLabel" name="label_HSI">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>HSI</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_HSI</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtGenericEdit" name="lineEdit_HSI">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Hop Stability/Storage index</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">hsi_pct</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_10">
-         <item>
-          <widget class="QLabel" name="label_origin">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Origin</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_origin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="lineEdit_origin">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Origin</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_14">
-         <item>
-          <widget class="QLabel" name="label_humulene">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Humulene (%)</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_humulene</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtGenericEdit" name="lineEdit_humulene">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Humulene</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">humulene_pct</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_13">
-         <item>
-          <widget class="QLabel" name="label_caryophyllene">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Caryophyllene (%)</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_caryophyllene</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtGenericEdit" name="lineEdit_caryophyllene">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Caryophyllene</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">caryophyllene_pct</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_12">
-         <item>
-          <widget class="QLabel" name="label_cohumulone">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Cohumulone (%)</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_cohumulone</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtGenericEdit" name="lineEdit_cohumulone">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Cohumulone</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">cohumulone_pct</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_11">
-         <item>
-          <widget class="QLabel" name="label_myrcene">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Myrcene (%)</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_myrcene</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtGenericEdit" name="lineEdit_myrcene">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Myrcene</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">myrcene_pct</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_15">
          <property name="text">
-          <string>Substitutes:</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="buddy">
-          <cstring>textEdit_substitutes</cstring>
+          <cstring>lineEdit_name</cstring>
          </property>
         </widget>
        </item>
+       <item row="0" column="1">
+        <widget class="BtStringEdit" name="lineEdit_name">
+         <property name="toolTip">
+          <string>Name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_alpha">
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Alpha %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_alpha</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_alpha">
+         <property name="toolTip">
+          <string>Alpha acids as percent by mass</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">alpha_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="BtMassLabel" name="label_amount">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Default Amount &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_amount</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="BtMassEdit" name="lineEdit_amount">
+         <property name="toolTip">
+          <string>Amount</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">amount_kg</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_use">
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Use&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_use</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="comboBox_use">
+         <property name="toolTip">
+          <string>Use</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Mash</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>First Wort</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Boil</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Aroma</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Dry Hop</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="BtMassLabel" name="label_inventory">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Amount in Inventory</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_inventory</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="BtMassEdit" name="lineEdit_inventory">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Amount in inventory</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">inventory</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_type">
+         <property name="text">
+          <string>Type</string>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_type</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="comboBox_type">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Type</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Bittering</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Aroma</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Both</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_form">
+         <property name="text">
+          <string>Form</string>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_form</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="comboBox_form">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Form</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Leaf</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Pellet</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Plug</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabWidget_editorPage2">
+      <attribute name="title">
+       <string>Extras</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="BtTimeLabel" name="label_time">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Time</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_time</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="BtTimeEdit" name="lineEdit_time">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Time</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">time_min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_HSI">
+         <property name="text">
+          <string>HSI</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_HSI</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_HSI">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Hop Stability/Storage index</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">hsi_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_origin">
+         <property name="text">
+          <string>Origin</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_origin</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="BtStringEdit" name="lineEdit_origin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Origin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_beta">
+         <property name="text">
+          <string>Beta %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_beta</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_beta">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Beta acids as percent by mass</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">beta_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_humulene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Humulene %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_humulene</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_humulene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Humulene</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">humulene_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_caryophyllene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Caryophyllene %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_caryophyllene</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_caryophyllene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Caryophyllene %</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">caryophyllene_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_cohumulone">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Cohumulone %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_cohumulone</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_cohumulone">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Cohumulone</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">cohumulone_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_myrcene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Myrcene %</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_myrcene</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_myrcene">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Myrcene</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">myrcene_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabWidget_editorPage4">
+      <attribute name="title">
+       <string>Substitutes</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QTextEdit" name="textEdit_substitutes">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -811,20 +558,17 @@
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QLabel" name="label_16">
-         <property name="text">
-          <string>Notes:</string>
-         </property>
-         <property name="buddy">
-          <cstring>textEdit_notes</cstring>
-         </property>
-        </widget>
-       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabWidget_editorPage5">
+      <attribute name="title">
+       <string>Notes</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="QTextEdit" name="textEdit_notes">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -843,37 +587,27 @@
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QDialogButtonBox" name="buttonBox">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="standardButtons">
-          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-         </property>
-        </widget>
-       </item>
       </layout>
-     </item>
-    </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>BtGenericEdit</class>
+   <class>BtStringEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>BtMassEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
-   <slots>
-    <signal>textModified()</signal>
-    <slot>lineChanged()</slot>
-    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   </slots>
   </customwidget>
   <customwidget>
    <class>BtTimeEdit</class>
@@ -892,6 +626,21 @@
    </slots>
   </customwidget>
   <customwidget>
+   <class>BtGenericEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BtMassEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <signal>textModified()</signal>
+    <slot>lineChanged()</slot>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
    <class>BtMassLabel</class>
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
@@ -901,6 +650,26 @@
    </slots>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget_editor</tabstop>
+  <tabstop>lineEdit_name</tabstop>
+  <tabstop>lineEdit_alpha</tabstop>
+  <tabstop>lineEdit_amount</tabstop>
+  <tabstop>comboBox_use</tabstop>
+  <tabstop>lineEdit_inventory</tabstop>
+  <tabstop>comboBox_type</tabstop>
+  <tabstop>comboBox_form</tabstop>
+  <tabstop>lineEdit_time</tabstop>
+  <tabstop>lineEdit_HSI</tabstop>
+  <tabstop>lineEdit_origin</tabstop>
+  <tabstop>lineEdit_beta</tabstop>
+  <tabstop>lineEdit_humulene</tabstop>
+  <tabstop>lineEdit_caryophyllene</tabstop>
+  <tabstop>lineEdit_cohumulone</tabstop>
+  <tabstop>lineEdit_myrcene</tabstop>
+  <tabstop>textEdit_substitutes</tabstop>
+  <tabstop>textEdit_notes</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>
@@ -932,54 +701,6 @@
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>label_amount</sender>
-   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   <receiver>lineEdit_amount</receiver>
-   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>87</x>
-     <y>91</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>168</x>
-     <y>93</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>label_time</sender>
-   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   <receiver>lineEdit_time</receiver>
-   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>66</x>
-     <y>141</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>159</x>
-     <y>139</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>label_inventory</sender>
-   <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   <receiver>lineEdit_inventory</receiver>
-   <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>50</x>
-     <y>170</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>177</x>
-     <y>180</y>
     </hint>
    </hints>
   </connection>

--- a/ui/mainWindow.ui
+++ b/ui/mainWindow.ui
@@ -511,6 +511,12 @@
                           <height>16777215</height>
                          </size>
                         </property>
+                        <property name="styleSheet">
+                         <string notr="true">combobox-popup: 0;</string>
+                        </property>
+                        <property name="maxVisibleItems">
+                         <number>15</number>
+                        </property>
                        </widget>
                       </item>
                      </layout>
@@ -2266,6 +2272,22 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>BtTimeEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtTimeLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
+  </customwidget>
+  <customwidget>
    <class>BtGenericEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
@@ -2319,22 +2341,6 @@
   </customwidget>
   <customwidget>
    <class>BtColorLabel</class>
-   <extends>QLabel</extends>
-   <header>BtLabel.h</header>
-   <slots>
-    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtTimeEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
-   <slots>
-    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtTimeLabel</class>
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>

--- a/ui/miscEditor.ui
+++ b/ui/miscEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>504</width>
-    <height>215</height>
+    <width>448</width>
+    <height>265</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,451 +16,445 @@
   <property name="configSection" stdset="0">
    <string notr="true">miscEditor</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QLabel" name="label_name">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Name</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_name</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="lineEdit_name">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Name</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_type">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Type</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="buddy">
-            <cstring>comboBox_type</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="comboBox_type">
-           <property name="toolTip">
-            <string>Type</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>Spice</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Fining</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Water Agent</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Herb</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Flavor</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Other</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QLabel" name="label_use">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Use</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="buddy">
-            <cstring>comboBox_use</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="comboBox_use">
-           <property name="toolTip">
-            <string>Use</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>Boil</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Mash</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Primary</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Secondary</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Bottling</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <widget class="BtTimeLabel" name="label_time">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="text">
-            <string>Time</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_time</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtTimeEdit" name="lineEdit_time">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Time</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">time</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <item>
-          <widget class="BtMixedLabel" name="label_amount">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="text">
-            <string>Default Amount</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_amount</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtMixedEdit" name="lineEdit_amount">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Amount</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">amount</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <item>
-          <widget class="QLabel" name="label_isWeight">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Check it if the amount listed is in kg instead of L.</string>
-           </property>
-           <property name="text">
-            <string>Amount is weight?</string>
-           </property>
-           <property name="buddy">
-            <cstring>checkBox_isWeight</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="checkBox_isWeight">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Checked if the given amount is weight instead of volume</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_17">
-         <item>
-          <widget class="BtMixedLabel" name="label_inventory">
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="text">
-            <string>Amount in Inventory</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_inventory</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtMixedEdit" name="lineEdit_inventory">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Amount in inventory</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">inventory</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="spacing">
-        <number>2</number>
-       </property>
-       <property name="sizeConstraint">
-        <enum>QLayout::SetFixedSize</enum>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_useFor">
-         <property name="text">
-          <string>Use for:</string>
-         </property>
-         <property name="buddy">
-          <cstring>textEdit_useFor</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTextEdit" name="textEdit_useFor">
+    <widget class="QTabWidget" name="tabWidget_editor">
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="tab_main">
+      <attribute name="title">
+       <string>Main</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="5" column="1">
+        <widget class="BtTimeEdit" name="lineEdit_time">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>200</horstretch>
-           <verstretch>50</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1000</width>
-           <height>50</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_notes">
-         <property name="text">
-          <string>Notes:</string>
-         </property>
-         <property name="buddy">
-          <cstring>textEdit_notes</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTextEdit" name="textEdit_notes">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>200</horstretch>
-           <verstretch>50</verstretch>
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="minimumSize">
           <size>
-           <width>200</width>
-           <height>50</height>
+           <width>100</width>
+           <height>0</height>
           </size>
          </property>
          <property name="maximumSize">
           <size>
-           <width>1000</width>
-           <height>1000</height>
+           <width>100</width>
+           <height>16777215</height>
           </size>
+         </property>
+         <property name="toolTip">
+          <string>Time</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">time</string>
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QDialogButtonBox" name="buttonBox">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+       <item row="0" column="4">
+        <widget class="QCheckBox" name="checkBox_isWeight">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="standardButtons">
-          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+         <property name="toolTip">
+          <string>Checked if the given amount is weight instead of volume</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_type">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Type</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_type</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_use">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Use</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_use</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="comboBox_type">
+         <property name="toolTip">
+          <string>Type</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Spice</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Fining</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Water Agent</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Herb</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Flavor</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Other</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="BtTimeLabel" name="label_time">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Time</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_time</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="BtStringEdit" name="lineEdit_name">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="comboBox_use">
+         <property name="toolTip">
+          <string>Use</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Boil</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mash</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Primary</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Secondary</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Bottling</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_name">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Name</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_name</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2" colspan="2">
+        <widget class="QLabel" name="label_isWeight">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Check it if the amount listed is in kg instead of L.</string>
+         </property>
+         <property name="text">
+          <string>Amount is weight?</string>
+         </property>
+         <property name="buddy">
+          <cstring>checkBox_isWeight</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="2">
+        <widget class="BtMixedLabel" name="label_amount">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Default Amount</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_amount</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="4">
+        <widget class="BtMixedEdit" name="lineEdit_amount">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Amount</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">amount</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="BtMixedLabel" name="label_inventory">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Amount in Inventory</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_inventory</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="4">
+        <widget class="BtMixedEdit" name="lineEdit_inventory">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Amount in inventory</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">inventory</string>
          </property>
         </widget>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="tab_usefor">
+      <attribute name="title">
+       <string>Use for</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QTextEdit" name="textEdit_useFor"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_notes">
+      <attribute name="title">
+       <string>Notes</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QTextEdit" name="textEdit_notes"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_new">
+       <property name="toolTip">
+        <string>New misc</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/smallPlus.svg</normaloff>:/images/smallPlus.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_save">
+       <property name="toolTip">
+        <string>Save and close</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/filesave.svg</normaloff>:/images/filesave.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_cancel">
+       <property name="toolTip">
+        <string>Discard and close</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/exit.svg</normaloff>:/images/exit.svg</iconset>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>BtStringEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+  </customwidget>
   <customwidget>
    <class>BtTimeEdit</class>
    <extends>QLineEdit</extends>
@@ -495,40 +489,25 @@
    </slots>
   </customwidget>
  </customwidgets>
- <resources/>
+ <tabstops>
+  <tabstop>tabWidget_editor</tabstop>
+  <tabstop>lineEdit_name</tabstop>
+  <tabstop>comboBox_type</tabstop>
+  <tabstop>comboBox_use</tabstop>
+  <tabstop>lineEdit_time</tabstop>
+  <tabstop>checkBox_isWeight</tabstop>
+  <tabstop>lineEdit_amount</tabstop>
+  <tabstop>lineEdit_inventory</tabstop>
+  <tabstop>pushButton_new</tabstop>
+  <tabstop>pushButton_save</tabstop>
+  <tabstop>pushButton_cancel</tabstop>
+  <tabstop>textEdit_useFor</tabstop>
+  <tabstop>textEdit_notes</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../brewtarget.qrc"/>
+ </resources>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>miscEditor</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>490</x>
-     <y>208</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>miscEditor</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>497</x>
-     <y>208</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>label_time</sender>
    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>

--- a/ui/styleEditor.ui
+++ b/ui/styleEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>586</width>
-    <height>600</height>
+    <width>466</width>
+    <height>375</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Style Editor</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_7">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_styles">
      <item>
@@ -75,804 +75,813 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_21">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_6">
-       <property name="spacing">
-        <number>1</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="groupBox_basic">
+    <widget class="QTabWidget" name="tabWidget_profile">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="tab_main">
+      <attribute name="title">
+       <string>Main</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_category">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title">
-          <string>Basic Information</string>
+         <property name="toolTip">
+          <string>Required</string>
          </property>
-         <property name="configSection" stdset="0">
-          <string notr="true">styleEditor</string>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Category&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_name">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Name</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_name</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="lineEdit_name">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Name</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_category">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Category</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_category</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="lineEdit_category">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Category</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_categoryNumber">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Category number</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_categoryNumber</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_styleLetter">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Style letter</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_styleLetter</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_styleGuide">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Style guide</string>
-            </property>
-            <property name="buddy">
-             <cstring>lineEdit_styleGuide</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_type">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="lineEdit_categoryNumber">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Category number</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="lineEdit_styleLetter">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Style letter</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QLineEdit" name="lineEdit_styleGuide">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Style guide</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QComboBox" name="comboBox_type">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Type of beverage</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>Lager</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Ale</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Mead</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Wheat</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Mixed</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Cider</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
+         <property name="buddy">
+          <cstring>lineEdit_category</cstring>
+         </property>
         </widget>
        </item>
-       <item>
-        <widget class="QGroupBox" name="styleEditor_vital">
+       <item row="5" column="3">
+        <widget class="BtStringEdit" name="lineEdit_styleLetter">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Style letter</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>styleLetter</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="3">
+        <widget class="BtStringEdit" name="lineEdit_styleGuide">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Style guide</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>styleGuide</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="3">
+        <widget class="BtStringEdit" name="lineEdit_categoryNumber">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Category number</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>categoryNumber</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="BtStringEdit" name="lineEdit_category">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Category</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>category</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_type">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title">
-          <string>Vital Statistics</string>
+         <property name="toolTip">
+          <string>Required</string>
          </property>
-         <property name="configSection" stdset="0">
-          <string notr="true">styleEditor</string>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Type&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_max">
-            <property name="text">
-             <string>Max</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="label_min">
-            <property name="text">
-             <string>Min</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="BtDensityLabel" name="label_og">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="text">
-             <string>OG</string>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">og</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="BtDensityEdit" name="lineEdit_ogMin">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">ogMin</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="BtDensityEdit" name="lineEdit_ogMax">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">ogMax</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="BtDensityLabel" name="label_fg">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="text">
-             <string>FG</string>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">fg</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="BtDensityEdit" name="lineEdit_fgMin">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">fgMin</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="BtDensityEdit" name="lineEdit_fgMax">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">fgMax</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_ibu">
-            <property name="text">
-             <string>IBUs</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="BtGenericEdit" name="lineEdit_ibuMin">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">ibuMin</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="BtGenericEdit" name="lineEdit_ibuMax">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">ibuMax</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="BtColorLabel" name="label_color">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="text">
-             <string>Color (SRM)</string>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">color_srm</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="BtColorEdit" name="lineEdit_colorMin">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">colorMin_srm</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="BtColorEdit" name="lineEdit_colorMax">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">colorMax_srm</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_carb">
-            <property name="text">
-             <string>Carb (vols)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="BtGenericEdit" name="lineEdit_carbMin">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">carbMin_vol</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="2">
-           <widget class="BtGenericEdit" name="lineEdit_carbMax">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">carbMax_vol</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_abv">
-            <property name="text">
-             <string>ABV (pct)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="BtGenericEdit" name="lineEdit_abvMin">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">abvMin_pct</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="2">
-           <widget class="BtGenericEdit" name="lineEdit_abvMax">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>100</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="editField" stdset="0">
-             <string notr="true">abvMax_pct</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
         </widget>
        </item>
-       <item>
+       <item row="7" column="3">
+        <widget class="QComboBox" name="comboBox_type">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Type of beverage</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Lager</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Ale</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mead</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Wheat</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mixed</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Cider</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_name">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_name</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="3">
+        <widget class="QLabel" name="label_categoryNumber">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Category number&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_categoryNumber</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QLabel" name="label_styleLetter">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Style letter&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_styleLetter</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="BtStringEdit" name="lineEdit_name">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Name</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string>name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="2">
+        <widget class="QLabel" name="label_styleGuide">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Required</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Style guide&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_styleGuide</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Minimum</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>0</height>
+           <height>40</height>
           </size>
          </property>
         </spacer>
        </item>
       </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_5">
-       <property name="spacing">
-        <number>1</number>
-       </property>
+     </widget>
+     <widget class="QWidget" name="tab_ranges">
+      <attribute name="title">
+       <string>Ranges</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="3" column="2">
+        <widget class="BtGenericEdit" name="lineEdit_ibuMax">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">ibuMax</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="BtColorEdit" name="lineEdit_colorMin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">colorMin_srm</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="2">
+        <widget class="BtGenericEdit" name="lineEdit_abvMax">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">abvMax_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="label_max">
+         <property name="text">
+          <string>Max</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_carbMin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">carbMin_vol</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="BtDensityLabel" name="label_fg">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>FG</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">fg</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_abv">
+         <property name="text">
+          <string>ABV (pct)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="BtDensityEdit" name="lineEdit_ogMin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">ogMin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_ibuMin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">ibuMin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="BtDensityEdit" name="lineEdit_ogMax">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">ogMax</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="BtColorEdit" name="lineEdit_colorMax">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">colorMax_srm</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="BtDensityEdit" name="lineEdit_fgMin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">fgMin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_carb">
+         <property name="text">
+          <string>Carb (vols)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="BtDensityEdit" name="lineEdit_fgMax">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">fgMax</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="BtColorLabel" name="label_color">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Color (SRM)</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">color_srm</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="BtGenericEdit" name="lineEdit_abvMin">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">abvMin_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="BtDensityLabel" name="label_og">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>OG</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">og</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="2">
+        <widget class="BtGenericEdit" name="lineEdit_carbMax">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">carbMax_vol</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="label_min">
+         <property name="text">
+          <string>Min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_ibu">
+         <property name="text">
+          <string>IBUs</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Profile</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_9">
        <item>
-        <widget class="QTabWidget" name="tabWidget_profile">
+        <widget class="QTextEdit" name="textEdit_profile">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="currentIndex">
-          <number>0</number>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
          </property>
-         <widget class="QWidget" name="tab">
-          <attribute name="title">
-           <string>Profile</string>
-          </attribute>
-          <layout class="QVBoxLayout" name="verticalLayout_9">
-           <item>
-            <widget class="QTextEdit" name="textEdit_profile">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="tab_2">
-          <attribute name="title">
-           <string>Ingredients</string>
-          </attribute>
-          <layout class="QVBoxLayout" name="verticalLayout_10">
-           <item>
-            <widget class="QTextEdit" name="textEdit_ingredients">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="tab_3">
-          <attribute name="title">
-           <string>Examples</string>
-          </attribute>
-          <layout class="QVBoxLayout" name="verticalLayout_11">
-           <item>
-            <widget class="QTextEdit" name="textEdit_examples">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="tab_4">
-          <attribute name="title">
-           <string>Notes</string>
-          </attribute>
-          <layout class="QVBoxLayout" name="verticalLayout_12">
-           <item>
-            <widget class="QTextEdit" name="textEdit_notes"/>
-           </item>
-          </layout>
-         </widget>
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Ingredients</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_10">
+       <item>
+        <widget class="QTextEdit" name="textEdit_ingredients">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Examples</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_11">
+       <item>
+        <widget class="QTextEdit" name="textEdit_examples">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_4">
+      <attribute name="title">
+       <string>Notes</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_12">
+       <item>
+        <widget class="QTextEdit" name="textEdit_notes"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_20">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
@@ -946,23 +955,12 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>BtDensityLabel</class>
-   <extends>QLabel</extends>
-   <header>BtLabel.h</header>
-   <slots>
-    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
-   </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtDensityEdit</class>
+   <class>BtGenericEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
-   <slots>
-    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
-   </slots>
   </customwidget>
   <customwidget>
-   <class>BtGenericEdit</class>
+   <class>BtStringEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
   </customwidget>
@@ -976,6 +974,22 @@
   </customwidget>
   <customwidget>
    <class>BtColorEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+   <slots>
+    <slot>lineChanged(Unit::unitDisplay,Unit::unitScale)</slot>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtDensityLabel</class>
+   <extends>QLabel</extends>
+   <header>BtLabel.h</header>
+   <slots>
+    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+   </slots>
+  </customwidget>
+  <customwidget>
+   <class>BtDensityEdit</class>
    <extends>QLineEdit</extends>
    <header>BtLineEdit.h</header>
    <slots>

--- a/ui/styleEditor.ui
+++ b/ui/styleEditor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>466</width>
-    <height>375</height>
+    <height>509</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -108,7 +108,7 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Category&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Category</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_category</cstring>
@@ -239,7 +239,7 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Type&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Type</string>
          </property>
         </widget>
        </item>
@@ -310,7 +310,7 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Name</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_name</cstring>
@@ -329,7 +329,7 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Category number&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Category number</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_categoryNumber</cstring>
@@ -348,7 +348,7 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Style letter&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Style letter</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_styleLetter</cstring>
@@ -395,7 +395,7 @@
           <string>Required</string>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#aa0000;&quot;&gt;Style guide&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Style guide</string>
          </property>
          <property name="buddy">
           <cstring>lineEdit_styleGuide</cstring>
@@ -898,7 +898,7 @@
      <item>
       <widget class="QPushButton" name="pushButton_new">
        <property name="toolTip">
-        <string>New</string>
+        <string>New style</string>
        </property>
        <property name="text">
         <string/>
@@ -915,7 +915,7 @@
      <item>
       <widget class="QPushButton" name="pushButton_save">
        <property name="toolTip">
-        <string>Save</string>
+        <string>Save and close</string>
        </property>
        <property name="text">
         <string/>
@@ -935,7 +935,7 @@
      <item>
       <widget class="QPushButton" name="pushButton_cancel">
        <property name="toolTip">
-        <string>Cancel</string>
+        <string>Discard and close</string>
        </property>
        <property name="text">
         <string/>
@@ -997,6 +997,36 @@
    </slots>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget_profile</tabstop>
+  <tabstop>styleComboBox</tabstop>
+  <tabstop>pushButton_remove</tabstop>
+  <tabstop>lineEdit_name</tabstop>
+  <tabstop>lineEdit_category</tabstop>
+  <tabstop>lineEdit_categoryNumber</tabstop>
+  <tabstop>lineEdit_styleLetter</tabstop>
+  <tabstop>lineEdit_styleGuide</tabstop>
+  <tabstop>comboBox_type</tabstop>
+  <tabstop>lineEdit_ogMin</tabstop>
+  <tabstop>lineEdit_ogMax</tabstop>
+  <tabstop>lineEdit_fgMin</tabstop>
+  <tabstop>lineEdit_fgMax</tabstop>
+  <tabstop>lineEdit_ibuMin</tabstop>
+  <tabstop>lineEdit_ibuMax</tabstop>
+  <tabstop>lineEdit_colorMin</tabstop>
+  <tabstop>lineEdit_colorMax</tabstop>
+  <tabstop>lineEdit_carbMin</tabstop>
+  <tabstop>lineEdit_carbMax</tabstop>
+  <tabstop>lineEdit_abvMin</tabstop>
+  <tabstop>lineEdit_abvMax</tabstop>
+  <tabstop>pushButton_new</tabstop>
+  <tabstop>pushButton_save</tabstop>
+  <tabstop>pushButton_cancel</tabstop>
+  <tabstop>textEdit_profile</tabstop>
+  <tabstop>textEdit_ingredients</tabstop>
+  <tabstop>textEdit_examples</tabstop>
+  <tabstop>textEdit_notes</tabstop>
+ </tabstops>
  <resources>
   <include location="../brewtarget.qrc"/>
  </resources>

--- a/ui/yeastEditor.ui
+++ b/ui/yeastEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>450</width>
-    <height>407</height>
+    <width>501</width>
+    <height>307</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,442 +16,454 @@
   <property name="configSection" stdset="0">
    <string notr="true">yeastEditor</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_17">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_15">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Required Fields</string>
+    <widget class="QTabWidget" name="tabWidget_editor">
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="tab_main">
+      <attribute name="title">
+       <string>Main</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_name">
+         <property name="text">
+          <string>Name</string>
          </property>
-         <property name="configSection" stdset="0">
-          <string notr="true">yeastEditor</string>
+         <property name="buddy">
+          <cstring>lineEdit_name</cstring>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>2</number>
-          </property>
-          <property name="topMargin">
-           <number>2</number>
-          </property>
-          <property name="rightMargin">
-           <number>2</number>
-          </property>
-          <property name="bottomMargin">
-           <number>2</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QLabel" name="label_name">
-              <property name="text">
-               <string>Name</string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_name</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="lineEdit_name">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Name</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="QLabel" name="label_type">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Type</string>
-              </property>
-              <property name="buddy">
-               <cstring>comboBox_type</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="comboBox_type">
-              <property name="toolTip">
-               <string>Type</string>
-              </property>
-              <item>
-               <property name="text">
-                <string>Ale</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Lager</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Wheat</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Wine</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Champagne</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLabel" name="label_form">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Form</string>
-              </property>
-              <property name="buddy">
-               <cstring>comboBox_form</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="comboBox_form">
-              <property name="toolTip">
-               <string>Form</string>
-              </property>
-              <item>
-               <property name="text">
-                <string>Liquid</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Dry</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Slant</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Culture</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="BtMixedLabel" name="label_amount">
-              <property name="contextMenuPolicy">
-               <enum>Qt::CustomContextMenu</enum>
-              </property>
-              <property name="text">
-               <string>Default Amount</string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_amount</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="BtMixedEdit" name="lineEdit_amount">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Amount</string>
-              </property>
-              <property name="editField" stdset="0">
-               <string notr="true">amount</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
-             <widget class="QLabel" name="label_amountIsWeight">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Check it if the amount given is in kg instead of L.</string>
-              </property>
-              <property name="text">
-               <string>Amount is weight?</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="checkBox_amountIsWeight">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Checked if the given amount is weight instead of volume</string>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer_3">
+       <item row="3" column="1">
+        <widget class="BtStringEdit" name="lineEdit_laboratory">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Lab</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_lab">
+         <property name="text">
+          <string>Lab</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_laboratory</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_form">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Form</string>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_form</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="BtStringEdit" name="lineEdit_inventory">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Quanta in inventory</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QLabel" name="label_inventory">
+         <property name="text">
+          <string>Quanta in Inventory</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_inventory</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="comboBox_type">
+         <property name="toolTip">
+          <string>Type</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Ale</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Lager</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Wheat</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Wine</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Champagne</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_type">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Type</string>
+         </property>
+         <property name="buddy">
+          <cstring>comboBox_type</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="BtStringEdit" name="lineEdit_name">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="comboBox_form">
+         <property name="toolTip">
+          <string>Form</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Liquid</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Dry</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Slant</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Culture</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Preferred</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>13</height>
+           <height>40</height>
           </size>
          </property>
         </spacer>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_16">
-         <item>
-          <widget class="QLabel" name="label_inventory">
-           <property name="text">
-            <string>Quanta in Inventory</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_inventory</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="lineEdit_inventory">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Quanta in inventory</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_productID">
+         <property name="text">
+          <string>Product ID</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_productID</cstring>
+         </property>
+        </widget>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_7">
-         <item>
-          <widget class="QLabel" name="label_lab">
-           <property name="text">
-            <string>Lab</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_laboratory</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="lineEdit_laboratory">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Lab</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="4" column="1">
+        <widget class="BtStringEdit" name="lineEdit_productID">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Product ID</string>
+         </property>
+        </widget>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <item>
-          <widget class="QLabel" name="label_productID">
-           <property name="text">
-            <string>Product ID</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_productID</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="lineEdit_productID">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Product ID</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="0" column="2">
+        <widget class="QLabel" name="label_amountIsWeight">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Check it if the amount given is in kg instead of L.</string>
+         </property>
+         <property name="text">
+          <string>Amount is weight?</string>
+         </property>
+        </widget>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
-         <item>
-          <widget class="BtTemperatureLabel" name="label_minTemperature">
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="text">
-            <string>Min Temp</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_minTemperature</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtTemperatureEdit" name="lineEdit_minTemperature">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Min temp</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">minTemperature_c</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="0" column="3">
+        <widget class="QCheckBox" name="checkBox_amountIsWeight">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Checked if the given amount is weight instead of volume</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_9">
-         <item>
-          <widget class="BtTemperatureLabel" name="label_maxTemperature">
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="text">
-            <string>Max Temp</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_maxTemperature</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtTemperatureEdit" name="lineEdit_maxTemperature">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Max temp</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">maxTemperature_c</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="1" column="2">
+        <widget class="BtMixedLabel" name="label_amount">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Default Amount</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_amount</cstring>
+         </property>
+        </widget>
        </item>
-       <item>
+       <item row="1" column="3">
+        <widget class="BtMixedEdit" name="lineEdit_amount">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Amount</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">amount</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_extra">
+      <attribute name="title">
+       <string>Extras</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="8" column="3">
+        <widget class="QCheckBox" name="checkBox_addToSecondary">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Checked means add this yeast to secondary instead of primary</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="5">
+        <widget class="QComboBox" name="comboBox_flocculation">
+         <property name="toolTip">
+          <string>Flocculation</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Low</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Medium</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>High</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Very High</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_attenuation">
+         <property name="text">
+          <string>Attenuation (%)</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_attenuation</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="4">
+        <widget class="QLabel" name="label_flocculation">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Flocculation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="3">
+        <widget class="BtTemperatureEdit" name="lineEdit_minTemperature">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Min temp</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">minTemperature_c</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="BtGenericEdit" name="lineEdit_attenuation">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Apparent attenuation as percentage of OG points</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">attenuation_pct</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="BtTemperatureLabel" name="label_minTemperature">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Min Temp</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_minTemperature</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="3">
+        <widget class="QLabel" name="label_addToSecondary">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Add to Secondary</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="3">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -464,249 +476,179 @@
          </property>
         </spacer>
        </item>
+       <item row="6" column="0">
+        <widget class="BtTemperatureLabel" name="label_maxTemperature">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="text">
+          <string>Max Temp</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_maxTemperature</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="3">
+        <widget class="BtTemperatureEdit" name="lineEdit_maxTemperature">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Max temp</string>
+         </property>
+         <property name="editField" stdset="0">
+          <string notr="true">maxTemperature_c</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="4">
+        <widget class="QLabel" name="label_timesCultured">
+         <property name="text">
+          <string>Times Recultured</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_timesCultured</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="5">
+        <widget class="BtStringEdit" name="lineEdit_timesCultured">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Times this yeast has been recultured</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="4">
+        <widget class="QLabel" name="label_maxReuse">
+         <property name="text">
+          <string>Max Recultures</string>
+         </property>
+         <property name="buddy">
+          <cstring>lineEdit_maxReuse</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="5">
+        <widget class="BtStringEdit" name="lineEdit_maxReuse">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Max recultures</string>
+         </property>
+        </widget>
+       </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="tab_bestfor">
+      <attribute name="title">
+       <string>Best For</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QTextEdit" name="textEdit_bestFor"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_notes">
+      <attribute name="title">
+       <string>Notes</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QTextEdit" name="textEdit_notes"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="spacing">
-        <number>0</number>
+      <widget class="QPushButton" name="pushButton_new">
+       <property name="toolTip">
+        <string>New yeast</string>
        </property>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_10">
-         <item>
-          <widget class="QLabel" name="label_flocculation">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Flocculation</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="comboBox_flocculation">
-           <property name="toolTip">
-            <string>Flocculation</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>Low</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Medium</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>High</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Very High</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_11">
-         <item>
-          <widget class="QLabel" name="label_attenuation">
-           <property name="text">
-            <string>Attenuation (%)</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_attenuation</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BtGenericEdit" name="lineEdit_attenuation">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Apparent attenuation as percentage of OG points</string>
-           </property>
-           <property name="editField" stdset="0">
-            <string notr="true">attenuation_pct</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_12">
-         <item>
-          <widget class="QLabel" name="label_timesCultured">
-           <property name="text">
-            <string>Times Recultured</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_timesCultured</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="lineEdit_timesCultured">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Times this yeast has been recultured</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_13">
-         <item>
-          <widget class="QLabel" name="label_maxReuse">
-           <property name="text">
-            <string>Max Recultures</string>
-           </property>
-           <property name="buddy">
-            <cstring>lineEdit_maxReuse</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="lineEdit_maxReuse">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Max recultures</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_14">
-         <item>
-          <widget class="QLabel" name="label_addToSecondary">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Add to Secondary</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="checkBox_addToSecondary">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Checked means add this yeast to secondary instead of primary</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_bestFor">
-         <property name="text">
-          <string>Best For:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTextEdit" name="textEdit_bestFor">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1000</width>
-           <height>1000</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_notes">
-         <property name="text">
-          <string>Notes:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTextEdit" name="textEdit_notes">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1000</width>
-           <height>1000</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QDialogButtonBox" name="buttonBox">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="standardButtons">
-          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/smallPlus.svg</normaloff>:/images/smallPlus.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_save">
+       <property name="toolTip">
+        <string>Save and close</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/filesave.svg</normaloff>:/images/filesave.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_cancel">
+       <property name="toolTip">
+        <string>Discard and close</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../brewtarget.qrc">
+         <normaloff>:/images/exit.svg</normaloff>:/images/exit.svg</iconset>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -751,41 +693,39 @@
     <slot>setIsWeight(bool)</slot>
    </slots>
   </customwidget>
+  <customwidget>
+   <class>BtStringEdit</class>
+   <extends>QLineEdit</extends>
+   <header>BtLineEdit.h</header>
+  </customwidget>
  </customwidgets>
- <resources/>
+ <tabstops>
+  <tabstop>tabWidget_editor</tabstop>
+  <tabstop>lineEdit_name</tabstop>
+  <tabstop>comboBox_type</tabstop>
+  <tabstop>comboBox_form</tabstop>
+  <tabstop>lineEdit_laboratory</tabstop>
+  <tabstop>lineEdit_productID</tabstop>
+  <tabstop>checkBox_amountIsWeight</tabstop>
+  <tabstop>lineEdit_amount</tabstop>
+  <tabstop>lineEdit_inventory</tabstop>
+  <tabstop>lineEdit_attenuation</tabstop>
+  <tabstop>lineEdit_minTemperature</tabstop>
+  <tabstop>lineEdit_maxTemperature</tabstop>
+  <tabstop>comboBox_flocculation</tabstop>
+  <tabstop>lineEdit_maxReuse</tabstop>
+  <tabstop>lineEdit_timesCultured</tabstop>
+  <tabstop>checkBox_addToSecondary</tabstop>
+  <tabstop>pushButton_new</tabstop>
+  <tabstop>pushButton_save</tabstop>
+  <tabstop>pushButton_cancel</tabstop>
+  <tabstop>textEdit_bestFor</tabstop>
+  <tabstop>textEdit_notes</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../brewtarget.qrc"/>
+ </resources>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>yeastEditor</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>yeastEditor</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>label_amount</sender>
    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>


### PR DESCRIPTION
This touches a few files, but it fairly simple to explain.

The core of it was that the high DPI work was not recalculating the size of the edit field. This works in most places, as we have 3 - 5 digits, a decimal place and then 3 digits. I simply caused the size to be recalculated on a BtStringEdit when new data was added. To keep this within reason, I decided that we would draw nothing less than 8 characters (unicode) and nothing more than 50.

When I went to fix the various editors, things broke. The hop editor, in particular, kept getting resized and looked awful. 

All the editors are now tabbed forms. I've tried to move what I consider important to the main page, while leaving the rest to the back pages. Depending on what you like, this will either be an improvement or absolutely horrible.

Test this one carefully. It won't impact your database, but make sure the tabbed editors work. If they don't, we can discuss what would work.