### PR TITLE
Partial solution to #596

### DIFF
--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -221,27 +221,48 @@ void EquipmentEditor::save()
          return;
    }
 
-   obsEquip->setName( lineEdit_name->text(), obsEquip->cacheOnly() );
+   // this is one idea for handling how clones work. It is a very brute force
+   // idea, and I am really not sold on it yet?
+   QString name           = lineEdit_name->text();
+   double boil_size       = lineEdit_boilSize->toSI();
+   double batch_size      = lineEdit_batchSize->toSI();
+   double tun_volume      = lineEdit_tunVolume->toSI();
+   double tun_weight      = lineEdit_tunWeight->toSI() ;
+   double tun_spec_heat   = lineEdit_tunSpecificHeat->toSI();
+   double boil_time       = lineEdit_boilTime->toSI();
+   double evap_rate_lhr   = lineEdit_evaporationRate->toSI();
+   double evap_rate_pct   = evap_rate_lhr/batch_size * 100.0;
+   double top_up_kettle   = lineEdit_topUpKettle->toSI();
+   double top_up_water    = lineEdit_topUpWater->toSI();
+   double trub_chill_loss = lineEdit_trubChillerLoss->toSI();
+   double lauter_deadspc  = lineEdit_lauterDeadspace->toSI();
+   double boiling_pnt     = lineEdit_boilingPoint->toSI();
+   double hop_utilization = lineEdit_hopUtilization->toSI();
+   QString notes          = textEdit_notes->toPlainText();
+   bool calc_boil_vol     = checkBox_calcBoilVolume->checkState() == Qt::Checked;
 
-   obsEquip->setBoilSize_l( lineEdit_boilSize->toSI() );
-   obsEquip->setBatchSize_l( lineEdit_batchSize->toSI() );
-   obsEquip->setTunVolume_l( lineEdit_tunVolume->toSI() );
+   obsEquip->setName( name, obsEquip->cacheOnly() );
 
-   obsEquip->setTunWeight_kg( lineEdit_tunWeight->toSI() );
+   obsEquip->setBoilSize_l(boil_size);
+   obsEquip->setBatchSize_l(batch_size);
+   obsEquip->setTunVolume_l(tun_volume);
 
-   obsEquip->setTunSpecificHeat_calGC( lineEdit_tunSpecificHeat->toSI() );
-   obsEquip->setBoilTime_min( lineEdit_boilTime->toSI());
-   obsEquip->setEvapRate_lHr(  lineEdit_evaporationRate->toSI() );
-   obsEquip->setTopUpKettle_l( lineEdit_topUpKettle->toSI() );
-   obsEquip->setTopUpWater_l(  lineEdit_topUpWater->toSI() );
-   obsEquip->setTrubChillerLoss_l( lineEdit_trubChillerLoss->toSI() );
-   obsEquip->setLauterDeadspace_l( lineEdit_lauterDeadspace->toSI() );
+   obsEquip->setTunWeight_kg(tun_weight);
+   obsEquip->setTunSpecificHeat_calGC(tun_spec_heat);
+   obsEquip->setBoilTime_min(boil_time);
+
+   obsEquip->setEvapRate_lHr(evap_rate_lhr);
+   obsEquip->setEvapRate_pctHr(evap_rate_pct);
+   obsEquip->setTopUpKettle_l(top_up_kettle);
+   obsEquip->setTopUpWater_l(top_up_water);
+   obsEquip->setTrubChillerLoss_l(trub_chill_loss);
+   obsEquip->setLauterDeadspace_l(lauter_deadspc);
    obsEquip->setGrainAbsorption_LKg( ga_LKg );
-   obsEquip->setBoilingPoint_c( lineEdit_boilingPoint->toSI() );
-   obsEquip->setHopUtilization_pct( lineEdit_hopUtilization->toSI() );
+   obsEquip->setBoilingPoint_c(boiling_pnt);
+   obsEquip->setHopUtilization_pct(hop_utilization);
 
-   obsEquip->setNotes(textEdit_notes->toPlainText());
-   obsEquip->setCalcBoilVolume(checkBox_calcBoilVolume->checkState() == Qt::Checked);
+   obsEquip->setNotes(notes);
+   obsEquip->setCalcBoilVolume(calc_boil_vol);
 
    if ( obsEquip->cacheOnly() ) {
       obsEquip->insertInDatabase();

--- a/src/database.h
+++ b/src/database.h
@@ -399,11 +399,9 @@ public:
    //! And lets not even get started on mash steps, am I right?
    Recipe* getParentRecipe( MashStep const* step );
 
-   //! These three items don't have inrec tables
-   Recipe* getParentRecipe(Equipment const* kit );
-   Recipe* getParentRecipe(Style const *style);
-   Recipe* getParentRecipe(Mash const *mash);
-   Recipe* getRecipeFromForeignKey(QString keyName, int key);
+   //! For things without in_recipe tables
+   QString findRecipeFromForeignKey(TableSchema* tbl, NamedEntity const *obj);
+   QString findRecipeFromInRec(TableSchema* tbl, TableSchema* inrec, NamedEntity const *obj);
 
    //! Interchange the step orders of the two steps. Must be in same mash.
    void swapMashStepOrder(MashStep* m1, MashStep* m2);

--- a/src/model/Equipment.cpp
+++ b/src/model/Equipment.cpp
@@ -132,14 +132,10 @@ QString Equipment::classNameStr()
 }
 
 //============================"SET" METHODS=====================================
-// The logic through here is similar to what's in Hop. When either cacheOnly
-// is true or setEasy return true (we didn't clone), then update the cached
-// value. Unfortunately, the additional signals don't allow quite the
-// compactness.
 void Equipment::setBoilSize_l( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: boil size negative: %1").arg(var);
+      qWarning() << "Equipment: boil size negative:" << var;
       return;
    }
 
@@ -149,6 +145,7 @@ void Equipment::setBoilSize_l( double var )
    else if ( setEasy(PropertyNames::Equipment::boilSize_l, var) ) {
       m_boilSize_l = var;
       emit changedBoilSize_l(var);
+      signalCacheChange(PropertyNames::Equipment::boilSize_l,var);
    }
 }
 
@@ -165,48 +162,61 @@ void Equipment::setBatchSize_l( double var )
    else if ( setEasy(PropertyNames::Equipment::batchSize_l, var) ) {
       m_batchSize_l = var;
       doCalculations();
+      signalCacheChange(PropertyNames::Equipment::batchSize_l, var);
    }
 }
 
 void Equipment::setTunVolume_l( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: tun volume negative: %1").arg(var);
+      qWarning() << "Equipment: tun volume negative:" << var;
       return;
    }
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::tunVolume_l, var) ) {
+   if ( m_cacheOnly ) {
       m_tunVolume_l = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::tunVolume_l, var) ) {
+      m_tunVolume_l = var;
+      signalCacheChange(PropertyNames::Equipment::tunVolume_l, var);
    }
 }
 
 void Equipment::setTunWeight_kg( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: tun weight negative: %1").arg(var);
+      qWarning() << "Equipment: tun weight negative:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::tunWeight_kg, var) ) {
+   if ( m_cacheOnly ) {
       m_tunWeight_kg = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::tunWeight_kg, var) ) {
+      m_tunWeight_kg = var;
+      signalCacheChange(PropertyNames::Equipment::tunWeight_kg, var);
    }
 }
 
 void Equipment::setTunSpecificHeat_calGC( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: tun sp heat negative: %1").arg(var);
+      qWarning() << "Equipment: tun sp heat negative:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::tunSpecificHeat_calGC, var) ) {
+   if ( m_cacheOnly ) {
       m_tunSpecificHeat_calGC = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::tunSpecificHeat_calGC, var) ) {
+      m_tunSpecificHeat_calGC = var;
+      signalCacheChange(PropertyNames::Equipment::tunSpecificHeat_calGC, var);
    }
 }
 
 void Equipment::setTopUpWater_l( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: top up water negative: %1").arg(var);
+      qWarning() << "Equipment: top up water negative:" << var;
       return;
    }
 
