### PR TITLE
Small typo in CmakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -259,7 +259,7 @@ SET( brewtarget_MOC_HEADERS
     ${SRCDIR}/BrewDayFormatter.h
     ${SRCDIR}/BrewDayScrollWidget.h
     ${SRCDIR}/BrewDayWidget.h
-    ${SRCDIR}/Brewken.h
+    ${SRCDIR}/brewtarget.h
     ${SRCDIR}/BrewNoteWidget.h
     ${SRCDIR}/BtDatePopup.h
     ${SRCDIR}/BtDigitWidget.h


### PR DESCRIPTION
In Cmake Lists there was an include to Brewken.h instead of brewtarget.h
 
It's not a showstopper, but to keep things in order. :)