### PR TITLE
Drag/drop integrated with undo

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1435,7 +1435,13 @@ void MainWindow::droppedRecipeFermentable(QList<Fermentable*>ferms)
 
    if ( tabWidget_ingredients->currentWidget() != fermentableTab )
       tabWidget_ingredients->setCurrentWidget(fermentableTab);
-   Database::instance().addToRecipe(recipeObs, ferms);
+   this->doOrRedoUpdate(
+      newUndoableAddOrRemove(*this->recipeObs,
+                             &Recipe::add<Fermentable>,
+                             ferms,
+                             &Recipe::remove<Fermentable>,
+                             tr("Drop fermentables on a recipe"))
+   );
 }
 
 void MainWindow::droppedRecipeHop(QList<Hop*>hops)
@@ -1445,7 +1451,13 @@ void MainWindow::droppedRecipeHop(QList<Hop*>hops)
 
    if ( tabWidget_ingredients->currentWidget() != hopsTab )
       tabWidget_ingredients->setCurrentWidget(hopsTab);
-   Database::instance().addToRecipe(recipeObs, hops);
+   this->doOrRedoUpdate(
+      newUndoableAddOrRemove(*this->recipeObs,
+                             &Recipe::add<Hop>,
+                             hops,
+                             &Recipe::remove<Hop>,
+                             tr("Drop hops on a recipe"))
+   );
 }
 
 void MainWindow::droppedRecipeMisc(QList<Misc*>miscs)
@@ -1455,7 +1467,13 @@ void MainWindow::droppedRecipeMisc(QList<Misc*>miscs)
 
    if ( tabWidget_ingredients->currentWidget() != miscTab )
       tabWidget_ingredients->setCurrentWidget(miscTab);
-   Database::instance().addToRecipe(recipeObs, miscs);
+   this->doOrRedoUpdate(
+      newUndoableAddOrRemove(*this->recipeObs,
+                             &Recipe::add<Misc>,
+                             miscs,
+                             &Recipe::remove<Misc>,
+                             tr("Drop misc on a recipe"))
+   );
 }
 
 void MainWindow::droppedRecipeYeast(QList<Yeast*>yeasts)
@@ -1465,7 +1483,13 @@ void MainWindow::droppedRecipeYeast(QList<Yeast*>yeasts)
 
    if ( tabWidget_ingredients->currentWidget() != yeastTab )
       tabWidget_ingredients->setCurrentWidget(yeastTab);
-   Database::instance().addToRecipe(recipeObs, yeasts);
+   this->doOrRedoUpdate(
+      newUndoableAddOrRemove(*this->recipeObs,
+                             &Recipe::add<Yeast>,
+                             yeasts,
+                             &Recipe::remove<Yeast>,
+                             tr("Drop yeast on a recipe"))
+   );
 }
 
 void MainWindow::updateRecipeBatchSize()

