### PR TITLE
Fix crash when creating new Equipment

### DIFF
--- a/src/EquipmentEditor.cpp
+++ b/src/EquipmentEditor.cpp
@@ -1,6 +1,6 @@
 /*
  * EquipmentEditor.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2021
+ * authors 2009-2022
  * - A.J. Drobnich <aj.drobnich@gmail.com>
  * - David Grundberg <individ@acc.umu.se>
  * - Matt Young <mfsy@yahoo.com>
@@ -191,7 +191,7 @@ void EquipmentEditor::save() {
       inform = inform + QString("<li>%1</li>").arg(tr("batch size"));
    }
 
-   if ( qFuzzyCompare(lineEdit_hopUtilization->toSI().quantity, 0.0) ) {
+   if ( qFuzzyCompare(lineEdit_hopUtilization->toDoubleRaw(), 0.0) ) {
       problems = true;
       inform = inform + QString("<li>%1</li>").arg(tr("hop utilization"));
    }
@@ -220,7 +220,7 @@ void EquipmentEditor::save() {
 
    this->obsEquip->setTunWeight_kg( lineEdit_tunWeight->toSI().quantity );
 
-   this->obsEquip->setTunSpecificHeat_calGC( lineEdit_tunSpecificHeat->toSI().quantity );
+   this->obsEquip->setTunSpecificHeat_calGC( lineEdit_tunSpecificHeat->toDoubleRaw() );
    this->obsEquip->setBoilTime_min( lineEdit_boilTime->toSI().quantity);
    this->obsEquip->setEvapRate_lHr(  lineEdit_evaporationRate->toSI().quantity );
    this->obsEquip->setTopUpKettle_l( lineEdit_topUpKettle->toSI().quantity );
@@ -229,7 +229,7 @@ void EquipmentEditor::save() {
    this->obsEquip->setLauterDeadspace_l( lineEdit_lauterDeadspace->toSI().quantity );
    this->obsEquip->setGrainAbsorption_LKg( ga_LKg );
    this->obsEquip->setBoilingPoint_c( lineEdit_boilingPoint->toSI().quantity );
-   this->obsEquip->setHopUtilization_pct( lineEdit_hopUtilization->toSI().quantity );
+   this->obsEquip->setHopUtilization_pct( lineEdit_hopUtilization->toDoubleRaw() );
 
    this->obsEquip->setNotes(textEdit_notes->toPlainText());
    this->obsEquip->setCalcBoilVolume(checkBox_calcBoilVolume->checkState() == Qt::Checked);

--- a/src/UiAmountWithUnits.h
+++ b/src/UiAmountWithUnits.h
@@ -121,7 +121,7 @@ public:
     * \brief Converts the numeric part of the input field to a double, ignoring any string suffix.  So "5.5 gal" will
     *        give 5.5, "20L" will return 20.0, and so on.
     */
-   double toDoubleRaw(bool * ok) const;
+   double toDoubleRaw(bool * ok = nullptr) const;
 
    /**
     * \brief Returns the field converted to canonical units for the relevant \c Measurement::PhysicalQuantity


### PR DESCRIPTION
Fix for https://github.com/Brewtarget/brewtarget/issues/634 plus more general tweak so we get an error message rather than an assert when trying to call `toSI()` for a BtLineEdit that does not related to a physical quantity.  (Though we should fix the inheritance hierarchy for BtGenericEdit etc so that these things get flushed out at compile time.)  