@@ -216,6 +226,7 @@ void Equipment::setTopUpWater_l( double var )
    else if ( setEasy(PropertyNames::Equipment::topUpWater_l,var) ) {
       m_topUpWater_l = var;
       doCalculations();
+      signalCacheChange(PropertyNames::Equipment::topUpWater_l,var);
    }
 }
 
@@ -237,45 +248,42 @@ void Equipment::setTrubChillerLoss_l( double var )
 
 void Equipment::setEvapRate_pctHr( double var )
 {
-   // NOTE: we never use evapRate_pctHr, but we do use evapRate_lHr. So keep them
-   // synced
+   // NOTE: evapRate_pctHr is only used in xml input/output. 
    if( var < 0.0 || var > 100.0) {
-      qWarning() << QString("Equipment: 0 < evap rate < 100: %1").arg(var);
+      qWarning() << "Equipment: 0 < evap rate < 100:" << var;
       return;
    }
 
-   if ( m_cacheOnly ||
-        setEasy(PropertyNames::Equipment::evapRate_pctHr, var) ||
-        setEasy(PropertyNames::Equipment::evapRate_lHr, var/100.0 * batchSize_l() ) ) {
+   if ( m_cacheOnly ) {
       m_evapRate_pctHr = var;
-      m_evapRate_lHr = var/100.0 * m_batchSize_l;
    }
-   // Right now, I am claiming this needs to happen regardless m_cacheOnly.
-   // I could be wrong
+   else if ( setEasy(PropertyNames::Equipment::evapRate_pctHr, var) ) {
+      m_evapRate_pctHr = var;
+      signalCacheChange(PropertyNames::Equipment::evapRate_pctHr, var);
+   }
    doCalculations();
 }
 
 void Equipment::setEvapRate_lHr( double var )
 {
-   // NOTE: We never use evapRate_pctHr, but we maintain here anyway.
    if( var < 0.0 ) {
       qWarning() << QString("Equipment: evap rate negative: %1").arg(var);
       return;
    }
-   if ( m_cacheOnly || 
-        setEasy(PropertyNames::Equipment::evapRate_lHr, var) || 
-        setEasy(PropertyNames::Equipment::evapRate_pctHr, var/batchSize_l() * 100.0)) {
+   if ( m_cacheOnly ) {
       m_evapRate_lHr = var;
-      m_evapRate_pctHr = var/batchSize_l() * 100.0;
+   }
+   else if ( setEasy(PropertyNames::Equipment::evapRate_lHr, var) ) {
+      m_evapRate_lHr = var;
+      signalCacheChange(PropertyNames::Equipment::evapRate_lHr, var);
    }
    doCalculations();
 }
 
 void Equipment::setBoilTime_min( double var )
 {
-   if( var < 0.0 )
-   {
-      qWarning() << QString("Equipment: boil time negative: %1").arg(var);
+   if( var < 0.0 ) {
+      qWarning() << "Equipment: boil time negative:" << var;
       return;
    }
 
@@ -285,6 +293,7 @@ void Equipment::setBoilTime_min( double var )
    else if ( setEasy(PropertyNames::Equipment::boilTime_min, var) ) {
       m_boilTime_min = var;
       emit changedBoilTime_min(var);
+      signalCacheChange(PropertyNames::Equipment::boilTime_min, var);
    }
    doCalculations();
 
@@ -292,8 +301,12 @@ void Equipment::setBoilTime_min( double var )
 
 void Equipment::setCalcBoilVolume( bool var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::calcBoilVolume, var) ) {
+   if ( m_cacheOnly ) {
       m_calcBoilVolume = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::calcBoilVolume, var) ) {
+      m_calcBoilVolume = var;
+      signalCacheChange(PropertyNames::Equipment::calcBoilVolume, var);
    }
 
    if ( var ) {
@@ -304,66 +317,90 @@ void Equipment::setCalcBoilVolume( bool var )
 void Equipment::setLauterDeadspace_l( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: deadspace negative: %1").arg(var);
+      qWarning() << "Equipment: deadspace negative:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::lauterDeadspace_l, var) ) {
+   if ( m_cacheOnly ) {
       m_lauterDeadspace_l = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::lauterDeadspace_l, var) ) {
+      m_lauterDeadspace_l = var;
+      signalCacheChange(PropertyNames::Equipment::lauterDeadspace_l, var);
    }
 }
 
 void Equipment::setTopUpKettle_l( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: top up kettle negative: %1").arg(var);
+      qWarning() << "Equipment: top up kettle negative:" << var;
       return;
    }
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::topUpKettle_l, var) ) {
+   if ( m_cacheOnly ) {
       m_topUpKettle_l = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::topUpKettle_l, var) ) {
+      m_topUpKettle_l = var;
+      signalCacheChange(PropertyNames::Equipment::topUpKettle_l, var);
    }
 }
 
 void Equipment::setHopUtilization_pct( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: 0 < hop utilization: %1").arg(var);
+      qWarning() << "Equipment: 0 < hop utilization:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::hopUtilization_pct, var) ) {
+   if ( m_cacheOnly ) {
       m_hopUtilization_pct = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::hopUtilization_pct, var) ) {
+      m_hopUtilization_pct = var;
+      signalCacheChange(PropertyNames::Equipment::hopUtilization_pct, var);
    }
 }
 
 void Equipment::setNotes( const QString &var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::notes, var) ) {
+   if ( m_cacheOnly ) {
       m_notes = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::notes, var) ) {
+      m_notes = var;
+      signalCacheChange(PropertyNames::Equipment::notes, var);
    }
 }
 
 void Equipment::setGrainAbsorption_LKg(double var)
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Equipment: absorption < 0: %1").arg(var);
+      qWarning() << "Equipment: absorption < 0:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::grainAbsorption_LKg, var) ) {
+   if ( m_cacheOnly ) {
       m_grainAbsorption_LKg = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::grainAbsorption_LKg, var) ) {
+      m_grainAbsorption_LKg = var;
+      signalCacheChange(PropertyNames::Equipment::grainAbsorption_LKg, var);
    }
 }
 
 void Equipment::setBoilingPoint_c(double var)
 {
    if ( var < 0.0 ) {
-      qWarning() << QString("Equipment: boiling point of water < 0: %1").arg(var);
+      qWarning() << "Equipment: boiling point of water < 0:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Equipment::boilingPoint_c, var) ) {
+   if ( m_cacheOnly ) {
       m_boilingPoint_c = var;
+   }
+   else if ( setEasy(PropertyNames::Equipment::boilingPoint_c, var) ) {
+      m_boilingPoint_c = var;
+      signalCacheChange(PropertyNames::Equipment::boilingPoint_c, var);
    }
 }
 

--- a/src/model/Fermentable.cpp
+++ b/src/model/Fermentable.cpp
@@ -271,8 +271,12 @@ bool Fermentable::isValidType( const QString& str )
 // Sets
 void Fermentable::setType( Type t )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Fermentable::type, types.at(t)) ) {
+   if ( m_cacheOnly ) {
       m_type = t;
+   }
+   else if ( setEasy(PropertyNames::Fermentable::type, types.at(t)) ) {
+      m_type = t;
+      signalCacheChange(PropertyNames::Fermentable::type, types.at(t));
    }
 }
 