--- a/src/UndoableAddOrRemove.h
+++ b/src/UndoableAddOrRemove.h
@@ -57,7 +57,7 @@ public:
     */
    UndoableAddOrRemove(UU & updatee,
                        VV * (UU::*doer)(VV *),
-                       VV * whatToAddOrRemove,
+                       VV * oneToAddOrRemove,
                        VV * (UU::*undoer)(VV *),
                        void (MainWindow::*doCallback)(VV *),
                        void (MainWindow::*undoCallback)(VV *),
@@ -66,10 +66,44 @@ public:
    : QUndoCommand(parent),
      updatee(updatee),
      doer(doer),
-     whatToAddOrRemove(whatToAddOrRemove),
+     whatToAddOrRemove(oneToAddOrRemove),
      undoer(undoer),
      doCallback(doCallback),
      undoCallback(undoCallback),
+     everDone(false)
+   {
+      this->setText(description);
+      return;
+   }
+   /*!
+    * This is the list version of the previous constructor. Some actions --
+    * like dropping hops from the tree on a recipe -- work on lists  of
+    * objects. We need this constructor because casting sucks. 
+    * \param updatee See above
+    * \param doer The method on the updatee to do the addition or removal.
+    *             This should return a QList of objects that need to be passed in to the \c undoer method.
+    * \param listToAddOrRemove The list of things we're adding or removing - eg fermentables
+    * \param undoer See above
+    * \param doCallback See above
+    * \param undoCallback See above
+    * \param description See above
+    * \param parent See above
+    */
+   UndoableAddOrRemove(UU & updatee,
+                       QList<VV *> (UU::*doer)(QList<VV *>),
+                       QList<VV *> listToAddOrRemove,
+                       QList<VV *> (UU::*undoer)(QList<VV *>),
+                       void (MainWindow::*doCallback)(QList<VV *>),
+                       void (MainWindow::*undoCallback)(QList<VV *>),
+                       QString const & description,
+                       QUndoCommand * parent = nullptr)
+   : QUndoCommand(parent),
+     updatee(updatee),
+     list_doer(doer),
+     list_whatToAddOrRemove(listToAddOrRemove),
+     list_undoer(undoer),
+     list_doCallback(doCallback),
+     list_undoCallback(undoCallback),
      everDone(false)
    {
       // Parent class handles storing description and making it accessible to the undo stack etc - we just have to give
@@ -89,7 +123,8 @@ public:
    void redo()
    {
       QUndoCommand::redo();
-      this->undoOrRedo(false);
+
+      this->whatToAddOrRemove != nullptr ? this->undoOrRedo(false) : this->listUndoOrRedo(false);
       return;
    }
 
@@ -99,7 +134,7 @@ public:
    void undo()
    {
       QUndoCommand::undo();
-      this->undoOrRedo(true);
+      this->whatToAddOrRemove != nullptr ? this->undoOrRedo(true) : this->listUndoOrRedo(true);
       return;
    }
 
@@ -123,38 +158,121 @@ private:
       // will cause it to be stored in the DB with a new ID.
       //
       if (!isUndo) {
-         qDebug() << QString("%1: %2 \"%3\" for #%4").arg(Q_FUNC_INFO).arg(this->everDone ? "Redo" : "Do" ).arg(this->text()).arg(this->whatToAddOrRemove->key());
+        qDebug() << QString("%1: %2 \"%3\" for #%4")
+                        .arg(Q_FUNC_INFO)
+                        .arg(this->everDone ? "Redo" : "Do" )
+                        .arg(this->text())
+                        .arg(this->whatToAddOrRemove->key());
 
-         this->whatToAddOrRemove = (this->updatee.*(this->doer))(this->whatToAddOrRemove);
+         this->whatToAddOrRemove = (this->updatee.*(this->doer))(whatToAddOrRemove);
 
-         qDebug() << QString("%1: %2 Returned #%3").arg(Q_FUNC_INFO).arg(this->everDone ? "Redo" : "Do" ).arg(this->whatToAddOrRemove->key());
+         qDebug() << QString("%1: %2 Returned #%3")
+                        .arg(Q_FUNC_INFO)
+                        .arg(this->everDone ? "Redo" : "Do" )
+                        .arg(this->whatToAddOrRemove->key());
+
          if (this->doCallback != nullptr) {
-            (Brewtarget::mainWindow()->*(this->doCallback))(this->whatToAddOrRemove);
+            (Brewtarget::mainWindow()->*(this->doCallback))(whatToAddOrRemove);
          }
 
          // In this implementation "Do" and "Redo" are identical, but it's nonetheless useful for debugging purposes to
          // be able to distinguish the two cases.
          this->everDone = true;
       } else {
-         qDebug() << QString("%1: Undo \"%2\" for #%3").arg(Q_FUNC_INFO).arg(this->text()).arg(this->whatToAddOrRemove->key());
+         qDebug() << QString("%1: Undo \"%2\" for #%3")
+            .arg(Q_FUNC_INFO)
+            .arg(this->text())
+            .arg(this->whatToAddOrRemove->key());
 
-         this->whatToAddOrRemove = (this->updatee.*(this->undoer))(this->whatToAddOrRemove);
+         this->whatToAddOrRemove = (this->updatee.*(this->undoer))(whatToAddOrRemove);
 
-         qDebug() << QString("%1: Undo Returned #%2").arg(Q_FUNC_INFO).arg(this->whatToAddOrRemove->key());
+         qDebug() << QString("%1: Undo Returned #%2")
+                        .arg(Q_FUNC_INFO)
+                        .arg(this->whatToAddOrRemove->key());
+
          if (this->undoCallback != nullptr) {
-            (Brewtarget::mainWindow()->*(this->undoCallback))(this->whatToAddOrRemove);
+            (Brewtarget::mainWindow()->*(this->undoCallback))(whatToAddOrRemove);
          }
       }
 
       return;
    }
 
+   void listUndoOrRedo(bool const isUndo)
+   {
+      //
+      // This function works on the assumption that Add and Remove both return "what was changed".
+      //
+      // If the action is Add, and the thing we are adding is of a type that gets copied, then the doer is going to
+      // return the copy that was created and added, which is what we'll want to remove if we undo.  If we then redo
+      // with this object, it will get stored in the DB with a new ID (and the object's key will be updated
+      // accordingly).  The same object (with now modified key) is returned and it's what we'll need if we want to undo
+      // again.
+      //
+      // If the action is Remove, then we'll get back a pointer to what we removed.  When we undo, passing this to added
+      // will cause it to be stored in the DB with a new ID.
+      //
+      QList<VV*> results;
+
+      if (!isUndo) {
+         qDebug() << QString("%1: %2 \"%3\" for #%4")
+                        .arg(Q_FUNC_INFO)
+                        .arg(this->everDone ? "Redo" : "Do" )
+                        .arg(this->text())
+                        .arg(this->list_whatToAddOrRemove.size());
+
+         // results.append((this->updatee.*(this->list_doer))(list_whatToAddOrRemove));
+         this->list_whatToAddOrRemove = (this->updatee.*(this->list_doer))(list_whatToAddOrRemove);
+
+         qDebug() << QString("%1: %2 Returned #%3")
+                        .arg(Q_FUNC_INFO)
+                        .arg(this->everDone ? "Redo" : "Do" )
+                        .arg(this->list_whatToAddOrRemove.size());
+
+         if (this->doCallback != nullptr) {
+            (Brewtarget::mainWindow()->*(this->list_doCallback))(list_whatToAddOrRemove);
+         }
+
+
+         // In this implementation "Do" and "Redo" are identical, but it's nonetheless useful for debugging purposes to
+         // be able to distinguish the two cases.
+         this->everDone = true;
+      } else {
+         qDebug() << QString("%1: Undo \"%2\" for #%3")
+            .arg(Q_FUNC_INFO)
+            .arg(this->text())
+            .arg(this->list_whatToAddOrRemove.size());
+
+         // results.append((this->updatee.*(this->list_undoer))(list_whatToAddOrRemove));
+         this->list_whatToAddOrRemove = (this->updatee.*(this->list_undoer))(list_whatToAddOrRemove);
+
+         qDebug() << QString("%1: Undo Returned #%2")
+                        .arg(Q_FUNC_INFO)
+                        .arg(this->list_whatToAddOrRemove.size());
+
+         if (this->undoCallback != nullptr) {
+            (Brewtarget::mainWindow()->*(this->list_undoCallback))(list_whatToAddOrRemove);
+         }
+      }
+      this->list_whatToAddOrRemove.append(results);
+
+      return;
+   }
    UU & updatee;
+   // singletons
    VV * (UU::*doer)(VV *);
    VV * whatToAddOrRemove;
    VV * (UU::*undoer)(VV *);
    void (MainWindow::*doCallback)(VV *);
    void (MainWindow::*undoCallback)(VV *);
+
+   // lists
+   QList<VV *> (UU::*list_doer)(QList<VV *>);
+   QList<VV *> list_whatToAddOrRemove;
+   QList<VV *> (UU::*list_undoer)(QList<VV *>);
+   void (MainWindow::*list_doCallback)(QList<VV *>);
+   void (MainWindow::*list_undoCallback)(QList<VV *>);
+
    bool everDone;
 };
 
