### PR TITLE
Partial fix for inventory bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,9 @@
 # See also ../CMakeLists.txt
 #
 
+# Uncomment the next line for verbose build output
+#set(CMAKE_VERBOSE_MAKEFILE ON)
+
 # The current directory in the original source.
 INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR} )
 # The current directory in the output build directory.
@@ -135,6 +138,7 @@ SET( brewtarget_SRCS
     ${SRCDIR}/model/MashStep.cpp
     ${SRCDIR}/model/Misc.cpp
     ${SRCDIR}/model/NamedEntity.cpp
+    ${SRCDIR}/model/NamedEntityWithInventory.cpp
     ${SRCDIR}/model/NamedParameterBundle.cpp
     ${SRCDIR}/model/Recipe.cpp
     ${SRCDIR}/model/Salt.cpp
@@ -298,6 +302,7 @@ SET( brewtarget_MOC_HEADERS
     ${SRCDIR}/model/MashStep.h
     ${SRCDIR}/model/Misc.h
     ${SRCDIR}/model/NamedEntity.h
+    ${SRCDIR}/model/NamedEntityWithInventory.h
     ${SRCDIR}/model/Recipe.h
     ${SRCDIR}/model/Salt.h
     ${SRCDIR}/model/Style.h
@@ -494,7 +499,11 @@ IF( NOT ${NO_QTMULTIMEDIA})
    SET( QT5_USE_MODULES_LIST ${QT5_USE_MODULES_LIST} Qt5::Multimedia)
 ENDIF()
 
-target_link_libraries( ${QT5_USE_MODULES_LIST} ${XercesC_LIBRARIES} ${XalanC_LIBRARIES})
+# The dl library is needed on non-Windows platforms for Boost Stacktrace
+IF(NOT WIN32)
+   SET(LIBDL dl)
+ENDIF()
+target_link_libraries( ${QT5_USE_MODULES_LIST} ${XercesC_LIBRARIES} ${XalanC_LIBRARIES} ${LIBDL} )
 
 #=================================Tests========================================
 
@@ -521,7 +530,7 @@ IF( NOT ${NO_QTMULTIMEDIA})
 SET( QT5_USE_MODULES_LIST ${QT5_USE_MODULES_LIST} Qt5::Multimedia)
 ENDIF()
 
-target_link_libraries(${QT5_USE_MODULES_LIST} ${XercesC_LIBRARIES} ${XalanC_LIBRARIES})
+target_link_libraries(${QT5_USE_MODULES_LIST} ${XercesC_LIBRARIES} ${XalanC_LIBRARIES} ${LIBDL})
 
 ADD_TEST(
    NAME pstdintTest

--- a/src/FermentableTableModel.cpp
+++ b/src/FermentableTableModel.cpp
@@ -1,6 +1,6 @@
 /*
  * FermentableTableModel.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2020
+ * authors 2009-2021
  * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
@@ -20,33 +20,32 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "FermentableTableModel.h"
 
-#include <QAbstractTableModel>
 #include <QAbstractItemModel>
 #include <QAbstractItemView>
-#include <QHeaderView>
-#include <QWidget>
-#include <QModelIndex>
-#include <QVariant>
-#include <QItemEditorFactory>
-#include <QStyle>
-#include <QRect>
-#include <QDebug>
-
-#include "database.h"
-#include "brewtarget.h"
-#include <QSize>
+#include <QAbstractTableModel>
 #include <QComboBox>
-#include <QListWidget>
-#include <QLineEdit>
-#include <QString>
-#include <QVector>
+#include <QDebug>
 #include <QHeaderView>
-#include "model/Fermentable.h"
-#include "FermentableTableModel.h"
-#include "Unit.h"
-#include "model/Recipe.h"
+#include <QItemEditorFactory>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QModelIndex>
+#include <QRect>
+#include <QSize>
+#include <QString>
+#include <QStyle>
+#include <QVariant>
+#include <QVector>
+#include <QWidget>
+
+#include "brewtarget.h"
+#include "database.h"
 #include "MainWindow.h"
+#include "model/Fermentable.h"
+#include "model/Recipe.h"
+#include "Unit.h"
 
 //=====================CLASS FermentableTableModel==============================
 FermentableTableModel::FermentableTableModel(QTableView* parent, bool editable)
@@ -629,7 +628,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
          if ( retVal ) {
             // Doing the set via doOrRedoUpdate() saves us from doing a static_cast<Fermentable::Type>() here (as the Q_PROPERTY system will do the casting for us).
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "type",
+                                                     PropertyNames::Fermentable::type,
                                                      value.toInt(),
                                                      tr("Change Fermentable Type"));
          }
@@ -639,7 +638,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
          if( retVal ) {
             // Inventory amount is in kg, but is just called "inventory" rather than "inventory_kg" in the Q_PROPERTY declaration in the Fermentable class
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "inventory",
+                                                     PropertyNames::NamedEntityWithInventory::inventory,
                                                      Brewtarget::qStringToSI(value.toString(), &Units::kilograms,dspUnit,dspScl),
                                                      tr("Change Inventory Amount"));
          }
@@ -650,7 +649,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
             // This is where the amount of a fermentable in a recipe gets updated
             // We need to refer back to the MainWindow to make this an undoable operation
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "amount_kg",
+                                                     PropertyNames::Fermentable::amount_kg,
                                                      Brewtarget::qStringToSI(value.toString(), &Units::kilograms,dspUnit,dspScl),
                                                      tr("Change Fermentable Amount"));
             if( rowCount() > 0 )
@@ -662,7 +661,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
          if( retVal ) {
             // Doing the set via doOrRedoUpdate() saves us from doing a static_cast<Fermentable::AdditionMethod>() here (as the Q_PROPERTY system will do the casting for us).
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "additionMethod",
+                                                     PropertyNames::Fermentable::additionMethod,
                                                      value.toInt(),
                                                      tr("Change Addition Method"));
          }
@@ -672,7 +671,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
          if( retVal ) {
             // Doing the set via doOrRedoUpdate() saves us from doing a static_cast<Fermentable::AdditionTime>() here (as the Q_PROPERTY system will do the casting for us).
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "additionTime",
+                                                     PropertyNames::Fermentable::additionTime,
                                                      value.toInt(),
                                                      tr("Change Addition Time"));
          }
@@ -690,7 +689,7 @@ bool FermentableTableModel::setData( const QModelIndex& index, const QVariant& v
          retVal = value.canConvert(QVariant::Double);
          if( retVal ) {
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "color_srm",
+                                                     PropertyNames::Fermentable::color_srm,
                                                      Brewtarget::qStringToSI(value.toString(), &Units::srm, dspUnit, dspScl),
                                                      tr("Change Color"));
          }

--- a/src/HopTableModel.cpp
+++ b/src/HopTableModel.cpp
@@ -43,30 +43,27 @@
 #include "brewtarget.h"
 #include "MainWindow.h"
 
-HopTableModel::HopTableModel(QTableView* parent, bool editable)
-   : QAbstractTableModel(parent),
-     colFlags(HOPNUMCOLS),
-     _inventoryEditable(false),
-     recObs(nullptr),
-     parentTableWidget(parent),
-     showIBUs(false)
-{
-   hopObs.clear();
-   setObjectName("hopTable");
+HopTableModel::HopTableModel(QTableView * parent, bool editable) :
+   QAbstractTableModel(parent),
+   colFlags(HOPNUMCOLS),
+   _inventoryEditable(false),
+   recObs(nullptr),
+   parentTableWidget(parent),
+   showIBUs(false) {
+   this->hopObs.clear();
+   this->setObjectName("hopTable");
 
-   int i;
-   for( i = 0; i < HOPNUMCOLS; ++i )
-   {
-      if( i == HOPNAMECOL )
+   for (int i = 0; i < HOPNUMCOLS; ++i) {
+      if (i == HOPNAMECOL) {
          colFlags[i] = Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled;
-      else if( i == HOPINVENTORYCOL )
+      } else if (i == HOPINVENTORYCOL) {
          colFlags[i] = Qt::ItemIsEnabled;
-      else
+      } else
          colFlags[i] = Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled |
-            Qt::ItemIsEnabled;
+                       Qt::ItemIsEnabled;
    }
 
-   QHeaderView* headerView = parentTableWidget->horizontalHeader();
+   QHeaderView * headerView = parentTableWidget->horizontalHeader();
    headerView->setContextMenuPolicy(Qt::CustomContextMenu);
    parentTableWidget->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
    parentTableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
@@ -76,31 +73,25 @@ HopTableModel::HopTableModel(QTableView* parent, bool editable)
    connect( &(Database::instance()), &Database::changedInventory, this, &HopTableModel::changedInventory );
 }
 
-HopTableModel::~HopTableModel()
-{
-   hopObs.clear();
+HopTableModel::~HopTableModel() {
+   this->hopObs.clear();
 }
 
-void HopTableModel::observeRecipe(Recipe* rec)
-{
-   if( recObs )
-   {
-      disconnect( recObs, nullptr, this, nullptr );
+void HopTableModel::observeRecipe(Recipe * rec) {
+   if (this->recObs) {
+      disconnect(this->recObs, nullptr, this, nullptr);
       removeAll();
    }
 
-   recObs = rec;
-   if( recObs )
-   {
-      connect( recObs, &NamedEntity::changed, this, &HopTableModel::changed );
-      addHops( recObs->hops() );
+   this->recObs = rec;
+   if (this->recObs) {
+      connect(this->recObs, &NamedEntity::changed, this, &HopTableModel::changed);
+      this->addHops(this->recObs->hops());
    }
 }
 
-void HopTableModel::observeDatabase(bool val)
-{
-   if( val )
-   {
+void HopTableModel::observeDatabase(bool val) {
+   if (val) {
       observeRecipe(nullptr);
       removeAll();
       connect( &(Database::instance()), qOverload<Hop*>(&Database::createdSignal), this, &HopTableModel::addHop );
@@ -156,14 +147,11 @@ void HopTableModel::addHops(QList<Hop*> hops)
    }
 }
 
-bool HopTableModel::removeHop(Hop* hop)
-{
-   int i;
-   i = hopObs.indexOf(hop);
-   if( i >= 0 )
-   {
-      beginRemoveRows( QModelIndex(), i, i );
-      disconnect( hop, nullptr, this, nullptr );
+bool HopTableModel::removeHop(Hop * hop) {
+   int i = hopObs.indexOf(hop);
+   if (i >= 0) {
+      beginRemoveRows(QModelIndex(), i, i);
+      disconnect(hop, nullptr, this, nullptr);
       hopObs.removeAt(i);
       //reset(); // Tell everybody the table has changed.
       endRemoveRows();
@@ -179,14 +167,11 @@ void HopTableModel::setShowIBUs( bool var )
    showIBUs = var;
 }
 
-void HopTableModel::removeAll()
-{
-   if (hopObs.size())
-   {
-      beginRemoveRows( QModelIndex(), 0, hopObs.size()-1 );
-      while( !hopObs.isEmpty() )
-      {
-         disconnect( hopObs.takeLast(), nullptr, this, nullptr );
+void HopTableModel::removeAll() {
+   if (hopObs.size()) {
+      beginRemoveRows(QModelIndex(), 0, hopObs.size() - 1);
+      while (!hopObs.isEmpty()) {
+         disconnect(hopObs.takeLast(), nullptr, this, nullptr);
       }
       endRemoveRows();
    }
@@ -207,6 +192,7 @@ void HopTableModel::changedInventory(Brewtarget::DBTable table, int invKey, QVar
          }
       }
    }
+   return;
 }
 
 void HopTableModel::changed(QMetaProperty prop, QVariant /*val*/)
@@ -214,59 +200,54 @@ void HopTableModel::changed(QMetaProperty prop, QVariant /*val*/)
    int i;
 
    // Find the notifier in the list
-   Hop* hopSender = qobject_cast<Hop*>(sender());
-   if( hopSender )
-   {
+   Hop * hopSender = qobject_cast<Hop *>(sender());
+   if (hopSender) {
       i = hopObs.indexOf(hopSender);
-      if( i < 0 )
+      if (i < 0) {
          return;
+      }
 
-      emit dataChanged( QAbstractItemModel::createIndex(i, 0),
-                        QAbstractItemModel::createIndex(i, HOPNUMCOLS-1));
-      emit headerDataChanged( Qt::Vertical, i, i );
+      emit dataChanged(QAbstractItemModel::createIndex(i, 0),
+                       QAbstractItemModel::createIndex(i, HOPNUMCOLS - 1));
+      emit headerDataChanged(Qt::Vertical, i, i);
       return;
    }
 
    // See if sender is our recipe.
-   Recipe* recSender = qobject_cast<Recipe*>(sender());
-   if( recSender && recSender == recObs )
-   {
-      if( QString(prop.name()) == "hops" )
-      {
+   Recipe * recSender = qobject_cast<Recipe *>(sender());
+   if (recSender && recSender == recObs) {
+      if (QString(prop.name()) == "hops") {
          removeAll();
-         addHops( recObs->hops() );
+         addHops(recObs->hops());
       }
-      if( rowCount() > 0 )
-         emit headerDataChanged( Qt::Vertical, 0, rowCount()-1 );
+      if (rowCount() > 0) {
+         emit headerDataChanged(Qt::Vertical, 0, rowCount() - 1);
+      }
       return;
    }
 }
 
-int HopTableModel::rowCount(const QModelIndex& /*parent*/) const
-{
+int HopTableModel::rowCount(const QModelIndex & /*parent*/) const {
    return hopObs.size();
 }
 
-int HopTableModel::columnCount(const QModelIndex& /*parent*/) const
-{
+int HopTableModel::columnCount(const QModelIndex & /*parent*/) const {
    return HOPNUMCOLS;
 }
 
-QVariant HopTableModel::data( const QModelIndex& index, int role ) const
-{
-   Hop* row;
+QVariant HopTableModel::data(const QModelIndex & index, int role) const {
+   Hop * row;
    int col = index.column();
    Unit::unitScale scale;
    Unit::unitDisplay unit;
 
    // Ensure the row is ok.
-   if( index.row() >= static_cast<int>(hopObs.size() ))
-   {
+   if (index.row() >= static_cast<int>(hopObs.size())) {
       qWarning() << QString("Bad model index. row = %1").arg(index.row());
       return QVariant();
-   }
-   else
+   } else {
       row = hopObs[index.row()];
+   }
 
    switch( index.column() )
    {
@@ -407,7 +388,7 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
          retVal = value.canConvert(QVariant::String);
          if( retVal ) {
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "inventoryAmount",
+                                                     PropertyNames::NamedEntityWithInventory::inventory,
                                                      Brewtarget::qStringToSI(value.toString(),&Units::kilograms, displayUnit(HOPINVENTORYCOL)),
                                                      tr("Change Hop Inventory Amount"));
          }
@@ -416,7 +397,7 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
          retVal = value.canConvert(QVariant::String);
          if( retVal ) {
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "amount_kg",
+                                                     PropertyNames::Hop::amount_kg,
                                                      Brewtarget::qStringToSI(value.toString(), &Units::kilograms, dspUnit, dspScl),
                                                      tr("Change Hop Amount"));
          }
@@ -425,7 +406,7 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
          retVal = value.canConvert(QVariant::Int);
          if( retVal ) {
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "use",
+                                                     PropertyNames::Hop::use,
                                                      static_cast<Hop::Use>(value.toInt()),
                                                      tr("Change Hop Use"));
          }
@@ -434,7 +415,7 @@ bool HopTableModel::setData( const QModelIndex& index, const QVariant& value, in
          retVal = value.canConvert(QVariant::Int);
          if( retVal ) {
             Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                     "form",
+                                                     PropertyNames::Hop::form,
                                                      static_cast<Hop::Form>(value.toInt()),
                                                      tr("Change Hop Form"));
          }

--- a/src/TableSchema.cpp
+++ b/src/TableSchema.cpp
@@ -1318,7 +1318,7 @@ void TableSchema::defineFermInventoryTable()
    m_key->addProperty(kpropKey, Brewtarget::PGSQL,  kcolKey, QString(""), QString("integer"), QVariant(0), 0, kPgSQLConstraint);
    m_key->addProperty(kpropKey, Brewtarget::SQLITE, kcolKey, QString(""), QString("integer"), QVariant(0), 0, kSQLiteConstraint);
 
-   m_properties[PropertyNames::Fermentable::inventory]      = new PropertySchema( PropertyNames::Fermentable::inventory,     kcolAmount,        kxmlPropAmount, QString("real"), QVariant(0.0));
+   m_properties[PropertyNames::NamedEntityWithInventory::inventory]      = new PropertySchema( PropertyNames::NamedEntityWithInventory::inventory,     kcolAmount,        kxmlPropAmount, QString("real"), QVariant(0.0));
 }
 
 void TableSchema::defineHopInventoryTable()
@@ -1329,7 +1329,7 @@ void TableSchema::defineHopInventoryTable()
    m_key->addProperty(kpropKey, Brewtarget::PGSQL,  kcolKey, QString(""), QString("integer"), QVariant(0), 0, kPgSQLConstraint);
    m_key->addProperty(kpropKey, Brewtarget::SQLITE, kcolKey, QString(""), QString("integer"), QVariant(0), 0, kSQLiteConstraint);
 
-   m_properties[PropertyNames::Hop::inventory] = new PropertySchema( PropertyNames::Hop::inventory, kcolAmount, kxmlPropAmount, QString("real"), QVariant(0.0));
+   m_properties[PropertyNames::NamedEntityWithInventory::inventory] = new PropertySchema( PropertyNames::NamedEntityWithInventory::inventory, kcolAmount, kxmlPropAmount, QString("real"), QVariant(0.0));
 }
 
 void TableSchema::defineMiscInventoryTable()
@@ -1340,7 +1340,7 @@ void TableSchema::defineMiscInventoryTable()
    m_key->addProperty(kpropKey, Brewtarget::PGSQL,  kcolKey, QString(""), QString("integer"), QVariant(0), 0, kPgSQLConstraint);
    m_key->addProperty(kpropKey, Brewtarget::SQLITE, kcolKey, QString(""), QString("integer"), QVariant(0), 0, kSQLiteConstraint);
 
-   m_properties[PropertyNames::Misc::inventory] = new PropertySchema( PropertyNames::Misc::inventory, kcolAmount, kxmlPropAmount, QString("real"), QVariant(0.0));
+   m_properties[PropertyNames::NamedEntityWithInventory::inventory] = new PropertySchema( PropertyNames::NamedEntityWithInventory::inventory, kcolAmount, kxmlPropAmount, QString("real"), QVariant(0.0));
 
 }
 
@@ -1352,7 +1352,7 @@ void TableSchema::defineYeastInventoryTable()
    m_key->addProperty(kpropKey, Brewtarget::PGSQL,  kcolKey, QString(""), QString("integer"), QVariant(0), 0, kPgSQLConstraint);
    m_key->addProperty(kpropKey, Brewtarget::SQLITE, kcolKey, QString(""), QString("integer"), QVariant(0), 0, kSQLiteConstraint);
 
-   m_properties[PropertyNames::Yeast::inventory] = new PropertySchema( kpropQuanta,  kcolYeastQuanta, kxmlPropAmount, QString("real"), QVariant(0.0));
+   m_properties[PropertyNames::NamedEntityWithInventory::inventory] = new PropertySchema(PropertyNames::NamedEntityWithInventory::inventory,  kcolYeastQuanta, kxmlPropAmount, QString("real"), QVariant(0.0));
 
 }
 

--- a/src/YeastTableModel.cpp
+++ b/src/YeastTableModel.cpp
@@ -1,6 +1,6 @@
 /*
  * YeastTableModel.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2020
+ * authors 2009-2021
  * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
@@ -20,35 +20,33 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "YeastTableModel.h"
 
-#include <QAbstractTableModel>
 #include <QAbstractItemModel>
-#include <QWidget>
-#include <QModelIndex>
-#include <QVariant>
-#include <QItemDelegate>
-#include <QStyleOptionViewItem>
+#include <QAbstractTableModel>
 #include <QComboBox>
+#include <QHeaderView>
+#include <QItemDelegate>
 #include <QLineEdit>
 #include <QString>
 #include <QVector>
-#include <QHeaderView>
+#include <QWidget>
 
-#include "database.h"
-#include "model/Yeast.h"
-#include "YeastTableModel.h"
-#include "Unit.h"
 #include "brewtarget.h"
-#include "model/Recipe.h"
+#include "database.h"
 #include "MainWindow.h"
+#include "model/Recipe.h"
+#include "model/Yeast.h"
+#include "Unit.h"
+#include "YeastTableModel.h"
 
-YeastTableModel::YeastTableModel(QTableView* parent, bool editable)
-   : QAbstractTableModel(parent),
-     editable(editable),
-     _inventoryEditable(false),
-     parentTableWidget(parent),
-     recObs(nullptr)
-{
+YeastTableModel::YeastTableModel(QTableView* parent, bool editable) :
+   QAbstractTableModel(parent),
+   editable(editable),
+   _inventoryEditable(false),
+   parentTableWidget(parent),
+   recObs(nullptr) {
+
    yeastObs.clear();
    setObjectName("yeastTableModel");
 
@@ -74,8 +72,9 @@ void YeastTableModel::addYeast(Yeast* yeast)
          yeast->deleted() ||
          !yeast->display()
       )
-   )
+   ) {
       return;
+   }
    int size = yeastObs.size();
    beginInsertRows( QModelIndex(), size, size );
    yeastObs.append(yeast);
@@ -187,7 +186,9 @@ void YeastTableModel::changedInventory(Brewtarget::DBTable table, int invKey, QV
          }
       }
    }
+   return;
 }
+
 void YeastTableModel::changed(QMetaProperty prop, QVariant /*val*/)
 {
    int i;
@@ -287,7 +288,7 @@ QVariant YeastTableModel::data( const QModelIndex& index, int role ) const
 
          return QVariant(
                            Brewtarget::displayAmount( row->amount(),
-                                                      row->amountIsWeight() ? static_cast<Unit const *>(&Units::kilograms) : static_cast<Unit const *>(&Units::liters),
+                                                      row->amountIsWeight() ? &Units::kilograms : &Units::liters,
                                                       3,
                                                       unit,
                                                       Unit::noScale
@@ -387,7 +388,7 @@ bool YeastTableModel::setData( const QModelIndex& index, const QVariant& value, 
          if( ! value.canConvert(QVariant::Int) )
             return false;
          Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                  "type",
+                                                  PropertyNames::Yeast::type,
                                                   static_cast<Yeast::Type>(value.toInt()),
                                                   tr("Change Yeast Type"));
          break;
@@ -395,7 +396,7 @@ bool YeastTableModel::setData( const QModelIndex& index, const QVariant& value, 
          if( ! value.canConvert(QVariant::Int) )
             return false;
          Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                  "form",
+                                                  PropertyNames::Yeast::form,
                                                   static_cast<Yeast::Form>(value.toInt()),
                                                   tr("Change Yeast Form"));
          break;
@@ -403,18 +404,18 @@ bool YeastTableModel::setData( const QModelIndex& index, const QVariant& value, 
          if( ! value.canConvert(QVariant::Int) )
             return false;
          Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                  "inventoryQuanta",
+                                                  PropertyNames::NamedEntityWithInventory::inventory,
                                                   value.toInt(),
-                                                  tr("Change Yeast Inventory Unit Size")); // .:TBD:. MY 2020-12-11 Whilst it's admirably concise, I find "quanta" unclear, and I'm not sure it's that easy to translate either
+                                                  tr("Change Yeast Inventory Amount"));
          break;
       case YEASTAMOUNTCOL:
          if( ! value.canConvert(QVariant::String) )
             return false;
 
-         unit = row->amountIsWeight() ? static_cast<Unit const *>(&Units::kilograms) : static_cast<Unit const *>(&Units::liters);
+         unit = row->amountIsWeight() ? &Units::kilograms : &Units::liters;
 
          Brewtarget::mainWindow()->doOrRedoUpdate(*row,
-                                                  "amount",
+                                                  PropertyNames::Yeast::amount,
                                                   Brewtarget::qStringToSI(value.toString(), unit, dspUnit, dspScl),
                                                   tr("Change Yeast Amount"));
          break;

--- a/src/brewtarget.h
+++ b/src/brewtarget.h
@@ -1,7 +1,8 @@
 /*
  * brewtarget.h is part of Brewtarget, and is Copyright the following
- * authors 2009-2014
+ * authors 2009-2021
  * - Dan Cavanagh <dan@dancavanagh.com>
+ * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
  * - Rob Taylor <robtaylor@floopily.org>
@@ -53,7 +54,6 @@ Q_DECLARE_METATYPE( QMetaProperty )
 
 /*!
  * \class Brewtarget
- * \author Philip G. Lee
  *
  * \brief The main class. Figures out stuff from the system, formats things appropriately, handles translation, etc.
  */
@@ -61,7 +61,7 @@ class Brewtarget : public QObject
 {
    Q_OBJECT
    Q_ENUMS(DBTypes)
-   Q_ENUMS(delOptions);
+   Q_ENUMS(delOptions)
 
    friend class OptionDialog;
    friend class IbuMethods;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -29,6 +29,10 @@
 
 #include "database.h"
 
+// Uncomment the following two includes to enable stacktraces with boost::stacktrace::stacktrace()
+#include <boost/stacktrace.hpp>
+#include <sstream>      // std::ostringstream
+
 #include <QList>
 #include <QDomDocument>
 #include <QIODevice>
@@ -1105,7 +1109,7 @@ Recipe* Database::getParentRecipe(NamedEntity const * ing)
    else {
       select = findRecipeFromInRec(table, inrec, ing);
    }
-   
+
    Recipe * parent = nullptr;
 
    QSqlQuery q(sqlDatabase());
@@ -2143,7 +2147,7 @@ void Database::setAncestor(Recipe* descendant, Recipe* ancestor, bool transact)
       q.finish();
    }
    catch( QString e ) {
-      if ( transact ) 
+      if ( transact )
          sqlDatabase().rollback();
       qCritical() << Q_FUNC_INFO << e;
       abort();
@@ -2180,7 +2184,7 @@ Recipe* Database::newRecipe(Recipe* other, bool ancestor)
       addToRecipe( tmp, other->style(), false, false);
 
       // if other is an ancestor, we need to set display false on other and
-      // link the two. 
+      // link the two.
       if ( ancestor ) {
          setAncestor(tmp,other,false);
       }
@@ -3020,7 +3024,10 @@ void Database::setInventory(NamedEntity* ins, QVariant value, int invKey, bool n
    int ndx = ins->metaObject()->indexOfProperty(invProp.toUtf8().data());
    // I would like to get rid of this, but I need it to properly signal
    if ( invKey == 0 ) {
-      qDebug() << "bad inventory call. find it an kill it";
+      // Uncomment this block if the message below is firing, as it will usually help find the bug quickly
+      std::ostringstream stacktrace;
+      stacktrace << boost::stacktrace::stacktrace();
+      qDebug().noquote() << Q_FUNC_INFO << "bad inventory call. find it an kill it.  Stack:\n" << QString::fromStdString(stacktrace.str());
    }
 
    if ( ! value.isValid() || value.isNull() ) {
@@ -3599,7 +3606,7 @@ QList<Hop*> Database::addToRecipe( Recipe* rec, QList<Hop*>hops, Hop* exclude, b
 
 Mash * Database::addToRecipe( Recipe* rec, Mash* m, bool noCopy, bool transact )
 {
-   if ( m == nullptr ) 
+   if ( m == nullptr )
       return nullptr;
 
    if ( rec->locked() )

--- a/src/model/BrewNote.cpp
+++ b/src/model/BrewNote.cpp
@@ -81,7 +81,7 @@ bool BrewNote::isEqualTo(NamedEntity const & other) const {
 
 // Initializers
 BrewNote::BrewNote(QString name, bool cache)
-   : NamedEntity(Brewtarget::BREWNOTETABLE,name,true),
+   : NamedEntity(Brewtarget::BREWNOTETABLE, cache, name, true),
      loading(false),
      m_brewDate(QDateTime()),
      m_fermentDate(QDateTime()),
@@ -112,16 +112,13 @@ BrewNote::BrewNote(QString name, bool cache)
      m_projABV_pct(0.0),
      m_projPoints(0.0),
      m_projFermPoints(0.0),
-     m_projAtten(0.0),
-     m_cacheOnly(cache)
-{
+     m_projAtten(0.0) {
+   return;
 }
 
 BrewNote::BrewNote(TableSchema* table, QSqlRecord rec, int t_key)
    : NamedEntity(table, rec, t_key),
-     loading(false),
-     m_cacheOnly(false)
-{
+     loading(false) {
      m_brewDate = QDateTime::fromString( rec.value( table->propertyToColumn( PropertyNames::BrewNote::brewDate )).toString(), Qt::ISODate);
      m_fermentDate = QDateTime::fromString(rec.value( table->propertyToColumn(PropertyNames::BrewNote::fermentDate)).toString(), Qt::ISODate);
      m_notes = rec.value( table->propertyToColumn(PropertyNames::BrewNote::notes)).toString();
@@ -263,40 +260,39 @@ void BrewNote::recalculateEff(Recipe* parent)
    calculateBrewHouseEff_pct();
 }
 
-BrewNote::BrewNote(BrewNote const& other)
-   : NamedEntity(other),
-     m_brewDate(other.m_brewDate),
-     m_fermentDate(other.m_fermentDate),
-     m_notes(other.m_notes),
-     m_sg(other.m_sg),
-     m_abv(other.m_abv),
-     m_effIntoBK_pct(other.m_effIntoBK_pct),
-     m_brewhouseEff_pct(other.m_brewhouseEff_pct),
-     m_volumeIntoBK_l(other.m_volumeIntoBK_l),
-     m_strikeTemp_c(other.m_strikeTemp_c),
-     m_mashFinTemp_c(other.m_mashFinTemp_c),
-     m_og(other.m_og),
-     m_postBoilVolume_l(other.m_postBoilVolume_l),
-     m_volumeIntoFerm_l(other.m_volumeIntoFerm_l),
-     m_pitchTemp_c(other.m_pitchTemp_c),
-     m_fg(other.m_fg),
-     m_attenuation(other.m_attenuation),
-     m_finalVolume_l(other.m_finalVolume_l),
-     m_boilOff_l(other.m_boilOff_l),
-     m_projBoilGrav(other.m_projBoilGrav),
-     m_projVolIntoBK_l(other.m_projVolIntoBK_l),
-     m_projStrikeTemp_c(other.m_projStrikeTemp_c),
-     m_projMashFinTemp_c(other.m_projMashFinTemp_c),
-     m_projOg(other.m_projOg),
-     m_projVolIntoFerm_l(other.m_projVolIntoFerm_l),
-     m_projFg(other.m_projFg),
-     m_projEff_pct(other.m_projEff_pct),
-     m_projABV_pct(other.m_projABV_pct),
-     m_projPoints(other.m_projPoints),
-     m_projFermPoints(other.m_projFermPoints),
-     m_projAtten(other.m_projAtten),
-     m_cacheOnly(other.m_cacheOnly)
-{
+BrewNote::BrewNote(BrewNote const& other) :
+   NamedEntity        {other                    },
+   m_brewDate         {other.m_brewDate         },
+   m_fermentDate      {other.m_fermentDate      },
+   m_notes            {other.m_notes            },
+   m_sg               {other.m_sg               },
+   m_abv              {other.m_abv              },
+   m_effIntoBK_pct    {other.m_effIntoBK_pct    },
+   m_brewhouseEff_pct {other.m_brewhouseEff_pct },
+   m_volumeIntoBK_l   {other.m_volumeIntoBK_l   },
+   m_strikeTemp_c     {other.m_strikeTemp_c     },
+   m_mashFinTemp_c    {other.m_mashFinTemp_c    },
+   m_og               {other.m_og               },
+   m_postBoilVolume_l {other.m_postBoilVolume_l },
+   m_volumeIntoFerm_l {other.m_volumeIntoFerm_l },
+   m_pitchTemp_c      {other.m_pitchTemp_c      },
+   m_fg               {other.m_fg               },
+   m_attenuation      {other.m_attenuation      },
+   m_finalVolume_l    {other.m_finalVolume_l    },
+   m_boilOff_l        {other.m_boilOff_l        },
+   m_projBoilGrav     {other.m_projBoilGrav     },
+   m_projVolIntoBK_l  {other.m_projVolIntoBK_l  },
+   m_projStrikeTemp_c {other.m_projStrikeTemp_c },
+   m_projMashFinTemp_c{other.m_projMashFinTemp_c},
+   m_projOg           {other.m_projOg           },
+   m_projVolIntoFerm_l{other.m_projVolIntoFerm_l},
+   m_projFg           {other.m_projFg           },
+   m_projEff_pct      {other.m_projEff_pct      },
+   m_projABV_pct      {other.m_projABV_pct      },
+   m_projPoints       {other.m_projPoints       },
+   m_projFermPoints   {other.m_projFermPoints   },
+   m_projAtten        {other.m_projAtten        } {
+   return;
 }
 
 // Setters=====================================================================
@@ -610,8 +606,6 @@ void BrewNote::setBoilOff_l(double var)
    }
 }
 
-void BrewNote::setCacheOnly(bool cache) { m_cacheOnly = cache; }
-
 void BrewNote::setRecipe(Recipe * recipe) { this->m_recipe = recipe; }
 
 
@@ -625,7 +619,6 @@ QString BrewNote::fermentDate_str() const { return m_fermentDate.toString(); }
 QString BrewNote::fermentDate_short() const { return Brewtarget::displayDateUserFormated(m_fermentDate.date()); }
 
 QString BrewNote::notes() const { return m_notes; }
-bool BrewNote::cacheOnly() const { return m_cacheOnly; }
 
 double BrewNote::sg() const { return m_sg; }
 double BrewNote::abv() const { return m_abv; }

--- a/src/model/BrewNote.h
+++ b/src/model/BrewNote.h
@@ -138,7 +138,6 @@ public:
    void populateNote(Recipe* parent);
    void recalculateEff(Recipe* parent);
    void setLoading(bool flag);
-   void setCacheOnly(bool cache);
    void setRecipe(Recipe * recipe);
 
    // Getters
@@ -210,7 +209,6 @@ public:
    double projPoints() const;
    double projFermPoints() const;
    double projAtten() const;
-   bool cacheOnly() const;
 
    // BrewNote objects do not have parents
    NamedEntity * getParent() { return nullptr; }
@@ -262,7 +260,6 @@ private:
    double m_projPoints;
    double m_projFermPoints;
    double m_projAtten;
-   bool m_cacheOnly;
    Recipe * m_recipe;
 
 ///   QHash<QString,double> info;

--- a/src/model/Equipment.cpp
+++ b/src/model/Equipment.cpp
@@ -56,7 +56,7 @@ bool Equipment::isEqualTo(NamedEntity const & other) const {
 
 //=============================CONSTRUCTORS=====================================
 Equipment::Equipment(QString t_name, bool cacheOnly)
-   : NamedEntity(Brewtarget::EQUIPTABLE, t_name, true),
+   : NamedEntity(Brewtarget::EQUIPTABLE, cacheOnly, t_name, true),
    m_boilSize_l(22.927),
    m_batchSize_l(18.927),
    m_tunVolume_l(0.0),
@@ -73,15 +73,12 @@ Equipment::Equipment(QString t_name, bool cacheOnly)
    m_hopUtilization_pct(100.0),
    m_notes(QString()),
    m_grainAbsorption_LKg(1.086),
-   m_boilingPoint_c(100.0),
-   m_cacheOnly(cacheOnly)
-{
+   m_boilingPoint_c(100.0) {
+   return;
 }
 
 Equipment::Equipment(TableSchema* table, QSqlRecord rec, int t_key)
-   : NamedEntity(table, rec, t_key ),
-   m_cacheOnly(false)
-{
+   : NamedEntity(table, rec, t_key ) {
    m_boilSize_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::boilSize_l)).toDouble();
    m_batchSize_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::batchSize_l)).toDouble();
    m_tunVolume_l = rec.value( table->propertyToColumn( PropertyNames::Equipment::tunVolume_l)).toDouble();
@@ -120,9 +117,8 @@ Equipment::Equipment( Equipment const& other )
    m_hopUtilization_pct(other.m_hopUtilization_pct),
    m_notes(other.m_notes),
    m_grainAbsorption_LKg(other.m_grainAbsorption_LKg),
-   m_boilingPoint_c(other.m_boilingPoint_c),
-   m_cacheOnly(other.m_cacheOnly)
-{
+   m_boilingPoint_c(other.m_boilingPoint_c) {
+   return;
 }
 
 QString Equipment::classNameStr()
@@ -248,7 +244,7 @@ void Equipment::setTrubChillerLoss_l( double var )
 
 void Equipment::setEvapRate_pctHr( double var )
 {
-   // NOTE: evapRate_pctHr is only used in xml input/output. 
+   // NOTE: evapRate_pctHr is only used in xml input/output.
    if( var < 0.0 || var > 100.0) {
       qWarning() << "Equipment: 0 < evap rate < 100:" << var;
       return;
@@ -404,8 +400,6 @@ void Equipment::setBoilingPoint_c(double var)
    }
 }
 
-void Equipment::setCacheOnly(bool cache) { m_cacheOnly = cache; }
-
 //============================"GET" METHODS=====================================
 
 QString Equipment::notes() const { return m_notes; }
@@ -425,7 +419,6 @@ double Equipment::topUpKettle_l() const { return m_topUpKettle_l; }
 double Equipment::hopUtilization_pct() const { return m_hopUtilization_pct; }
 double Equipment::grainAbsorption_LKg() { return m_grainAbsorption_LKg; }
 double Equipment::boilingPoint_c() const { return m_boilingPoint_c; }
-bool Equipment::cacheOnly() const { return m_cacheOnly; }
 
 void Equipment::doCalculations()
 {

--- a/src/model/Equipment.h
+++ b/src/model/Equipment.h
@@ -115,7 +115,6 @@ public:
    void setNotes( const QString &var );
    void setGrainAbsorption_LKg(double var);
    void setBoilingPoint_c(double var);
-   void setCacheOnly(bool cache);
 
    // Get
    double boilSize_l() const;
@@ -135,7 +134,6 @@ public:
    QString notes() const;
    double grainAbsorption_LKg();
    double boilingPoint_c() const;
-   bool cacheOnly() const;
 
    //! \brief Calculate how much wort is left immediately at knockout.
    double wortEndOfBoil_l( double kettleWort_l ) const;
@@ -190,7 +188,6 @@ private:
    QString m_notes;
    double m_grainAbsorption_LKg;
    double m_boilingPoint_c;
-   bool m_cacheOnly;
 
    // Calculate the boil size.
    void doCalculations();

--- a/src/model/Fermentable.cpp
+++ b/src/model/Fermentable.cpp
@@ -33,7 +33,8 @@
 #include "FermentableSchema.h"
 #include "TableSchemaConst.h"
 
-#define SUPER NamedEntity
+// .:TBD:. I think (and hope) that we can dispense with the following line!
+//#define SUPER NamedEntity
 
 QStringList Fermentable::types = QStringList() << "Grain" << "Sugar" << "Extract" << "Dry Extract" << "Adjunct";
 
@@ -62,8 +63,8 @@ QString Fermentable::classNameStr()
    return name;
 }
 
-Fermentable::Fermentable(QString name, bool cache)
-   : NamedEntity(Brewtarget::FERMTABLE, name, true),
+Fermentable::Fermentable(QString name, bool cache) :
+   NamedEntityWithInventory(Brewtarget::FERMTABLE, cache, name, true),
      m_typeStr(QString()),
      m_type(static_cast<Fermentable::Type>(0)),
      m_amountKg(0.0),
@@ -80,18 +81,12 @@ Fermentable::Fermentable(QString name, bool cache)
      m_maxInBatchPct(100.0),
      m_recommendMash(false),
      m_ibuGalPerLb(0.0),
-     m_inventory(-1.0),
-     m_inventory_id(0),
-     m_isMashed(false),
-     m_cacheOnly(cache)
-{
+     m_isMashed(false) {
+   return;
 }
 
-Fermentable::Fermentable(TableSchema* table, QSqlRecord rec, int t_key)
-   : NamedEntity(table, rec, t_key),
-     m_inventory(-1.0),
-     m_cacheOnly(false)
-{
+Fermentable::Fermentable(TableSchema* table, QSqlRecord rec, int t_key) :
+   NamedEntityWithInventory(table, rec, t_key) {
      m_typeStr = rec.value( table->propertyToColumn( PropertyNames::Fermentable::type)).toString();
      m_amountKg = rec.value( table->propertyToColumn( PropertyNames::Fermentable::amount_kg)).toDouble();
      m_yieldPct = rec.value( table->propertyToColumn( PropertyNames::Fermentable::yield_pct)).toDouble();
@@ -109,55 +104,30 @@ Fermentable::Fermentable(TableSchema* table, QSqlRecord rec, int t_key)
      m_ibuGalPerLb = rec.value( table->propertyToColumn( PropertyNames::Fermentable::ibuGalPerLb)).toDouble();
      m_isMashed = rec.value( table->propertyToColumn( PropertyNames::Fermentable::isMashed)).toBool();
 
-     // keys is different critters
-     m_inventory_id = rec.value( table->foreignKeyToColumn(PropertyNames::Fermentable::inventory_id)).toInt();
-
      // calculated, not retrieved from the db
      m_type = static_cast<Fermentable::Type>(types.indexOf(m_typeStr));
 }
 
-Fermentable::Fermentable( Fermentable &other )
-        : NamedEntity( other ),
-     m_typeStr(other.m_typeStr),
-     m_type(other.m_type),
-     m_amountKg(other.m_amountKg),
-     m_yieldPct(other.m_yieldPct),
-     m_colorSrm(other.m_colorSrm),
-     m_isAfterBoil(other.m_isAfterBoil),
-     m_origin(other.m_origin),
-     m_supplier(other.m_supplier),
-     m_notes(other.m_notes),
-     m_coarseFineDiff(other.m_coarseFineDiff),
-     m_moisturePct(other.m_moisturePct),
-     m_diastaticPower(other.m_diastaticPower),
-     m_proteinPct(other.m_proteinPct),
-     m_maxInBatchPct(other.m_maxInBatchPct),
-     m_recommendMash(other.m_recommendMash),
-     m_ibuGalPerLb(other.m_ibuGalPerLb),
-     m_inventory(other.m_inventory),
-     m_inventory_id(other.m_inventory_id),
-     m_isMashed(other.m_isMashed),
-     m_cacheOnly(other.m_cacheOnly)
-{
-   setType( other.type() );
-   setAmount_kg( other.amount_kg() );
-   setInventoryAmount( other.inventory() );
-   setYield_pct( other.yield_pct() );
-   setColor_srm( other.color_srm() );
-   setAddAfterBoil( other.addAfterBoil() );
-   setOrigin( other.origin() );
-   setSupplier( other.supplier() );
-   setNotes( other.notes() );
-   setCoarseFineDiff_pct( other.coarseFineDiff_pct() );
-   setMoisture_pct( other.moisture_pct() );
-   setDiastaticPower_lintner( other.diastaticPower_lintner() );
-   setProtein_pct( other.protein_pct() );
-   setMaxInBatch_pct( other.maxInBatch_pct() );
-   setRecommendMash( other.recommendMash() );
-   setInventoryAmount( other.inventory() );
-   setInventoryId( other.inventoryId() );
-   setIbuGalPerLb( other.ibuGalPerLb() );
-   setIsMashed(other.isMashed());
+Fermentable::Fermentable(Fermentable const & other) :
+   NamedEntityWithInventory{other                 },
+   m_typeStr       {other.m_typeStr       },
+   m_type          {other.m_type          },
+   m_amountKg      {other.m_amountKg      },
+   m_yieldPct      {other.m_yieldPct      },
+   m_colorSrm      {other.m_colorSrm      },
+   m_isAfterBoil   {other.m_isAfterBoil   },
+   m_origin        {other.m_origin        },
+   m_supplier      {other.m_supplier      },
+   m_notes         {other.m_notes         },
+   m_coarseFineDiff{other.m_coarseFineDiff},
+   m_moisturePct   {other.m_moisturePct   },
+   m_diastaticPower{other.m_diastaticPower},
+   m_proteinPct    {other.m_proteinPct    },
+   m_maxInBatchPct {other.m_maxInBatchPct },
+   m_recommendMash {other.m_recommendMash },
+   m_ibuGalPerLb   {other.m_ibuGalPerLb   },
+   m_isMashed      {other.m_isMashed      } {
+   return;
 }
 
 // Gets
@@ -178,7 +148,6 @@ double Fermentable::maxInBatch_pct() const { return m_maxInBatchPct; }
 bool Fermentable::recommendMash() const { return m_recommendMash; }
 double Fermentable::ibuGalPerLb() const { return m_ibuGalPerLb; }
 bool Fermentable::isMashed() const { return m_isMashed; }
-bool Fermentable::cacheOnly() const { return m_cacheOnly; }
 
 Fermentable::AdditionMethod Fermentable::additionMethod() const
 {
@@ -394,47 +363,6 @@ void Fermentable::setAmount_kg( double num )
    }
 }
 
-// changes to inventory amounts do NOT create a version
-void Fermentable::setInventoryAmount( double num )
-{
-   if( num < 0.0 ) {
-      qWarning() << "Fermentable: negative inventory:" << num;
-      return;
-   }
-
-   m_inventory = num;
-   if ( ! m_cacheOnly ) {
-      setInventory(num,m_inventory_id);
-   }
-}
-
-// I will regret this, but I don't think this happens at any point other than
-// load time, so no versions
-void Fermentable::setInventoryId( int key )
-{
-   if( key < 1 ) {
-      qWarning() << "Fermentable: bad inventory id:" << key;
-      return;
-   }
-   m_inventory_id = key;
-   if ( ! m_cacheOnly ) {
-      setEasy(kpropInventoryId,key);
-   }
-}
-
-double Fermentable::inventory()
-{
-   if ( m_inventory < 0 ) {
-      m_inventory = getInventory().toDouble();
-   }
-   return m_inventory;
-}
-
-int Fermentable::inventoryId()
-{
-   return m_inventory_id;
-}
-
 void Fermentable::setYield_pct( double num )
 {
    if ( num < 0.0 || num > 100.0 ) {
@@ -539,8 +467,6 @@ void Fermentable::setMaxInBatch_pct( double num )
       signalCacheChange( PropertyNames::Fermentable::maxInBatch_pct, num);
    }
 }
-
-void Fermentable::setCacheOnly( bool cache ) { m_cacheOnly = cache; }
 
 NamedEntity * Fermentable::getParent() {
    Fermentable * myParent = nullptr;

--- a/src/model/Fermentable.h
+++ b/src/model/Fermentable.h
@@ -27,27 +27,27 @@
 #include <QStringList>
 #include <QString>
 
-#include "model/NamedEntity.h"
+#include "model/NamedEntityWithInventory.h"
 #include "Unit.h"
 
-namespace PropertyNames::Fermentable { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
-namespace PropertyNames::Fermentable { static char const * const inventory_id = "inventory_id"; /* previously kpropInventoryId */ }
-namespace PropertyNames::Fermentable { static char const * const origin = "origin"; /* previously kpropOrigin */ }
+namespace PropertyNames::Fermentable { static char const * const addAfterBoil = "addAfterBoil"; /* previously kpropAddAfterBoil */ }
+namespace PropertyNames::Fermentable { static char const * const additionMethod = "additionMethod"; }
+namespace PropertyNames::Fermentable { static char const * const additionTime = "additionTime"; }
 namespace PropertyNames::Fermentable { static char const * const amount_kg = "amount_kg"; /* previously kpropAmountKg */ }
-namespace PropertyNames::Fermentable { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
-namespace PropertyNames::Fermentable { static char const * const type = "type"; /* previously kpropType */ }
-namespace PropertyNames::Fermentable { static char const * const notes = "notes"; /* previously kpropNotes */ }
+namespace PropertyNames::Fermentable { static char const * const coarseFineDiff_pct = "coarseFineDiff_pct"; /* previously kpropCoarseFineDiff */ }
+namespace PropertyNames::Fermentable { static char const * const color_srm = "color_srm"; /* previously kpropColor */ }
+namespace PropertyNames::Fermentable { static char const * const diastaticPower_lintner = "diastaticPower_lintner"; /* previously kpropDiastaticPower */ }
 namespace PropertyNames::Fermentable { static char const * const ibuGalPerLb = "ibuGalPerLb"; /* previously kpropIBUGalPerLb */ }
 namespace PropertyNames::Fermentable { static char const * const isMashed = "isMashed"; /* previously kpropIsMashed */ }
-namespace PropertyNames::Fermentable { static char const * const recommendMash = "recommendMash"; /* previously kpropRecommendMash */ }
 namespace PropertyNames::Fermentable { static char const * const maxInBatch_pct = "maxInBatch_pct"; /* previously kpropMaxInBatch */ }
-namespace PropertyNames::Fermentable { static char const * const protein_pct = "protein_pct"; /* previously kpropProtein */ }
-namespace PropertyNames::Fermentable { static char const * const diastaticPower_lintner = "diastaticPower_lintner"; /* previously kpropDiastaticPower */ }
 namespace PropertyNames::Fermentable { static char const * const moisture_pct = "moisture_pct"; /* previously kpropMoisture */ }
-namespace PropertyNames::Fermentable { static char const * const coarseFineDiff_pct = "coarseFineDiff_pct"; /* previously kpropCoarseFineDiff */ }
+namespace PropertyNames::Fermentable { static char const * const notes = "notes"; /* previously kpropNotes */ }
+namespace PropertyNames::Fermentable { static char const * const origin = "origin"; /* previously kpropOrigin */ }
+namespace PropertyNames::Fermentable { static char const * const protein_pct = "protein_pct"; /* previously kpropProtein */ }
+namespace PropertyNames::Fermentable { static char const * const recommendMash = "recommendMash"; /* previously kpropRecommendMash */ }
 namespace PropertyNames::Fermentable { static char const * const supplier = "supplier"; /* previously kpropSupplier */ }
-namespace PropertyNames::Fermentable { static char const * const addAfterBoil = "addAfterBoil"; /* previously kpropAddAfterBoil */ }
-namespace PropertyNames::Fermentable { static char const * const color_srm = "color_srm"; /* previously kpropColor */ }
+namespace PropertyNames::Fermentable { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
+namespace PropertyNames::Fermentable { static char const * const type = "type"; /* previously kpropType */ }
 namespace PropertyNames::Fermentable { static char const * const yield_pct = "yield_pct"; /* previously kpropYield */ }
 
 
@@ -56,8 +56,7 @@ namespace PropertyNames::Fermentable { static char const * const yield_pct = "yi
  *
  * \brief Model for a fermentable record in the database.
  */
-class Fermentable : public NamedEntity
-{
+class Fermentable : public NamedEntityWithInventory {
    Q_OBJECT
    Q_CLASSINFO("signal", "fermentables")
 
@@ -94,10 +93,6 @@ public:
    Q_PROPERTY( QString additionTimeStringTr  READ additionTimeStringTr   /*WRITE*/                       /*NOTIFY changed*/ /*changedAdditionTimeStringTr*/   STORED false )
    //! \brief The amount in kg.
    Q_PROPERTY( double amount_kg              READ amount_kg              WRITE setAmount_kg              /*NOTIFY changed*/ /*changedAmount_kg*/ )
-   //! \brief The amount in inventory in kg.
-   Q_PROPERTY( double inventory              READ inventory              WRITE setInventoryAmount        /*NOTIFY changed*/ /*changedInventory*/ )
-   //! \brief The inventory table id, needed for signals
-   Q_PROPERTY( double inventoryId            READ inventoryId            WRITE setInventoryId            /*NOTIFY changed*/ /*changedInventoryId*/ )
    //! \brief The yield (when finely milled) as a percentage of equivalent glucose.
    Q_PROPERTY( double yield_pct              READ yield_pct              WRITE setYield_pct              /*NOTIFY changed*/ /*changedYield_pct*/ )
    //! \brief The color in SRM.
@@ -135,8 +130,6 @@ public:
 
    Type type() const;
    double amount_kg() const;
-   double inventory();
-   int inventoryId();
    double yield_pct() const;
    double color_srm() const;
    bool addAfterBoil() const;
@@ -165,14 +158,12 @@ public:
    double equivSucrose_kg() const;
    bool isExtract() const;
    bool isSugar() const;
-   bool cacheOnly() const;
 
 
    void setType( Type t );
    void setAdditionMethod( AdditionMethod m );
    void setAdditionTime( AdditionTime t );
    void setAmount_kg( double num );
-   void setInventoryAmount( double num );
    void setYield_pct( double num );
    void setColor_srm( double num );
    void setAddAfterBoil( bool b );
@@ -187,8 +178,6 @@ public:
    void setRecommendMash( bool b );
    void setIbuGalPerLb( double num );
    void setIsMashed(bool var );
-   void setCacheOnly(bool cache );
-   void setInventoryId(int key);
 
    void save();
 
@@ -207,7 +196,7 @@ private:
 //   Fermentable(Brewtarget::DBTable table, int key);
    Fermentable(TableSchema* table, QSqlRecord rec, int t_key = -1);
 
-   Fermentable( Fermentable &other );
+   Fermentable(Fermentable const & other);
 
    static bool isValidType( const QString& str );
    static QStringList types;
@@ -228,10 +217,7 @@ private:
    double m_maxInBatchPct;
    bool m_recommendMash;
    double m_ibuGalPerLb;
-   double m_inventory;
-   int m_inventory_id;
    bool m_isMashed;
-   bool m_cacheOnly;
 };
 
 Q_DECLARE_METATYPE( QList<Fermentable*> )

--- a/src/model/Hop.cpp
+++ b/src/model/Hop.cpp
@@ -76,8 +76,8 @@ QString Hop::classNameStr()
    return name;
 }
 
-Hop::Hop(QString name, bool cache)
-   : NamedEntity(Brewtarget::HOPTABLE, name, true),
+Hop::Hop(QString name, bool cache) :
+   NamedEntityWithInventory(Brewtarget::HOPTABLE, cache, name, true),
      m_useStr(QString()),
      m_use(static_cast<Hop::Use>(0)),
      m_typeStr(QString()),
@@ -95,18 +95,12 @@ Hop::Hop(QString name, bool cache)
      m_humulene_pct(0.0),
      m_caryophyllene_pct(0.0),
      m_cohumulone_pct(0.0),
-     m_myrcene_pct(0.0),
-     m_inventory(-1.0),
-     m_inventory_id(0),
-     m_cacheOnly(cache)
-{
+     m_myrcene_pct(0.0) {
+   return;
 }
 
-Hop::Hop(TableSchema* table, QSqlRecord rec, int t_key)
-   : NamedEntity(table, rec, t_key),
-     m_inventory(-1.0),
-     m_cacheOnly(false)
-{
+Hop::Hop(TableSchema* table, QSqlRecord rec, int t_key) :
+   NamedEntityWithInventory(table, rec, t_key) {
      m_useStr = rec.value(table->propertyToColumn(PropertyNames::Hop::use)).toString();
      m_typeStr = rec.value(table->propertyToColumn(PropertyNames::Hop::type)).toString();
      m_formStr = rec.value(table->propertyToColumn(PropertyNames::Hop::form)).toString();
@@ -123,17 +117,14 @@ Hop::Hop(TableSchema* table, QSqlRecord rec, int t_key)
      m_cohumulone_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::cohumulone_pct)).toDouble();
      m_myrcene_pct = rec.value(table->propertyToColumn(PropertyNames::Hop::myrcene_pct)).toDouble();
 
-     // keys need special handling
-     m_inventory_id = rec.value(table->foreignKeyToColumn(PropertyNames::Hop::inventory_id)).toInt();
-
      // these are not taken directly from the SQL record
      m_use  = static_cast<Hop::Use>(uses.indexOf(m_useStr));
      m_type = static_cast<Hop::Type>(types.indexOf(m_typeStr));
      m_form = static_cast<Hop::Form>(forms.indexOf(m_formStr));
 }
 
-Hop::Hop( Hop & other )
-   : NamedEntity(other),
+Hop::Hop( Hop & other ) :
+   NamedEntityWithInventory(other),
      m_useStr(other.m_useStr),
      m_use(other.m_use),
      m_typeStr(other.m_typeStr),
@@ -151,11 +142,8 @@ Hop::Hop( Hop & other )
      m_humulene_pct(other.m_humulene_pct),
      m_caryophyllene_pct(other.m_caryophyllene_pct),
      m_cohumulone_pct(other.m_cohumulone_pct),
-     m_myrcene_pct(other.m_myrcene_pct),
-     m_inventory(other.m_inventory),
-     m_inventory_id(other.m_inventory_id),
-     m_cacheOnly(other.m_cacheOnly)
-{
+     m_myrcene_pct(other.m_myrcene_pct) {
+   return;
 }
 
 //============================="SET" METHODS====================================
@@ -189,27 +177,6 @@ void Hop::setAmount_kg( double num )
    else if ( setEasy(PropertyNames::Hop::amount_kg,num) ) {
       m_amount_kg = num;
       signalCacheChange(PropertyNames::Hop::amount_kg,num);
-   }
-}
-
-void Hop::setInventoryAmount( double num )
-{
-   if( num < 0.0 ) {
-      qWarning() << "Hop: inventory < 0:" << num;
-      return;
-   }
-
-   m_inventory = num;
-   if ( ! m_cacheOnly ) {
-      setInventory(num,m_inventory_id);
-   }
-}
-
-void Hop::setInventoryId( int key )
-{
-   m_inventory_id = key;
-   if ( ! m_cacheOnly ) {
-      setEasy(PropertyNames::Hop::inventory_id, key);
    }
 }
 
@@ -412,8 +379,6 @@ void Hop::setMyrcene_pct( double num )
    }
 }
 
-void Hop::setCacheOnly(bool cache) { m_cacheOnly = cache; }
-
 //============================="GET" METHODS====================================
 
 Hop::Use Hop::use() const { return m_use; }
@@ -434,21 +399,6 @@ double Hop::humulene_pct() const { return m_humulene_pct; }
 double Hop::caryophyllene_pct() const { return m_caryophyllene_pct; }
 double Hop::cohumulone_pct() const { return m_cohumulone_pct; }
 double Hop::myrcene_pct() const { return m_myrcene_pct; }
-bool   Hop::cacheOnly() const { return m_cacheOnly; }
-
-// a little different in that we don't get the results in advance, but on the fly. I had to undo some const action to make this work
-double Hop::inventory()
-{
-   if ( m_inventory < 0 ) {
-      m_inventory = getInventory().toDouble();
-   }
-   return m_inventory;
-}
-
-int Hop::inventoryId() const
-{
-   return m_inventory_id;
-}
 
 const QString Hop::useStringTr() const
 {

--- a/src/model/Hop.h
+++ b/src/model/Hop.h
@@ -22,42 +22,39 @@
  */
 #ifndef MODEL_HOP_H
 #define MODEL_HOP_H
+#pragma once
 
 #include <QString>
 #include <QStringList>
 
-#include "model/NamedEntity.h"
+#include "model/NamedEntityWithInventory.h"
 #include "TableSchema.h"
 
-namespace PropertyNames::Hop { static char const * const form = "form"; /* previously kpropForm */ }
-namespace PropertyNames::Hop { static char const * const time_min = "time_min"; /* previously kpropTime */ }
-namespace PropertyNames::Hop { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
-namespace PropertyNames::Hop { static char const * const inventory_id = "inventory_id"; /* previously kpropInventoryId */ }
-namespace PropertyNames::Hop { static char const * const useString = "useString"; /* previously kpropUseString */ }
-namespace PropertyNames::Hop { static char const * const use = "use"; /* previously kpropUse */ }
-namespace PropertyNames::Hop { static char const * const origin = "origin"; /* previously kpropOrigin */ }
+namespace PropertyNames::Hop { static char const * const alpha_pct = "alpha_pct"; /* previously kpropAlpha */ }
 namespace PropertyNames::Hop { static char const * const amount_kg = "amount_kg"; /* previously kpropAmountKg */ }
+namespace PropertyNames::Hop { static char const * const beta_pct = "beta_pct"; /* previously kpropBeta */ }
+namespace PropertyNames::Hop { static char const * const caryophyllene_pct = "caryophyllene_pct"; /* previously kpropCaryophyllene */ }
+namespace PropertyNames::Hop { static char const * const cohumulone_pct = "cohumulone_pct"; /* previously kpropCohumulone */ }
+namespace PropertyNames::Hop { static char const * const form = "form"; /* previously kpropForm */ }
+namespace PropertyNames::Hop { static char const * const formString = "formString"; /* previously kpropFormString */ }
+namespace PropertyNames::Hop { static char const * const hsi_pct = "hsi_pct"; /* previously kpropHSI */ }
+namespace PropertyNames::Hop { static char const * const humulene_pct = "humulene_pct"; /* previously kpropHumulene */ }
+namespace PropertyNames::Hop { static char const * const myrcene_pct = "myrcene_pct"; /* previously kpropMyrcene */ }
+namespace PropertyNames::Hop { static char const * const notes = "notes"; /* previously kpropNotes */ }
+namespace PropertyNames::Hop { static char const * const origin = "origin"; /* previously kpropOrigin */ }
+namespace PropertyNames::Hop { static char const * const substitutes = "substitutes"; /* previously kpropSubstitutes */ }
+namespace PropertyNames::Hop { static char const * const time_min = "time_min"; /* previously kpropTime */ }
 namespace PropertyNames::Hop { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
 namespace PropertyNames::Hop { static char const * const type = "type"; /* previously kpropType */ }
-namespace PropertyNames::Hop { static char const * const notes = "notes"; /* previously kpropNotes */ }
-namespace PropertyNames::Hop { static char const * const formString = "formString"; /* previously kpropFormString */ }
-namespace PropertyNames::Hop { static char const * const myrcene_pct = "myrcene_pct"; /* previously kpropMyrcene */ }
-namespace PropertyNames::Hop { static char const * const cohumulone_pct = "cohumulone_pct"; /* previously kpropCohumulone */ }
-namespace PropertyNames::Hop { static char const * const caryophyllene_pct = "caryophyllene_pct"; /* previously kpropCaryophyllene */ }
-namespace PropertyNames::Hop { static char const * const humulene_pct = "humulene_pct"; /* previously kpropHumulene */ }
-namespace PropertyNames::Hop { static char const * const substitutes = "substitutes"; /* previously kpropSubstitutes */ }
-namespace PropertyNames::Hop { static char const * const hsi_pct = "hsi_pct"; /* previously kpropHSI */ }
-namespace PropertyNames::Hop { static char const * const beta_pct = "beta_pct"; /* previously kpropBeta */ }
-namespace PropertyNames::Hop { static char const * const alpha_pct = "alpha_pct"; /* previously kpropAlpha */ }
-
+namespace PropertyNames::Hop { static char const * const useString = "useString"; /* previously kpropUseString */ }
+namespace PropertyNames::Hop { static char const * const use = "use"; /* previously kpropUse */ }
 
 /*!
  * \class Hop
  *
  * \brief Model class for a hop record in the database.
  */
-class Hop : public NamedEntity
-{
+class Hop : public NamedEntityWithInventory {
    Q_OBJECT
    Q_CLASSINFO("signal", "hops")
 
@@ -86,10 +83,6 @@ public:
    Q_PROPERTY( double alpha_pct READ alpha_pct WRITE setAlpha_pct /*NOTIFY changed*/ /*changedAlpha_pct*/ )
    //! \brief The amount in kg.
    Q_PROPERTY( double amount_kg READ amount_kg WRITE setAmount_kg /*NOTIFY changed*/ /*changedAmount_kg*/ )
-   //! \brief The amount in inventory in kg.
-   Q_PROPERTY( double inventory READ inventory WRITE setInventoryAmount /*NOTIFY changed*/ /*changedInventory*/ )
-   //! \brief The inventory ID -- needed for signal processing. This is pretty much readonly
-   Q_PROPERTY( double inventoryId READ inventoryId WRITE setInventoryId /*NOTIFY changed*/ /*changedInventory*/ )
    //! \brief The \c Use.
    Q_PROPERTY( Use use READ use WRITE setUse /*NOTIFY changed*/ /*changedUse*/ )
    //! \brief The untranslated \c Use string.
@@ -125,8 +118,6 @@ public:
 
    double alpha_pct() const;
    double amount_kg() const;
-   double inventory();
-   int inventoryId() const;
    // Use in enumerated, untranslated and translated versions
    Use use() const;
    const QString useString() const;
@@ -153,12 +144,10 @@ public:
    double caryophyllene_pct() const;
    double cohumulone_pct() const;
    double myrcene_pct() const;
-   bool cacheOnly() const;
 
    //set
    void setAlpha_pct( double num);
    void setAmount_kg( double num);
-   void setInventoryAmount( double num);
    void setUse( Use u);
    void setTime_min( double num);
 
@@ -173,8 +162,6 @@ public:
    void setCaryophyllene_pct( double num);
    void setCohumulone_pct( double num);
    void setMyrcene_pct( double num);
-   void setCacheOnly(bool cache);
-   void setInventoryId(int key);
 
    static QString classNameStr();
 
@@ -210,9 +197,6 @@ private:
    double m_caryophyllene_pct;
    double m_cohumulone_pct;
    double m_myrcene_pct;
-   double m_inventory;
-   int m_inventory_id;
-   bool m_cacheOnly;
 
    void setDefaults();
 
@@ -226,17 +210,7 @@ private:
 };
 
 Q_DECLARE_METATYPE( QList<Hop*> )
-/*
-inline bool HopPtrLt( Hop* lhs, Hop* rhs)
-{
-   return *lhs < *rhs;
-}
 
-inline bool HopPtrEq( Hop* lhs, Hop* rhs)
-{
-   return *lhs == *rhs;
-}
-*/
 inline bool hopLessThanByTime(const Hop* lhs, const Hop* rhs)
 {
    if ( lhs->use() == rhs->use() )
@@ -248,21 +222,5 @@ inline bool hopLessThanByTime(const Hop* lhs, const Hop* rhs)
    }
    return lhs->use() < rhs->use();
 }
-/*
-struct Hop_ptr_cmp
-{
-   bool operator()( Hop* lhs, Hop* rhs)
-   {
-      return *lhs < *rhs;
-   }
-};
 
-struct Hop_ptr_equals
-{
-   bool operator()( Hop* lhs, Hop* rhs )
-   {
-      return *lhs == *rhs;
-   }
-};
-*/
-#endif // _HOP_H
+#endif

--- a/src/model/Instruction.cpp
+++ b/src/model/Instruction.cpp
@@ -43,20 +43,18 @@ QString Instruction::classNameStr()
 }
 
 Instruction::Instruction(QString name, bool cache)
-   : NamedEntity(Brewtarget::INSTRUCTIONTABLE, name, true),
+   : NamedEntity(Brewtarget::INSTRUCTIONTABLE, cache, name, true),
      m_directions(QString()),
      m_hasTimer  (false),
      m_timerValue(QString()),
      m_completed (false),
      m_interval  (0.0),
-     m_cacheOnly(cache),
      m_recipe   (nullptr)
 {
 }
 
 Instruction::Instruction(TableSchema* table, QSqlRecord rec, int t_key)
    : NamedEntity(table, rec, t_key),
-     m_cacheOnly(false),
      m_recipe   (nullptr)
 {
      m_directions = rec.value( table->propertyToColumn( PropertyNames::Instruction::directions)).toString();
@@ -137,7 +135,6 @@ void Instruction::addReagent(const QString& reagent)
 
 void Instruction::setRecipe(Recipe * const recipe) { this->m_recipe = recipe; }
 
-void Instruction::setCacheOnly(bool cache) { m_cacheOnly = cache; }
 // Accessors ==================================================================
 QString Instruction::directions() { return m_directions; }
 
@@ -152,8 +149,6 @@ QList<QString> Instruction::reagents() { return m_reagents; }
 double Instruction::interval() { return m_interval; }
 
 int Instruction::instructionNumber() const { return Database::instance().instructionNumber(this); }
-
-bool Instruction::cacheOnly() { return m_cacheOnly; }
 
 int Instruction::insertInDatabase() {
    qDebug() << Q_FUNC_INFO << "this->m_recipe:" << static_cast<void *>(this->m_recipe);

--- a/src/model/Instruction.h
+++ b/src/model/Instruction.h
@@ -70,7 +70,6 @@ public:
    void setTimerValue(const QString& timerVal);
    void setCompleted(bool comp);
    void setInterval(double interval);
-   void setCacheOnly(bool cache);
    void addReagent(const QString& reagent);
    void setRecipe(Recipe * const recipe);
 
@@ -82,7 +81,6 @@ public:
    //! This is a non-stored temporary in-memory set.
    QList<QString> reagents();
    double interval();
-   bool cacheOnly();
 
    int instructionNumber() const;
 
@@ -107,7 +105,6 @@ private:
    QString m_timerValue;
    bool    m_completed;
    double  m_interval;
-   bool    m_cacheOnly;
    Recipe * m_recipe;
 
    QList<QString> m_reagents;

--- a/src/model/Mash.cpp
+++ b/src/model/Mash.cpp
@@ -56,7 +56,7 @@ QString Mash::classNameStr()
 }
 
 Mash::Mash(QString name, bool cache)
-   : NamedEntity(Brewtarget::MASHTABLE, name, true),
+   : NamedEntity(Brewtarget::MASHTABLE, cache, name, true),
      m_grainTemp_c(0.0),
      m_notes(QString()),
      m_tunTemp_c(0.0),
@@ -64,15 +64,12 @@ Mash::Mash(QString name, bool cache)
      m_ph(0.0),
      m_tunWeight_kg(0.0),
      m_tunSpecificHeat_calGC(0.0),
-     m_equipAdjust(true),
-     m_cacheOnly(cache)
-{
+     m_equipAdjust(true) {
+   return;
 }
 
-Mash::Mash(TableSchema* table, QSqlRecord rec, int t_key)
-   : NamedEntity(table, rec, t_key),
-     m_cacheOnly(false)
-{
+Mash::Mash(TableSchema* table, QSqlRecord rec, int t_key) :
+   NamedEntity(table, rec, t_key) {
      m_grainTemp_c = rec.value( table->propertyToColumn(PropertyNames::Mash::grainTemp_c)).toDouble();
      m_notes = rec.value( table->propertyToColumn(PropertyNames::Mash::notes)).toString();
      m_tunTemp_c = rec.value( table->propertyToColumn(PropertyNames::Mash::tunTemp_c)).toDouble();
@@ -197,8 +194,6 @@ void Mash::removeAllMashSteps()
    emit mashStepsChanged();
 }
 
-void Mash::setCacheOnly(bool cache) { m_cacheOnly = cache; }
-
 //============================="GET" METHODS====================================
 QString Mash::notes() const { return m_notes; }
 
@@ -215,8 +210,6 @@ double Mash::tunWeight_kg() const { return m_tunWeight_kg; }
 double Mash::tunSpecificHeat_calGC() const { return m_tunSpecificHeat_calGC; }
 
 bool Mash::equipAdjust() const { return m_equipAdjust; }
-
-bool Mash::cacheOnly() const { return m_cacheOnly; }
 
 // === other methods ===
 double Mash::totalMashWater_l()

--- a/src/model/Mash.h
+++ b/src/model/Mash.h
@@ -90,7 +90,6 @@ public:
    void setTunWeight_kg( double var );
    void setTunSpecificHeat_calGC( double var );
    void setEquipAdjust( bool var );
-   void setCacheOnly( bool cache );
 
    // Getters
    double grainTemp_c() const;
@@ -102,7 +101,6 @@ public:
    double tunWeight_kg() const;
    double tunSpecificHeat_calGC() const;
    bool equipAdjust() const;
-   bool cacheOnly() const;
 
    // Calculated getters
    //! \brief all the mash water, sparge and strike
@@ -153,7 +151,6 @@ private:
    double m_tunWeight_kg;
    double m_tunSpecificHeat_calGC;
    bool m_equipAdjust;
-   bool m_cacheOnly;
 
    QList<MashStep*> m_mashSteps;
 

--- a/src/model/MashStep.cpp
+++ b/src/model/MashStep.cpp
@@ -58,7 +58,7 @@ QString MashStep::classNameStr()
 //==============================CONSTRUCTORS====================================
 
 MashStep::MashStep(QString name, bool cache)
-   : NamedEntity(Brewtarget::MASHSTEPTABLE, name, true),
+   : NamedEntity(Brewtarget::MASHSTEPTABLE, cache, name, true),
      m_typeStr(QString()),
      m_type(static_cast<MashStep::Type>(0)),
      m_infuseAmount_l(0.0),
@@ -68,15 +68,12 @@ MashStep::MashStep(QString name, bool cache)
      m_endTemp_c(0.0),
      m_infuseTemp_c(0.0),
      m_decoctionAmount_l(0.0),
-     m_stepNumber(0.0),
-     m_cacheOnly(cache)
-{
+     m_stepNumber(0.0) {
+   return;
 }
 
 MashStep::MashStep(TableSchema* table, QSqlRecord rec, int t_key)
-   : NamedEntity(table, rec, t_key),
-     m_cacheOnly(false)
-{
+   : NamedEntity(table, rec, t_key) {
      m_typeStr = rec.value( table->propertyToColumn( PropertyNames::MashStep::type)).toString();
      m_infuseAmount_l = rec.value( table->propertyToColumn( PropertyNames::MashStep::infuseAmount_l)).toDouble();
      m_stepTemp_c = rec.value( table->propertyToColumn( PropertyNames::MashStep::stepTemp_c)).toDouble();
@@ -223,8 +220,6 @@ void MashStep::setDecoctionAmount_l(double var )
    }
 }
 
-void MashStep::setCacheOnly( bool cache ) { m_cacheOnly = cache; }
-
 void MashStep::setMash( Mash * mash ) { this->m_mash = mash; }
 
 //============================="GET" METHODS====================================
@@ -244,7 +239,6 @@ double MashStep::rampTime_min() const { return m_rampTime_min; }
 double MashStep::endTemp_c() const { return m_endTemp_c; }
 double MashStep::decoctionAmount_l() const { return m_decoctionAmount_l; }
 int MashStep::stepNumber() const { return m_stepNumber; }
-bool MashStep::cacheOnly( ) const { return m_cacheOnly; }
 Mash * MashStep::mash( ) const { return m_mash; }
 
 bool MashStep::isInfusion() const

--- a/src/model/MashStep.h
+++ b/src/model/MashStep.h
@@ -21,9 +21,10 @@
 #ifndef MODEL_MASHSTEP_H
 #define MODEL_MASHSTEP_H
 
-#include "model/NamedEntity.h"
 #include <QStringList>
 #include <QString>
+
+#include "model/NamedEntity.h"
 #include "model/Mash.h"
 
 namespace PropertyNames::MashStep { static char const * const stepNumber = "stepNumber"; /* previously kpropStepNumber */ }
@@ -45,7 +46,7 @@ namespace PropertyNames::MashStep { static char const * const type = "type"; /* 
 class MashStep : public NamedEntity
 {
    Q_OBJECT
-   Q_CLASSINFO("signal", "mashsteps");
+   Q_CLASSINFO("signal", "mashsteps")
 
    // this seems to be a class with a lot of friends
    friend class Database;
@@ -94,7 +95,6 @@ public:
    void setEndTemp_c( double var);
    void setInfuseTemp_c( double var);
    void setDecoctionAmount_l( double var);
-   void setCacheOnly(bool cache);
    void setMash(Mash * mash);
 
    Type type() const;
@@ -107,7 +107,6 @@ public:
    double endTemp_c() const;
    double infuseTemp_c() const;
    double decoctionAmount_l() const;
-   bool cacheOnly() const;
    Mash * mash() const;
 
    //! What number this step is in the mash.
@@ -146,7 +145,6 @@ private:
    double m_infuseTemp_c;
    double m_decoctionAmount_l;
    int m_stepNumber;
-   bool m_cacheOnly;
    Mash * m_mash;
 
    bool isValidType( const QString &str ) const;

--- a/src/model/Misc.h
+++ b/src/model/Misc.h
@@ -22,30 +22,28 @@
  */
 #ifndef MODEL_MISC_H
 #define MODEL_MISC_H
+#pragma once
 
 #include <QString>
 
-#include "model/NamedEntity.h"
-
+#include "model/NamedEntityWithInventory.h"
 namespace PropertyNames::Misc { static char const * const amount = "amount"; /* previously kpropAmount */ }
 namespace PropertyNames::Misc { static char const * const amountIsWeight = "amountIsWeight"; /* previously kpropAmtIsWgt */ }
-namespace PropertyNames::Misc { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
-namespace PropertyNames::Misc { static char const * const inventory_id = "inventory_id"; /* previously kpropInventoryId */ }
-namespace PropertyNames::Misc { static char const * const useString = "useString"; /* previously kpropUseString */ }
-namespace PropertyNames::Misc { static char const * const use = "use"; /* previously kpropUse */ }
-namespace PropertyNames::Misc { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
-namespace PropertyNames::Misc { static char const * const type = "type"; /* previously kpropType */ }
+namespace PropertyNames::Misc { static char const * const amountType = "amountType"; }
 namespace PropertyNames::Misc { static char const * const notes = "notes"; /* previously kpropNotes */ }
 namespace PropertyNames::Misc { static char const * const time = "time"; /* previously kpropMiscTime */ }
+namespace PropertyNames::Misc { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
+namespace PropertyNames::Misc { static char const * const type = "type"; /* previously kpropType */ }
 namespace PropertyNames::Misc { static char const * const useFor = "useFor"; /* previously kpropUseFor */ }
+namespace PropertyNames::Misc { static char const * const useString = "useString"; /* previously kpropUseString */ }
+namespace PropertyNames::Misc { static char const * const use = "use"; /* previously kpropUse */ }
 
 /*!
  * \class Misc
  *
  * \brief Model for a misc record in the database.
  */
-class Misc : public NamedEntity
-{
+class Misc : public NamedEntityWithInventory {
    Q_OBJECT
    Q_CLASSINFO("signal", "miscs")
 
@@ -88,10 +86,6 @@ public:
    Q_PROPERTY( double time READ time WRITE setTime /*NOTIFY changed*/ /*changedTime*/ )
    //! \brief The amount in either kg or L, depending on \c amountIsWeight().
    Q_PROPERTY( double amount READ amount WRITE setAmount /*NOTIFY changed*/ /*changedAmount*/ )
-   //! \brief The amount in inventory in either kg or L, depending on \c amountIsWeight().
-   Q_PROPERTY( double inventory READ inventory WRITE setInventoryAmount /*NOTIFY changed*/ /*changedAmount*/ )
-   //! \brief The inventory id.
-   Q_PROPERTY( double inventoryId READ inventoryId WRITE setInventoryId /*NOTIFY changed*/ /*changedAmount*/ )
    //! \brief Whether the amount is weight (kg), or volume (L).
    Q_PROPERTY( bool amountIsWeight READ amountIsWeight WRITE setAmountIsWeight /*NOTIFY changed*/ /*changedAmountIsWeight*/ )
    //! \brief What to use it for.
@@ -104,13 +98,11 @@ public:
    void setUse( Use u );
    void setAmountType( AmountType t );
    void setAmount( double var );
-   void setInventoryAmount( double var );
+
    void setTime( double var );
    void setAmountIsWeight( bool var );
    void setUseFor( const QString &var );
    void setNotes( const QString &var );
-   void setCacheOnly( bool cache );
-   void setInventoryId( int key );
 
    // Get
 //   QString name() const;
@@ -124,13 +116,10 @@ public:
    const QString amountTypeString() const;
    const QString amountTypeStringTr() const;
    double amount() const;
-   double inventory();
-   int inventoryId() const;
    double time() const;
    bool amountIsWeight() const;
    QString useFor() const;
    QString notes() const;
-   bool cacheOnly() const;
 
    static QString classNameStr();
 
@@ -149,7 +138,7 @@ protected:
 
 private:
    Misc(TableSchema* table, QSqlRecord rec, int t_key = -1);
-   Misc(Misc & other);
+   Misc(Misc const & other);
 
    QString m_typeString;
    Type m_type;
@@ -160,9 +149,6 @@ private:
    bool m_amountIsWeight;
    QString m_useFor;
    QString m_notes;
-   double m_inventory;
-   int m_inventory_id;
-   bool m_cacheOnly;
 
    bool isValidType( const QString &var );
    bool isValidUse( const QString &var );
@@ -173,31 +159,5 @@ private:
 };
 
 Q_DECLARE_METATYPE( QList<Misc*> )
-/*
-inline bool MiscPtrLt( Misc* lhs, Misc* rhs)
-{
-   return lhs->name() < rhs->name();
-}
 
-inline bool MiscPtrEq( Misc* lhs, Misc* rhs)
-{
-   return lhs->name() == rhs->name();
-}
-
-struct Misc_ptr_cmp
-{
-   bool operator()( Misc* lhs, Misc* rhs)
-   {
-      return lhs->name() < rhs->name();
-   }
-};
-
-struct Misc_ptr_equals
-{
-   bool operator()( Misc* lhs, Misc* rhs )
-   {
-      return lhs->name() == rhs->name();
-   }
-};
-*/
-#endif   /* _MISC_H */
+#endif

--- a/src/model/NamedEntityWithInventory.cpp
+++ b/src/model/NamedEntityWithInventory.cpp
@@ -1,0 +1,91 @@
+/*
+ * model/NamedEntityWithInventory.cpp is part of Brewtarget, and is Copyright the following
+ * authors 2021
+ * - Matt Young <mfsy@yahoo.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "model/NamedEntityWithInventory.h"
+
+NamedEntityWithInventory::NamedEntityWithInventory(Brewtarget::DBTable table, bool cache, QString t_name, bool t_display, QString folder) :
+   NamedEntity   {table, cache, t_name, t_display},
+   m_inventory{0},
+   m_inventory_id{-1} {
+   return;
+}
+
+NamedEntityWithInventory::NamedEntityWithInventory(TableSchema* table, QSqlRecord rec, int t_key) :
+   NamedEntity(table, rec, t_key),
+   m_inventory{0} {
+
+   // keys need special handling
+   m_inventory_id = rec.value( table->foreignKeyToColumn(PropertyNames::NamedEntityWithInventory::inventoryId)).toInt();
+
+   return;
+}
+
+NamedEntityWithInventory::NamedEntityWithInventory(NamedParameterBundle const & namedParameterBundle) :
+   NamedEntity   {namedParameterBundle},
+   m_inventory_id{namedParameterBundle(PropertyNames::NamedEntityWithInventory::inventoryId).toInt()} {
+   return;
+}
+
+NamedEntityWithInventory::NamedEntityWithInventory(NamedEntityWithInventory const & other) :
+   NamedEntity     {other                 },
+   // Don't copy Inventory ID as new object should have its own inventory - unless it's a child
+   m_inventory{0},
+   m_inventory_id {-1} {
+   return;
+}
+
+void NamedEntityWithInventory::setInventoryId(int key) {
+   if( key < 1 ) {
+      qWarning() << Q_FUNC_INFO << this->metaObject()->className() << ": bad inventory id:" << key;
+      return;
+   }
+   m_inventory_id = key;
+   if ( ! m_cacheOnly ) {
+      setEasy(PropertyNames::NamedEntityWithInventory::inventoryId, key);
+   }
+   return;
+}
+
+int NamedEntityWithInventory::inventoryId() const {
+   return m_inventory_id;
+}
+
+
+// changes to inventory amounts do NOT create a version
+void NamedEntityWithInventory::setInventoryAmount(double num) {
+   if( num < 0.0 ) {
+      qWarning() << Q_FUNC_INFO << this->metaObject()->className() << ": negative inventory:" << num;
+      return;
+   }
+
+   m_inventory = num;
+   if ( ! m_cacheOnly ) {
+      if( m_inventory_id < 1 ) {
+         qWarning() << Q_FUNC_INFO << this->metaObject()->className() << ": bad inventory id:" << m_inventory_id;
+         return;
+      }
+      setInventory(num,m_inventory_id);
+   }
+}
+
+double NamedEntityWithInventory::inventory() const {
+   if ( m_inventory < 0 ) {
+      m_inventory = getInventory().toDouble();
+   }
+   return m_inventory;
+}

--- a/src/model/NamedEntityWithInventory.h
+++ b/src/model/NamedEntityWithInventory.h
@@ -1,0 +1,59 @@
+/*
+ * model/NamedEntityWithInventory.h is part of Brewtarget, and is Copyright the following
+ * authors 2021
+ * - Matt Young <mfsy@yahoo.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef MODEL_NAMEDENTITYWITHINVENTORY_H
+#define MODEL_NAMEDENTITYWITHINVENTORY_H
+#pragma once
+
+#include "model/NamedEntity.h"
+
+namespace PropertyNames::NamedEntityWithInventory { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
+namespace PropertyNames::NamedEntityWithInventory { static char const * const inventoryId = "inventoryId"; /* previously kpropInventoryId */ }
+
+/**
+ * \class NamedEntityWithInventory
+ *
+ * \brief Extends \c NamedEntity to provide functionality for storing in Inventory
+ */
+class NamedEntityWithInventory : public NamedEntity {
+   Q_OBJECT
+public:
+   NamedEntityWithInventory(Brewtarget::DBTable table, bool cache = true, QString t_name = QString(), bool t_display = false, QString folder = QString());
+   NamedEntityWithInventory(TableSchema* table, QSqlRecord rec, int t_key = -1);
+   NamedEntityWithInventory(NamedEntityWithInventory const & other);
+   NamedEntityWithInventory(NamedParameterBundle const & namedParameterBundle);
+
+   virtual ~NamedEntityWithInventory() = default;
+
+   //! \brief The amount in inventory (usually in kg)
+   Q_PROPERTY( double inventory              READ inventory              WRITE setInventoryAmount        /*NOTIFY changed*/ /*changedInventory*/ )
+   //! \brief The inventory table id, needed for signals
+   Q_PROPERTY( double inventoryId            READ inventoryId            WRITE setInventoryId            /*NOTIFY changed*/ /*changedInventoryId*/ )
+
+   virtual double inventory() const;
+   int inventoryId() const;
+
+   virtual void setInventoryAmount(double amount);
+   void setInventoryId(int key);
+
+protected:
+   mutable double m_inventory;
+   int m_inventory_id;
+};
+
+#endif

--- a/src/model/NamedParameterBundle.cpp
+++ b/src/model/NamedParameterBundle.cpp
@@ -24,6 +24,14 @@
 #include <QDebug>
 #include <QString>
 
+namespace {
+   template <class T> T valueFromQVariant(QVariant const & qv);
+   template <> QString valueFromQVariant(QVariant const & qv) {return qv.toString();}
+   template <> bool    valueFromQVariant(QVariant const & qv) {return qv.toBool();}
+   template <> int     valueFromQVariant(QVariant const & qv) {return qv.toInt();}
+   template <> double  valueFromQVariant(QVariant const & qv) {return qv.toDouble();}
+}
+
 NamedParameterBundle::NamedParameterBundle() : QHash<char const * const, QVariant>() {
    return;
 }
@@ -53,20 +61,15 @@ QVariant NamedParameterBundle::operator()(char const * const parameterName) cons
    return returnValue;
 }
 
+template <class T> T NamedParameterBundle::operator()(char const * const parameterName, T const & defaultValue) const {
+   return this->contains(parameterName) ? valueFromQVariant<T>(this->value(parameterName)) : defaultValue;
+}
 
-template <> void NamedParameterBundle::operator()<QString>(char const * const parameterName, QString & storeIn) const {
-   storeIn = this->operator()(parameterName).toString();
-   return;
-}
-template <> void NamedParameterBundle::operator()<bool>(char const * const parameterName, bool & storeIn) const {
-   storeIn = this->operator()(parameterName).toBool();
-   return;
-}
-template <> void NamedParameterBundle::operator()<int>(char const * const parameterName, int & storeIn) const {
-   storeIn = this->operator()(parameterName).toInt();
-   return;
-}
-template <> void NamedParameterBundle::operator()<double>(char const * const parameterName, double & storeIn) const {
-   storeIn = this->operator()(parameterName).toDouble();
-   return;
-}
+//
+// Instantiate the above template function for the types that are going to use it
+// (This is all just a trick to allow the template definition to be here in the .cpp file and not in the header.)
+//
+template QString    NamedParameterBundle::operator()(char const * const parameterName, QString const & defaultValue) const;
+template bool       NamedParameterBundle::operator()(char const * const parameterName, bool    const & defaultValue) const;
+template int        NamedParameterBundle::operator()(char const * const parameterName, int     const & defaultValue) const;
+template double     NamedParameterBundle::operator()(char const * const parameterName, double  const & defaultValue) const;

--- a/src/model/NamedParameterBundle.h
+++ b/src/model/NamedParameterBundle.h
@@ -40,14 +40,14 @@ public:
    QVariant operator()(char const * const parameterName) const;
 
    /**
-    * \brief Get and store the value of a parameter that is required to be present
+    * \brief Get the value of a parameter that is not required to be present
     *
     *        (NB: There is no general implementation of this templated function, just specific specialisations)
     *
     * \param parameterName
-    * \param storeIn
+    * \param defaultValue  What to return if the parameter is not present in the bundle
     */
-   template <class T> void operator()(char const * const parameterName, T & storeIn) const;
+   template <class T> T operator()(char const * const parameterName, T const & defaultValue) const;
 };
 
 #endif

--- a/src/model/Recipe.cpp
+++ b/src/model/Recipe.cpp
@@ -111,7 +111,7 @@ QString Recipe::classNameStr()
 }
 
 Recipe::Recipe(QString name, bool cache)
-   : NamedEntity(Brewtarget::RECTABLE, name, true),
+   : NamedEntity(Brewtarget::RECTABLE, cache, name, true),
    m_type(QString("All Grain")),
    m_brewer(QString("")),
    m_asstBrewer(QString("Brewtarget: free beer software")),
@@ -141,7 +141,6 @@ Recipe::Recipe(QString name, bool cache)
    m_style_id(0),
    m_og(1.0),
    m_fg(1.0),
-   m_cacheOnly(cache),
    m_locked(false),
    m_hasDescendants(false)
 {
@@ -149,7 +148,6 @@ Recipe::Recipe(QString name, bool cache)
 
 Recipe::Recipe(TableSchema* table, QSqlRecord rec, int t_key)
    : NamedEntity(table, rec, t_key),
-   m_cacheOnly(false),
    m_hasDescendants(false)
 {
    m_type = rec.value( table->propertyToColumn( PropertyNames::Recipe::type)).toString();
@@ -215,7 +213,6 @@ Recipe::Recipe( Recipe const& other ) : NamedEntity(other),
    m_style_id(other.m_style_id),
    m_og(other.m_og),
    m_fg(other.m_fg),
-   m_cacheOnly(other.m_cacheOnly),
    m_locked(other.m_locked),
    m_hasDescendants(false)
 {
@@ -1380,8 +1377,6 @@ void Recipe::setLocked(bool isLocked )
    }
 }
 
-void Recipe::setCacheOnly( bool cache ) { m_cacheOnly = cache; }
-
 //==========================Calculated Getters============================
 
 double Recipe::og()
@@ -1613,7 +1608,6 @@ double Recipe::primingSugarEquiv() const { return m_primingSugarEquiv; }
 double Recipe::kegPrimingFactor() const { return m_kegPrimingFactor; }
 int Recipe::fermentationStages() const { return m_fermentationStages; }
 QDate Recipe::date() const { return m_date; }
-bool Recipe::cacheOnly() const { return m_cacheOnly; }
 bool Recipe::locked() const { return m_locked; }
 
 //=============================Adders and Removers========================================

--- a/src/model/Recipe.h
+++ b/src/model/Recipe.h
@@ -381,7 +381,6 @@ public:
    double carbonationTemp_c() const;
    double primingSugarEquiv() const;
    double kegPrimingFactor() const;
-   bool cacheOnly() const;
    bool locked() const;
 
    // Calculated getters.
@@ -483,7 +482,6 @@ public:
    void setCarbonationTemp_c( double var );
    void setPrimingSugarEquiv( double var );
    void setKegPrimingFactor( double var );
-   void setCacheOnly( bool cache );
    void setLocked(bool isLocked);
    void setHasDescendants(bool spawned);
 
@@ -565,7 +563,6 @@ private:
    double m_og_fermentable;
    double m_fg_fermentable;
 
-   bool m_cacheOnly;
    bool m_locked;
    // True when constructed, indicates whether recalcAll has been called.
    bool m_uninitializedCalcs;

--- a/src/model/Salt.cpp
+++ b/src/model/Salt.cpp
@@ -54,35 +54,31 @@ QString Salt::classNameStr()
 }
 
 Salt::Salt(QString name, bool cache)
-   : NamedEntity(Brewtarget::SALTTABLE, name, true),
+   : NamedEntity(Brewtarget::SALTTABLE, cache, name, true),
    m_amount(0.0),
    m_add_to(NEVER),
    m_type(NONE),
    m_amount_is_weight(true),
    m_percent_acid(0.0),
    m_is_acid(false),
-   m_misc_id(-1),
-   m_cacheOnly(cache)
-{
+   m_misc_id(-1) {
+   return;
 }
 
 Salt::Salt(Salt & other)
-   : NamedEntity(Brewtarget::SALTTABLE, other.name(), true),
+   : NamedEntity(other),
    m_amount(other.m_amount),
    m_add_to(other.m_add_to),
    m_type(other.m_type),
    m_amount_is_weight(other.m_amount_is_weight),
    m_percent_acid(other.m_percent_acid),
    m_is_acid(other.m_is_acid),
-   m_misc_id(other.m_misc_id),
-   m_cacheOnly(other.m_cacheOnly)
-{
+   m_misc_id(other.m_misc_id) {
+   return;
 }
 
 Salt::Salt(TableSchema* table, QSqlRecord rec, int t_key)
-   : NamedEntity(table, rec, t_key),
-   m_cacheOnly(false)
-{
+   : NamedEntity(table, rec, t_key) {
    m_amount = rec.value(table->propertyToColumn( PropertyNames::Salt::amount)).toDouble();
    m_amount_is_weight = rec.value( table->propertyToColumn( PropertyNames::Salt::amountIsWeight)).toBool();
    m_percent_acid = rec.value( table->propertyToColumn( PropertyNames::Salt::percentAcid)).toDouble();
@@ -123,7 +119,7 @@ void Salt::setType(Salt::Types type)
 
    bool anAcid = (type > NAHCO3);
    bool isWeight = ! (type == LACTIC || type == H3PO4);
-   if ( m_cacheOnly || 
+   if ( m_cacheOnly ||
         setEasy(PropertyNames::Salt::type, type) ||
         setEasy(PropertyNames::Salt::isAcid, anAcid) ||
         setEasy(PropertyNames::Salt::amountIsWeight, isWeight) ) {
@@ -153,13 +149,11 @@ void Salt::setPercentAcid(double var)
       m_percent_acid = var;
    }
 }
-void Salt::setCacheOnly(bool cache) { m_cacheOnly = cache; }
 
 //=========================="GET" METHODS=======================================
 double Salt::amount() const { return m_amount; }
 Salt::WhenToAdd Salt::addTo() const { return m_add_to; }
 Salt::Types Salt::type() const { return m_type; }
-bool Salt::cacheOnly() const { return m_cacheOnly; }
 int Salt::miscId() const { return m_misc_id; }
 bool Salt::isAcid() const { return m_is_acid; }
 bool Salt::amountIsWeight() const { return m_amount_is_weight; }

--- a/src/model/Salt.h
+++ b/src/model/Salt.h
@@ -93,8 +93,6 @@ public:
    Q_PROPERTY( bool isAcid READ isAcid WRITE setIsAcid /*NOTIFY changed*/ /*changedIsAcid*/ )
    //! \brief A link to the salt in the MISC table. Not sure I'm going to use this
    Q_PROPERTY( int miscId READ miscId /* WRITE setMiscId*/ /*NOTIFY changed*/ /*changedSulfate_ppm*/ )
-   //! \brief To cache or not to cache
-   Q_PROPERTY( bool cacheOnly READ cacheOnly WRITE setCacheOnly /*NOTIFY changed*/ /*changedSulfate_ppm*/ )
 
    double amount() const;
    Salt::WhenToAdd addTo() const;
@@ -103,7 +101,6 @@ public:
    double percentAcid() const;
    bool isAcid() const;
    int miscId() const;
-   bool cacheOnly() const;
 
    void setAmount( double var );
    void setAddTo( Salt::WhenToAdd var );
@@ -111,7 +108,6 @@ public:
    void setAmountIsWeight( bool var );
    void setPercentAcid(double var);
    void setIsAcid( bool var );
-   void setCacheOnly( bool var );
 
    static QString classNameStr();
 
@@ -145,7 +141,6 @@ private:
    double m_percent_acid;
    bool m_is_acid;
    int m_misc_id;
-   bool m_cacheOnly;
 
 };
 

--- a/src/model/Style.cpp
+++ b/src/model/Style.cpp
@@ -52,7 +52,7 @@ QString Style::classNameStr()
 
 // suitable for something that will be written to the db later
 Style::Style(QString t_name, bool cacheOnly)
-   : NamedEntity(Brewtarget::STYLETABLE, t_name, true),
+   : NamedEntity(Brewtarget::STYLETABLE, cacheOnly, t_name, true),
      m_category(QString()),
      m_categoryNumber(QString()),
      m_styleLetter(QString()),
@@ -74,16 +74,13 @@ Style::Style(QString t_name, bool cacheOnly)
      m_notes(QString()),
      m_profile(QString()),
      m_ingredients(QString()),
-     m_examples(QString()),
-     m_cacheOnly(cacheOnly)
-{
+     m_examples(QString()) {
+   return;
 }
 
 // suitable for creating a Style from a database record
 Style::Style(TableSchema* table, QSqlRecord rec, int t_key)
-   : NamedEntity(table, rec, t_key),
-     m_cacheOnly(false)
-{
+   : NamedEntity(table, rec, t_key) {
      m_category = rec.value( table->propertyToColumn( PropertyNames::Style::category)).toString();
      m_categoryNumber = rec.value( table->propertyToColumn( PropertyNames::Style::categoryNumber)).toString();
      m_styleLetter = rec.value( table->propertyToColumn( PropertyNames::Style::styleLetter)).toString();
@@ -359,8 +356,6 @@ void Style::setExamples( const QString& var )
    }
 }
 
-void Style::setCacheOnly( const bool cache ) { m_cacheOnly = cache; }
-
 //============================="GET" METHODS====================================
 QString Style::category() const { return m_category; }
 QString Style::categoryNumber() const { return m_categoryNumber; }
@@ -373,7 +368,6 @@ QString Style::examples() const { return m_examples; }
 Style::Type Style::type() const { return m_type; }
 const QString Style::typeString() const { return m_typeStr; }
 
-bool   Style::cacheOnly() const { return m_cacheOnly; }
 double Style::ogMin() const { return m_ogMin; }
 double Style::ogMax() const { return m_ogMax; }
 double Style::fgMin() const { return m_fgMin; }

--- a/src/model/Style.h
+++ b/src/model/Style.h
@@ -140,7 +140,6 @@ public:
    void setProfile( const QString& var);
    void setNamedEntitys( const QString& var);
    void setExamples( const QString& var);
-   void setCacheOnly(const bool cache);
 
    QString category() const;
    QString categoryNumber() const;
@@ -164,7 +163,6 @@ public:
    QString profile() const;
    QString ingredients() const;
    QString examples() const;
-   bool cacheOnly() const;
 
    static QString classNameStr();
 
@@ -205,8 +203,6 @@ private:
    QString m_profile;
    QString m_ingredients;
    QString m_examples;
-
-   bool m_cacheOnly;
 
    bool isValidType( const QString &str );
    static QStringList m_types;

--- a/src/model/Water.cpp
+++ b/src/model/Water.cpp
@@ -50,7 +50,7 @@ QString Water::classNameStr()
 }
 
 Water::Water(QString name, bool cache)
-   : NamedEntity(Brewtarget::WATERTABLE, name, true),
+   : NamedEntity(Brewtarget::WATERTABLE, cache, name, true),
    m_amount(0.0),
    m_calcium_ppm(0.0),
    m_bicarbonate_ppm(0.0),
@@ -61,7 +61,6 @@ Water::Water(QString name, bool cache)
    m_ph(0.0),
    m_alkalinity(0.0),
    m_notes(QString()),
-   m_cacheOnly(cache),
    m_type(NONE),
    m_mash_ro(0.0),
    m_sparge_ro(0.0),
@@ -70,7 +69,7 @@ Water::Water(QString name, bool cache)
 }
 
 Water::Water(Water const& other, bool cache)
-   : NamedEntity(Brewtarget::WATERTABLE, other.name(), true),
+   : NamedEntity(Brewtarget::WATERTABLE, cache, other.name(), true),
    m_amount(other.m_amount),
    m_calcium_ppm(other.m_calcium_ppm),
    m_bicarbonate_ppm(other.m_bicarbonate_ppm),
@@ -81,7 +80,6 @@ Water::Water(Water const& other, bool cache)
    m_ph(other.m_ph),
    m_alkalinity(other.m_alkalinity),
    m_notes(other.m_notes),
-   m_cacheOnly(cache),
    m_type(other.m_type),
    m_mash_ro(other.m_mash_ro),
    m_sparge_ro(other.m_sparge_ro),
@@ -90,9 +88,7 @@ Water::Water(Water const& other, bool cache)
 }
 
 Water::Water(TableSchema* table, QSqlRecord rec, int t_key)
-   : NamedEntity(table, rec, t_key),
-   m_cacheOnly(false)
-{
+   : NamedEntity(table, rec, t_key) {
    m_amount = rec.value( table->propertyToColumn( PropertyNames::Water::amount)).toDouble();
    m_calcium_ppm = rec.value( table->propertyToColumn( PropertyNames::Water::calcium_ppm)).toDouble();
    m_bicarbonate_ppm = rec.value( table->propertyToColumn( PropertyNames::Water::bicarbonate_ppm)).toDouble();
@@ -182,8 +178,6 @@ void Water::setNotes( const QString &var )
    }
 }
 
-void Water::setCacheOnly(bool cache) { m_cacheOnly = cache; }
-
 void Water::setType(Types type)
 {
    if ( type < NONE || type > TARGET ) {
@@ -227,7 +221,6 @@ double Water::sodium_ppm() const { return m_sodium_ppm; }
 double Water::magnesium_ppm() const { return m_magnesium_ppm; }
 double Water::ph() const { return m_ph; }
 double Water::alkalinity() const { return m_alkalinity; }
-bool Water::cacheOnly() const { return m_cacheOnly; }
 Water::Types Water::type() const { return m_type; }
 double Water::mashRO() const { return m_mash_ro; }
 double Water::spargeRO() const { return m_sparge_ro; }

--- a/src/model/Water.h
+++ b/src/model/Water.h
@@ -121,7 +121,6 @@ public:
    double ph() const;
    double alkalinity() const;
    QString notes() const;
-   bool cacheOnly() const;
    Water::Types type() const;
    double mashRO() const;
    double spargeRO() const;
@@ -138,7 +137,6 @@ public:
    void setPh( double var );
    void setAlkalinity(double var);
    void setNotes( const QString &var );
-   void setCacheOnly( bool cache );
    void setType(Types type);
    void setMashRO(double var);
    void setSpargeRO(double var);
@@ -170,7 +168,6 @@ private:
    double m_ph;
    double m_alkalinity;
    QString m_notes;
-   bool m_cacheOnly;
    Water::Types m_type;
    double m_mash_ro;
    double m_sparge_ro;

--- a/src/model/Yeast.h
+++ b/src/model/Yeast.h
@@ -20,40 +20,39 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef _YEAST_H
-#define _YEAST_H
+#ifndef MODEL_YEAST_H
+#define MODEL_YEAST_H
 
-#include "model/NamedEntity.h"
 #include <QString>
 #include <QStringList>
-namespace PropertyNames::Yeast { static char const * const amount = "amount"; /* previously kpropAmount */ }
-namespace PropertyNames::Yeast { static char const * const form = "form"; /* previously kpropForm */ }
-namespace PropertyNames::Yeast { static char const * const amountIsWeight = "amountIsWeight"; /* previously kpropAmtIsWgt */ }
-namespace PropertyNames::Yeast { static char const * const inventory = "inventory"; /* previously kpropInventory */ }
-namespace PropertyNames::Yeast { static char const * const inventory_id = "inventory_id"; /* previously kpropInventoryId */ }
-namespace PropertyNames::Yeast { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
-namespace PropertyNames::Yeast { static char const * const type = "type"; /* previously kpropType */ }
-namespace PropertyNames::Yeast { static char const * const notes = "notes"; /* previously kpropNotes */ }
+
+#include "model/NamedEntityWithInventory.h"
+
 namespace PropertyNames::Yeast { static char const * const addToSecondary = "addToSecondary"; /* previously kpropAddToSec */ }
-namespace PropertyNames::Yeast { static char const * const maxReuse = "maxReuse"; /* previously kpropMaxReuse */ }
-namespace PropertyNames::Yeast { static char const * const timesCultured = "timesCultured"; /* previously kpropTimesCultd */ }
-namespace PropertyNames::Yeast { static char const * const bestFor = "bestFor"; /* previously kpropBestFor */ }
+namespace PropertyNames::Yeast { static char const * const amount = "amount"; /* previously kpropAmount */ }
+namespace PropertyNames::Yeast { static char const * const amountIsWeight = "amountIsWeight"; /* previously kpropAmtIsWgt */ }
 namespace PropertyNames::Yeast { static char const * const attenuation_pct = "attenuation_pct"; /* previously kpropAttenPct */ }
-namespace PropertyNames::Yeast { static char const * const flocculationString = "flocculationString"; /* previously kpropFlocString */ }
+namespace PropertyNames::Yeast { static char const * const bestFor = "bestFor"; /* previously kpropBestFor */ }
 namespace PropertyNames::Yeast { static char const * const flocculation = "flocculation"; /* previously kpropFloc */ }
+namespace PropertyNames::Yeast { static char const * const flocculationString = "flocculationString"; /* previously kpropFlocString */ }
+namespace PropertyNames::Yeast { static char const * const form = "form"; /* previously kpropForm */ }
+namespace PropertyNames::Yeast { static char const * const formString = "formString"; /* previously kpropFormString */ }
+namespace PropertyNames::Yeast { static char const * const laboratory = "laboratory"; /* previously kpropLab */ }
+namespace PropertyNames::Yeast { static char const * const maxReuse = "maxReuse"; /* previously kpropMaxReuse */ }
 namespace PropertyNames::Yeast { static char const * const maxTemperature_c = "maxTemperature_c"; /* previously kpropMaxTemp */ }
 namespace PropertyNames::Yeast { static char const * const minTemperature_c = "minTemperature_c"; /* previously kpropMinTemp */ }
+namespace PropertyNames::Yeast { static char const * const notes = "notes"; /* previously kpropNotes */ }
 namespace PropertyNames::Yeast { static char const * const productID = "productID"; /* previously kpropProductID */ }
-namespace PropertyNames::Yeast { static char const * const laboratory = "laboratory"; /* previously kpropLab */ }
-namespace PropertyNames::Yeast { static char const * const formString = "formString"; /* previously kpropFormString */ }
+namespace PropertyNames::Yeast { static char const * const timesCultured = "timesCultured"; /* previously kpropTimesCultd */ }
+namespace PropertyNames::Yeast { static char const * const typeString = "typeString"; /* previously kpropTypeString */ }
+namespace PropertyNames::Yeast { static char const * const type = "type"; /* previously kpropType */ }
 
 /*!
  * \class Yeast
  *
  * \brief Model for yeast records in the database.
  */
-class Yeast : public NamedEntity
-{
+class Yeast : public NamedEntityWithInventory {
    Q_OBJECT
    Q_CLASSINFO("signal", "yeasts")
 
@@ -71,7 +70,7 @@ public:
    Q_ENUMS( Type Form Flocculation )
 
    Yeast(QString name, bool cache = true);
-   virtual ~Yeast() {}
+   virtual ~Yeast() = default;
 
    //! \brief The \c Type.
    Q_PROPERTY( Type type READ type WRITE setType /*NOTIFY changed*/ /*changedType*/ )
@@ -87,10 +86,6 @@ public:
    Q_PROPERTY( QString formStringTr READ formStringTr )
    //! \brief The amount in either liters or kg depending on \c amountIsWeight().
    Q_PROPERTY( double amount READ amount WRITE setAmount /*NOTIFY changed*/ /*changedAmount*/ )
-   //! \brief The amount in inventory in either liters or kg depending on \c amountIsWeight().
-   Q_PROPERTY( double inventory READ inventory WRITE setInventoryQuanta /*NOTIFY changed*/ /*changedInventory*/ )
-   //! \brief The inventory id
-   Q_PROPERTY( double inventoryId READ inventoryId WRITE setInventoryId /*NOTIFY changed*/ /*changedInventory*/ )
    //! \brief Whether the \c amount() is weight (kg) or volume (liters).
    Q_PROPERTY( bool amountIsWeight READ amountIsWeight WRITE setAmountIsWeight /*NOTIFY changed*/ /*changedAmountIsWeight*/ )
    //! \brief The lab from which it came.
@@ -137,8 +132,6 @@ public:
    void setTimesCultured( int var);
    void setMaxReuse( int var);
    void setAddToSecondary( bool var);
-   void setCacheOnly( bool cache);
-   void setInventoryId( int key);
 
    // Getters
    Type type() const;
@@ -148,8 +141,6 @@ public:
    const QString formString() const;
    const QString formStringTr() const;
    double amount() const;
-   int inventory();
-   int inventoryId() const;
    bool amountIsWeight() const;
    QString laboratory() const;
    QString productID() const;
@@ -164,7 +155,6 @@ public:
    int timesCultured() const;
    int maxReuse() const;
    bool addToSecondary() const;
-   bool cacheOnly() const;
 
    static QString classNameStr();
 
@@ -180,7 +170,7 @@ protected:
 private:
 //   Yeast(Brewtarget::DBTable table, int key);
    Yeast(TableSchema* table, QSqlRecord rec, int t_key = -1);
-   Yeast(Yeast & other);
+   Yeast(Yeast const & other);
 
    QString m_typeString;
    Type m_type;
@@ -200,9 +190,6 @@ private:
    int m_timesCultured;
    int m_maxReuse;
    bool m_addToSecondary;
-   int m_inventory;
-   int m_inventory_id;
-   bool m_cacheOnly;
 
    static QStringList types;
    static QStringList forms;
@@ -242,4 +229,4 @@ struct Yeast_ptr_equals
    }
 };
 */
-#endif
+#endif   // YEAST_H


### PR DESCRIPTION
This stops the crashing reported in https://github.com/Brewtarget/brewtarget/issues/601, but doesn't fix the problem that not everything has an inventory ID.  (This is fixed in Brewken because, when I rewrote the DB layer, I added some logic that automatically creates an inventory ID for anything that doesn't have one.  That fix will get backported soon, I hope, when I backport the new database layer.) 