@@ -288,50 +292,78 @@ void Fermentable::setAdditionTime( Fermentable::AdditionTime t )
 
 void Fermentable::setAddAfterBoil( bool b )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Fermentable::addAfterBoil, b) ) {
+   if ( m_cacheOnly ) {
       m_isAfterBoil = b;
+   }
+   else if ( setEasy(PropertyNames::Fermentable::addAfterBoil, b) ) {
+      m_isAfterBoil = b;
+      signalCacheChange(PropertyNames::Fermentable::addAfterBoil, b);
    }
 }
 
 void Fermentable::setOrigin( const QString& str )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::origin, str) ) {
+   if ( m_cacheOnly ) {
       m_origin = str;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::origin, str) ) {
+      m_origin = str;
+      signalCacheChange( PropertyNames::Fermentable::origin, str);
    }
 }
 
 void Fermentable::setSupplier( const QString& str)
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::supplier, str) ) {
+   if ( m_cacheOnly ) {
       m_supplier = str;
+   }
+   else if ( setEasy(PropertyNames::Fermentable::supplier, str) ) {
+      m_supplier = str;
+      signalCacheChange(PropertyNames::Fermentable::supplier, str);
    }
 }
 
 void Fermentable::setNotes( const QString& str )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::notes, str) ) {
+   if ( m_cacheOnly ) {
       m_notes = str;
+   }
+   else if ( setEasy(PropertyNames::Fermentable::notes, str) ) {
+      m_notes = str;
+      signalCacheChange(PropertyNames::Fermentable::notes, str);
    }
 }
 
 void Fermentable::setRecommendMash( bool b )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::recommendMash, b) ) {
+   if ( m_cacheOnly ) {
       m_recommendMash = b;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::recommendMash, b) ) {
+      m_recommendMash = b;
+      signalCacheChange( PropertyNames::Fermentable::recommendMash, b);
    }
 }
 
 void Fermentable::setIsMashed(bool var)
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::isMashed, var) ) {
+   if ( m_cacheOnly ) {
       m_isMashed = var;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::isMashed, var) ) {
+      m_isMashed = var;
+      signalCacheChange( PropertyNames::Fermentable::isMashed, var);
    }
 }
 
 void Fermentable::setIbuGalPerLb( double num )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::ibuGalPerLb, num) ) {
+   if ( m_cacheOnly ) {
       m_ibuGalPerLb = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::ibuGalPerLb, num) ) {
+      m_ibuGalPerLb = num;
+      signalCacheChange( PropertyNames::Fermentable::ibuGalPerLb, num);
    }
 }
 
@@ -349,13 +381,16 @@ double Fermentable::equivSucrose_kg() const
 void Fermentable::setAmount_kg( double num )
 {
    if( num < 0.0 ) {
-      qWarning() << QString("Fermentable: negative amount: %1").arg(num);
+      qWarning() << "Fermentable: negative amount:" << num;
       return;
    }
 
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::amount_kg, num) ) {
-      qInfo() << Q_FUNC_INFO << "updating cache:" << num;
+   if ( m_cacheOnly ) {
       m_amountKg = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::amount_kg, num) ) {
+      m_amountKg = num;
+      signalCacheChange( PropertyNames::Fermentable::amount_kg, num);
    }
 }
 
@@ -363,7 +398,7 @@ void Fermentable::setAmount_kg( double num )
 void Fermentable::setInventoryAmount( double num )
 {
    if( num < 0.0 ) {
-      qWarning() << QString("Fermentable: negative inventory: %1").arg(num);
+      qWarning() << "Fermentable: negative inventory:" << num;
       return;
    }
 
@@ -378,7 +413,7 @@ void Fermentable::setInventoryAmount( double num )
 void Fermentable::setInventoryId( int key )
 {
    if( key < 1 ) {
-      qWarning() << QString("Fermentable: bad inventory id: %1").arg(key);
+      qWarning() << "Fermentable: bad inventory id:" << key;
       return;
    }
    m_inventory_id = key;
@@ -402,84 +437,106 @@ int Fermentable::inventoryId()
 
 void Fermentable::setYield_pct( double num )
 {
-   if( num >= 0.0 && num <= 100.0 ) {
-      if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::yield_pct, num) ) {
-         m_yieldPct = num;
-      }
+   if ( num < 0.0 || num > 100.0 ) {
+      qWarning() << "Fermentable: 0 < yield < 100:" << num;
+      return;
    }
-   else {
-      qWarning() << QString("Fermentable: 0 < yield < 100: %1").arg(num);
+
+   if ( m_cacheOnly ) {
+      m_yieldPct = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::yield_pct, num) ) {
+      m_yieldPct = num;
+      signalCacheChange( PropertyNames::Fermentable::yield_pct, num);
    }
 }
 
 void Fermentable::setColor_srm( double num )
 {
    if( num < 0.0 ) {
-      qWarning() << QString("Fermentable: negative color: %1").arg(num);
+      qWarning() << "Fermentable: negative color:" << num;
       return;
    }
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::color_srm, num) ) {
+   if ( m_cacheOnly ) {
       m_colorSrm = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::color_srm, num) ) {
+      m_colorSrm = num;
+      signalCacheChange( PropertyNames::Fermentable::color_srm, num);
    }
 }
 
 void Fermentable::setCoarseFineDiff_pct( double num )
 {
-   if( num >= 0.0 && num <= 100.0 ) {
-      if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::coarseFineDiff_pct, num) ) {
-         m_coarseFineDiff = num;
-      }
+   if ( num < 0.0 || num > 100.0 ) {
+      qWarning() << "Fermentable: 0 < coarsefinediff < 100:" << num;
+      return;
    }
-   else {
-      qWarning() << QString("Fermentable: 0 < coarsefinediff < 100: %1").arg(num);
+   if ( m_cacheOnly ) {
+      m_coarseFineDiff = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::coarseFineDiff_pct, num) ) {
+      m_coarseFineDiff = num;
+      signalCacheChange( PropertyNames::Fermentable::coarseFineDiff_pct, num);
    }
 }
 
 void Fermentable::setMoisture_pct( double num )
 {
-   if( num >= 0.0 && num <= 100.0 ) {
-      if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::moisture_pct, num) ) {
-         m_moisturePct = num;
-      }
+   if ( num < 0.0 || num > 100.0 ) {
+      qWarning() << "Fermentable: 0 < moisture < 100:" << num;
+      return;
    }