@@ -167,10 +285,28 @@ private:
  */
 template<class UU, class VV> UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemove(UU & updatee,
                                                                                   VV * (UU::*doer)(VV *),
-                                                                                  VV * whatToAddOrRemove,
+                                                                                  VV * oneToAddOrRemove,
                                                                                   VV * (UU::*undoer)(VV *),
                                                                                   void (MainWindow::*doCallback)(VV *),
                                                                                   void (MainWindow::*undoCallback)(VV *),
+                                                                                  QString const & description,
+                                                                                  QUndoCommand * parent = nullptr) {
+   return new UndoableAddOrRemove<UU, VV>(updatee,
+                                          doer,
+                                          oneToAddOrRemove,
+                                          undoer,
+                                          doCallback,
+                                          undoCallback,
+                                          description,
+                                          parent);
+}
+
+template<class UU, class VV> UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemove(UU & updatee,
+                                                                                  QList<VV *> (UU::*doer)(QList<VV *>),
+                                                                                  QList<VV *> whatToAddOrRemove,
+                                                                                  QList<VV *> (UU::*undoer)(QList<VV *>),
+                                                                                  void (MainWindow::*doCallback)(QList<VV *>),
+                                                                                  void (MainWindow::*undoCallback)(QList<VV *>),
                                                                                   QString const & description,
                                                                                   QUndoCommand * parent = nullptr) {
    return new UndoableAddOrRemove<UU, VV>(updatee,
@@ -182,7 +318,6 @@ template<class UU, class VV> UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemov
                                           description,
                                           parent);
 }
