### PR TITLE
More XML import fixes

### DIFF
--- a/src/beerxml.cpp
+++ b/src/beerxml.cpp
@@ -317,7 +317,7 @@ namespace {
       {"Infusion",     MashStep::Infusion},
       {"Temperature",  MashStep::Temperature},
       {"Decoction",    MashStep::Decoction}
-      // Inside Brewken we also have MashStep::flySparge and MashStep::batchSparge which are not mentioned in the
+      // Inside Brewtarget we also have MashStep::flySparge and MashStep::batchSparge which are not mentioned in the
       // BeerXML 1.0 Standard.  They get treated as "Infusion" when we write to BeerXML
    };
    XmlRecord::FieldDefinitions const BEER_XML_MASH_STEP_RECORD_FIELDS {
@@ -440,7 +440,7 @@ namespace {
       {XmlRecord::Double,  "PROJECTED_MASH_FIN_TEMP", PropertyNames::BrewNote::projMashFinTemp_c,    nullptr},
       {XmlRecord::Double,  "PROJECTED_OG",            PropertyNames::BrewNote::projOg,               nullptr},
       {XmlRecord::Double,  "PROJECTED_VOL_INTO_FERM", PropertyNames::BrewNote::projVolIntoFerm_l,    nullptr},
-      {XmlRecord::Double,  "FG",                      PropertyNames::BrewNote::projFg,               nullptr},
+      {XmlRecord::Double,  "PROJECTED_FG",            PropertyNames::BrewNote::projFg,               nullptr},
       {XmlRecord::Double,  "PROJECTED_EFF",           PropertyNames::BrewNote::projEff_pct,          nullptr},
       {XmlRecord::Double,  "PROJECTED_ABV",           PropertyNames::BrewNote::projABV_pct,          nullptr},
       {XmlRecord::Double,  "PROJECTED_POINTS",        PropertyNames::BrewNote::projPoints,           nullptr},

--- a/src/beerxml.cpp
+++ b/src/beerxml.cpp
@@ -333,7 +333,7 @@ namespace {
       {XmlRecord::String,  "DESCRIPTION",        nullptr,                                    nullptr}, // Extension tag
       {XmlRecord::String,  "WATER_GRAIN_RATIO",  nullptr,                                    nullptr}, // Extension tag
       {XmlRecord::String,  "DECOCTION_AMT",      nullptr,                                    nullptr}, // Extension tag
-      {XmlRecord::String,  "INFUSE_TEMP",        nullptr,                                    nullptr}, // Extension tag
+      {XmlRecord::String,  "INFUSE_TEMP",        PropertyNames::MashStep::infuseTemp_c,      nullptr}, // Extension tag
       {XmlRecord::String,  "DISPLAY_STEP_TEMP",  nullptr,                                    nullptr}, // Extension tag
       {XmlRecord::String,  "DISPLAY_INFUSE_AMT", nullptr,                                    nullptr}, // Extension tag
       {XmlRecord::Double,  "DECOCTION_AMOUNT",   PropertyNames::MashStep::decoctionAmount_l, nullptr}  // Non-standard tag, not part of BeerXML 1.0 standard

--- a/src/database.h
+++ b/src/database.h
@@ -377,7 +377,11 @@ public:
          emit deletedSignal(ing);
    }
 
-   //! Get the recipe that this \b note is part of.
+   //! Get the recipe that this \b ing is part of.
+   Recipe* getParentRecipe(NamedEntity const * ing);
+
+   //! Get the recipe that this \b note is part of.  (BrewNotes are stored differently so we need a different function
+   //  for them.)
    Recipe* getParentRecipe( BrewNote const* note );
 
    //! Interchange the step orders of the two steps. Must be in same mash.


### PR DESCRIPTION
This is primarily improving the logic for how we decide whether to make a copy of whatever we're trying to add to a Recipe (Hop, Fermentable, etc).  Both the XML import and the undo/redo functionality benefit from having the Recipe object itself work out what the right thing to do is in such circumstances.