-   else {
-      qWarning() << QString("Fermentable: 0 < moisture < 100: %1").arg(num);
+   if ( m_cacheOnly ) {
+      m_moisturePct = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::moisture_pct, num) ) {
+      m_moisturePct = num;
+      signalCacheChange( PropertyNames::Fermentable::moisture_pct, num);
    }
 }
 
 void Fermentable::setDiastaticPower_lintner( double num )
 {
-   if( num < 0.0 )
-   {
-      qWarning() << QString("Fermentable: negative DP: %1").arg(num);
+   if( num < 0.0 ) {
+      qWarning() << "Fermentable: negative DP:" << num;
       return;
    }
-   if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::diastaticPower_lintner, num) ) {
+   if ( m_cacheOnly ) {
       m_diastaticPower = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::diastaticPower_lintner, num) ) {
+      m_diastaticPower = num;
+      signalCacheChange( PropertyNames::Fermentable::diastaticPower_lintner, num);
    }
 }
 
 void Fermentable::setProtein_pct( double num )
 {
-   if( num >= 0.0 && num <= 100.0 ) {
-      if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::protein_pct, num) ) {
-         m_proteinPct = num;
-      }
+   if ( num < 0.0 || num > 100.0 ) {
+      qWarning() << "Fermentable: 0 < protein < 100:" << num;
+      return;
    }
-   else {
-      qWarning() << QString("Fermentable: 0 < protein < 100: %1").arg(num);
+   if ( m_cacheOnly ) {
+      m_proteinPct = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::protein_pct, num) ) {
+      m_proteinPct = num;
+      signalCacheChange( PropertyNames::Fermentable::protein_pct, num);
    }
 }
 
 void Fermentable::setMaxInBatch_pct( double num )
 {
-   if( num >= 0.0 && num <= 100.0 ) {
-      if ( m_cacheOnly || setEasy( PropertyNames::Fermentable::maxInBatch_pct, num) ) {
-         m_maxInBatchPct = num;
-      }
-   }
-   else {
+   if ( num < 0.0 || num > 100.0 ) {
       qWarning() << QString("Fermentable: 0 < maxinbatch < 100: %1").arg(num);
+   }
+   if ( m_cacheOnly ) {
+      m_maxInBatchPct = num;
+   }
+   else if ( setEasy( PropertyNames::Fermentable::maxInBatch_pct, num) ) {
+      m_maxInBatchPct = num;
+      signalCacheChange( PropertyNames::Fermentable::maxInBatch_pct, num);
    }
 }
 

--- a/src/model/Hop.cpp
+++ b/src/model/Hop.cpp
@@ -160,58 +160,48 @@ Hop::Hop( Hop & other )
 
 //============================="SET" METHODS====================================
 //
-// setEasy returns false when we clone. The logic you see repeated through
-// here is basically a short cut. If cacheOnly is true or we didn't clone,
-// then update the cached values. If cacheOnly is false and we did clone, then
-// don't update the cache because this didn't change
-// Boolean short circuit makes sure we don't call setEasy() if cacheOnly is
-// set.
 void Hop::setAlpha_pct( double num )
 {
-   if( num < 0.0 || num > 100.0 )
-   {
-      qWarning() << QString("Hop: 0 < alpha < 100: %1").arg(num);
+   if( num < 0.0 || num > 100.0 ) {
+      qWarning() << "Hop: 0 < alpha < 100:" << num;
       return;
    }
-   else
-   {
-      if ( m_cacheOnly || setEasy(PropertyNames::Hop::alpha_pct, num) ) {
-         m_alpha_pct = num;
-      }
+
+   if ( m_cacheOnly ) {
+      m_alpha_pct = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::alpha_pct, num) ) {
+      m_alpha_pct = num;
+      signalCacheChange(PropertyNames::Hop::alpha_pct, num);
    }
 }
 
 void Hop::setAmount_kg( double num )
 {
-   if( num < 0.0 )
-   {
-      qWarning() << QString("Hop: amount < 0: %1").arg(num);
+   if( num < 0.0 ) {
+      qWarning() << "Hop: amount < 0:" << num;
       return;
    }
-   else
-   {
-      if ( m_cacheOnly ) {
-         m_amount_kg = num;
-      }
-      else if ( setEasy(PropertyNames::Hop::amount_kg,num) ) {
-         m_amount_kg = num;
-      }
+
+   if ( m_cacheOnly ) {
+      m_amount_kg = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::amount_kg,num) ) {
+      m_amount_kg = num;
+      signalCacheChange(PropertyNames::Hop::amount_kg,num);
    }
 }
 
 void Hop::setInventoryAmount( double num )
 {
-   if( num < 0.0 )
-   {
-      qWarning() << QString("Hop: inventory < 0: %1").arg(num);
+   if( num < 0.0 ) {
+      qWarning() << "Hop: inventory < 0:" << num;
       return;
    }
-   else
-   {
-      m_inventory = num;
-      if ( ! m_cacheOnly ) {
-         setInventory(num,m_inventory_id);
-      }
+
+   m_inventory = num;
+   if ( ! m_cacheOnly ) {
+      setInventory(num,m_inventory_id);
    }
 }
 
@@ -225,136 +215,200 @@ void Hop::setInventoryId( int key )
 
 void Hop::setUse(Use u)
 {
-   if ( u < uses.size()) {
-      if ( m_cacheOnly || setEasy(PropertyNames::Hop::use, uses.at(u)) ) {
-         m_use = u;
-         m_useStr = uses.at(u);
-      }
+   if ( u >= uses.size() ) {
+      qWarning() << "Hop: unrecognized use:" << u;
+      return;
+   }
+
+   if ( m_cacheOnly ) {
+      m_use = u;
+      m_useStr = uses.at(u);
+   }
+   else if ( setEasy(PropertyNames::Hop::use, uses.at(u)) ) {
+      m_use = u;
+      m_useStr = uses.at(u);
+      signalCacheChange(PropertyNames::Hop::use, uses.at(u));
    }
 }
 
 void Hop::setTime_min( double num )
 {
    if( num < 0.0 ) {
-      qWarning() << QString("Hop: time < 0: %1").arg(num);
+      qWarning() << "Hop: time < 0:" << num;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::time_min, num) ) {
+   if ( m_cacheOnly ) {
       m_time_min = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::time_min, num) ) {
+      m_time_min = num;
+      signalCacheChange(PropertyNames::Hop::time_min, num);
    }
 }
 
 void Hop::setNotes( const QString& str )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::notes, str) ) {
+   if ( m_cacheOnly ) {
       m_notes = str;
+   }
+   else if ( setEasy(PropertyNames::Hop::notes, str) ) {
+      m_notes = str;
+      signalCacheChange(PropertyNames::Hop::notes, str);
    }
 }
 
 void Hop::setType(Type t)
 {
-   if ( t < types.size() ) {
-      if ( m_cacheOnly || setEasy(PropertyNames::Hop::type, m_typeStr) ) {
-         m_type = t;
-         m_typeStr = types.at(t);
-      }
+   if ( t >= types.size() ) {
+      qWarning() << "Hop: unrecognized type:" << t;
+      return;
+   }
+
+   if ( m_cacheOnly ) {
+      m_type = t;
+      m_typeStr = types.at(t);
+   }
+   else if ( setEasy(PropertyNames::Hop::type, m_typeStr) ) {
+      m_type = t;
+      m_typeStr = types.at(t);
+      signalCacheChange(PropertyNames::Hop::type, m_typeStr);
    }
 }
 
 void Hop::setForm( Form f )
 {
-   if ( f < forms.size() ) {
+   if ( f >= forms.size() ) {
+      qWarning() << "Hop: unrecognized form:" << f;
+      return;
+   }
+
+   if ( m_cacheOnly ) {
       m_form = f;
-      if ( m_cacheOnly || setEasy(PropertyNames::Hop::form, m_formStr) ) {
-         m_formStr = forms.at(f);
-      }
+      m_formStr = forms.at(f);
+   }
+   else if ( setEasy(PropertyNames::Hop::form, m_formStr) ) {
+      m_form = f;
+      m_formStr = forms.at(f);
+      signalCacheChange(PropertyNames::Hop::form, m_formStr);
    }
 }
 
 void Hop::setBeta_pct( double num )
 {
    if( num < 0.0 || num > 100.0 ) {
-      qWarning() << QString("Hop: 0 < beta < 100: %1").arg(num);
+      qWarning() << "Hop: 0 < beta < 100:" << num;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::beta_pct, num) ) {
+   if ( m_cacheOnly ) {
       m_beta_pct = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::beta_pct, num) ) {
+      m_beta_pct = num;
+      signalCacheChange(PropertyNames::Hop::beta_pct, num);
    }
 }
 
 void Hop::setHsi_pct( double num )
 {
    if( num < 0.0 || num > 100.0 ) {
-      qWarning() << QString("Hop: 0 < hsi < 100: %1").arg(num);
+      qWarning() << "Hop: 0 < hsi < 100:" << num;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::hsi_pct, num) ) {
+   if ( m_cacheOnly ) {
       m_hsi_pct = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::hsi_pct, num) ) {
+      m_hsi_pct = num;
+      signalCacheChange(PropertyNames::Hop::hsi_pct, num);
    }
 }
 
 void Hop::setOrigin( const QString& str )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::origin, str) ) {
+   if ( m_cacheOnly ) {
       m_origin = str;
+   }
+   else if ( setEasy(PropertyNames::Hop::origin, str) ) {
+      m_origin = str;
+      signalCacheChange(PropertyNames::Hop::origin, str);
    }
 }
 
 void Hop::setSubstitutes( const QString& str )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::substitutes, str) ) {
+   if ( m_cacheOnly ) {
       m_substitutes = str;
+   }
+   else if ( setEasy(PropertyNames::Hop::substitutes, str) ) {
+      m_substitutes = str;
+      signalCacheChange(PropertyNames::Hop::substitutes, str);
    }
 }
 
 void Hop::setHumulene_pct( double num )
 {
    if( num < 0.0 || num > 100.0 ) {
-      qWarning() << QString("Hop: 0 < humulene < 100: %1").arg(num);
+      qWarning() << "Hop: 0 < humulene < 100:" << num;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::humulene_pct,num) ) {
+   if ( m_cacheOnly ) {
       m_humulene_pct = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::humulene_pct,num) ) {
+      m_humulene_pct = num;
+      signalCacheChange(PropertyNames::Hop::humulene_pct,num);
    }
 }
 
 void Hop::setCaryophyllene_pct( double num )
 {
    if( num < 0.0 || num > 100.0 ) {
-      qWarning() << QString("Hop: 0 < cary < 100: %1").arg(num);
+      qWarning() << "Hop: 0 < cary < 100:" << num;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::caryophyllene_pct, num) ) {
+   if ( m_cacheOnly ) {
       m_caryophyllene_pct = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::caryophyllene_pct, num) ) {
+      m_caryophyllene_pct = num;
+      signalCacheChange(PropertyNames::Hop::caryophyllene_pct, num);
    }
 }
 
 void Hop::setCohumulone_pct( double num )
 {
    if( num < 0.0 || num > 100.0 ) {
-      qWarning() << QString("Hop: 0 < cohumulone < 100: %1").arg(num);
+      qWarning() << "Hop: 0 < cohumulone < 100:" << num;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::cohumulone_pct, num) ) {
+   if ( m_cacheOnly ) {
       m_cohumulone_pct = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::cohumulone_pct, num) ) {
+      m_cohumulone_pct = num;
+      signalCacheChange(PropertyNames::Hop::cohumulone_pct, num);
    }
 }
 
 void Hop::setMyrcene_pct( double num )
 {
    if( num < 0.0 || num > 100.0 ) {
-      qWarning() << QString("Hop: 0 < myrcene < 100: %1").arg(num);
+      qWarning() << "Hop: 0 < myrcene < 100:" << num;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Hop::myrcene_pct, num) ) {
+   if ( m_cacheOnly ) {
       m_myrcene_pct = num;
+   }
+   else if ( setEasy(PropertyNames::Hop::myrcene_pct, num) ) {
+      m_myrcene_pct = num;
+      signalCacheChange(PropertyNames::Hop::myrcene_pct, num);
    }
 }
 