-
 /*!
  * \brief Helper function that allows UndoableAddOrRemove to be instantiated with automatic template argument deduction.
  *
@@ -190,16 +325,32 @@ template<class UU, class VV> UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemov
  */
 template<class UU, class VV> UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemove(UU & updatee,
                                                                                   VV * (UU::*doer)(VV *),
-                                                                                  VV * whatToAddOrRemove,
+                                                                                  VV * oneToAddOrRemove,
                                                                                   VV * (UU::*undoer)(VV *),
+                                                                                  QString const & description,
+                                                                                  QUndoCommand * parent = nullptr) {
+   return new UndoableAddOrRemove<UU, VV>(updatee,
+                                          doer,
+                                          oneToAddOrRemove,
+                                          undoer,
+                                          static_cast<void (MainWindow::*)(VV *)>(nullptr),
+                                          static_cast<void (MainWindow::*)(VV *)>(nullptr),
+                                          description,
+                                          parent);
+}
+
+template<class UU, class VV> UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemove(UU & updatee,
+                                                                                  QList<VV *> (UU::*doer)(QList<VV *>),
+                                                                                  QList<VV *> whatToAddOrRemove,
+                                                                                  QList<VV *> (UU::*undoer)(QList<VV *>),
                                                                                   QString const & description,
                                                                                   QUndoCommand * parent = nullptr) {
    return new UndoableAddOrRemove<UU, VV>(updatee,
                                           doer,
                                           whatToAddOrRemove,
                                           undoer,
-                                          static_cast<void (MainWindow::*)(VV *)>(nullptr),
-                                          static_cast<void (MainWindow::*)(VV *)>(nullptr),
+                                          static_cast<void (MainWindow::*)(QList<VV *>)>(nullptr),
+                                          static_cast<void (MainWindow::*)(QList<VV *>)>(nullptr),
                                           description,
                                           parent);
 }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -975,15 +975,20 @@ NamedEntity * Database::removeNamedEntityFromRecipe( Recipe* rec, NamedEntity* i
                                     .arg(ing->_key);
          qDebug() << QString("Delete From Children SQL: %1").arg(deleteFromChildren);
          if ( ! q.exec( deleteFromChildren ) ) {
+            qInfo() << Q_FUNC_INFO << q.lastQuery() << q.lastError().text();
             throw QString("failed to delete children.");
          }
       }
 
-      if ( ! q.exec(deleteFromInRecipe) )
+      if ( ! q.exec(deleteFromInRecipe) ) {
+         qInfo() << Q_FUNC_INFO << q.lastQuery() << q.lastError().text();
          throw QString("failed to delete in_recipe.");
+      }
 
-      if ( ! q.exec( deleteNamedEntity ) )
+      if ( ! q.exec( deleteNamedEntity ) ) {
+         qInfo() << Q_FUNC_INFO << q.lastQuery() << q.lastError().text();
          throw QString("failed to delete ingredient.");
+      }
 
    }
    catch ( QString e ) {
@@ -3021,10 +3026,12 @@ Fermentable * Database::addToRecipe( Recipe* rec, Fermentable* ferm, bool noCopy
    }
 }
 
-void Database::addToRecipe( Recipe* rec, QList<Fermentable*>ferms, bool transact )
+QList<Fermentable*> Database::addToRecipe( Recipe* rec, QList<Fermentable*>ferms, bool transact )
 {
+   QList<Fermentable*> rets;
+
    if ( ferms.size() == 0 )
-      return;
+      return rets;
 
    if ( transact ) {
       sqlDatabase().transaction();
@@ -3035,6 +3042,7 @@ void Database::addToRecipe( Recipe* rec, QList<Fermentable*>ferms, bool transact
       {
          Fermentable* newFerm = addNamedEntityToRecipe<Fermentable>(rec,ferm,false,&allFermentables,true,false);
          connect( newFerm, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptFermChange(QMetaProperty,QVariant)) );
+         rets.append(newFerm);
       }
    }
    catch ( QString e  ) {
@@ -3048,6 +3056,7 @@ void Database::addToRecipe( Recipe* rec, QList<Fermentable*>ferms, bool transact
       sqlDatabase().commit();
       rec->recalcAll();
    }
+   return rets;
 }
 
 Hop * Database::addToRecipe( Recipe* rec, Hop* hop, bool noCopy, bool transact )
@@ -3066,10 +3075,12 @@ Hop * Database::addToRecipe( Recipe* rec, Hop* hop, bool noCopy, bool transact )
    }
 }
 
