### PR TITLE
My half to close #576 - beer xml imports don't seem to be working

### DIFF
--- a/src/beerxml.cpp
+++ b/src/beerxml.cpp
@@ -317,7 +317,7 @@ namespace {
       {"Infusion",     MashStep::Infusion},
       {"Temperature",  MashStep::Temperature},
       {"Decoction",    MashStep::Decoction}
-      // Inside Brewken we also have MashStep::flySparge and MashStep::batchSparge which are not mentioned in the
+      // we also have MashStep::flySparge and MashStep::batchSparge which are not mentioned in the
       // BeerXML 1.0 Standard.  They get treated as "Infusion" when we write to BeerXML
    };
    XmlRecord::FieldDefinitions const BEER_XML_MASH_STEP_RECORD_FIELDS {
@@ -333,7 +333,7 @@ namespace {
       {XmlRecord::String,  "DESCRIPTION",        nullptr,                                    nullptr}, // Extension tag
       {XmlRecord::String,  "WATER_GRAIN_RATIO",  nullptr,                                    nullptr}, // Extension tag
       {XmlRecord::String,  "DECOCTION_AMT",      nullptr,                                    nullptr}, // Extension tag
-      {XmlRecord::String,  "INFUSE_TEMP",        nullptr,                                    nullptr}, // Extension tag
+      {XmlRecord::String,  "INFUSE_TEMP",        PropertyNames::MashStep::infuseTemp_c,      nullptr}, // Extension tag
       {XmlRecord::String,  "DISPLAY_STEP_TEMP",  nullptr,                                    nullptr}, // Extension tag
       {XmlRecord::String,  "DISPLAY_INFUSE_AMT", nullptr,                                    nullptr}, // Extension tag
       {XmlRecord::Double,  "DECOCTION_AMOUNT",   PropertyNames::MashStep::decoctionAmount_l, nullptr}  // Non-standard tag, not part of BeerXML 1.0 standard
@@ -723,10 +723,11 @@ void BeerXML::toXml( BrewNote* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -749,10 +750,11 @@ void BeerXML::toXml( Equipment* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -775,10 +777,11 @@ void BeerXML::toXml( Fermentable* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -803,10 +806,11 @@ void BeerXML::toXml( Hop* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -831,10 +835,11 @@ void BeerXML::toXml( Instruction* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -860,10 +865,11 @@ void BeerXML::toXml( Mash* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -895,21 +901,17 @@ void BeerXML::toXml( MashStep* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          QString val;
          // flySparge and batchSparge aren't part of the BeerXML spec.
-         // This makes sure we give BeerXML something it understands.
+         // prop makes sure we give BeerXML something it understands.
          if ( element == PropertyNames::MashStep::type ) {
-            if ( (a->type() == MashStep::flySparge) || (a->type() == MashStep::batchSparge ) ) {
-               val = MashStep::types[0];
-            }
-            else {
-               val = a->typeString();
-            }
+            val = a->isSparge() ? MashStep::types[0] : a->typeString();
          }
          else {
-            val = textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element));
+            val = textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element));
          }
          tmpElement = doc.createElement(tbl->propertyToXml(element));
          tmpText    = doc.createTextNode(val);
@@ -936,10 +938,11 @@ void BeerXML::toXml( Misc* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -963,10 +966,11 @@ void BeerXML::toXml( Recipe* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -1043,10 +1047,11 @@ void BeerXML::toXml( Style* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -1069,10 +1074,11 @@ void BeerXML::toXml( Water* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }
@@ -1096,10 +1102,11 @@ void BeerXML::toXml( Yeast* a, QDomDocument& doc, QDomNode& parent )
    tmpElement.appendChild(tmpText);
    node.appendChild(tmpElement);
 
-   foreach (QString element, tbl->allPropertyNames()) {
+   foreach (QString element, tbl->allProperties()) {
       if ( ! tbl->propertyToXml(element).isEmpty() ) {
+         QString prop = tbl->propertyName(element);
          tmpElement = doc.createElement(tbl->propertyToXml(element));
-         tmpText    = doc.createTextNode(textFromValue(a->property(element.toUtf8().data()), tbl->propertyColumnType(element)));
+         tmpText    = doc.createTextNode(textFromValue(a->property(prop.toUtf8().data()), tbl->propertyColumnType(element)));
          tmpElement.appendChild(tmpText);
          node.appendChild(tmpElement);
       }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -2012,7 +2012,7 @@ int Database::insertElement(NamedEntity * ins)
 
    TableSchema* schema = dbDefn->table(ins->table());
    QString insertQ = schema->generateInsertProperties(Brewtarget::dbType());
-   QStringList allProps = schema->allPropertyNames(Brewtarget::dbType());
+   QStringList allProps = schema->allProperties();
 
    qDebug() << Q_FUNC_INFO << "SQL:" << insertQ;
    q.prepare(insertQ);
@@ -2020,7 +2020,9 @@ int Database::insertElement(NamedEntity * ins)
    QString sqlParameters;
    QTextStream sqlParametersConcat(&sqlParameters);
    foreach (QString prop, allProps) {
-      QVariant val_to_ins = ins->property(prop.toUtf8().data());
+      QString pname = schema->propertyName(prop);
+      QVariant val_to_ins = ins->property(pname.toUtf8().data());
+
       if ( ins->table() == Brewtarget::BREWNOTETABLE && prop == PropertyNames::BrewNote::brewDate ) {
          val_to_ins = val_to_ins.toString();
       }
@@ -2683,7 +2685,7 @@ void Database::updateEntry( NamedEntity* object, QString propName, QVariant valu
       qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
       if ( transact )
          sqlDatabase().rollback();
-      throw;
+      abort();
    }
 
    if ( transact )
@@ -2748,44 +2750,51 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table)
       QString queryString = QString("SELECT DISTINCT %1 FROM %2")
             .arg(tbl->propertyToColumn(PropertyNames::NamedEntity::name)).arg(tbl->tableName());
 
+      qDebug() << Q_FUNC_INFO << "DISTINCT:" << queryString;
       QSqlQuery nameq( queryString, sqlDatabase() );
 
-      if ( ! nameq.isActive() )
+      if ( ! nameq.exec() ) {
          throw QString("%1 %2").arg(nameq.lastQuery()).arg(nameq.lastError().text());
+      }
 
       while (nameq.next()) {
          QString name = nameq.record().value(0).toString();
-         queryString = QString( "SELECT %1 FROM %2 WHERE ( %3=:name AND %4=:boolean ) ORDER BY %1 ASC LIMIT 1")
+         // select id from [tablename] where ( name = :name and display = :boolean ) order by id asc
+         queryString = QString( "SELECT %1 FROM %2 WHERE ( %3=:name AND %4=:boolean ) ORDER BY %1")
                      .arg(tbl->keyName())
                      .arg(tbl->tableName())
                      .arg(tbl->propertyToColumn(PropertyNames::NamedEntity::name))
                      .arg(tbl->propertyToColumn(PropertyNames::NamedEntity::display));
          QSqlQuery query( sqlDatabase() );
+         qDebug() << Q_FUNC_INFO << "FIND:" << queryString;
 
+         // find the first element with display set true (assumed parent)
          query.prepare(queryString);
          query.bindValue(":name", name);
          query.bindValue(":boolean",Brewtarget::dbTrue());
-         query.exec();
-
-         if ( !query.isActive() )
+         
+         if ( !query.exec() ) {
             throw QString("%1 %2").arg(query.lastQuery()).arg(query.lastError().text());
+         }
 
          query.first();
          QString parentID = query.record().value(tbl->keyName()).toString();
 
+         // find the every element with display set false (assumed children)
          query.bindValue(":name", name);
          query.bindValue(":boolean", Brewtarget::dbFalse());
-         query.exec();
 
-         if ( !query.isActive() )
+         if ( !query.exec() ) {
             throw QString("%1 %2").arg(query.lastQuery()).arg(query.lastError().text());
+         }
+
          // Postgres uses a more verbose upsert syntax. I don't like this, but
          // I'm not seeing a better way yet.
          while (query.next()) {
             QString childID = query.record().value(tbl->keyName()).toString();
             switch( Brewtarget::dbType() ) {
                case Brewtarget::PGSQL:
-                //  INSERT INTO %1 (parent_id, child_id) VALUES (%2, %3) ON CONFLICT(child_id) DO UPDATE set parent_id = EXCLUDED.parent_id
+                //  INSERT INTO [child table] (parent_id, child_id) VALUES (:parentid, child_id) ON CONFLICT(child_id) DO UPDATE set parent_id = EXCLUDED.parent_id
                   queryString = QString("INSERT INTO %1 (%2, %3) VALUES (%4, %5) ON CONFLICT(%3) DO UPDATE set %2 = EXCLUDED.%2")
                         .arg(dbDefn->childTableName((table)))
                         .arg(cld->parentIndexName())
@@ -2794,6 +2803,7 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table)
                         .arg(childID);
                   break;
                default:
+                  // insert or replace into [child table] (parent_id, child_id) values (:parentid,:childid)
                   queryString = QString("INSERT OR REPLACE INTO %1 (%2, %3) VALUES (%4, %5)")
                               .arg(dbDefn->childTableName(table))
                               .arg(cld->parentIndexName())
@@ -2801,15 +2811,17 @@ void Database::populateChildTablesByName(Brewtarget::DBTable table)
                               .arg(parentID)
                               .arg(childID);
             }
+            qDebug() << Q_FUNC_INFO << "UPSERT:" << queryString;
             QSqlQuery insertq( queryString, sqlDatabase() );
-            if ( !insertq.isActive() )
+            if ( !insertq.exec() ) {
                throw QString("%1 %2").arg(insertq.lastQuery()).arg(insertq.lastError().text());
+            }
          }
       }
    }
    catch (QString e) {
       qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
-      throw QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
+      abort();
    }
 }
 
@@ -3543,6 +3555,7 @@ bool Database::updateSchema(bool* err)
          throw QString("%1 %2").arg(popchildq.lastQuery()).arg(popchildq.lastError().text());
 
       if(repopChild == 1) {
+         qDebug() << Q_FUNC_INFO << "calling populateChildTablesByName()";
          populateChildTablesByName();
 
          QSqlQuery popchildq( "UPDATE settings SET repopulateChildrenOnNextStart = 0", sqlDatabase() );
@@ -3963,12 +3976,17 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
       bool mustPrepare = true;
       int maxid = -1;
 
-      QString findAllQuery = QString("SELECT * FROM %1 order by %2 asc").arg(tname).arg(table->keyName(oldType));
+      // select * from [table] order by id asc
+      QString findAllQuery = QString("SELECT * FROM %1 order by %2 asc")
+                                 .arg(tname)
+                                 .arg(table->keyName(oldType)); // make sure we specify the right db type
+      qDebug() << Q_FUNC_INFO << "FIND ALL:" << findAllQuery;
       try {
-         if (! readOld.exec(findAllQuery) )
+         if (! readOld.exec(findAllQuery) ) {
             throw QString("Could not execute %1 : %2")
                .arg(readOld.lastQuery())
                .arg(readOld.lastError().text());
+         }
 
          newDb.transaction();
 
@@ -3997,6 +4015,7 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
                mustPrepare = false;
             }
 
+            qDebug() << Q_FUNC_INFO << "INSERT:" << upsertQuery;
             // All that's left is to bind
             for(int i = 0; i < here.count(); ++i) {
                if ( table->dbTable() == Brewtarget::BREWNOTETABLE
@@ -4010,10 +4029,11 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
                }
             }
             // and execute
-            if ( ! upsertNew.exec() )
+            if ( ! upsertNew.exec() ) {
                throw QString("Could not insert new row %1 : %2")
                   .arg(upsertNew.lastQuery())
                   .arg(upsertNew.lastError().text());
+            }
          }
          // We need to create the increment and decrement things for the
          // instructions_in_recipe table. This seems a little weird to do this
@@ -4026,12 +4046,14 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
                qCritical() << QString("No increment triggers found for %1").arg(table->tableName());
             }
             else {
+               qDebug() << "INC TRIGGER:" << trigger;
                upsertNew.exec(trigger);
                trigger =  table->generateDecrementTrigger(newType);
                if ( trigger.isEmpty() ) {
                   qCritical() << QString("No decrement triggers found for %1").arg(table->tableName());
                }
                else {
+                  qDebug() << "DEC TRIGGER:" << trigger;
                   if ( ! upsertNew.exec(trigger) ) {
                      throw QString("Could not insert new row %1 : %2")
                         .arg(upsertNew.lastQuery())
@@ -4040,12 +4062,14 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
                }
             }
          }
-         // We need to manually reset the sequences
+         // We need to manually reset the sequences in postgresql
          if ( newType == Brewtarget::PGSQL ) {
              // this probably should be fixed somewhere, but this is enough for now?
-            //
-            QString seq = QString("SELECT setval('%1_%2_seq',(SELECT MAX(id) FROM %1))").arg(table->tableName()).arg(table->keyName());
-
+             // SELECT setval(hop_id_seq,(SELECT MAX(id) from hop))
+            QString seq = QString("SELECT setval('%1_%2_seq',(SELECT MAX(%2) FROM %1))")
+                                          .arg(table->tableName())
+                                          .arg(table->keyName());
+            qDebug() << "SEQ reset: " << seq;
             if ( ! upsertNew.exec(seq) )
                throw QString("Could not reset the sequences: %1 %2")
                   .arg(seq).arg(upsertNew.lastError().text());
@@ -4054,7 +4078,7 @@ void Database::copyDatabase( Brewtarget::DBTypes oldType, Brewtarget::DBTypes ne
       catch (QString e) {
          qCritical() << QString("%1 %2").arg(Q_FUNC_INFO).arg(e);
          newDb.rollback();
-         throw;
+         abort();
       }
 
       newDb.commit();

--- a/src/xml/XmlNamedEntityRecord.h
+++ b/src/xml/XmlNamedEntityRecord.h
@@ -151,11 +151,13 @@ private:
 
 // Specialisations for cases where duplicates are allowed
 template<> inline bool XmlNamedEntityRecord<Instruction>::isDuplicate() { return false; }
+template<> inline bool XmlNamedEntityRecord<Mash>::isDuplicate() { return false; }
 template<> inline bool XmlNamedEntityRecord<MashStep>::isDuplicate() { return false; }
 template<> inline bool XmlNamedEntityRecord<BrewNote>::isDuplicate() { return false; }
 
 // Specialisations for cases where name is not required to be unique
 template<> inline void XmlNamedEntityRecord<Instruction>::normaliseName() { return; }
+template<> inline void XmlNamedEntityRecord<Mash>::normaliseName() { return; }
 template<> inline void XmlNamedEntityRecord<MashStep>::normaliseName() { return; }
 template<> inline void XmlNamedEntityRecord<BrewNote>::normaliseName() { return; }
 


### PR DESCRIPTION
The first issue is anything using allPropertyNames is probably doing it wrong. Whenever we are storing a type string in the database, there is a difference in the property names of the objects (which is how we key the m_properties hash) and the name of the property we store in the
database. This causes many problems and we should fix it some day. Until then, we should always use allProperties() to loop, and request the propertyName().

The second issue was a missing property in the XMLRecord::FieldDefinitions for BEER_XML_MASH_STEP_RECORD_FIELDS. Since we didn't map the infusion temps to a property, they never got read.

The final issue was that we were treating mashes has having to be unique. They do not, and enforcing it caused problems when importing two recipes, each with an unnamed mash.