--- a/src/model/Instruction.cpp
+++ b/src/model/Instruction.cpp
@@ -69,29 +69,45 @@ Instruction::Instruction(TableSchema* table, QSqlRecord rec, int t_key)
 // Setters ====================================================================
 void Instruction::setDirections(const QString& dir)
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Instruction::directions,  dir) ) {
+   if ( m_cacheOnly ) {
       m_directions = dir;
+   }
+   else if ( setEasy(PropertyNames::Instruction::directions,  dir) ) {
+      m_directions = dir;
+      signalCacheChange(PropertyNames::Instruction::directions,  dir);
    }
 }
 
 void Instruction::setHasTimer(bool has)
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Instruction::hasTimer,  has) ) {
+   if ( m_cacheOnly ) {
       m_hasTimer = has;
+   }
+   else if ( setEasy(PropertyNames::Instruction::hasTimer,  has) ) {
+      m_hasTimer = has;
+      signalCacheChange(PropertyNames::Instruction::hasTimer,  has);
    }
 }
 
 void Instruction::setTimerValue(const QString& timerVal)
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Instruction::timerValue,  timerVal) ) {
+   if ( m_cacheOnly ) {
       m_timerValue = timerVal;
+   }
+   else if ( setEasy(PropertyNames::Instruction::timerValue,  timerVal) ) {
+      m_timerValue = timerVal;
+      signalCacheChange(PropertyNames::Instruction::timerValue,  timerVal);
    }
 }
 
 void Instruction::setCompleted(bool comp)
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Instruction::completed,  comp) ) {
+   if ( m_cacheOnly ) {
       m_completed = comp;
+   }
+   else if ( setEasy(PropertyNames::Instruction::completed,  comp) ) {
+      m_completed = comp;
+      signalCacheChange(PropertyNames::Instruction::completed,  comp);
    }
 }
 
@@ -105,8 +121,12 @@ void Instruction::setReagent(const QString& reagent)
 
 void Instruction::setInterval(double time)
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Instruction::interval,  time) ) {
+   if ( m_cacheOnly ) {
       m_interval = time;
+   }
+   else if ( setEasy(PropertyNames::Instruction::interval,  time) ) {
+      m_interval = time;
+      signalCacheChange(PropertyNames::Instruction::interval,  time);
    }
 }
 

