### PR TITLE
Fix various Signal/DB/XML import issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,6 +184,7 @@ SET( brewtarget_SRCS
     ${SRCDIR}/Unit.cpp
     ${SRCDIR}/UnitSystem.cpp
     ${SRCDIR}/utils/BtStringConst.cpp
+    ${SRCDIR}/utils/EnumStringMapping.cpp
     ${SRCDIR}/WaterButton.cpp
     ${SRCDIR}/WaterDialog.cpp
     ${SRCDIR}/WaterEditor.cpp

--- a/src/FermentableTableModel.cpp
+++ b/src/FermentableTableModel.cpp
@@ -111,13 +111,27 @@ void FermentableTableModel::addFermentable(int fermId) {
    Fermentable * ferm = ObjectStoreWrapper::getByIdRaw<Fermentable>(fermId);
    qDebug() << Q_FUNC_INFO << ferm->name();
 
-   //Check to see if it's already in the list
-   if( fermObs.contains(ferm) )
+   // Check to see if it's already in the list
+   if (this->fermObs.contains(ferm)) {
       return;
+   }
+
    // If we are observing the database, ensure that the ferm is undeleted and
    // fit to display.
-   if( recObs == nullptr && ( ferm->deleted() || !ferm->display() ) )
+   if (this->recObs == nullptr && (ferm->deleted() || !ferm->display())) {
       return;
+   }
+
+   // If we are watching a Recipe and the new Fermentable does not belong to it then there is nothing for us to do
+   if (this->recObs) {
+      Recipe * recipeOfNewFermentable = ferm->getOwningRecipe();
+      if (recipeOfNewFermentable && this->recObs->key() != recipeOfNewFermentable->key()) {
+         qDebug() <<
+            Q_FUNC_INFO << "Ignoring signal about new Ferementable #" << ferm->key() << "as it belongs to Recipe #" <<
+            recipeOfNewFermentable->key() << "and we are watching Recipe #" << this->recObs->key();
+         return;
+      }
+   }
 
    int size = fermObs.size();
    beginInsertRows( QModelIndex(), size, size );

--- a/src/HopTableModel.cpp
+++ b/src/HopTableModel.cpp
@@ -148,8 +148,19 @@ void HopTableModel::addHop(int hopId) {
 
    // If we are observing the database, ensure that the item is undeleted and
    // fit to display.
-   if (recObs == nullptr && (hop->deleted() || !hop->display())) {
+   if (this->recObs == nullptr && (hop->deleted() || !hop->display())) {
       return;
+   }
+
+   // If we are watching a Recipe and the new Hop does not belong to it then there is nothing for us to do
+   if (this->recObs) {
+      Recipe * recipeOfNewHop = hop->getOwningRecipe();
+      if (recipeOfNewHop && this->recObs->key() != recipeOfNewHop->key()) {
+         qDebug() <<
+            Q_FUNC_INFO << "Ignoring signal about new Hop #" << hop->key() << "as it belongs to Recipe #" <<
+            recipeOfNewHop->key() << "and we are watching Recipe #" << this->recObs->key();
+         return;
+      }
    }
 
    int size = hopObs.size();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1821,6 +1821,7 @@ void MainWindow::addYeastToRecipe(Yeast* yeast) {
 }
 
 void MainWindow::addMashStepToMash(std::shared_ptr<MashStep> mashStep) {
+   qDebug() << Q_FUNC_INFO;
    //
    // Mash Steps are a bit different from most other NamedEntity objects in that they don't really have an independent
    // existence.  If you ask a Mash to remove a MashStep then it will also tell the ObjectStore to delete it, but, when

--- a/src/MashEditor.cpp
+++ b/src/MashEditor.cpp
@@ -149,9 +149,8 @@ void MashEditor::showChanges(QMetaProperty* prop) {
    bool updateAll = false;
    QString propName;
 
-   if( mashObs == nullptr )
-   {
-      clear();
+   if (mashObs == nullptr) {
+      this->clear();
       return;
    }
 

--- a/src/MashStepTableModel.h
+++ b/src/MashStepTableModel.h
@@ -23,14 +23,13 @@
 #define MASHSTEPTABLEMODEL_H
 
 #include <QAbstractTableModel>
-#include <QWidget>
-#include <QModelIndex>
-#include <QVariant>
-#include <QMetaProperty>
-#include <QVariant>
 #include <QItemDelegate>
-#include <QVector>
+#include <QMetaProperty>
+#include <QModelIndex>
 #include <QTableView>
+#include <QVariant>
+#include <QVector>
+#include <QWidget>
 
 #include "model/MashStep.h"
 #include "model/Mash.h"
@@ -42,7 +41,6 @@ enum{ MASHSTEPNAMECOL, MASHSTEPTYPECOL, MASHSTEPAMOUNTCOL, MASHSTEPTEMPCOL, MASH
 
 /*!
  * \class MashStepTableModel
- *
  *
  * \brief Model for the list of mash steps in a mash.
  */
@@ -103,7 +101,6 @@ private:
    QTableView* parentTableWidget;
    QList<MashStep*> steps;
 
-//   void reorderMashSteps();
    void reorderMashStep(MashStep *step, int current);
 };
 
@@ -113,8 +110,7 @@ private:
  *
  * An item delegate for mash step tables.
  */
-class MashStepItemDelegate : public QItemDelegate
-{
+class MashStepItemDelegate : public QItemDelegate {
    Q_OBJECT
 
 public:

--- a/src/MiscTableModel.cpp
+++ b/src/MiscTableModel.cpp
@@ -95,14 +95,20 @@ void MiscTableModel::addMisc(int miscId) {
 
    // If we are observing the database, ensure that the item is undeleted and
    // fit to display.
-   if(
-      recObs == nullptr &&
-      (
-         misc->deleted() ||
-         !misc->display()
-      )
-   ) {
+   if (recObs == nullptr &&
+      (misc->deleted() || !misc->display())) {
       return;
+   }
+
+   // If we are watching a Recipe and the new Misc does not belong to it then there is nothing for us to do
+   if (this->recObs) {
+      Recipe * recipeOfNewMisc = misc->getOwningRecipe();
+      if (recipeOfNewMisc && this->recObs->key() != recipeOfNewMisc->key()) {
+         qDebug() <<
+            Q_FUNC_INFO << "Ignoring signal about new Misc #" << misc->key() << "as it belongs to Recipe #" <<
+            recipeOfNewMisc->key() << "and we are watching Recipe #" << this->recObs->key();
+         return;
+      }
    }
 
    int size = miscObs.size();

--- a/src/NamedMashEditor.cpp
+++ b/src/NamedMashEditor.cpp
@@ -206,12 +206,12 @@ void NamedMashEditor::clear()
 }
 
 void NamedMashEditor::addMashStep() {
-   if ( ! this->mashObs ) {
+   if (!this->mashObs) {
       return;
    }
 
+   // The call to Mash::addMashStep() will also store the MashStep in the ObjectStore / DB
    auto step = std::make_shared<MashStep>();
-   ObjectStoreWrapper::insert(step);
    this->mashObs->addMashStep(step);
    mashStepEditor->setMashStep(step);
    mashStepEditor->setVisible(true);

--- a/src/YeastTableModel.cpp
+++ b/src/YeastTableModel.cpp
@@ -74,15 +74,22 @@ void YeastTableModel::addYeast(int yeastId) {
 
    // If we are observing the database, ensure that the item is undeleted and
    // fit to display.
-   if(
-      recObs == nullptr &&
-      (
-         yeast->deleted() ||
-         !yeast->display()
-      )
-   ) {
+   if (this->recObs == nullptr &&
+       (yeast->deleted() || !yeast->display())) {
       return;
    }
+
+   // If we are watching a Recipe and the new Yeast does not belong to it then there is nothing for us to do
+   if (this->recObs) {
+      Recipe * recipeOfNewYeast = yeast->getOwningRecipe();
+      if (recipeOfNewYeast && this->recObs->key() != recipeOfNewYeast->key()) {
+         qDebug() <<
+            Q_FUNC_INFO << "Ignoring signal about new Yeast #" << yeast->key() << "as it belongs to Recipe #" <<
+            recipeOfNewYeast->key() << "and we are watching Recipe #" << this->recObs->key();
+         return;
+      }
+   }
+
    int size = yeastObs.size();
    beginInsertRows( QModelIndex(), size, size );
    yeastObs.append(yeast);

--- a/src/database/ObjectStoreTyped.h
+++ b/src/database/ObjectStoreTyped.h
@@ -321,6 +321,9 @@ private:
          ne->hardDeleteOwnedEntities();
          // Base class does the heavy lifting on removing the NamedEntity from the DB
          this->ObjectStore::defaultHardDelete(id);
+         // Some related entities can only be deleted after the thing to which they are related has been removed from
+         // the database.  This is the opportunity to do that.
+         ne->hardDeleteOrphanedEntities();
          // Setting the deleted object's ID to -1 now puts it in the same state as a newly-created object.
          ne->setKey(-1);
          ne->setCacheOnly(true);

--- a/src/model/MashStep.cpp
+++ b/src/model/MashStep.cpp
@@ -66,7 +66,7 @@ MashStep::MashStep(QString name, bool cache) :
    m_endTemp_c(0.0),
    m_infuseTemp_c(0.0),
    m_decoctionAmount_l(0.0),
-   m_stepNumber(0.0),
+   m_stepNumber(0),
    mashId(-1) {
    return;
 }
@@ -141,7 +141,11 @@ void MashStep::setStepNumber(int stepNumber) {
    this->setAndNotify(PropertyNames::MashStep::stepNumber, this->m_stepNumber, stepNumber);
 }
 
-void MashStep::setMashId(int mashId) { this->mashId = mashId; }
+void MashStep::setMashId(int mashId) {
+   this->mashId = mashId;
+   this->propagatePropertyChange(PropertyNames::MashStep::mashId, false);
+   return;
+}
 
 //============================="GET" METHODS====================================
 MashStep::Type MashStep::type() const { return m_type; }

--- a/src/model/MashStep.h
+++ b/src/model/MashStep.h
@@ -94,7 +94,7 @@ public:
    Q_PROPERTY( double infuseTemp_c READ infuseTemp_c WRITE setInfuseTemp_c /*NOTIFY changed*/ /*changedInfuseTemp_c*/ )
    //! \brief The decoction amount in liters.
    Q_PROPERTY( double decoctionAmount_l READ decoctionAmount_l WRITE setDecoctionAmount_l /*NOTIFY changed*/ /*changedDecoctionAmount_l*/ )
-   //! \brief The step number in a sequence of other steps.
+   //! \brief The step number in a sequence of other steps.  Step numbers start from 1.
    Q_PROPERTY( int stepNumber READ stepNumber WRITE setStepNumber /*NOTIFY changed*/ STORED false )
    //! \brief The Mash to which this MashStep belongs
    Q_PROPERTY( int mashId READ getMashId WRITE setMashId )

--- a/src/model/NamedEntity.cpp
+++ b/src/model/NamedEntity.cpp
@@ -84,6 +84,8 @@ NamedEntity::NamedEntity(NamedParameterBundle const & namedParameterBundle) :
    return;
 }
 
+NamedEntity::~NamedEntity() = default;
+
 void NamedEntity::makeChild(NamedEntity const & copiedFrom) {
    // It's a coding error if we're not starting out with objects that are copies of each other
    Q_ASSERT(*this == copiedFrom);
@@ -331,11 +333,6 @@ void NamedEntity::prepareForPropertyChange(BtStringConst const & propertyName) {
 }
 
 void NamedEntity::propagatePropertyChange(BtStringConst const & propertyName, bool notify) const {
-   // If we're in "cache only" mode, there's nothing to do
-   if (this->m_cacheOnly) {
-      return;
-   }
-
    // If we're already stored in the object store, tell it about the property change so that it can write it to the
    // database.  (We don't pass the new value as it will get read out of the object via propertyName.)
    if (this->m_key > 0) {
@@ -372,6 +369,12 @@ void NamedEntity::setParent(NamedEntity const & parentNamedEntity) {
 void NamedEntity::hardDeleteOwnedEntities() {
    // If we are not overridden in the subclass then there is no work to do
    qDebug() << Q_FUNC_INFO << this->metaObject()->className() << "owns no other entities";
+   return;
+}
+
+void NamedEntity::hardDeleteOrphanedEntities() {
+   // If we are not overridden in the subclass then there is no work to do
+   qDebug() << Q_FUNC_INFO << this->metaObject()->className() << "leaves no other entities as orphans";
    return;
 }
 

--- a/src/model/NamedEntity.h
+++ b/src/model/NamedEntity.h
@@ -106,7 +106,7 @@ public:
    // Our destructor needs to be virtual because we sometimes point to an instance of a derived class through a pointer
    // to this class -- ie NamedEntity * namedEntity = new Hop() and suchlike.  We do already get a virtual destructor by
    // virtue of inheriting from QObject, but this declaration does no harm.
-   virtual ~NamedEntity() = default;
+   virtual ~NamedEntity();
 
    /**
     * \brief Turns a straight copy of an object into a "child" copy that can be used in a Recipe.  (A child copy is
@@ -240,6 +240,15 @@ public:
     *        By default this function does nothing.  Subclasses override it if needed.
     */
    virtual void hardDeleteOwnedEntities();
+
+   /**
+    * \brief Similar to \c hardDeleteOwnedEntities but for cases where the related entities need to be deleted
+    *        immediately \b after rather than immediately \b before the entity to which they are related.  (Which is
+    *        required typically depends on the order of the underlying foreign key relationships in the database.)
+    *
+    *        By default this function does nothing.  Subclasses override it if needed.
+    */
+   virtual void hardDeleteOrphanedEntities();
 
 signals:
    /*!

--- a/src/model/Recipe.h
+++ b/src/model/Recipe.h
@@ -550,6 +550,13 @@ public:
     */
    virtual void hardDeleteOwnedEntities();
 
+   /**
+    * \brief Deleting a Recipe usually results in an orphaned Mash record (which cannot be removed by
+    *        \c hardDeleteOwnedEntities because of the direction of foreign key constraints) and needs to be deleted
+    *        immediately after the Recipe record has been removed from the database.
+    */
+   virtual void hardDeleteOrphanedEntities();
+
 signals:
 
 public slots:

--- a/src/utils/EnumStringMapping.cpp
+++ b/src/utils/EnumStringMapping.cpp
@@ -1,0 +1,43 @@
+/*
+ * utils/EnumStringMapping.cpp is part of Brewtarget, and is Copyright the following
+ * authors 2021
+ * - Matt Young <mfsy@yahoo.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "utils/EnumStringMapping.h"
+
+#include <algorithm>
+
+std::optional<int> EnumStringMapping::stringToEnum(QString const & stringValue) const {
+   auto match = std::find_if(this->begin(),
+                             this->end(),
+                             [stringValue](EnumAndItsString const & ii){return stringValue == ii.string;});
+   if (match == this->end()) {
+      return std::nullopt;
+   }
+
+   return std::optional<int>{match->native};
+}
+
+std::optional<QString> EnumStringMapping::enumToString(int const enumValue) const {
+   auto match = std::find_if(this->begin(),
+                             this->end(),
+                             [enumValue](EnumAndItsString const & ii){return enumValue == ii.native;});
+   if (match == this->end()) {
+      return std::nullopt;
+   }
+
+   return std::optional<QString>{match->string};
+}

--- a/src/utils/EnumStringMapping.h
+++ b/src/utils/EnumStringMapping.h
@@ -1,0 +1,54 @@
+/*
+ * utils/EnumStringMapping.h is part of Brewtarget, and is Copyright the following
+ * authors 2021
+ * - Matt Young <mfsy@yahoo.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef UTILS_ENUMSTRINGMAPPING_H
+#define UTILS_ENUMSTRINGMAPPING_H
+#pragma once
+
+#include <optional>
+
+#include <QString>
+#include <QVector>
+
+/**
+ * \brief Associates an enum value with a string representation (eg in the DB or BeerXML or BeerJSON).  Storing a
+ *        string is in some cases required by the external serialisation but, even for "internal" storage in the DB,
+ *        is more robust than just storing the raw numerical value of the enum.
+ */
+struct EnumAndItsString {
+   QString string;
+   int     native;
+};
+
+/**
+ * \class EnumStringMapping
+ *
+ *        We don't actually bother creating hashmaps or similar between enum values and string representations
+ *        because it's usually going to be a short list that we can search through pretty quickly (probably faster
+ *        than calculating the hash of a key!)
+ */
+class EnumStringMapping : public QVector<EnumAndItsString> {
+public:
+   // We're not adding data members so we can just use the base class constructors
+   using QVector::QVector;
+
+   std::optional<int>     stringToEnum(QString const & stringValue) const;
+   std::optional<QString> enumToString(int const       enumValue) const;
+};
+
+#endif

--- a/src/xml/BeerXml.cpp
+++ b/src/xml/BeerXml.cpp
@@ -84,19 +84,19 @@ namespace {
    // Field mappings for <HOP>...</HOP> BeerXML records
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> QString const BEER_XML_RECORD_NAME<Hop>{"HOP"};
-   XmlRecord::EnumLookupMap const BEER_XML_HOP_USE_MAPPER {
+   EnumStringMapping const BEER_XML_HOP_USE_MAPPER {
       {"Boil",       Hop::Boil},
       {"Dry Hop",    Hop::Dry_Hop},
       {"Mash",       Hop::Mash},
       {"First Wort", Hop::First_Wort},
       {"Aroma",      Hop::UseAroma}
    };
-   XmlRecord::EnumLookupMap const BEER_XML_HOP_TYPE_MAPPER {
+   EnumStringMapping const BEER_XML_HOP_TYPE_MAPPER {
       {"Bittering", Hop::Bittering},
       {"Aroma",     Hop::Aroma},
       {"Both",      Hop::Both}
    };
-   XmlRecord::EnumLookupMap const BEER_XML_HOP_FORM_MAPPER {
+   EnumStringMapping const BEER_XML_HOP_FORM_MAPPER {
       {"Pellet", Hop::Pellet},
       {"Plug",   Hop::Plug},
       {"Leaf",   Hop::Leaf}
@@ -104,7 +104,7 @@ namespace {
    template<> XmlRecord::FieldDefinitions const BEER_XML_RECORD_FIELDS<Hop> {
       // Type              XPath             Q_PROPERTY                             Enum Mapper
       {XmlRecord::String,  "NAME",           PropertyNames::NamedEntity::name,      nullptr},
-      {XmlRecord::RequiredConstant, "VERSION", VERSION1,                                 nullptr},
+      {XmlRecord::RequiredConstant, "VERSION", VERSION1,                            nullptr},
       {XmlRecord::Double,  "ALPHA",          PropertyNames::Hop::alpha_pct,         nullptr},
       {XmlRecord::Double,  "AMOUNT",         PropertyNames::Hop::amount_kg,         nullptr},
       {XmlRecord::Enum,    "USE",            PropertyNames::Hop::use,               &BEER_XML_HOP_USE_MAPPER},
@@ -129,7 +129,7 @@ namespace {
    // Field mappings for <FERMENTABLE>...</FERMENTABLE> BeerXML records
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> QString const BEER_XML_RECORD_NAME<Fermentable>{"FERMENTABLE"};
-   XmlRecord::EnumLookupMap const BEER_XML_FERMENTABLE_TYPE_MAPPER {
+   EnumStringMapping const BEER_XML_FERMENTABLE_TYPE_MAPPER {
       {"Grain",       Fermentable::Grain},
       {"Sugar",       Fermentable::Sugar},
       {"Extract",     Fermentable::Extract},
@@ -139,7 +139,7 @@ namespace {
    template<> XmlRecord::FieldDefinitions const BEER_XML_RECORD_FIELDS<Fermentable> {
       // Type              XPath               Q_PROPERTY                                          Enum Mapper
       {XmlRecord::String,  "NAME",             PropertyNames::NamedEntity::name,                   nullptr},
-      {XmlRecord::RequiredConstant,  "VERSION", VERSION1,                                               nullptr},
+      {XmlRecord::RequiredConstant,  "VERSION", VERSION1,                                          nullptr},
       {XmlRecord::Enum,    "TYPE",             PropertyNames::Fermentable::type,                   &BEER_XML_FERMENTABLE_TYPE_MAPPER},
       {XmlRecord::Double,  "AMOUNT",           PropertyNames::Fermentable::amount_kg,              nullptr},
       {XmlRecord::Double,  "YIELD",            PropertyNames::Fermentable::yield_pct,              nullptr},
@@ -166,20 +166,20 @@ namespace {
    // Field mappings for <YEAST>...</YEAST> BeerXML records
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> QString const BEER_XML_RECORD_NAME<Yeast>{"YEAST"};
-   XmlRecord::EnumLookupMap const BEER_XML_YEAST_TYPE_MAPPER {
+   EnumStringMapping const BEER_XML_YEAST_TYPE_MAPPER {
       {"Ale",       Yeast::Ale},
       {"Lager",     Yeast::Lager},
       {"Wheat",     Yeast::Wheat},
       {"Wine",      Yeast::Wine},
       {"Champagne", Yeast::Champagne}
    };
-   XmlRecord::EnumLookupMap const BEER_XML_YEAST_FORM_MAPPER {
+   EnumStringMapping const BEER_XML_YEAST_FORM_MAPPER {
       {"Liquid",  Yeast::Liquid},
       {"Dry",     Yeast::Dry},
       {"Slant",   Yeast::Slant},
       {"Culture", Yeast::Culture}
    };
-   XmlRecord::EnumLookupMap const BEER_XML_YEAST_FLOCCULATION_MAPPER {
+   EnumStringMapping const BEER_XML_YEAST_FLOCCULATION_MAPPER {
       {"Low",       Yeast::Low},
       {"Medium",    Yeast::Medium},
       {"High",      Yeast::High},
@@ -215,7 +215,7 @@ namespace {
    // Field mappings for <MISC>...</MISC> BeerXML records
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> QString const BEER_XML_RECORD_NAME<Misc>{"MISC"};
-   XmlRecord::EnumLookupMap const BEER_XML_MISC_TYPE_MAPPER {
+   EnumStringMapping const BEER_XML_MISC_TYPE_MAPPER {
       {"Spice",       Misc::Spice},
       {"Fining",      Misc::Fining},
       {"Water Agent", Misc::Water_Agent},
@@ -223,7 +223,7 @@ namespace {
       {"Flavor",      Misc::Flavor},
       {"Other",       Misc::Other}
    };
-   XmlRecord::EnumLookupMap const BEER_XML_MISC_USE_MAPPER {
+   EnumStringMapping const BEER_XML_MISC_USE_MAPPER {
       {"Boil",      Misc::Boil},
       {"Mash",      Misc::Mash},
       {"Primary",   Misc::Primary},
@@ -270,7 +270,7 @@ namespace {
    // Field mappings for <STYLE>...</STYLE> BeerXML records
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> QString const BEER_XML_RECORD_NAME<Style>{"STYLE"};
-   XmlRecord::EnumLookupMap const BEER_XML_STYLE_TYPE_MAPPER {
+   EnumStringMapping const BEER_XML_STYLE_TYPE_MAPPER {
       {"Lager", Style::Lager},
       {"Ale",   Style::Ale},
       {"Mead",  Style::Mead},
@@ -321,14 +321,15 @@ namespace {
    // Field mappings for <MASH_STEP>...</MASH_STEP> BeerXML records
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> QString const BEER_XML_RECORD_NAME<MashStep>{"MASH_STEP"};
-   XmlRecord::EnumLookupMap const BEER_XML_MASH_STEP_TYPE_MAPPER {
+   EnumStringMapping const BEER_XML_MASH_STEP_TYPE_MAPPER {
       {"Infusion",     MashStep::Infusion},
       {"Temperature",  MashStep::Temperature},
       {"Decoction",    MashStep::Decoction},
       // Inside Brewtarget we also have MashStep::flySparge and MashStep::batchSparge which are not mentioned in the
       // BeerXML 1.0 Standard.  They get treated as "Infusion" when we write to BeerXML
-      {"Infusion",     MashStep::flySparge},
-      {"Infusion",     MashStep::batchSparge}
+      // Note that we include a comment here to ensure we don't have multiple mappings from "Infusion"
+      {"Infusion<!-- Fly Sparge -->",     MashStep::flySparge},
+      {"Infusion<!-- Batch Sparge -->",     MashStep::batchSparge}
    };
    template<> XmlRecord::FieldDefinitions const BEER_XML_RECORD_FIELDS<MashStep> {
       // Type              XPath                 Q_PROPERTY                                  Enum Mapper
@@ -470,7 +471,7 @@ namespace {
    // Field mappings for <RECIPE>...</RECIPE> BeerXML records
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> QString const BEER_XML_RECORD_NAME<Recipe>{"RECIPE"};
-   XmlRecord::EnumLookupMap const BEER_XML_RECIPE_STEP_TYPE_MAPPER {
+   EnumStringMapping const BEER_XML_RECIPE_STEP_TYPE_MAPPER {
       {"Extract",      Recipe::Extract},
       {"Partial Mash", Recipe::PartialMash},
       {"All Grain",    Recipe::AllGrain}
@@ -520,7 +521,7 @@ namespace {
       {XmlRecord::String,        "EST_OG",                   BtString::NULL_STR,                        nullptr}, // Extension tag
       {XmlRecord::String,        "EST_FG",                   BtString::NULL_STR,                        nullptr}, // Extension tag
       {XmlRecord::String,        "EST_COLOR",                BtString::NULL_STR,                        nullptr}, // Extension tag
-      {XmlRecord::String,        "IBU",                      BtString::NULL_STR,                        nullptr}, // Extension tag
+      {XmlRecord::String,        "IBU",                      PropertyNames::Recipe::IBU,                nullptr}, // Extension tag.  We write but ignore on read if present.
       {XmlRecord::String,        "IBU_METHOD",               BtString::NULL_STR,                        nullptr}, // Extension tag
       {XmlRecord::String,        "EST_ABV",                  BtString::NULL_STR,                        nullptr}, // Extension tag
       {XmlRecord::String,        "ABV",                      BtString::NULL_STR,                        nullptr}, // Extension tag
@@ -604,7 +605,7 @@ public:
       QFile inputFile;
       inputFile.setFileName(fileName);
 
-      if(! inputFile.open(QIODevice::ReadOnly)) {
+      if(!inputFile.open(QIODevice::ReadOnly)) {
          qWarning() << Q_FUNC_INFO << ": Could not open " << fileName << " for reading";
          return false;
       }
@@ -619,9 +620,9 @@ public:
       //
       // † The BeerXML 1.0 standard diverges from valid/standard XML in a few ways:
       //    • It mandates an XML Declaration (which it calls the "XML Header"), which is normally an optional part of
-      //       any UTF-8 encoded XML document.  (This is perhaps because it seems to mandate an ISO-8859-1 coding of
-      //       BeerXML files, though there is no explicit discussion of file encodings in the standard, and this seems
-      //       an unnecessary constraint to place on files.)
+      //      any UTF-8 encoded XML document.  (This is perhaps because it seems to mandate an ISO-8859-1 coding of
+      //      BeerXML files, though there is no explicit discussion of file encodings in the standard, and this seems
+      //      an unnecessary constraint to place on files.)
       //    • It omits to specify a single root element, even though this is a required part of any valid XML document.
       //    • It uses "TRUE" and "FALSE" (ie caps) for boolean values instead of the XML standard "true" and "false"
       //      (ie lower case).

--- a/src/xml/XmlCoding.h
+++ b/src/xml/XmlCoding.h
@@ -244,7 +244,7 @@ template<> inline
 XmlRecord * XmlCoding::construct<void>(QString const & recordName,
                                        XmlCoding const & xmlCoding,
                                        XmlRecord::FieldDefinitions const & fieldDefinitions) {
-   return new XmlRecord{recordName, xmlCoding, fieldDefinitions};
+   return new XmlRecord{recordName, xmlCoding, fieldDefinitions, ""};
 }
 template<> inline
 XmlRecord * XmlCoding::construct<Mash>(QString const & recordName,

--- a/src/xml/XmlMashRecord.cpp
+++ b/src/xml/XmlMashRecord.cpp
@@ -44,10 +44,10 @@ void XmlMashRecord::subRecordToXml(XmlRecord::FieldDefinition const & fieldDefin
    return;
 }
 
-void XmlMashRecord::setContainingEntity(NamedEntity * containingEntity) {
+void XmlMashRecord::setContainingEntity(std::shared_ptr<NamedEntity> containingEntity) {
    // Don't include Mash in stats is it's in a Recipe (ie if the cast below succeeds); DO include it if it's not (ie if
    // there's no containing entity or the cast below fails).
-   this->includeInStats = (nullptr == dynamic_cast<Recipe *>(containingEntity));
+   this->includeInStats = (nullptr == dynamic_cast<Recipe *>(containingEntity.get()));
    qDebug() << Q_FUNC_INFO << (this->includeInStats ? "Included in" : "Excluded from") << "stats";
    return;
 }

--- a/src/xml/XmlMashRecord.h
+++ b/src/xml/XmlMashRecord.h
@@ -54,7 +54,7 @@ protected:
     *        Additionally, if the Recipe gets deleted after being read in (because at that point we determine it's a
     *        duplicate), this means we don't have to try to unpick stats about Mashes.
     */
-   virtual void setContainingEntity(NamedEntity * containingEntity);
+   virtual void setContainingEntity(std::shared_ptr<NamedEntity> containingEntity);
 };
 
 #endif

--- a/src/xml/XmlMashStepRecord.h
+++ b/src/xml/XmlMashStepRecord.h
@@ -37,13 +37,19 @@ protected:
     *        in the DB other in association with its Mash.
     * \param containingEntity The Mash with which the MashStep needs to be associated
     */
-   virtual XmlRecord::ProcessingResult normaliseAndStoreInDb(NamedEntity * containingEntity,
+   virtual XmlRecord::ProcessingResult normaliseAndStoreInDb(std::shared_ptr<NamedEntity> containingEntity,
                                                              QTextStream & userMessage,
                                                              XmlRecordCount & stats);
    /**
     * \brief We need this override a MashStep is owned by its Mash
     */
-   virtual void setContainingEntity(NamedEntity * containingEntity);
+   virtual void setContainingEntity(std::shared_ptr<NamedEntity> containingEntity);
+
+   /**
+    * \brief We override the usual version of this function because the \c MashStep gets inserted in the database when
+    *        we call \c Mash::addMashStep(), before this function is called.
+    */
+   virtual int storeNamedEntityInDb();
 
 };
 #endif

--- a/src/xml/XmlRecipeRecord.cpp
+++ b/src/xml/XmlRecipeRecord.cpp
@@ -73,55 +73,53 @@ void XmlRecipeRecord::addChildren() {
    // This cast is safe because we know this->namedEntity was populated with a Recipe * in the constructor of our
    // parent class (XmlNamedEntityRecord<Recipe>).
    //
-   Recipe * recipe = static_cast<Recipe *>(this->namedEntity);
+   auto recipe = std::static_pointer_cast<Recipe>(this->namedEntity);
 
    char const * const childClassName = CNE::staticMetaObject.className();
-
    //
-   // QMultiHash guarantees that items that share the same key will appear consecutively, from the most recently to
-   // the least recently inserted value.  So the most efficient way to obtain all values with the same key is to call
-   // find() and iterate from there.  (The alternative, is to call values() which returns a QList of matching values,
-   // but requires a copy which is (a) less efficient and (b) not accepted by all compilers for the types we are
-   // using.)
+   // Previously we stored child records in a QMultiHash, which makes accessing children of a particular type easy but
+   // gives an iteration order the opposite of insertion order, which is annoying when order matters (eg for Mash Steps
+   // in BeerXML).  Using a list gives us a slightly less elegant loop here, but ensures that
+   // normaliseAndStoreChildRecordsInDb() deals with children in the right order.
    //
-   for (auto ii = this->childRecords.find(childClassName);
-        ii != this->childRecords.end() && ii.key() == childClassName;
-        ++ii) {
-      qDebug() << Q_FUNC_INFO << "Adding " << childClassName << " to Recipe";
+   for (auto ii : this->childRecords) {
+      if (ii.xmlRecord->namedEntityClassName == childClassName) {
+         qDebug() << Q_FUNC_INFO << "Adding " << childClassName << " to Recipe";
 
-      // It would be a (pretty unexpected) coding error if the NamedEntity subclass object stored against a class name
-      // isn't of the same class against which it was stored.
-      Q_ASSERT(ii->second->getNamedEntity()->metaObject()->className() == QString(childClassName));
+         // It would be a (pretty unexpected) coding error if the NamedEntity subclass object isn't of the class it's
+         // supposed to be.
+         Q_ASSERT(ii.xmlRecord->getNamedEntity()->metaObject()->className() == QString(childClassName));
 
-      // Actually add the Hop/Yeast/etc to the Recipe
-      std::shared_ptr<CNE> child{static_cast<CNE *>(ii->second->getNamedEntity())};
-      auto added = recipe->add<CNE>(child);
+         // Actually add the Hop/Yeast/etc to the Recipe
+         std::shared_ptr<CNE> child{std::static_pointer_cast<CNE>(ii.xmlRecord->getNamedEntity())};
+         auto added = recipe->add<CNE>(child);
 
-      //
-      // For historical reasons (specifically that early versions of Brewtarget stored data in BeerXML files, not a
-      // database), the amount of each Hop/Fermentable/etc in a Recipe is stored, not in the Recipe object but in the
-      // Hop/Fermentable/etc in question.  The same is true for addition times for Hops.
-      //
-      // When we add something to a Recipe, typically a copy is made so that we have a Hop/Fermentable/etc that is not
-      // shared with any other Recipes and thus there is no ambiguity about storing the amount in it.
-      //
-      // However, when we read in from BeerXML, we try to avoid creating unnecessary duplicates of things.  If there's
-      // a Fuggle hop in the file and we already have a Fuggle hop in the database, then we don't create another one
-      // for the sake of it.  This is the right thing to do if we're reading in Hops outside the context of a Recipe.
-      // But if the hop in the BeerXML file was inside a Recipe record, then we we need to make sure we captured the
-      // "how much and when to add" info inside that hop record.
-      //
-      // So, now that we added the Hop/Fermentable/etc to the Recipe, and we have the actual object associated with the
-      // Recipe, we need to set the "how much and when to add" info based on the fields we retained from XML record.
-      //
-      Q_ASSERT(added);
-      setAmountsEtc(*added, ii->second->getNamedParameterBundle());
+         //
+         // For historical reasons (specifically that early versions of Brewtarget stored data in BeerXML files, not a
+         // database), the amount of each Hop/Fermentable/etc in a Recipe is stored, not in the Recipe object but in the
+         // Hop/Fermentable/etc in question.  The same is true for addition times for Hops.
+         //
+         // When we add something to a Recipe, typically a copy is made so that we have a Hop/Fermentable/etc that is not
+         // shared with any other Recipes and thus there is no ambiguity about storing the amount in it.
+         //
+         // However, when we read in from BeerXML, we try to avoid creating unnecessary duplicates of things.  If there's
+         // a Fuggle hop in the file and we already have a Fuggle hop in the database, then we don't create another one
+         // for the sake of it.  This is the right thing to do if we're reading in Hops outside the context of a Recipe.
+         // But if the hop in the BeerXML file was inside a Recipe record, then we we need to make sure we captured the
+         // "how much and when to add" info inside that hop record.
+         //
+         // So, now that we added the Hop/Fermentable/etc to the Recipe, and we have the actual object associated with the
+         // Recipe, we need to set the "how much and when to add" info based on the fields we retained from XML record.
+         //
+         Q_ASSERT(added);
+         setAmountsEtc(*added, ii.xmlRecord->getNamedParameterBundle());
+      }
    }
    return;
 }
 
 
-XmlRecord::ProcessingResult XmlRecipeRecord::normaliseAndStoreInDb(NamedEntity * containingEntity,
+XmlRecord::ProcessingResult XmlRecipeRecord::normaliseAndStoreInDb(std::shared_ptr<NamedEntity> containingEntity,
                                                                    QTextStream & userMessage,
                                                                    XmlRecordCount & stats) {
    // This call to the base class function will store the Recipe and all the objects it contains, as well as link the

--- a/src/xml/XmlRecipeRecord.h
+++ b/src/xml/XmlRecipeRecord.h
@@ -38,7 +38,7 @@ protected:
     *        properties is hard unless you make the getters and setters all use the same list type, eg QList<QVariant>
     *        instead of QList<Hop *>, QList<Fermentable *>, QList<Instruction *>, etc.
     */
-   virtual XmlRecord::ProcessingResult normaliseAndStoreInDb(NamedEntity * containingEntity,
+   virtual XmlRecord::ProcessingResult normaliseAndStoreInDb(std::shared_ptr<NamedEntity> containingEntity,
                                                              QTextStream & userMessage,
                                                              XmlRecordCount & stats);
 


### PR DESCRIPTION
See https://github.com/Brewtarget/brewtarget/issues/628

A couple of changes here, fixing things from new DB layer and from XML import code.

- Firstly, there was a signals bug where if we have more than one instance of HopTableModel (or MashStepTableModel or similar) then each table model was getting and acting on signals for all table models of the same type - in particular when a new Hop/MashStep/etc is created. I think this is because I changed the source of the signals when I created ObjectStore. Anyway, fix is to add filtering so that when a message is received about a new Hop/MashStep/etc being created, we first check whether it belongs to the Recipe/Mash we're watching.
- Secondly when we were creating new MashSteps, there was an inconsistency about where they get added to the Mash and where they get stored in the DB.  I've changed callers to use Mash::addMashStep (which already had pretty much the right logic).
- Still on MashSteps, they were being put in reverse order when imported from XML.  (This was because, if you put a bunch of things in a QMultiHash with the same key, then iterating over them gives you most-recently-added first.  Changing to a QVector gives an iteration order that goes from first-added to last-added.) 
- I also found an d'oh bug in the XML code where I was being an idiot with std::shared_ptr.  Result was a crash if you import the same XML file twice.  Now that we have the new ObjectStore stuff, we don't have to use raw pointers so much in the XML code so it's easier to be consistent.  (Essentially the issue is that, if you have a shared_ptr to something and you want to make an additional shared_ptr to it, you must copy the new shared_ptr from the existing one -- so that they'll share reference counts etc.  If you make the new one from the raw pointer then you'll have two separate completely unrelated shared_ptrs each thinking they own the same object and it will get deleted before you expect resulting in a crash. 
- I had a one-line fix for https://github.com/Brewtarget/brewtarget/issues/452 (inclusion of IBU in BeerXML export) coded in Brewken which I've brought across because I was editing that file anyway.
- Finally, there was a bug when deleting a Recipe that you would get a foreign key violation in the DB.  This is down to trying to delete an about-to-be-unused unnamed Mash before the Recipe being deleted instead of afterwards.  New function Recipe::hardDeleteOrphanedEntities() now ensures things get deleted in the correct order.

As an aside it feels like there is a bunch of common code that could be pulled out of the FooTableModel classes, but that's for another time.  (I've started doing a little bit of this in the separate branch I'm working on for BeerJSON, but only the very low-hanging fruit so far!)