-void Database::addToRecipe( Recipe* rec, QList<Hop*>hops, bool transact )
+QList<Hop*> Database::addToRecipe( Recipe* rec, QList<Hop*>hops, bool transact )
 {
+   QList<Hop*> rets;
+
    if ( hops.size() == 0 )
-      return;
+      return rets;
 
    if ( transact ) {
       sqlDatabase().transaction();
@@ -3079,6 +3090,7 @@ void Database::addToRecipe( Recipe* rec, QList<Hop*>hops, bool transact )
       foreach (Hop* hop, hops ) {
          Hop* newHop = addNamedEntityToRecipe<Hop>( rec, hop, false, &allHops, true, false );
          connect( newHop, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptHopChange(QMetaProperty,QVariant)));
+         rets.append(newHop);
       }
    }
    catch (QString e) {
@@ -3093,6 +3105,7 @@ void Database::addToRecipe( Recipe* rec, QList<Hop*>hops, bool transact )
       sqlDatabase().commit();
       rec->recalcIBU();
    }
+   return rets;
 }
 
 Mash * Database::addToRecipe( Recipe* rec, Mash* m, bool noCopy, bool transact )
@@ -3149,17 +3162,20 @@ Misc * Database::addToRecipe( Recipe* rec, Misc* m, bool noCopy, bool transact )
    }
 }
 
-void Database::addToRecipe( Recipe* rec, QList<Misc*>miscs, bool transact )
+QList<Misc*> Database::addToRecipe( Recipe* rec, QList<Misc*>miscs, bool transact )
 {
+
+   QList<Misc*> rets;
+
    if ( miscs.size() == 0 )
-      return;
+      return rets;
 
    if ( transact )
       sqlDatabase().transaction();
 
    try {
       foreach (Misc* misc, miscs ) {
-         addNamedEntityToRecipe( rec, misc, false, &allMiscs,true,false );
+         rets.append( addNamedEntityToRecipe( rec, misc, false, &allMiscs,true,false ) );
       }
    }
    catch (QString e) {
@@ -3173,6 +3189,7 @@ void Database::addToRecipe( Recipe* rec, QList<Misc*>miscs, bool transact )
       sqlDatabase().commit();
       rec->recalcAll();
    }
+   return rets;
 }
 
 Water * Database::addToRecipe( Recipe* rec, Water* w, bool noCopy, bool transact )
@@ -3249,10 +3266,12 @@ Yeast * Database::addToRecipe( Recipe* rec, Yeast* y, bool noCopy, bool transact
    }
 }
 
-void Database::addToRecipe( Recipe* rec, QList<Yeast*>yeasts, bool transact )
+QList<Yeast*> Database::addToRecipe( Recipe* rec, QList<Yeast*>yeasts, bool transact )
 {
+   QList<Yeast*> rets;
+
    if ( yeasts.size() == 0 )
-      return;
+      return rets;
 
    if ( transact )
       sqlDatabase().transaction();
@@ -3262,6 +3281,7 @@ void Database::addToRecipe( Recipe* rec, QList<Yeast*>yeasts, bool transact )
       {
          Yeast* newYeast = addNamedEntityToRecipe( rec, yeast, false, &allYeasts,true,false );
          connect( newYeast, SIGNAL(changed(QMetaProperty,QVariant)), rec, SLOT(acceptYeastChange(QMetaProperty,QVariant)));
+         rets.append(newYeast);
       }
    }
    catch (QString e) {
@@ -3276,6 +3296,7 @@ void Database::addToRecipe( Recipe* rec, QList<Yeast*>yeasts, bool transact )
       rec->recalcOgFg();
       rec->recalcABV_pct();
    }
+   return rets;
 }
 
 

--- a/src/database.h
+++ b/src/database.h
@@ -294,10 +294,10 @@ public:
    //void addToRecipe( Recipe* rec, Instruction* ins );
    //
    //! \brief bulk add to a recipe.