--- a/src/model/Mash.cpp
+++ b/src/model/Mash.cpp
@@ -86,36 +86,56 @@ Mash::Mash(TableSchema* table, QSqlRecord rec, int t_key)
 
 void Mash::setGrainTemp_c( double var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Mash::grainTemp_c, var) ) {
+   if ( m_cacheOnly ) {
       m_grainTemp_c = var;
+   }
+   else if ( setEasy(PropertyNames::Mash::grainTemp_c, var) ) {
+      m_grainTemp_c = var;
+      signalCacheChange(PropertyNames::Mash::grainTemp_c, var);
    }
 }
 
 void Mash::setNotes( const QString& var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Mash::notes, var) ) {
+   if ( m_cacheOnly ) {
       m_notes = var;
+   }
+   else if ( setEasy(PropertyNames::Mash::notes, var) ) {
+      m_notes = var;
+      signalCacheChange(PropertyNames::Mash::notes, var);
    }
 }
 
 void Mash::setTunTemp_c( double var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Mash::tunTemp_c, var) ) {
+   if ( m_cacheOnly ) {
       m_tunTemp_c = var;
+   }
+   else if ( setEasy(PropertyNames::Mash::tunTemp_c, var) ) {
+      m_tunTemp_c = var;
+      signalCacheChange(PropertyNames::Mash::tunTemp_c, var);
    }
 }
 
 void Mash::setSpargeTemp_c( double var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Mash::spargeTemp_c, var) ) {
+   if ( m_cacheOnly ) {
       m_spargeTemp_c = var;
+   }
+   else if ( setEasy(PropertyNames::Mash::spargeTemp_c, var) ) {
+      m_spargeTemp_c = var;
+      signalCacheChange(PropertyNames::Mash::spargeTemp_c, var);
    }
 }
 
 void Mash::setEquipAdjust( bool var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Mash::equipAdjust, var) ) {
+   if ( m_cacheOnly ) {
       m_equipAdjust = var;
+   }
+   else if ( setEasy(PropertyNames::Mash::equipAdjust, var) ) {
+      m_equipAdjust = var;
+      signalCacheChange(PropertyNames::Mash::equipAdjust, var);
    }
 }
 
@@ -125,8 +145,12 @@ void Mash::setPh( double var )
       qWarning() << QString("Mash: 0 < pH < 14: %1").arg(var);
       return;
    }
-   if ( m_cacheOnly || setEasy(PropertyNames::Mash::ph, var) ) {
+   if ( m_cacheOnly ) {
       m_ph = var;
+   }
+   else if ( setEasy(PropertyNames::Mash::ph, var) ) {
+      m_ph = var;
+      signalCacheChange(PropertyNames::Mash::ph, var);
    }
 }
 
@@ -138,8 +162,12 @@ void Mash::setTunWeight_kg( double var )
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Mash::tunWeight_kg, var) ) {
+   if ( m_cacheOnly ) {
       m_tunWeight_kg = var;
+   }
+   else if ( setEasy(PropertyNames::Mash::tunWeight_kg, var) ) {
+      m_tunWeight_kg = var;
+      signalCacheChange(PropertyNames::Mash::tunWeight_kg, var);
    }
 }
 
@@ -150,8 +178,12 @@ void Mash::setTunSpecificHeat_calGC( double var )
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Mash::tunSpecificHeat_calGC, var) ) {
+   if ( m_cacheOnly ) {
       m_tunSpecificHeat_calGC = var;
+   }
+   else if ( setEasy(PropertyNames::Mash::tunSpecificHeat_calGC, var) ) {
+      m_tunSpecificHeat_calGC = var;
+      signalCacheChange(PropertyNames::Mash::tunSpecificHeat_calGC, var);
    }
 }
 

--- a/src/model/MashStep.cpp
+++ b/src/model/MashStep.cpp
@@ -100,84 +100,126 @@ void MashStep::setInfuseTemp_c(double var )
       m_infuseTemp_c = var;
    }
    else if ( m_stepNumber == 1 ) {
+      m_infuseTemp_c = var;
       setEasy(PropertyNames::MashStep::infuseTemp_c, var, true, true);
    }
