### PR TITLE
Quickfix with null-check on mash when copy recipe

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -3110,6 +3110,9 @@ QList<Hop*> Database::addToRecipe( Recipe* rec, QList<Hop*>hops, bool transact )
 
 Mash * Database::addToRecipe( Recipe* rec, Mash* m, bool noCopy, bool transact )
 {
+   if ( m == nullptr )
+      return nullptr;
+
    Mash* newMash = m;
    TableSchema* tbl = dbDefn->table(Brewtarget::RECTABLE);
 


### PR DESCRIPTION
Close #589 
Null checking added to addToRecipe (mash) as new recipes do not have mashes by default the copy mechanism crashed when trying to handle a nullptr.

Quickfix waiting for a possible rework further down the road.