-   void addToRecipe(Recipe* rec, QList<Fermentable*> ferms, bool transact = true);
-   void addToRecipe(Recipe* rec, QList<Hop*> hops, bool transact = true);
-   void addToRecipe(Recipe* rec, QList<Misc*> miscs, bool transact = true);
-   void addToRecipe(Recipe* rec, QList<Yeast*> yeasts, bool transact = true);
+   QList<Fermentable*> addToRecipe(Recipe* rec, QList<Fermentable*> ferms, bool transact = true);
+   QList<Hop*> addToRecipe(Recipe* rec, QList<Hop*> hops, bool transact = true);
+   QList<Misc*> addToRecipe(Recipe* rec, QList<Misc*> miscs, bool transact = true);
+   QList<Yeast*> addToRecipe(Recipe* rec, QList<Yeast*> yeasts, bool transact = true);
 
    /**
    * \brief  This function is intended to be called by an ingredient that has not already cached its parent's key

--- a/src/model/Recipe.cpp
+++ b/src/model/Recipe.cpp
@@ -908,6 +908,15 @@ template<class T> T * Recipe::add(T * var) {
    // Parameter has no parent, so add a copy of it
    return Database::instance().addToRecipe(this, var, false);
 }
+
+template<class T> QList<T *> Recipe::add(QList<T *> many) {
+
+   QList<T*> added;
+
+   added = Database::instance().addToRecipe(this, many, true);
+   return added;
+}
+
 template Hop *         Recipe::add(Hop *         var);
 template Fermentable * Recipe::add(Fermentable * var);
 template Misc *        Recipe::add(Misc *        var);
@@ -915,6 +924,11 @@ template Yeast *       Recipe::add(Yeast *       var);
 template Water *       Recipe::add(Water *       var);
 template Salt *        Recipe::add(Salt *        var);
 
+// only these objects need the list version
+template QList<Hop *        > Recipe::add(QList<Hop *        > many);
+template QList<Fermentable *> Recipe::add(QList<Fermentable *> many);
+template QList<Misc *       > Recipe::add(QList<Misc *       > many);
+template QList<Yeast *      > Recipe::add(QList<Yeast *      > many);
 
 void Recipe::setStyle(Style * var)
 {
@@ -1552,6 +1566,24 @@ NamedEntity * Recipe::removeNamedEntity( NamedEntity *var )
    } else {
       return Database::instance().removeNamedEntityFromRecipe( this, var );
    }
+}
+
+QList<NamedEntity *> Recipe::removeNamedEntity( QList<NamedEntity *> many )
+{
+
+   QList<NamedEntity*> removed;
+
+   foreach( NamedEntity* victim, many ) {
+      // brewnotes a bit odd
+      if ( dynamic_cast<BrewNote*>(victim) ) {
+         // the cast is required to force the template to gets it thing right
+         Database::instance().remove(qobject_cast<BrewNote*>(victim));
+         removed.append(victim);
+      } else {
+         removed.append( Database::instance().removeNamedEntityFromRecipe( this, victim ) );
+      }
+   }
+   return removed;
 }
 
 double Recipe::batchSizeNoLosses_l()

--- a/src/model/Recipe.h
+++ b/src/model/Recipe.h
@@ -277,6 +277,22 @@ public:
       return static_cast<T *>(this->removeNamedEntity(var));
    }
 
+   template<class T> QList<T *> remove(QList<T *> many) {
+
+      QList<NamedEntity*> into;
+      QList<T*> outof;
+
+      foreach(auto i, many) {
+         into.append( static_cast<NamedEntity*>(i));
+      }
+
+      foreach(auto i, this->removeNamedEntity(into)) {
+         outof.append( static_cast<T*>(i) );
+      }
+
+      return outof;
+   }
+
    /*!
     * \brief Add a copy of \c var from the recipe and return the copy
     *
@@ -301,6 +317,7 @@ public:
     *      just one copy of them in the DB and in memory.
     */
    template<class T> T * add(T * var);
+   template<class T> QList<T *> add(QList<T *> many);
 
    void removeBrewNote(BrewNote* var);
    void removeInstruction( Instruction* ins );
@@ -543,6 +560,7 @@ private:
     * \brief Remove \c var from the recipe and return what was removed - ie \c var
     */
    NamedEntity * removeNamedEntity( NamedEntity *var);
+   QList<NamedEntity *> removeNamedEntity( QList<NamedEntity *> many);
 
    /* Recalculates all the calculated properties.
     *


### PR DESCRIPTION
The undo functionality didn't work when dropping ingredients from the trees onto the recipe. As this is my primary method of creating recipes, the undo not work was frustrating. I fixed it.

I probably did some bad things by not creating two classes, but I was afraid of creating two different undo queues. This wastes some pointers, but makes sure there is one queue.

This is my second try at this, because git and I are not friends.