-   else {
-      setEasy(PropertyNames::MashStep::infuseTemp_c, var);
+   else if ( setEasy(PropertyNames::MashStep::infuseTemp_c, var) ) {
+      m_infuseTemp_c = var;
+      signalCacheChange(PropertyNames::MashStep::infuseTemp_c,var);
+
    }
 }
 
 void MashStep::setType( Type t )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::MashStep::type, m_typeStr) ) {
+   if ( t >= types.size() ) {
+      qWarning() << "MashStep: invalid type:" << t;
+      return;
+   }
+
+   if ( m_cacheOnly ) {
       m_type = t;
       m_typeStr = types.at(t);
+   }
+   else if ( setEasy(PropertyNames::MashStep::type, m_typeStr) ) {
+      m_type = t;
+      m_typeStr = types.at(t);
+      signalCacheChange(PropertyNames::MashStep::type, m_typeStr);
    }
 }
 
 void MashStep::setInfuseAmount_l( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << Q_FUNC_INFO << "number cannot be negative:" << var;
+      qWarning() << "Infuse amount cannot be negative:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::MashStep::infuseAmount_l, var) ) {
+   if ( m_cacheOnly ) {
       m_infuseAmount_l = var;
+   }
+   else if ( setEasy(PropertyNames::MashStep::infuseAmount_l, var) ) {
+      m_infuseAmount_l = var;
+      signalCacheChange(PropertyNames::MashStep::infuseAmount_l, var);
    }
 }
 
 void MashStep::setStepTemp_c( double var )
 {
    if( var < PhysicalConstants::absoluteZero ) {
-      qWarning() << Q_FUNC_INFO << "temp below absolute zero:" << var;
+      qWarning() << "Step temp below absolute zero:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::MashStep::stepTemp_c, var) ) {
+   if ( m_cacheOnly ) {
       m_stepTemp_c = var;
+   }
+   else if ( setEasy(PropertyNames::MashStep::stepTemp_c, var) ) {
+      m_stepTemp_c = var;
+      signalCacheChange(PropertyNames::MashStep::stepTemp_c, var);
    }
 }
 
 void MashStep::setStepTime_min( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << Q_FUNC_INFO << "step time cannot be negative:" << var;
+      qWarning() << "step time cannot be negative:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::MashStep::stepTime_min, var) ) {
+   if ( m_cacheOnly ) {
       m_stepTime_min = var;
+   }
+   else if ( setEasy(PropertyNames::MashStep::stepTime_min, var) ) {
+      m_stepTime_min = var;
+      signalCacheChange(PropertyNames::MashStep::stepTime_min, var);
    }
 }
 
 void MashStep::setRampTime_min( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << Q_FUNC_INFO << "ramp time cannot be negative:" << var;
+      qWarning() << "ramp time cannot be negative:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::MashStep::rampTime_min, var) ) {
+   if ( m_cacheOnly ) {
       m_rampTime_min = var;
+   }
+   else if ( setEasy(PropertyNames::MashStep::rampTime_min, var) ) {
+      m_rampTime_min = var;
+      signalCacheChange(PropertyNames::MashStep::rampTime_min, var);
    }
 }
 
 void MashStep::setEndTemp_c( double var )
 {
    if( var < PhysicalConstants::absoluteZero ) {
-      qWarning() << Q_FUNC_INFO << "temp below absolute zero:" << var;
+      qWarning() << "End temp below absolute zero:" << var;
       return;
    }
-   if ( m_cacheOnly || setEasy(PropertyNames::MashStep::endTemp_c, var) ) {
+   if ( m_cacheOnly ) {
       m_endTemp_c = var;
+   }
+   else if ( setEasy(PropertyNames::MashStep::endTemp_c, var) ) {
+      m_endTemp_c = var;
+      signalCacheChange(PropertyNames::MashStep::endTemp_c, var);
    }
 }
 
 void MashStep::setDecoctionAmount_l(double var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::MashStep::decoctionAmount_l, var) ) {
+   if ( var < 0.0 ) {
+      qWarning() << "Decoction amount cannot be negative";
+      return;
+   }
+
+   if ( m_cacheOnly ) {
       m_decoctionAmount_l = var;
+   }
+   else if ( setEasy(PropertyNames::MashStep::decoctionAmount_l, var) ) {
+      m_decoctionAmount_l = var;
+      signalCacheChange(PropertyNames::MashStep::decoctionAmount_l, var);
    }
 }
 

--- a/src/model/Misc.cpp
+++ b/src/model/Misc.cpp
@@ -181,61 +181,91 @@ bool Misc::cacheOnly() const { return m_cacheOnly; }
 //============================"SET" METHODS=====================================
 void Misc::setType( Type t )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Misc::type, types.at(t) ) ) {
+   if ( t >= types.size() ) {
+      qWarning() << "Unrecognized misc type:" << t;
+      return;
+   }
+
+   if ( m_cacheOnly ) {
       m_type = t;
       m_typeString = types.at(t);
+   }
+   else if ( setEasy( PropertyNames::Misc::type, types.at(t) ) ) {
+      m_type = t;
+      m_typeString = types.at(t);
+      signalCacheChange( PropertyNames::Misc::type, types.at(t) );
    }
 }
 
 void Misc::setUse( Use u )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Misc::use, uses.at(u) ) ) {
+   if ( u >= uses.size() ) {
+      qWarning() << "Unrecognized misc use:" << u;
+      return;
+   }
+   if ( m_cacheOnly ) {
       m_use = u;
       m_useString = uses.at(u);
+   }
+   else if ( setEasy( PropertyNames::Misc::use, uses.at(u) ) ) {
+      m_use = u;
+      m_useString = uses.at(u);
+      signalCacheChange( PropertyNames::Misc::use, uses.at(u) );
    }
 }
 
 void Misc::setUseFor( const QString& var )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Misc::useFor, var ) ) {
+   if ( m_cacheOnly ) {
       m_useFor = var;
+   }
+   else if ( setEasy( PropertyNames::Misc::useFor, var ) ) {
+      m_useFor = var;
+      signalCacheChange( PropertyNames::Misc::useFor, var );
    }
 }
 
 void Misc::setNotes( const QString& var )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Misc::notes, var ) ) {
+   if ( m_cacheOnly ) {
       m_notes = var;
+   }
+   else if ( setEasy( PropertyNames::Misc::notes, var ) ) {
+      m_notes = var;
+      signalCacheChange( PropertyNames::Misc::notes, var );
    }
 }
 
 void Misc::setAmountType( AmountType t )
 {
    bool is_a_weight = t == AmountType_Weight;
-   if ( m_cacheOnly ) {
-      m_amountIsWeight = is_a_weight;
-   }
-   else {
-      setAmountIsWeight(is_a_weight);
-   }
+   setAmountIsWeight(is_a_weight);
 }
 
 void Misc::setAmountIsWeight( bool var )
 {
-   if ( m_cacheOnly || setEasy( PropertyNames::Misc::amountIsWeight, var ) ) {
+   if ( m_cacheOnly ) {
       m_amountIsWeight = var;
+   }
+   else if ( setEasy( PropertyNames::Misc::amountIsWeight, var ) ) {
+      m_amountIsWeight = var;
+      signalCacheChange( PropertyNames::Misc::amountIsWeight, var );
    }
 }
 
 void Misc::setAmount( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Misc: amount < 0: %1").arg(var);
+      qWarning() << "Misc: amount < 0:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy( PropertyNames::Misc::amount, var ) ) {
+   if ( m_cacheOnly ) {
       m_amount = var;
+   }
+   else if ( setEasy( PropertyNames::Misc::amount, var ) ) {
+      m_amount = var;
+      signalCacheChange( PropertyNames::Misc::amount, var );
    }
 }
 
@@ -262,11 +292,15 @@ void Misc::setInventoryId( int key )
 void Misc::setTime( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Misc: time < 0: %1").arg(var);
+      qWarning() << "Misc: time < 0:" << var;
       return;
    }
-   if ( m_cacheOnly || setEasy( PropertyNames::Misc::time, var ) ) {
+   if ( m_cacheOnly ) {
       m_time = var;
+   }
+   else if ( setEasy( PropertyNames::Misc::time, var ) ) {
+      m_time = var;
+      signalCacheChange( PropertyNames::Misc::time, var );
    }
 }
 

--- a/src/model/NamedEntity.cpp
+++ b/src/model/NamedEntity.cpp
@@ -29,6 +29,7 @@
 #include <QDomNode>
 #include <QMetaProperty>
 
+#include "NamedEntity.h"
 #include "brewtarget.h"
 #include "database.h"
 
@@ -363,6 +364,12 @@ bool NamedEntity::setEasy(QString prop_name, QVariant value, bool notify, bool u
    }
 }
 
+void NamedEntity::signalCacheChange(QString propName, QVariant value)
+{
+   int idx = this->metaObject()->indexOfProperty(propName.toUtf8().data());
+   QMetaProperty mProp = this->metaObject()->property(idx);
+   emit changed(mProp,value);
+}
 
 QVariant NamedEntity::get( const QString& col_name ) const
 {

--- a/src/model/NamedEntity.h
+++ b/src/model/NamedEntity.h
@@ -272,6 +272,7 @@ protected:
    QVariant getInventory() const;
 
    QVariantMap getColumnValueMap() const;
+   void signalCacheChange(QString propName, QVariant value);
 
 private:
   mutable QString m_folder;

--- a/src/model/Yeast.cpp
+++ b/src/model/Yeast.cpp
@@ -216,45 +216,59 @@ void Yeast::setType( Yeast::Type t )
    // a wise person once said always makes sure things are in range before you
    // use them
    if ( types.at(t) == nullptr ) {
-      qWarning() << Q_FUNC_INFO << "invalid yeast type:" << t;
+      qWarning() << "invalid yeast type:" << t;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::type, types.at(t)) ) {
+   if ( m_cacheOnly ) {
       m_type = t;
       m_typeString = types.at(t);
+   }
+   else if ( setEasy(PropertyNames::Yeast::type, types.at(t)) ) {
+      m_type = t;
+      m_typeString = types.at(t);
+      signalCacheChange(PropertyNames::Yeast::type, types.at(t));
    }
 }
 
 void Yeast::setForm( Yeast::Form f )
 {
    if ( forms.at(f) == nullptr ) {
-      qWarning() << Q_FUNC_INFO << "invalid yeast form:" << f;
+      qWarning() << "invalid yeast form:" << f;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::form, forms.at(f)) ) {
+   if ( m_cacheOnly ) {
       m_form = f;
       m_formString = forms.at(f);
+   }
+   else if ( setEasy(PropertyNames::Yeast::form, forms.at(f)) ) {
+      m_form = f;
+      m_formString = forms.at(f);
+      signalCacheChange(PropertyNames::Yeast::form, forms.at(f));
    }
 }
 
 void Yeast::setAmount( double var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Yeast: amount < 0: %1").arg(var);
+      qWarning() << "Yeast: amount < 0:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::amount, var) ) {
+   if ( m_cacheOnly ) {
       m_amount = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::amount, var) ) {
+      m_amount = var;
+      signalCacheChange(PropertyNames::Yeast::amount, var);
    }
 }
 
 void Yeast::setInventoryQuanta( int var )
 {
    if( var < 0.0 ) {
-      qWarning() << QString("Yeast: inventory < 0: %1").arg(var);
+      qWarning() << "Yeast: inventory < 0:" << var;
       return;
    }
 
@@ -274,46 +288,66 @@ void Yeast::setInventoryId( int key )
 
 void Yeast::setAmountIsWeight( bool var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::amountIsWeight, var) ) {
+   if ( m_cacheOnly ) {
       m_amountIsWeight = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::amountIsWeight, var) ) {
+      m_amountIsWeight = var;
+      signalCacheChange(PropertyNames::Yeast::amountIsWeight, var);
    }
 }
 
 void Yeast::setLaboratory( const QString& var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::laboratory, var) ) {
+   if ( m_cacheOnly ) {
       m_laboratory = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::laboratory, var) ) {
+      m_laboratory = var;
+      signalCacheChange(PropertyNames::Yeast::laboratory, var);
    }
 }
 
 void Yeast::setProductID( const QString& var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::productID, var) ) {
+   if ( m_cacheOnly ) {
       m_productID = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::productID, var) ) {
+      m_productID = var;
+      signalCacheChange(PropertyNames::Yeast::productID, var);
    }
 }
 
 void Yeast::setMinTemperature_c( double var )
 {
    if( var < PhysicalConstants::absoluteZero ) {
-      qWarning() << Q_FUNC_INFO << "temperature below absolute zero:" << var;
+      qWarning() << "Minimum temperature below absolute zero:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::minTemperature_c, var) ) {
+   if ( m_cacheOnly ) {
       m_minTemperature_c = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::minTemperature_c, var) ) {
+      m_minTemperature_c = var;
+      signalCacheChange(PropertyNames::Yeast::minTemperature_c, var);
    }
 }
 
 void Yeast::setMaxTemperature_c( double var )
 {
    if( var < PhysicalConstants::absoluteZero ) {
-      qWarning() << Q_FUNC_INFO << "temperature below absolute zero:" << var;
+      qWarning() << "Max temperature below absolute zero:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::maxTemperature_c, var) ) {
+   if ( m_cacheOnly ) {
       m_maxTemperature_c = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::maxTemperature_c, var) ) {
+      m_maxTemperature_c = var;
+      signalCacheChange(PropertyNames::Yeast::maxTemperature_c, var);
    }
 }
 
@@ -322,70 +356,99 @@ void Yeast::setMaxTemperature_c( double var )
 void Yeast::setFlocculation( Yeast::Flocculation f)
 {
    if ( flocculations.at(f) == nullptr ) {
-      qWarning() << Q_FUNC_INFO << "invalid flocculation type:" << f;
+      qWarning() << "invalid flocculation type:" << f;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::flocculation, flocculations.at(f)) ) {
+   if ( m_cacheOnly ) {
       m_flocculation = f;
       m_flocculationString = flocculations.at(f);
+   }
+   else if ( setEasy(PropertyNames::Yeast::flocculation, flocculations.at(f)) ) {
+      m_flocculation = f;
+      m_flocculationString = flocculations.at(f);
+      signalCacheChange(PropertyNames::Yeast::flocculation, flocculations.at(f));
    }
 }
 
 void Yeast::setAttenuation_pct( double var )
 {
    if( var < 0.0 || var > 100.0 ) {
-      qWarning() << Q_FUNC_INFO << "invalid attenuation:" << var;
+      qWarning() << "invalid attenuation:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::attenuation_pct, var) ) {
+   if ( m_cacheOnly ) {
       m_attenuation_pct = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::attenuation_pct, var) ) {
+      m_attenuation_pct = var;
+      signalCacheChange(PropertyNames::Yeast::attenuation_pct, var);
    }
 }
 
 void Yeast::setNotes( const QString& var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::notes, var) ) {
+   if ( m_cacheOnly ) {
       m_notes = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::notes, var) ) {
+      m_notes = var;
+      signalCacheChange(PropertyNames::Yeast::notes, var);
    }
 }
 
 void Yeast::setBestFor( const QString& var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::bestFor, var) ) {
+   if ( m_cacheOnly ) {
       m_bestFor = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::bestFor, var) ) {
+      m_bestFor = var;
+      signalCacheChange(PropertyNames::Yeast::bestFor, var);
    }
 }
 
 void Yeast::setTimesCultured( int var )
 {
    if( var < 0 ) {
-      qWarning() << Q_FUNC_INFO << "invalid times cultured:" << var;
+      qWarning() << "invalid times cultured:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::timesCultured, var) ) {
+   if ( m_cacheOnly ) {
       m_timesCultured = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::timesCultured, var) ) {
+      m_timesCultured = var;
+      signalCacheChange(PropertyNames::Yeast::timesCultured, var);
    }
 }
 
 void Yeast::setMaxReuse( int var )
 {
    if( var < 0 ) {
-      qWarning() << Q_FUNC_INFO << "invalid max reuse:" << var;
+      qWarning() << "invalid max reuse:" << var;
       return;
    }
 
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::maxReuse, var) ) {
+   if ( m_cacheOnly ) {
       m_maxReuse = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::maxReuse, var) ) {
+      m_maxReuse = var;
+      signalCacheChange(PropertyNames::Yeast::maxReuse, var);
    }
 }
 
 void Yeast::setAddToSecondary( bool var )
 {
-   if ( m_cacheOnly || setEasy(PropertyNames::Yeast::addToSecondary, var) ) {
+   if ( m_cacheOnly ) {
       m_addToSecondary = var;
+   }
+   else if ( setEasy(PropertyNames::Yeast::addToSecondary, var) ) {
+      m_addToSecondary = var;
+      signalCacheChange(PropertyNames::Yeast::addToSecondary, var);
    }
 }
 


### PR DESCRIPTION
The problem as seen in #596 was directly related to how I reordered the cache and flush.

Changing an existing hop (or anything else) on a non-versioning recipe would cause the NamedEntity:changed() signal to fire before the cache value was updated. Since everybody uses the cache value, nothing would change until we had reason to reload the recipe and re-read the values.

I am somewhat trapped for a solution on this. The order is very specific and versioning requires brewtarget clone before it updates the cache. It simply doesn't work any other way.

This means brewtarget must wait until after the clone decision is made to emit a NamedEntity::changed signal. The cache has to be updated before we signal and that can only be done in the derived class (eg Hop) and it cannot be done in NamedEntity.

This has had a kind of largish knock on effect, as every (almost) set* method in (almost) every major class had to change. BrewNote, Salt and Water escaped the carnage entirely -- none of those can fork a recipe.  Inventory changes on all the classes which support inventory also escaped, as changing inventory does not fork

I had to clean up Database a little, as the alternate findParentRecipe methods weren't actually being called. I removed those and made the idea work.

The last pain was that modifying a recipe's equipment profile was not quite working. I am not certain that changing something on the equipment profile should fork a recipe, but it does for now. The hard part was that the first field updated would fork the recipe, which would signal MainWindow which would reload the Equipment editor which would reset all the fields. My solution was to get the field values before we start writing. It mostly works. It is ugly.

The equipment thing may work better if I enable cacheOnly, and then use generateUpdateRow() to blast the entire thing record at once. That will neatly solve the ugly and the signal problem. It will require I make a clone-aware method for doing it, but I've done worse.