### PR TITLE
Fix for Mash Designer problems (https://github.com/Brewtarget/brewtarget/issues/620)

### DIFF
--- a/src/BrewDayFormatter.cpp
+++ b/src/BrewDayFormatter.cpp
@@ -235,7 +235,7 @@ QString BrewDayFormatter::buildInstructionHtml() {
              .arg(tr("Step"));
 
    QList<Instruction *> instructions = recObs->instructions();
-   QList<MashStep *> mashSteps = recObs->mash()->mashSteps();
+   auto mashSteps = recObs->mash()->mashSteps();
    int size = instructions.size();
    for (int i = 0; i < size; ++i) {
       QString stepTime, tmp;
@@ -300,7 +300,7 @@ QList<QStringList> BrewDayFormatter::buildInstructionList() {
    row.clear();
 
    QList<Instruction *> instructions = recObs->instructions();
-   QList<MashStep *> mashSteps = recObs->mash()->mashSteps();
+   auto mashSteps = recObs->mash()->mashSteps();
    size = instructions.size();
    for (i = 0; i < size; ++i) {
       QString stepTime, tmp;

--- a/src/BrewDayScrollWidget.cpp
+++ b/src/BrewDayScrollWidget.cpp
@@ -63,15 +63,19 @@ BrewDayScrollWidget::BrewDayScrollWidget(QWidget* parent) : QWidget{parent},
    this->setupUi(this);
    this->setObjectName("BrewDayScrollWidget");
 
-   connect(listWidget,                      SIGNAL(currentRowChanged(int)), this, SLOT(showInstruction(int)) );
-   connect(btTextEdit,                      SIGNAL(textModified()),         this, SLOT(saveInstruction()));
-   connect(pushButton_insert,               SIGNAL(clicked()),              this, SLOT(insertInstruction()) );
-   connect(pushButton_remove,               SIGNAL(clicked()),              this, SLOT(removeSelectedInstruction()) );
-   connect(pushButton_up,                   SIGNAL(clicked()),              this, SLOT(pushInstructionUp()) );
-   connect(pushButton_down,                 SIGNAL(clicked()),              this, SLOT(pushInstructionDown()) );
-   connect(pushButton_generateInstructions, SIGNAL(clicked()),              this, SLOT(generateInstructions()) );
+   connect(listWidget,                      &QListWidget::currentRowChanged, this, &BrewDayScrollWidget::showInstruction          );
+   connect(btTextEdit,                      SIGNAL(textModified()),          this, SLOT(saveInstruction())                        );
+//   connect(btTextEdit,                      &BtLineEdit::textModified,       this, &BrewDayScrollWidget::saveInstruction          );
+   connect(pushButton_insert,               &QAbstractButton::clicked,       this, &BrewDayScrollWidget::insertInstruction        );
+   connect(pushButton_remove,               &QAbstractButton::clicked,       this, &BrewDayScrollWidget::removeSelectedInstruction);
+   connect(pushButton_up,                   &QAbstractButton::clicked,       this, &BrewDayScrollWidget::pushInstructionUp        );
+   connect(pushButton_down,                 &QAbstractButton::clicked,       this, &BrewDayScrollWidget::pushInstructionDown      );
+   connect(pushButton_generateInstructions, &QAbstractButton::clicked,       this, &BrewDayScrollWidget::generateInstructions     );
+
    return;
 }
+
+BrewDayScrollWidget::~BrewDayScrollWidget() = default;
 
 void BrewDayScrollWidget::saveInstruction() {
   this->recObs->instructions()[ listWidget->currentRow() ]->setDirections( btTextEdit->toPlainText() );
@@ -156,51 +160,44 @@ void BrewDayScrollWidget::pushInstructionDown() {
    return;
 }
 
-bool BrewDayScrollWidget::loadComplete(bool ok)
-{
-   doc->print(printer);
+bool BrewDayScrollWidget::loadComplete(bool ok) {
+   this->doc->print(this->printer);
    return ok;
 }
 
-void BrewDayScrollWidget::print(QPrinter *mainPrinter,
-      int action, QFile* outFile)
-{
-   QString pDoc;
-
-   if( recObs == nullptr )
+void BrewDayScrollWidget::print(QPrinter *mainPrinter, int action, QFile* outFile) {
+   if (this->recObs == nullptr) {
       return;
+   }
 
-   /* Connect the webview's signal */
-   if ( action == PRINT )
-   {
-      printer = mainPrinter;
+   // Connect the webview's signal
+   if (action == PRINT) {
+      this->printer = mainPrinter;
    }
 
    // Start building the document to be printed.  The HTML doesn't work with
    // the image since it is a compiled resource
-   pDoc = buildTitleTable( action != HTML );
+   QString pDoc = buildTitleTable(action != HTML);
    pDoc += buildInstructionTable();
    pDoc += buildFooterTable();
 
    pDoc += tr("<h2>Notes</h2>");
-   if ( recObs->notes() != "" )
+   if (this->recObs->notes() != "" )
       pDoc += QString("<div id=\"customNote\">%1</div>\n").arg(recObs->notes());
 
    pDoc += "</body></html>";
 
-   doc->setHtml(pDoc);
-   if ( action == PREVIEW )
-      doc->show();
-   else if ( action == HTML )
-{
+   this->doc->setHtml(pDoc);
+   if (action == PREVIEW) {
+      this->doc->show();
+   } else if ( action == HTML ) {
       QTextStream out(outFile);
       out << pDoc;
       outFile->close();
+   } else {
+       this->loadComplete(true);
    }
-   else
-   {
-       loadComplete(true);
-   }
+   return;
 }
 
 void BrewDayScrollWidget::setRecipe(Recipe* rec) {
@@ -266,6 +263,7 @@ void BrewDayScrollWidget::acceptChanges(QMetaProperty prop, QVariant /*value*/) 
       }
       showChanges();
    }
+   return;
 }
 
 void BrewDayScrollWidget::acceptInsChanges(QMetaProperty prop, QVariant /*value*/) {
@@ -276,8 +274,9 @@ void BrewDayScrollWidget::acceptInsChanges(QMetaProperty prop, QVariant /*value*
       showChanges();
    } else if (propName == PropertyNames::Instruction::directions) {
       // This will make the displayed text directions update.
-      listWidget->setCurrentRow( listWidget->currentRow() );
+      listWidget->setCurrentRow(listWidget->currentRow());
    }
+   return;
 }
 
 void BrewDayScrollWidget::clear() {
@@ -325,7 +324,7 @@ QString BrewDayScrollWidget::buildTitleTable(bool includeImage) {
    QString header = Html::createHeader(BrewDayScrollWidget::tr("Brewday"), cssName);
 
    QString body = QString("<h1>%1</h1>").arg(recObs->name());
-   if ( includeImage ) {
+   if (includeImage) {
       body += QString("<img src=\"%1\" />").arg("qrc:/images/title.svg");
    }
 
@@ -409,7 +408,7 @@ QString BrewDayScrollWidget::buildInstructionTable() {
          .arg(tr("Step"));
 
    QList<Instruction*> instructions = this->recObs->instructions();
-   QList<MashStep*> mashSteps = this->recObs->mash()->mashSteps();
+   auto mashSteps = this->recObs->mash()->mashSteps();
    int size = instructions.size();
    for (int i = 0; i < size; ++i ) {
 

--- a/src/BrewDayScrollWidget.h
+++ b/src/BrewDayScrollWidget.h
@@ -56,7 +56,7 @@ public:
    enum { PRINT, PREVIEW, HTML, NUMACTIONS };
 
    BrewDayScrollWidget(QWidget* parent=nullptr);
-   virtual ~BrewDayScrollWidget() {}
+   virtual ~BrewDayScrollWidget();
    //! \brief Sets the observed recipe.
    void setRecipe(Recipe* rec);
 

--- a/src/BtTabWidget.h
+++ b/src/BtTabWidget.h
@@ -1,6 +1,6 @@
 /*
  * BtTabWidget.h is part of Brewtarget, and is Copyright the following
- * authors 2009-2014
+ * authors 2009-2022
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
  *
@@ -45,29 +45,28 @@ class Yeast;
  * as a dynamic property on the UI object.
  *
  */
-class BtTabWidget : public QTabWidget
-{
+class BtTabWidget : public QTabWidget {
    Q_OBJECT
 
 public:
-      BtTabWidget(QWidget* parent=0);
+   BtTabWidget(QWidget* parent = nullptr);
 
 signals:
-      void setRecipe(Recipe* rec);
-      void setEquipment(Equipment* kit);
-      void setStyle(Style* kit);
-      void setFermentables(QList<Fermentable*>ferms);
-      void setHops(QList<Hop*>hops);
-      void setMiscs(QList<Misc*>miscs);
-      void setYeasts(QList<Yeast*>yeasts);
+   void setRecipe(Recipe* rec);
+   void setEquipment(Equipment* kit);
+   void setStyle(Style* kit);
+   void setFermentables(QList<Fermentable*>ferms);
+   void setHops(QList<Hop*>hops);
+   void setMiscs(QList<Misc*>miscs);
+   void setYeasts(QList<Yeast*>yeasts);
 
 protected:
-      void dropEvent(QDropEvent *dpEvent);
-      // void dragMoveEvent(QDragMoveEvent *dmEvent);
-      virtual void dragEnterEvent(QDragEnterEvent *deEvent);
+   void dropEvent(QDropEvent *dpEvent);
+   // void dragMoveEvent(QDragMoveEvent *dmEvent);
+   virtual void dragEnterEvent(QDragEnterEvent *deEvent);
 
 protected:
-      QString acceptMime;
+   QString acceptMime;
 
 };
 

--- a/src/BtTreeFilterProxyModel.h
+++ b/src/BtTreeFilterProxyModel.h
@@ -1,6 +1,6 @@
 /*
  * BtTreeFilterProxyModel.h is part of Brewtarget, and is Copyright the following
- * authors 2009-2021
+ * authors 2009-2022
  * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
@@ -32,8 +32,7 @@
  *
  * \brief Proxy model for sorting brewtarget trees.
  */
-class BtTreeFilterProxyModel : public QSortFilterProxyModel
-{
+class BtTreeFilterProxyModel : public QSortFilterProxyModel {
    Q_OBJECT
 
 public:
@@ -45,15 +44,6 @@ protected:
 
 private:
    BtTreeModel::TypeMasks treeMask;
-
-   bool lessThanRecipe(BtTreeModel* model,const QModelIndex &left, const QModelIndex &right) const;
-   bool lessThanEquip(BtTreeModel* model,const QModelIndex &left, const QModelIndex &right) const;
-   bool lessThanFerment(BtTreeModel* model,const QModelIndex &left, const QModelIndex &right) const;
-   bool lessThanMisc(BtTreeModel* model,const QModelIndex &left, const QModelIndex &right) const;
-   bool lessThanHop(BtTreeModel* model,const QModelIndex &left, const QModelIndex &right) const;
-   bool lessThanYeast(BtTreeModel* model,const QModelIndex &left, const QModelIndex &right) const;
-   bool lessThanStyle(BtTreeModel* model,const QModelIndex &left, const QModelIndex &right) const;
-   bool lessThanWater(BtTreeModel* model,const QModelIndex &left, const QModelIndex &right) const;
 };
 
 #endif

--- a/src/BtTreeItem.cpp
+++ b/src/BtTreeItem.cpp
@@ -1,6 +1,6 @@
 /*
  * BtTreeItem.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2021
+ * authors 2009-2022
  * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  *
@@ -42,34 +42,50 @@
 #include "model/Water.h"
 #include "model/Yeast.h"
 #include "PersistentSettings.h"
+#include "utils/EnumStringMapping.h"
 
 namespace {
-   QHash<BtTreeItem::ITEMTYPE, char const *> const ItemTypeToName {
-      {BtTreeItem::RECIPE,      "RECIPE"     },
-      {BtTreeItem::EQUIPMENT,   "EQUIPMENT"  },
-      {BtTreeItem::FERMENTABLE, "FERMENTABLE"},
-      {BtTreeItem::HOP,         "HOP"        },
-      {BtTreeItem::MISC,        "MISC"       },
-      {BtTreeItem::YEAST,       "YEAST"      },
-      {BtTreeItem::BREWNOTE,    "BREWNOTE"   },
-      {BtTreeItem::STYLE,       "STYLE"      },
-      {BtTreeItem::FOLDER,      "FOLDER"     },
-      {BtTreeItem::WATER,       "WATER"      }
+   EnumStringMapping const itemTypeToName {
+      {QT_TR_NOOP("RECIPE"     )          , BtTreeItem::Type::RECIPE      },
+      {QT_TR_NOOP("EQUIPMENT"  )          , BtTreeItem::Type::EQUIPMENT   },
+      {QT_TR_NOOP("FERMENTABLE")          , BtTreeItem::Type::FERMENTABLE },
+      {QT_TR_NOOP("HOP"        )          , BtTreeItem::Type::HOP         },
+      {QT_TR_NOOP("MISC"       )          , BtTreeItem::Type::MISC        },
+      {QT_TR_NOOP("YEAST"      )          , BtTreeItem::Type::YEAST       },
+      {QT_TR_NOOP("BREWNOTE"   )          , BtTreeItem::Type::BREWNOTE    },
+      {QT_TR_NOOP("STYLE"      )          , BtTreeItem::Type::STYLE       },
+      {QT_TR_NOOP("FOLDER"     )          , BtTreeItem::Type::FOLDER      },
+      {QT_TR_NOOP("WATER"      )          , BtTreeItem::Type::WATER       }
    };
 }
 
+template<> BtTreeItem::Type BtTreeItem::typeOf<Recipe>()      { return BtTreeItem::Type::RECIPE;      }
+template<> BtTreeItem::Type BtTreeItem::typeOf<Equipment>()   { return BtTreeItem::Type::EQUIPMENT;   }
+template<> BtTreeItem::Type BtTreeItem::typeOf<Fermentable>() { return BtTreeItem::Type::FERMENTABLE; }
+template<> BtTreeItem::Type BtTreeItem::typeOf<Hop>()         { return BtTreeItem::Type::HOP;         }
+template<> BtTreeItem::Type BtTreeItem::typeOf<Misc>()        { return BtTreeItem::Type::MISC;        }
+template<> BtTreeItem::Type BtTreeItem::typeOf<Yeast>()       { return BtTreeItem::Type::YEAST;       }
+template<> BtTreeItem::Type BtTreeItem::typeOf<BrewNote>()    { return BtTreeItem::Type::BREWNOTE;    }
+template<> BtTreeItem::Type BtTreeItem::typeOf<Style>()       { return BtTreeItem::Type::STYLE;       }
+template<> BtTreeItem::Type BtTreeItem::typeOf<BtFolder>()    { return BtTreeItem::Type::FOLDER;      }
+template<> BtTreeItem::Type BtTreeItem::typeOf<Water>()       { return BtTreeItem::Type::WATER;       }
+
+
 bool operator==(BtTreeItem & lhs, BtTreeItem & rhs) {
    // Things of different types are not equal
-   if (lhs._type != rhs._type) {
+   if (lhs.itemType != rhs.itemType) {
       return false;
    }
 
-   return lhs.data(lhs._type, 0) == rhs.data(rhs._type, 0);
+   return lhs.data(0) == rhs.data(0);
 }
 
-BtTreeItem::BtTreeItem(int _type, BtTreeItem * parent)
-   : parentItem(parent), _thing(nullptr), m_showMe(false) {
-   setType(_type);
+BtTreeItem::BtTreeItem(BtTreeItem::Type itemType, BtTreeItem * parent) :
+   parentItem{parent},
+   itemType{itemType},
+   _thing{nullptr},
+   m_showMe{false} {
+   return;
 }
 
 BtTreeItem::~BtTreeItem() {
@@ -88,68 +104,68 @@ BtTreeItem * BtTreeItem::parent() {
    return parentItem;
 }
 
-int BtTreeItem::type() {
-   return _type;
+BtTreeItem::Type BtTreeItem::type() const {
+   return this->itemType;
 }
 
 int BtTreeItem::childCount() const {
    return this->childItems.count();
 }
 
-int BtTreeItem::columnCount(int _type) const {
-   switch (_type) {
-      case RECIPE:
+int BtTreeItem::columnCount(BtTreeItem::Type itemType) const {
+   switch (itemType) {
+      case BtTreeItem::Type::RECIPE:
          return RECIPENUMCOLS;
-      case EQUIPMENT:
+      case BtTreeItem::Type::EQUIPMENT:
          return EQUIPMENTNUMCOLS;
-      case FERMENTABLE:
+      case BtTreeItem::Type::FERMENTABLE:
          return FERMENTABLENUMCOLS;
-      case HOP:
+      case BtTreeItem::Type::HOP:
          return HOPNUMCOLS;
-      case MISC:
+      case BtTreeItem::Type::MISC:
          return MISCNUMCOLS;
-      case YEAST:
+      case BtTreeItem::Type::YEAST:
          return YEASTNUMCOLS;
-      case STYLE:
+      case BtTreeItem::Type::STYLE:
          return STYLENUMCOLS;
-      case BREWNOTE:
+      case BtTreeItem::Type::BREWNOTE:
          return BREWNUMCOLS;
-      case FOLDER:
+      case BtTreeItem::Type::FOLDER:
          return FOLDERNUMCOLS;
-      case WATER:
+      case BtTreeItem::Type::WATER:
          return WATERNUMCOLS;
       default:
-         qWarning() << QString("BtTreeItem::columnCount Bad column: %1").arg(_type);
+         qWarning() << Q_FUNC_INFO << "Bad column:" << static_cast<int>(itemType);
          return 0;
    }
 
 }
 
-QVariant BtTreeItem::data(int _type, int column) {
+QVariant BtTreeItem::data(/*BtTreeItem::Type itemType, */int column) {
 
-   switch (_type) {
-      case RECIPE:
+   switch (this->itemType) {
+      case BtTreeItem::Type::RECIPE:
          return dataRecipe(column);
-      case EQUIPMENT:
+      case BtTreeItem::Type::EQUIPMENT:
          return dataEquipment(column);
-      case FERMENTABLE:
+      case BtTreeItem::Type::FERMENTABLE:
          return dataFermentable(column);
-      case HOP:
+      case BtTreeItem::Type::HOP:
          return dataHop(column);
-      case MISC:
+      case BtTreeItem::Type::MISC:
          return dataMisc(column);
-      case YEAST:
+      case BtTreeItem::Type::YEAST:
          return dataYeast(column);
-      case STYLE:
+      case BtTreeItem::Type::STYLE:
          return dataStyle(column);
-      case BREWNOTE:
+      case BtTreeItem::Type::BREWNOTE:
          return dataBrewNote(column);
-      case FOLDER:
+      case BtTreeItem::Type::FOLDER:
          return dataFolder(column);
-      case WATER:
+      case BtTreeItem::Type::WATER:
          return dataWater(column);
       default:
-         qWarning() << QString("BtTreeItem::data Bad column: %1").arg(column);
+         qWarning() << Q_FUNC_INFO << "Bad column:" << static_cast<int>(itemType);
          return QVariant();
    }
 }
@@ -161,26 +177,22 @@ int BtTreeItem::childNumber() const {
    return 0;
 }
 
-void BtTreeItem::setData(int t, QObject * d) {
-   _thing = d;
-   _type  = t;
+void BtTreeItem::setData(BtTreeItem::Type t, QObject * d) {
+   this->_thing = d;
+   this->itemType = t;
 }
 
-QVariant BtTreeItem::data(int column) {
-   return data(type(), column);
-}
-
-bool BtTreeItem::insertChildren(int position, int count, int _type) {
+bool BtTreeItem::insertChildren(int position, int count, BtTreeItem::Type itemType) {
 //   qDebug() <<
-//      Q_FUNC_INFO << "Inserting" << count << "children of type" << _type << "(" <<
-//      this->itemTypeToString(static_cast<BtTreeItem::ITEMTYPE>(_type)) << ") at position" << position;
+//      Q_FUNC_INFO << "Inserting" << count << "children of type" << itemType << "(" <<
+//      this->itemTypeToString(static_cast<BtTreeItem::Type>(itemType)) << ") at position" << position;
    if (position < 0  || position > this->childItems.size()) {
       qWarning() << Q_FUNC_INFO << "Position" << position << "outside range (0, " << this->childItems.size() << ")";
       return false;
    }
 
    for (int row = 0; row < count; ++row) {
-      BtTreeItem * newItem = new BtTreeItem(_type, this);
+      BtTreeItem * newItem = new BtTreeItem(itemType, this);
       this->childItems.insert(position + row, newItem);
    }
 
@@ -439,84 +451,28 @@ QVariant BtTreeItem::dataWater(int column) {
    return QVariant();
 }
 
-void BtTreeItem::setType(int t) {
-   _type = t;
-}
 
-Recipe * BtTreeItem::recipe() {
-   if (_type == RECIPE && _thing) {
-      return qobject_cast<Recipe *>(_thing);
+template<class T>
+T * BtTreeItem::getData() {
+   if (this->itemType == BtTreeItem::typeOf<T>() && this->_thing) {
+      return qobject_cast<T *>(this->_thing);
    }
 
    return nullptr;
 }
-
-Equipment * BtTreeItem::equipment() {
-   if (_type == EQUIPMENT) {
-      return qobject_cast<Equipment *>(_thing);
-   }
-   return nullptr;
-}
-
-Fermentable * BtTreeItem::fermentable() {
-   if (_type == FERMENTABLE) {
-      return qobject_cast<Fermentable *>(_thing);
-   }
-   return nullptr;
-}
-
-Hop * BtTreeItem::hop() {
-   if (_type == HOP) {
-      return qobject_cast<Hop *>(_thing);
-   }
-   return nullptr;
-}
-
-Misc * BtTreeItem::misc() {
-   if (_type == MISC) {
-      return qobject_cast<Misc *>(_thing);
-   }
-   return nullptr;
-}
-
-Yeast * BtTreeItem::yeast() {
-   if (_type == YEAST) {
-      return qobject_cast<Yeast *>(_thing);
-   }
-   return nullptr;
-}
-
-BrewNote * BtTreeItem::brewNote() {
-   if (_type == BREWNOTE && _thing) {
-      return qobject_cast<BrewNote *>(_thing);
-   }
-
-   return nullptr;
-}
-
-Style * BtTreeItem::style() {
-   if (_type == STYLE && _thing) {
-      return qobject_cast<Style *>(_thing);
-   }
-
-   return nullptr;
-}
-
-BtFolder * BtTreeItem::folder() {
-   if (_type == FOLDER && _thing) {
-      return qobject_cast<BtFolder *>(_thing);
-   }
-
-   return nullptr;
-}
-
-Water * BtTreeItem::water() {
-   if (_type == WATER && _thing) {
-      return qobject_cast<Water *>(_thing);
-   }
-
-   return nullptr;
-}
+//
+// Instantiate the above template function for the types that are going to use it
+//
+template Recipe      * BtTreeItem::getData<Recipe     >();
+template Equipment   * BtTreeItem::getData<Equipment  >();
+template Fermentable * BtTreeItem::getData<Fermentable>();
+template Hop         * BtTreeItem::getData<Hop        >();
+template Misc        * BtTreeItem::getData<Misc       >();
+template Yeast       * BtTreeItem::getData<Yeast      >();
+template BrewNote    * BtTreeItem::getData<BrewNote   >();
+template Style       * BtTreeItem::getData<Style      >();
+template BtFolder    * BtTreeItem::getData<BtFolder   >();
+template Water       * BtTreeItem::getData<Water      >();
 
 NamedEntity * BtTreeItem::thing() {
    if (_thing) {
@@ -533,13 +489,6 @@ QString BtTreeItem::name() {
    }
    tmp = qobject_cast<NamedEntity *>(_thing);
    return tmp->name();
-}
-
-char const * const BtTreeItem::itemTypeToString(BtTreeItem::ITEMTYPE itemType) {
-   if (ItemTypeToName.contains(itemType)) {
-      return ItemTypeToName.value(itemType);
-   }
-   return "Unknown!";
 }
 
 bool BtTreeItem::showMe() const {

--- a/src/BtTreeItem.h
+++ b/src/BtTreeItem.h
@@ -1,6 +1,6 @@
 /*
  * BtTreeItem.h is part of Brewtarget, and is Copyright the following
- * authors 2009-2021
+ * authors 2009-2022
  * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  * - Philip G. Lee <rocketman768@gmail.com>
@@ -18,19 +18,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef BTTTREEITEM_H
+#define BTTTREEITEM_H
+#pragma once
 
-#ifndef BTTTREEITEM_H_
-#define BTTTREEITEM_H_
-
-class BtTreeItem;
-
-#include <QSharedPointer>
 #include <QList>
-#include <QVariant>
 #include <QModelIndex>
-#include <QWidget>
-#include <QVector>
 #include <QObject>
+#include <QSharedPointer>
+#include <QVariant>
+#include <QVector>
+#include <QWidget>
 
 #include "model/NamedEntity.h"
 
@@ -48,7 +46,6 @@ class Water;
 
 /*!
  * \class BtTreeItem
- *
  *
  * \brief Model for an item in a tree.
  *
@@ -202,7 +199,7 @@ public:
    /*!
     * This enum lists the different things that we can store in an item
     */
-   enum ITEMTYPE {
+   enum class Type {
       RECIPE,
       EQUIPMENT,
       FERMENTABLE,
@@ -212,15 +209,21 @@ public:
       BREWNOTE,
       STYLE,
       FOLDER,
-      WATER,
-      NUMTYPES
+      WATER
    };
+
+   /**
+    * \brief This templated function will convert a class to its \c BtTreeItem::Type. Eg \c typeOf<Hop>() returns
+    *        \c BtTreeItem::Type::Hop
+    */
+   template<class T>
+   static BtTreeItem::Type typeOf();
 
    friend bool operator==(BtTreeItem & lhs, BtTreeItem & rhs);
 
    //! \brief A constructor that sets the \c type of the BtTreeItem and
    // the \c parent
-   BtTreeItem(int _type = NUMTYPES, BtTreeItem * parent = nullptr);
+   BtTreeItem(BtTreeItem::Type itemType = BtTreeItem::Type::FOLDER, BtTreeItem * parent = nullptr);
    virtual ~BtTreeItem();
 
    //! \brief returns the child at \c number
@@ -229,48 +232,27 @@ public:
    BtTreeItem * parent();
 
    //! \brief returns item's type
-   int type();
+   BtTreeItem::Type type() const;
    //! \brief returns the number of the item's children
    int childCount() const;
    //! \brief returns number of columns associated with the item's \c type
-   int columnCount(int _type) const;
+   int columnCount(BtTreeItem::Type itemType) const;
    //! \brief returns the data of the item of \c type at \c column
-   QVariant data(int _type, int column);
+   QVariant data(/*BtTreeItem::Type itemType, */int column);
    //! \brief returns the index of the item in it's parents list
    int childNumber() const;
 
-   //! \brief provides a wrapper to data() so that the caller doesn't need to
-   // know the type of the item
-   QVariant data(int column);
-
    //! \brief sets the \c t type of the object and the \c d data
-   void setData(int t, QObject * d);
+   void setData(BtTreeItem::Type t, QObject * d);
 
-   //! \brief returns the data as a Recipe
-   Recipe   *   recipe();
-   //! \brief returns the data as an Equipment
-   Equipment  * equipment();
-   //! \brief returns the data as a fermentable
-   Fermentable * fermentable();
-   //! \brief returns the data as a hop
-   Hop     *    hop();
-   //! \brief returns the data as a misc
-   Misc    *    misc();
-   //! \brief returns the data as a yeast
-   Yeast    *   yeast();
-   //! \brief returns the data as a brewnote
-   BrewNote  *  brewNote();
-   //! \brief returns the data as a style
-   Style    *   style();
-   //! \brief returns data as a folder
-   BtFolder  * folder();
-   //! \brief returns data as a water
-   Water  * water();
+   //! \brief returns the data as a T
+   template<class T> T * getData();
+
    //! \brief returns the data as a NamedEntity
    NamedEntity * thing();
 
    //! \brief inserts \c count new items of \c type, starting at \c position
-   bool insertChildren(int position, int count, int _type = RECIPE);
+   bool insertChildren(int position, int count, BtTreeItem::Type itemType = BtTreeItem::Type::RECIPE);
    //! \brief removes \c count items starting at \c position
    bool removeChildren(int position, int count);
 
@@ -281,9 +263,6 @@ public:
    //! \brief does the node want to be shown regardless of display()
    bool showMe() const;
 
-   //! \brief For logging an ITEMTYPE
-   char const * const itemTypeToString(ITEMTYPE);
-
 private:
    /*!  Keep a pointer to the parent tree item. */
    BtTreeItem * parentItem;
@@ -291,7 +270,8 @@ private:
    QList<BtTreeItem *> childItems;
 
    /*! the type of this item */
-   int _type;
+   BtTreeItem::Type itemType;
+
    /*! the data associated with this item */
    QObject * _thing;
    //! \b overrides the display()
@@ -308,8 +288,6 @@ private:
    QVariant dataStyle(int column);
    QVariant dataFolder(int column);
    QVariant dataWater(int column);
-
-   void setType(int t);
 };
 
 #endif

--- a/src/BtTreeModel.cpp
+++ b/src/BtTreeModel.cpp
@@ -49,6 +49,36 @@
 #include "utils/BtStringConst.h"
 #include "PersistentSettings.h"
 
+namespace {
+   NamedEntity * getElement(BtTreeItem::Type oType, int id) {
+      switch (oType) {
+         case BtTreeItem::Type::RECIPE:
+            // .:TODO:. For now we just pull the raw pointer out of the shared pointer, but the rest of this code needs refactoring
+            return ObjectStoreWrapper::getById<Recipe>(id).get();
+         case BtTreeItem::Type::EQUIPMENT:
+            return ObjectStoreWrapper::getById<Equipment>(id).get();
+         case BtTreeItem::Type::FERMENTABLE:
+            return ObjectStoreWrapper::getById<Fermentable>(id).get();
+         case BtTreeItem::Type::HOP:
+            return ObjectStoreWrapper::getById<Hop>(id).get();
+         case BtTreeItem::Type::MISC:
+            return ObjectStoreWrapper::getById<Misc>(id).get();
+         case BtTreeItem::Type::STYLE:
+            return ObjectStoreWrapper::getById<Style>(id).get();
+         case BtTreeItem::Type::YEAST:
+            return ObjectStoreWrapper::getById<Yeast>(id).get();
+         case BtTreeItem::Type::WATER:
+            return ObjectStoreWrapper::getById<Water>(id).get();
+         case BtTreeItem::Type::FOLDER:
+            break;
+         default:
+            return nullptr;
+      }
+
+      return nullptr;
+   }
+}
+
 // =========================================================================
 // ============================ CLASS STUFF ================================
 // =========================================================================
@@ -61,7 +91,7 @@ BtTreeModel::BtTreeModel(BtTreeView * parent, TypeMasks type) :
 
    switch (type) {
       case RECIPEMASK:
-         rootItem->insertChildren(items, 1, BtTreeItem::RECIPE);
+         rootItem->insertChildren(items, 1, BtTreeItem::Type::RECIPE);
          connect(&ObjectStoreTyped<Recipe>::getInstance(), &ObjectStoreTyped<Recipe>::signalObjectInserted, this, &BtTreeModel::elementAddedRecipe);
          connect(&ObjectStoreTyped<Recipe>::getInstance(), &ObjectStoreTyped<Recipe>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedRecipe);
          // Brewnotes need love too!
@@ -69,63 +99,63 @@ BtTreeModel::BtTreeModel(BtTreeView * parent, TypeMasks type) :
          connect(&ObjectStoreTyped<BrewNote>::getInstance(), &ObjectStoreTyped<BrewNote>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedBrewNote);
          // And some versioning stuff, because why not?
          connect(&ObjectStoreTyped<Recipe>::getInstance(), &ObjectStoreTyped<Recipe>::signalPropertyChanged, this, &BtTreeModel::recipePropertyChanged);
-         _type = BtTreeItem::RECIPE;
+         this->itemType = BtTreeItem::Type::RECIPE;
          _mimeType = "application/x-brewtarget-recipe";
          m_maxColumns = BtTreeItem::RECIPENUMCOLS;
          break;
       case EQUIPMASK:
-         rootItem->insertChildren(items, 1, BtTreeItem::EQUIPMENT);
+         rootItem->insertChildren(items, 1, BtTreeItem::Type::EQUIPMENT);
          connect(&ObjectStoreTyped<Equipment>::getInstance(), &ObjectStoreTyped<Equipment>::signalObjectInserted, this, &BtTreeModel::elementAddedEquipment);
          connect(&ObjectStoreTyped<Equipment>::getInstance(), &ObjectStoreTyped<Equipment>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedEquipment);
-         _type = BtTreeItem::EQUIPMENT;
+         this->itemType = BtTreeItem::Type::EQUIPMENT;
          _mimeType = "application/x-brewtarget-recipe";
          m_maxColumns = BtTreeItem::EQUIPMENTNUMCOLS;
          break;
       case FERMENTMASK:
-         rootItem->insertChildren(items, 1, BtTreeItem::FERMENTABLE);
+         rootItem->insertChildren(items, 1, BtTreeItem::Type::FERMENTABLE);
          connect(&ObjectStoreTyped<Fermentable>::getInstance(), &ObjectStoreTyped<Fermentable>::signalObjectInserted, this, &BtTreeModel::elementAddedFermentable);
          connect(&ObjectStoreTyped<Fermentable>::getInstance(), &ObjectStoreTyped<Fermentable>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedFermentable);
-         _type = BtTreeItem::FERMENTABLE;
+         this->itemType = BtTreeItem::Type::FERMENTABLE;
          _mimeType = "application/x-brewtarget-ingredient";
          m_maxColumns = BtTreeItem::FERMENTABLENUMCOLS;
          break;
       case HOPMASK:
-         rootItem->insertChildren(items, 1, BtTreeItem::HOP);
+         rootItem->insertChildren(items, 1, BtTreeItem::Type::HOP);
          connect(&ObjectStoreTyped<Hop>::getInstance(), &ObjectStoreTyped<Hop>::signalObjectInserted, this, &BtTreeModel::elementAddedHop);
          connect(&ObjectStoreTyped<Hop>::getInstance(), &ObjectStoreTyped<Hop>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedHop);
-         _type = BtTreeItem::HOP;
+         this->itemType = BtTreeItem::Type::HOP;
          _mimeType = "application/x-brewtarget-ingredient";
          m_maxColumns = BtTreeItem::HOPNUMCOLS;
          break;
       case MISCMASK:
-         rootItem->insertChildren(items, 1, BtTreeItem::MISC);
+         rootItem->insertChildren(items, 1, BtTreeItem::Type::MISC);
          connect(&ObjectStoreTyped<Misc>::getInstance(), &ObjectStoreTyped<Misc>::signalObjectInserted, this, &BtTreeModel::elementAddedMisc);
          connect(&ObjectStoreTyped<Misc>::getInstance(), &ObjectStoreTyped<Misc>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedMisc);
-         _type = BtTreeItem::MISC;
+         this->itemType = BtTreeItem::Type::MISC;
          _mimeType = "application/x-brewtarget-ingredient";
          m_maxColumns = BtTreeItem::MISCNUMCOLS;
          break;
       case STYLEMASK:
-         rootItem->insertChildren(items, 1, BtTreeItem::STYLE);
+         rootItem->insertChildren(items, 1, BtTreeItem::Type::STYLE);
          connect(&ObjectStoreTyped<Style>::getInstance(), &ObjectStoreTyped<Style>::signalObjectInserted, this, &BtTreeModel::elementAddedStyle);
          connect(&ObjectStoreTyped<Style>::getInstance(), &ObjectStoreTyped<Style>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedStyle);
-         _type = BtTreeItem::STYLE;
+         this->itemType = BtTreeItem::Type::STYLE;
          _mimeType = "application/x-brewtarget-recipe";
          m_maxColumns = BtTreeItem::STYLENUMCOLS;
          break;
       case YEASTMASK:
-         rootItem->insertChildren(items, 1, BtTreeItem::YEAST);
+         rootItem->insertChildren(items, 1, BtTreeItem::Type::YEAST);
          connect(&ObjectStoreTyped<Yeast>::getInstance(), &ObjectStoreTyped<Yeast>::signalObjectInserted, this, &BtTreeModel::elementAddedYeast);
          connect(&ObjectStoreTyped<Yeast>::getInstance(), &ObjectStoreTyped<Yeast>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedYeast);
-         _type = BtTreeItem::YEAST;
+         this->itemType = BtTreeItem::Type::YEAST;
          _mimeType = "application/x-brewtarget-ingredient";
          m_maxColumns = BtTreeItem::YEASTNUMCOLS;
          break;
       case WATERMASK:
-         rootItem->insertChildren(items, 1, BtTreeItem::WATER);
+         rootItem->insertChildren(items, 1, BtTreeItem::Type::WATER);
          connect(&ObjectStoreTyped<Water>::getInstance(), &ObjectStoreTyped<Water>::signalObjectInserted, this, &BtTreeModel::elementAddedWater);
          connect(&ObjectStoreTyped<Water>::getInstance(), &ObjectStoreTyped<Water>::signalObjectDeleted,  this, &BtTreeModel::elementRemovedWater);
-         _type = BtTreeItem::WATER;
+         this->itemType = BtTreeItem::Type::WATER;
          _mimeType = "application/x-brewtarget-ingredient";
          m_maxColumns = BtTreeItem::WATERNUMCOLS;
          break;
@@ -146,7 +176,7 @@ BtTreeModel::~BtTreeModel() {
 }
 
 // =========================================================================
-// =================== ABSTRACTITEMMODEL STUFF =============================
+// =================== AbstractItemModel STUFF =============================
 // =========================================================================
 
 BtTreeItem * BtTreeModel::item(const QModelIndex & index) const {
@@ -255,7 +285,7 @@ QVariant BtTreeModel::data(const QModelIndex & index, int role) const {
       case Qt::DisplayRole:
          return itm->data(index.column());
       case Qt::DecorationRole:
-         if (index.column() == 0 && itm->type() == BtTreeItem::FOLDER) {
+         if (index.column() == 0 && itm->type() == BtTreeItem::Type::FOLDER) {
             return QIcon(":images/folder.png");
          }
          break;
@@ -461,20 +491,20 @@ QVariant BtTreeModel::waterHeader(int section) const {
 
 }
 
-bool BtTreeModel::insertRow(int row, const QModelIndex & parent, QObject * victim, int victimType) {
+bool BtTreeModel::insertRow(int row, const QModelIndex & parent, QObject * victim, std::optional<BtTreeItem::Type> victimType) {
    if (! parent.isValid()) {
       return false;
    }
 
    BtTreeItem * pItem = item(parent);
-   int type = pItem->type();
+   auto type = pItem->type();
 
    bool success = true;
 
    beginInsertRows(parent, row, row);
    success = pItem->insertChildren(row, 1, type);
    if (victim && success) {
-      type = victimType == -1 ? type : victimType;
+      type = (victimType ? *victimType : type);
       BtTreeItem * added = pItem->child(row);
       added->setData(type, victim);
    }
@@ -527,8 +557,8 @@ QModelIndex BtTreeModel::findElement(NamedEntity * thing, BtTreeItem * parent) {
 
          // If we have a folder, or we are looking for a brewnote and have a
          // recipe in hand, push the child onto the stack
-         if (target->child(i)->type() == BtTreeItem::FOLDER ||
-             (qobject_cast<BrewNote *>(thing) && target->child(i)->type() == BtTreeItem::RECIPE)) {
+         if (target->child(i)->type() == BtTreeItem::Type::FOLDER ||
+             (qobject_cast<BrewNote *>(thing) && target->child(i)->type() == BtTreeItem::Type::RECIPE)) {
             folders.append(target->child(i));
          }
       }
@@ -615,7 +645,7 @@ void BtTreeModel::loadTreeModel() {
          ndxLocal = createIndex(i, 0, local);
       }
 
-      if (!this->insertRow(i, ndxLocal, elem, _type)) {
+      if (!this->insertRow(i, ndxLocal, elem, this->itemType)) {
          qWarning() << "Insert failed in loadTreeModel()";
          continue;
       }
@@ -642,7 +672,7 @@ void BtTreeModel::addAncestoralTree(Recipe * rec, int i, BtTreeItem * parent) {
    for (Recipe * stor : rec->ancestors()) {
       // insert the ancestor. This is most of magic. One day, I understood it.
       // Now I simply copy/paste it
-      if (! insertRow(j, createIndex(i, 0, temp), stor, BtTreeItem::RECIPE)) {
+      if (! insertRow(j, createIndex(i, 0, temp), stor, BtTreeItem::Type::RECIPE)) {
          qWarning() << "Ancestor insert failed in loadTreeModel()";
          continue;
       }
@@ -667,7 +697,7 @@ void BtTreeModel::addBrewNoteSubTree(Recipe * rec, int i, BtTreeItem * parent, b
    for (BrewNote * note : notes) {
       // In previous insert loops, we ignore the error and soldier on. So we
       // will do that here too
-      if (! insertRow(j, createIndex(i, 0, temp), note, BtTreeItem::BREWNOTE)) {
+      if (! insertRow(j, createIndex(i, 0, temp), note, BtTreeItem::Type::BREWNOTE)) {
          qWarning() << "Brewnote insert failed in loadTreeModel()";
          continue;
       }
@@ -676,92 +706,48 @@ void BtTreeModel::addBrewNoteSubTree(Recipe * rec, int i, BtTreeItem * parent, b
    }
 }
 
-Recipe * BtTreeModel::recipe(QModelIndex const & index) const {
-   return index.isValid() ? item(index)->recipe() : nullptr;
+template<class T>
+T * BtTreeModel::getItem(QModelIndex const & index) const {
+   return index.isValid() ? this->item(index)->getData<T>() : nullptr;
 }
-
-Equipment * BtTreeModel::equipment(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->equipment() : nullptr;
-}
-
-Fermentable * BtTreeModel::fermentable(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->fermentable() : nullptr;
-}
-
-Hop * BtTreeModel::hop(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->hop() : nullptr;
-}
-
-Misc * BtTreeModel::misc(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->misc() : nullptr;
-}
-
-Yeast * BtTreeModel::yeast(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->yeast() : nullptr;
-}
-
-Style * BtTreeModel::style(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->style() : nullptr;
-}
-
-BrewNote * BtTreeModel::brewNote(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->brewNote() : nullptr;
-}
-
-BtFolder * BtTreeModel::folder(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->folder() : nullptr;
-}
-
-Water * BtTreeModel::water(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->water() : nullptr;
-}
+//
+// Instantiate the above template function for the types that are going to use it
+//
+template Recipe      * BtTreeModel::getItem<Recipe     >(QModelIndex const & index) const;
+template Equipment   * BtTreeModel::getItem<Equipment  >(QModelIndex const & index) const;
+template Fermentable * BtTreeModel::getItem<Fermentable>(QModelIndex const & index) const;
+template Hop         * BtTreeModel::getItem<Hop        >(QModelIndex const & index) const;
+template Misc        * BtTreeModel::getItem<Misc       >(QModelIndex const & index) const;
+template Yeast       * BtTreeModel::getItem<Yeast      >(QModelIndex const & index) const;
+template BrewNote    * BtTreeModel::getItem<BrewNote   >(QModelIndex const & index) const;
+template Style       * BtTreeModel::getItem<Style      >(QModelIndex const & index) const;
+template BtFolder    * BtTreeModel::getItem<BtFolder   >(QModelIndex const & index) const;
+template Water       * BtTreeModel::getItem<Water      >(QModelIndex const & index) const;
 
 NamedEntity * BtTreeModel::thing(const QModelIndex & index) const {
    return index.isValid() ? item(index)->thing() : nullptr;
 }
 
-bool BtTreeModel::isRecipe(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::RECIPE;
+template<class T>
+bool BtTreeModel::itemIs(QModelIndex const & index) const {
+   return this->type(index) == BtTreeItem::typeOf<T>();
 }
+//
+// Instantiate the above template function for the types that are going to use it
+//
+template bool BtTreeModel::itemIs<Recipe     >(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<Equipment  >(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<Fermentable>(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<Hop        >(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<Misc       >(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<Yeast      >(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<BrewNote   >(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<Style      >(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<BtFolder   >(QModelIndex const & index) const;
+template bool BtTreeModel::itemIs<Water      >(QModelIndex const & index) const;
 
-bool BtTreeModel::isEquipment(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::EQUIPMENT;
-}
-
-bool BtTreeModel::isFermentable(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::FERMENTABLE;
-}
-
-bool BtTreeModel::isHop(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::HOP;
-}
-
-bool BtTreeModel::isMisc(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::MISC;
-}
-
-bool BtTreeModel::isYeast(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::YEAST;
-}
-
-bool BtTreeModel::isStyle(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::STYLE;
-}
-
-bool BtTreeModel::isBrewNote(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::BREWNOTE;
-}
-
-bool BtTreeModel::isWater(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::WATER;
-}
-
-bool BtTreeModel::isFolder(const QModelIndex & index) const {
-   return type(index) == BtTreeItem::FOLDER;
-}
-
-int BtTreeModel::type(const QModelIndex & index) const {
-   return index.isValid() ? item(index)->type() : -1;
+std::optional<BtTreeItem::Type> BtTreeModel::type(const QModelIndex & index) const {
+   return index.isValid() ? std::optional<BtTreeItem::Type>{item(index)->type()} : std::nullopt;
 }
 
 QString BtTreeModel::name(const QModelIndex & idx) {
@@ -784,68 +770,77 @@ void BtTreeModel::copySelected(QList< QPair<QModelIndex, QString>> toBeCopied) {
       // std::shared_ptr<Fermentable>, etc) which is why the setName and insert calls cannot be pulled out of the
       // switch.
       //
-      switch (type(ndx)) {
-         case BtTreeItem::EQUIPMENT: {
-            auto copy = ObjectStoreWrapper::copy(*this->equipment(ndx)); // Create a deep copy.
-            copy->setName(name);
-            ObjectStoreWrapper::insert(copy);
-            this->folderChanged(copy.get());
+      auto theType = type(ndx);
+      if (!theType) {
+         qWarning() << Q_FUNC_INFO << "Unknown type for ndx" << ndx;
+      } else {
+         switch (*theType) {
+            case BtTreeItem::Type::EQUIPMENT: {
+                  auto copy = ObjectStoreWrapper::copy(*this->getItem<Equipment>(ndx)); // Create a deep copy.
+                  copy->setName(name);
+                  ObjectStoreWrapper::insert(copy);
+                  this->folderChanged(copy.get());
+               }
+               break;
+            case BtTreeItem::Type::FERMENTABLE: {
+                  auto copy = ObjectStoreWrapper::copy(*this->getItem<Fermentable>(ndx)); // Create a deep copy.
+                  copy->setName(name);
+                  ObjectStoreWrapper::insert(copy);
+                  this->folderChanged(copy.get());
+               }
+               break;
+            case BtTreeItem::Type::HOP: {
+                  auto copy = ObjectStoreWrapper::copy(*this->getItem<Hop>(ndx)); // Create a deep copy.
+                  copy->setName(name);
+                  ObjectStoreWrapper::insert(copy);
+                  this->folderChanged(copy.get());
+               }
+               break;
+            case BtTreeItem::Type::MISC: {
+                  auto copy = ObjectStoreWrapper::copy(*this->getItem<Misc>(ndx)); // Create a deep copy.
+                  copy->setName(name);
+                  ObjectStoreWrapper::insert(copy);
+                  this->folderChanged(copy.get());
+               }
+               break;
+            case BtTreeItem::Type::RECIPE: {
+                  auto copy = ObjectStoreWrapper::copy(*this->getItem<Recipe>(ndx)); // Create a deep copy.
+                  qDebug() <<
+                     Q_FUNC_INFO << "display:" <<  copy->display() << "isLocked:" << copy->locked() <<
+                     "hasDescendants:" << copy->hasDescendants();
+                  copy->setName(name);
+                  ObjectStoreWrapper::insert(copy);
+                  this->folderChanged(copy.get());
+               }
+               break;
+            case BtTreeItem::Type::STYLE: {
+                  auto copy = ObjectStoreWrapper::copy(*this->getItem<Style>(ndx)); // Create a deep copy.
+                  copy->setName(name);
+                  ObjectStoreWrapper::insert(copy);
+                  this->folderChanged(copy.get());
+               }
+               break;
+            case BtTreeItem::Type::YEAST: {
+                  auto copy = ObjectStoreWrapper::copy(*this->getItem<Yeast>(ndx)); // Create a deep copy.
+                  copy->setName(name);
+                  ObjectStoreWrapper::insert(copy);
+                  this->folderChanged(copy.get());
+               }
+               break;
+            case BtTreeItem::Type::WATER: {
+                  auto copy = ObjectStoreWrapper::copy(*this->getItem<Water>(ndx)); // Create a deep copy.
+                  copy->setName(name);
+                  ObjectStoreWrapper::insert(copy);
+                  this->folderChanged(copy.get());
+               }
+               break;
+            case BtTreeItem::Type::BREWNOTE:
+            case BtTreeItem::Type::FOLDER:
+               // These cases shouldn't arise (I think!) but the compiler will emit a warning if we don't explicitly
+               // have code to handle them (which is good!).
+               qWarning() << Q_FUNC_INFO << "Unexpected item type" << static_cast<int>(*theType);
+               break;
          }
-         break;
-         case BtTreeItem::FERMENTABLE: {
-            auto copy = ObjectStoreWrapper::copy(*this->fermentable(ndx)); // Create a deep copy.
-            copy->setName(name);
-            ObjectStoreWrapper::insert(copy);
-            this->folderChanged(copy.get());
-         }
-         break;
-         case BtTreeItem::HOP: {
-            auto copy = ObjectStoreWrapper::copy(*this->hop(ndx)); // Create a deep copy.
-            copy->setName(name);
-            ObjectStoreWrapper::insert(copy);
-            this->folderChanged(copy.get());
-         }
-         break;
-         case BtTreeItem::MISC: {
-            auto copy = ObjectStoreWrapper::copy(*this->misc(ndx)); // Create a deep copy.
-            copy->setName(name);
-            ObjectStoreWrapper::insert(copy);
-            this->folderChanged(copy.get());
-         }
-         break;
-         case BtTreeItem::RECIPE: {
-            auto copy = ObjectStoreWrapper::copy(*this->recipe(ndx)); // Create a deep copy.
-            qDebug() <<
-               Q_FUNC_INFO << "display:" <<  copy->display() << "isLocked:" << copy->locked() <<
-               "hasDescendants:" << copy->hasDescendants();
-            copy->setName(name);
-            ObjectStoreWrapper::insert(copy);
-            this->folderChanged(copy.get());
-         }
-         break;
-         case BtTreeItem::STYLE: {
-            auto copy = ObjectStoreWrapper::copy(*this->style(ndx)); // Create a deep copy.
-            copy->setName(name);
-            ObjectStoreWrapper::insert(copy);
-            this->folderChanged(copy.get());
-         }
-         break;
-         case BtTreeItem::YEAST: {
-            auto copy = ObjectStoreWrapper::copy(*this->yeast(ndx)); // Create a deep copy.
-            copy->setName(name);
-            ObjectStoreWrapper::insert(copy);
-            this->folderChanged(copy.get());
-         }
-         break;
-         case BtTreeItem::WATER: {
-            auto copy = ObjectStoreWrapper::copy(*this->water(ndx)); // Create a deep copy.
-            copy->setName(name);
-            ObjectStoreWrapper::insert(copy);
-            this->folderChanged(copy.get());
-         }
-         break;
-         default:
-            qWarning() << QString("copySelected:: unknown type %1").arg(type(ndx));
       }
       if (failed) {
          QMessageBox::warning(nullptr,
@@ -858,31 +853,34 @@ void BtTreeModel::copySelected(QList< QPair<QModelIndex, QString>> toBeCopied) {
 
 void BtTreeModel::deleteSelected(QModelIndexList victims) {
    QModelIndexList toBeDeleted = victims; // trust me
-   Recipe * rec;
-   int deletewhat;
 
    // There are black zones of shadow close to our daily paths,
    // and now and then some evil soul breaks a passage through.
 
    while (! toBeDeleted.isEmpty()) {
       QModelIndex ndx = toBeDeleted.takeFirst();
-      switch (type(ndx)) {
-         case BtTreeItem::EQUIPMENT:
-            ObjectStoreWrapper::softDelete(*equipment(ndx));
+      auto theType = type(ndx);
+      if (!theType) {
+         qWarning() << Q_FUNC_INFO << "Unknown type for ndx" << ndx;
+         continue;
+      }
+      switch (*theType) {
+         case BtTreeItem::Type::EQUIPMENT:
+            ObjectStoreWrapper::softDelete(*this->getItem<Equipment>(ndx));
             break;
-         case BtTreeItem::FERMENTABLE:
-            ObjectStoreWrapper::softDelete(*fermentable(ndx));
+         case BtTreeItem::Type::FERMENTABLE:
+            ObjectStoreWrapper::softDelete(*this->getItem<Fermentable>(ndx));
             break;
-         case BtTreeItem::HOP:
-            ObjectStoreWrapper::softDelete(*hop(ndx));
+         case BtTreeItem::Type::HOP:
+            ObjectStoreWrapper::softDelete(*this->getItem<Hop>(ndx));
             break;
-         case BtTreeItem::MISC:
-            ObjectStoreWrapper::softDelete(*misc(ndx));
+         case BtTreeItem::Type::MISC:
+            ObjectStoreWrapper::softDelete(*this->getItem<Misc>(ndx));
             break;
-         case BtTreeItem::RECIPE:
+         case BtTreeItem::Type::RECIPE:
             {
-               rec = recipe(ndx);
-               deletewhat = PersistentSettings::value(PersistentSettings::Names::deletewhat, Recipe::DESCENDANT).toInt();
+               auto rec = this->getItem<Recipe>(ndx);
+               int deletewhat = PersistentSettings::value(PersistentSettings::Names::deletewhat, Recipe::DESCENDANT).toInt();
                if (deletewhat == Recipe::DESCENDANT) {
                   this->revertRecipeToPreviousVersion(ndx);
                } else {
@@ -893,27 +891,27 @@ void BtTreeModel::deleteSelected(QModelIndexList victims) {
                ObjectStoreWrapper::softDelete(*rec);
             }
             break;
-         case BtTreeItem::STYLE:
-            ObjectStoreWrapper::softDelete(*style(ndx));
+         case BtTreeItem::Type::STYLE:
+            ObjectStoreWrapper::softDelete(*this->getItem<Style>(ndx));
             break;
-         case BtTreeItem::YEAST:
-            ObjectStoreWrapper::softDelete(*yeast(ndx));
+         case BtTreeItem::Type::YEAST:
+            ObjectStoreWrapper::softDelete(*this->getItem<Yeast>(ndx));
             break;
-         case BtTreeItem::BREWNOTE:
-            ObjectStoreWrapper::softDelete(*brewNote(ndx));
+         case BtTreeItem::Type::BREWNOTE:
+            ObjectStoreWrapper::softDelete(*this->getItem<BrewNote>(ndx));
             break;
-         case BtTreeItem::WATER:
-            ObjectStoreWrapper::softDelete(*water(ndx));
+         case BtTreeItem::Type::WATER:
+            ObjectStoreWrapper::softDelete(*this->getItem<Water>(ndx));
             break;
-         case BtTreeItem::FOLDER:
-            // This one is weird.
-            toBeDeleted += allChildren(ndx);
-            removeFolder(ndx);
+         case BtTreeItem::Type::FOLDER:
+            // We want to delete the contents of the folder (and remove it from from the model) before remove the folder
+            // itself, otherwise the QModelIndex values for the contents will not be valid.
+            this->deleteSelected(allChildren(ndx));
+            this->removeFolder(ndx);
             break;
-         default:
-            qWarning() << QString("deleteSelected:: unknown type %1").arg(type(ndx));
       }
    }
+   return;
 }
 
 // =========================================================================
@@ -926,18 +924,19 @@ void BtTreeModel::deleteSelected(QModelIndexList victims) {
 // index after we have removed the recipe. BAD THINGS happen otherwise.
 //
 void BtTreeModel::folderChanged(QString name) {
-   NamedEntity * test = qobject_cast<NamedEntity *>(sender());
+   qDebug() << Q_FUNC_INFO << name;
 
-   Q_UNUSED(name)
-   if (! test) {
-      return;
+   NamedEntity * test = qobject_cast<NamedEntity *>(sender());
+   if (test) {
+      this->folderChanged(test);
    }
 
-   this->folderChanged(test);
    return;
 }
 
 void BtTreeModel::folderChanged(NamedEntity * test) {
+   qDebug() << Q_FUNC_INFO << test;
+
    // Find it.
    QModelIndex ndx = findElement(test);
    if (! ndx.isValid()) {
@@ -950,15 +949,14 @@ void BtTreeModel::folderChanged(NamedEntity * test) {
 
    pIndex = parent(ndx); // Get the parent
    // If the parent isn't valid, its the root
-   if (! pIndex.isValid()) {
+   if (!pIndex.isValid()) {
       pIndex = createIndex(0, 0, rootItem->child(0));
    }
 
-   int i = item(ndx)->childNumber();
-
+   int ii = item(ndx)->childNumber();
    // Remove it
-   if (! removeRows(i, 1, pIndex)) {
-      qWarning() << Q_FUNC_INFO << "Could not remove row";
+   if (!this->removeRows(ii, 1, pIndex)) {
+      qWarning() << Q_FUNC_INFO << "Could not remove row" << ii;
       return;
    }
 
@@ -972,15 +970,15 @@ void BtTreeModel::folderChanged(NamedEntity * test) {
    }
 
    BtTreeItem * local = item(newNdx);
-   int j = local->childCount();
+   int jj = local->childCount();
 
-   if (!  insertRow(j, newNdx, test, _type)) {
-      qWarning() << Q_FUNC_INFO << "Could not insert row";
+   if (!insertRow(jj, newNdx, test, this->itemType)) {
+      qWarning() << Q_FUNC_INFO << "Could not insert row" << jj;
       return;
    }
    // If we have brewnotes, set them up here.
    if (treeMask & RECIPEMASK) {
-      addBrewNoteSubTree(qobject_cast<Recipe *>(test), j, local);
+      addBrewNoteSubTree(qobject_cast<Recipe *>(test), jj, local);
    }
 
    if (expand) {
@@ -1014,24 +1012,23 @@ bool BtTreeModel::removeFolder(QModelIndex ndx) {
 
 QModelIndexList BtTreeModel::allChildren(QModelIndex ndx) {
    QModelIndexList leafNodes;
-   QList<BtTreeItem *> folders;
-   int i;
 
    // Don't send an invalid index or something that isn't a folder
-   if (! ndx.isValid() || type(ndx) != BtTreeItem::FOLDER) {
+   if (! ndx.isValid() || type(ndx) != BtTreeItem::Type::FOLDER) {
       return leafNodes;
    }
 
    BtTreeItem * start = item(ndx);
+   QList<BtTreeItem *> folders;
    folders.append(start);
 
    while (! folders.isEmpty()) {
       BtTreeItem * target = folders.takeFirst();
 
-      for (i = 0; i < target->childCount(); ++i) {
+      for (int i = 0; i < target->childCount(); ++i) {
          BtTreeItem * next = target->child(i);
          // If a folder, push it onto the folders stack for later processing
-         if (next->type() == BtTreeItem::FOLDER) {
+         if (next->type() == BtTreeItem::Type::FOLDER) {
             folders.append(next);
          } else { // Leafnode
             leafNodes.append(createIndex(i, 0, next));
@@ -1082,7 +1079,7 @@ bool BtTreeModel::renameFolder(BtFolder * victim, QString newName) {
          // don't move it, so we need to get the item beyond that.
          BtTreeItem * next = target->child(src);
          // If a folder, push it onto the folders stack for latter processing
-         if (next->type() == BtTreeItem::FOLDER) {
+         if (next->type() == BtTreeItem::Type::FOLDER) {
             QPair<QString, BtTreeItem *> newTarget;
             newTarget.first = targetPath % "/" % next->name();
             newTarget.second = next;
@@ -1109,14 +1106,13 @@ QModelIndex BtTreeModel::createFolderTree(QStringList dirs, BtTreeItem * parent,
    // column counts. Just using the rowsAboutToBeAdded throws ugly errors and
    // then a sigsegv
    emit layoutAboutToBeChanged();
-   foreach (QString cur, dirs) {
+   for (QString cur : dirs) {
       QString fPath;
       BtFolder * temp = new BtFolder();
-      int i;
 
       // If the parent item is a folder, use its full path
-      if (pItem->type() == BtTreeItem::FOLDER) {
-         fPath = pItem->folder()->fullPath() % "/" % cur;
+      if (pItem->type() == BtTreeItem::Type::FOLDER) {
+         fPath = pItem->getData<BtFolder>()->fullPath() % "/" % cur;
       } else {
          fPath = pPath % "/" % cur;   // If it isn't we need the parent path
       }
@@ -1125,10 +1121,10 @@ QModelIndex BtTreeModel::createFolderTree(QStringList dirs, BtTreeItem * parent,
 
       // Set the full path, which will set the name and the path
       temp->setfullPath(fPath);
-      i = pItem->childCount();
+      int i = pItem->childCount();
 
-      pItem->insertChildren(i, 1, BtTreeItem::FOLDER);
-      pItem->child(i)->setData(BtTreeItem::FOLDER, temp);
+      pItem->insertChildren(i, 1, BtTreeItem::Type::FOLDER);
+      pItem->child(i)->setData(BtTreeItem::Type::FOLDER, temp);
 
       // Set the parent item to point to the newly created tree
       pItem = pItem->child(i);
@@ -1181,9 +1177,9 @@ QModelIndex BtTreeModel::findFolder(QString name, BtTreeItem * parent, bool crea
    while (i < pItem->childCount()) {
       BtTreeItem * kid = pItem->child(i);
       // The kid is a folder
-      if (kid->type() == BtTreeItem::FOLDER) {
+      if (kid->type() == BtTreeItem::Type::FOLDER) {
          // The folder name matches the part we are looking at
-         if (kid->folder()->isFolder(targetPath)) {
+         if (kid->getData<BtFolder>()->isFolder(targetPath)) {
             // If there are no more subtrees to look for, we found it
             if (dirs.isEmpty()) {
                return createIndex(i, 0, kid);
@@ -1277,29 +1273,28 @@ void BtTreeModel::elementAddedWater(int victimId) {
 
 // I guess this isn't too bad. Better than this same function copied 7 times
 void BtTreeModel::elementAdded(NamedEntity * victim) {
-   QModelIndex pIdx;
-   int lType = _type;
 
-   if (! victim->display()) {
+   if (!victim->display()) {
       return;
    }
 
+   QModelIndex pIdx;
+   auto lType = this->itemType;
    if (qobject_cast<BrewNote *>(victim)) {
       auto brewNote = qobject_cast<BrewNote *>(victim);
       Recipe * recipe = ObjectStoreWrapper::getByIdRaw<Recipe>(brewNote->getRecipeId());
       pIdx = findElement(recipe);
-      lType = BtTreeItem::BREWNOTE;
+      lType = BtTreeItem::Type::BREWNOTE;
    } else {
       pIdx = createIndex(0, 0, rootItem->child(0));
    }
 
-   if (! pIdx.isValid()) {
+   if (!pIdx.isValid()) {
       return;
    }
 
    int breadth = rowCount(pIdx);
-
-   if (! insertRow(breadth, pIdx, victim, lType)) {
+   if (!insertRow(breadth, pIdx, victim, lType)) {
       return;
    }
 
@@ -1310,14 +1305,15 @@ void BtTreeModel::elementAdded(NamedEntity * victim) {
 
       if (notes.size()) {
          pIdx = findElement(parent);
-         lType = BtTreeItem::BREWNOTE;
+         lType = BtTreeItem::Type::BREWNOTE;
          int row = 0;
-         foreach (BrewNote * note, notes) {
+         for (BrewNote * note : notes) {
             insertRow(row++, pIdx, note, lType);
          }
       }
    }
    observeElement(victim);
+   return;
 }
 
 void BtTreeModel::elementRemovedRecipe(int victimId, std::shared_ptr<QObject> victim) {
@@ -1349,27 +1345,27 @@ void BtTreeModel::elementRemovedWater(int victimId, std::shared_ptr<QObject> vic
 }
 
 void BtTreeModel::elementRemoved(NamedEntity * victim) {
-   QModelIndex index, pIndex;
 
-   if (! victim) {
+   if (!victim) {
       return;
    }
 
-   index = findElement(victim);
-   if (! index.isValid()) {
+   QModelIndex index = findElement(victim);
+   if (!index.isValid()) {
       return;
    }
 
-   pIndex = parent(index);
-   if (! pIndex.isValid()) {
+   QModelIndex pIndex = parent(index);
+   if (!pIndex.isValid()) {
       return;
    }
 
-   if (!removeRows(index.row(), 1, pIndex)) {
+   if (!this->removeRows(index.row(), 1, pIndex)) {
       return;
    }
 
    disconnect(victim, nullptr, this, nullptr);
+   return;
 }
 
 void BtTreeModel::recipePropertyChanged(int recipeId, BtStringConst const & propertyName) {
@@ -1423,38 +1419,13 @@ void BtTreeModel::observeElement(NamedEntity * d) {
 // =========================================================================
 // ===================== DRAG AND DROP STUFF ===============================
 // =========================================================================
-NamedEntity * getElement(int oType, int id) {
-   switch (oType) {
-      case BtTreeItem::RECIPE:
-         // .:TODO:. For now we just pull the raw pointer out of the shared pointer, but the rest of this code needs refactoring
-         return ObjectStoreWrapper::getById<Recipe>(id).get();
-      case BtTreeItem::EQUIPMENT:
-         return ObjectStoreWrapper::getById<Equipment>(id).get();
-      case BtTreeItem::FERMENTABLE:
-         return ObjectStoreWrapper::getById<Fermentable>(id).get();
-      case BtTreeItem::HOP:
-         return ObjectStoreWrapper::getById<Hop>(id).get();
-      case BtTreeItem::MISC:
-         return ObjectStoreWrapper::getById<Misc>(id).get();
-      case BtTreeItem::STYLE:
-         return ObjectStoreWrapper::getById<Style>(id).get();
-      case BtTreeItem::YEAST:
-         return ObjectStoreWrapper::getById<Yeast>(id).get();
-      case BtTreeItem::WATER:
-         return ObjectStoreWrapper::getById<Water>(id).get();
-      case BtTreeItem::FOLDER:
-         break;
-      default:
-         return nullptr;
-   }
+bool BtTreeModel::dropMimeData(QMimeData const * data,
+                               Qt::DropAction action,
+                               int row,
+                               int column,
+                               QModelIndex const & parent) {
+   qDebug() << Q_FUNC_INFO;
 
-
-   return nullptr;
-}
-
-
-bool BtTreeModel::dropMimeData(const QMimeData * data, Qt::DropAction action,
-                               int row, int column, const QModelIndex & parent) {
    QByteArray encodedData;
 
    if (data->hasFormat(_mimeType)) {
@@ -1465,21 +1436,15 @@ bool BtTreeModel::dropMimeData(const QMimeData * data, Qt::DropAction action,
       return false;   // Don't know what we got, but we don't want it
    }
 
-
-   QDataStream stream(&encodedData, QIODevice::ReadOnly);
-   int oType, id;
-   QString target = "";
-   QString name = "";
-   NamedEntity * something = nullptr;
-
    if (! parent.isValid()) {
       return false;
    }
 
-   if (isFolder(parent)) {
-      target = folder(parent)->fullPath();
+   QString target = "";
+   if (this->itemIs<BtFolder>(parent)) {
+      target = this->getItem<BtFolder>(parent)->fullPath();
    } else {
-      something = thing(parent);
+      NamedEntity * something = this->thing(parent);
 
       // Did you know there's a space between elements in a tree, and you can
       // actually drop things there? If somebody drops something there, don't
@@ -1492,18 +1457,27 @@ bool BtTreeModel::dropMimeData(const QMimeData * data, Qt::DropAction action,
    }
 
    // Pull the stream apart and do that which needs done. Late binding ftw!
-   while (!stream.atEnd()) {
+   for (QDataStream stream{&encodedData, QIODevice::ReadOnly}; !stream.atEnd(); ) {
+      int oTypeRaw;
+      int id;
+      QString name = "";
       QString text;
-      stream >> oType >> id >> name;
+      stream >> oTypeRaw >> id >> name;
+      BtTreeItem::Type oType = static_cast<BtTreeItem::Type>(oTypeRaw);
       NamedEntity * elem = getElement(oType, id);
 
-      if (elem == nullptr && oType != BtTreeItem::FOLDER) {
+      if (elem == nullptr && oType != BtTreeItem::Type::FOLDER) {
          return false;
       }
 
       // this is the work.
-      if (oType != BtTreeItem::FOLDER) {
+      if (oType != BtTreeItem::Type::FOLDER) {
+         qDebug() << Q_FUNC_INFO << "Moving" << elem << "from folder" << elem->folder() << "to folder" << target;
+         // Dropping an item in a folder just means setting the folder name on that item
          elem->setFolder(target);
+         // Now we have to update our own model (ie that of BtTreeModel) so that the display will update!
+         this->folderChanged(elem);
+
       } else {
          // I need the actual folder object that got dropped.
          BtFolder * victim = new BtFolder;
@@ -1516,48 +1490,15 @@ bool BtTreeModel::dropMimeData(const QMimeData * data, Qt::DropAction action,
    return true;
 }
 
-/*
- * Looks like this is unused
-// do not call up any that you can not put down
-void BtTreeModel::makeAncestors(NamedEntity * ancestor, NamedEntity * descendant) {
-   if (ancestor == descendant) {
-      return;
-   }
-
-   // I need these as their recipes later, so cast'em
-   Recipe * r_desc = qobject_cast<Recipe *>(descendant);
-   Recipe * r_anc = qobject_cast<Recipe *>(ancestor);
-
-   // find the ancestor in the tree
-   QModelIndex ancNdx = findElement(ancestor);
-
-   // remove the ancestor
-   removeRows(ancNdx.row(), 1, this->parent(ancNdx));
-
-   // this does the database work
-   r_desc->setAncestor(*r_anc);
-
-   // now we need to find the descendant. This has to be done after we remove
-   // the rows.
-   QModelIndex descNdx = findElement(descendant);
-   BtTreeItem * node = item(descNdx);
-
-   // Remove all the brewnotes in the tree first. We get dupes otherwise.
-   removeRows(0, node->childCount(), descNdx);
-
-   // Add the ancestor's brewnotes to the descendant
-   addBrewNoteSubTree(r_desc, descNdx.row(), node->parent(), true);
-}
-*/
 void BtTreeModel::revertRecipeToPreviousVersion(QModelIndex ndx) {
    BtTreeItem * node = item(ndx);
    BtTreeItem * pNode = node->parent();
    QModelIndex pIndex = parent(ndx);
 
    // The recipe referred to by the index is the one that's about to be deleted
-   Recipe * recipeToRevert = recipe(ndx);
+   auto recipeToRevert = this->getItem<Recipe>(ndx);
 
-   Recipe * ancestor = recipeToRevert->revertToPreviousVersion();
+   auto ancestor = recipeToRevert->revertToPreviousVersion();
 
    // don't do anything if there is nothing to do
    if (!ancestor) {
@@ -1568,7 +1509,7 @@ void BtTreeModel::revertRecipeToPreviousVersion(QModelIndex ndx) {
    removeRows(0, node->childCount(), ndx);
 
    // Put the ancestor into the tree
-   if (! insertRow(pIndex.row(), pIndex, ancestor, BtTreeItem::RECIPE)) {
+   if (! insertRow(pIndex.row(), pIndex, ancestor, BtTreeItem::Type::RECIPE)) {
       qWarning() << Q_FUNC_INFO << "Could not add ancestor to tree";
    }
 
@@ -1591,7 +1532,7 @@ void BtTreeModel::orphanRecipe(QModelIndex ndx) {
    QModelIndex pIndex = parent(ndx);
 
    // I need the recipe referred to by the index
-   Recipe *orphan = recipe(ndx);
+   auto orphan = this->getItem<Recipe>(ndx);
 
    // don't do anything if there is nothing to do
    if ( ! orphan->hasAncestors() ) {
@@ -1599,7 +1540,7 @@ void BtTreeModel::orphanRecipe(QModelIndex ndx) {
    }
 
    // And I need its immediate ancestor
-   Recipe *ancestor = orphan->ancestors().at(0);
+   auto ancestor = orphan->ancestors().at(0);
 
    // Deal with the soon-to-be orphan first
    // Remove all the rows associated with the orphan
@@ -1617,7 +1558,7 @@ void BtTreeModel::orphanRecipe(QModelIndex ndx) {
    ancestor->setLocked(false);
 
    // Put the ancestor into the tree
-   if ( ! insertRow(pIndex.row(), pIndex, ancestor, BtTreeItem::RECIPE) ) {
+   if ( ! insertRow(pIndex.row(), pIndex, ancestor, BtTreeItem::Type::RECIPE) ) {
       qWarning() << Q_FUNC_INFO << "Could not add ancestor to tree";
    }
 
@@ -1635,7 +1576,7 @@ void BtTreeModel::orphanRecipe(QModelIndex ndx) {
 
 void BtTreeModel::spawnRecipe(QModelIndex ndx) {
    Q_ASSERT(ndx.isValid());
-   Recipe * ancestor = this->recipe(ndx);
+   auto ancestor = this->getItem<Recipe>(ndx);
    Q_ASSERT(ancestor);
    std::shared_ptr<Recipe> descendant = std::make_shared<Recipe>(*ancestor);
    // We want to store the new Recipe first so that it gets an ID...
@@ -1727,7 +1668,7 @@ void BtTreeModel::showAncestors(QModelIndex ndx) {
    }
 
    BtTreeItem * node = item(ndx);
-   Recipe * descendant = recipe(ndx);
+   auto descendant = this->getItem<Recipe>(ndx);
    QList<Recipe *> ancestors = descendant->ancestors();
 
    removeRows(0, node->childCount(), ndx);
@@ -1740,9 +1681,9 @@ void BtTreeModel::showAncestors(QModelIndex ndx) {
 
    // Now loop through the ancestors. The nature of the beast is nearest
    // ancestors are first
-   for (Recipe * ancestor : ancestors) {
+   for (auto ancestor : ancestors) {
       int j = node->childCount();
-      if (! insertRow(j, ndx, ancestor, BtTreeItem::RECIPE)) {
+      if (! insertRow(j, ndx, ancestor, BtTreeItem::Type::RECIPE)) {
          qWarning() << "Could not add ancestoral brewnotes";
       }
       QModelIndex cIndex = findElement(ancestor, node);
@@ -1753,6 +1694,7 @@ void BtTreeModel::showAncestors(QModelIndex ndx) {
       // add the brewnotes to the ancestors, but make sure we don't recurse
       addBrewNoteSubTree(ancestor, j, node, false);
    }
+   return;
 }
 
 void BtTreeModel::hideAncestors(QModelIndex ndx) {
@@ -1765,7 +1707,7 @@ void BtTreeModel::hideAncestors(QModelIndex ndx) {
 
    // remove all the currently shown children
    removeRows(0, node->childCount(), ndx);
-   Recipe * descendant = recipe(ndx);
+   auto descendant = this->getItem<Recipe>(ndx);
 
    // put the brewnotes back, including those from the ancestors.
    addBrewNoteSubTree(descendant, ndx.row(), node->parent());
@@ -1774,11 +1716,12 @@ void BtTreeModel::hideAncestors(QModelIndex ndx) {
    setShowChild(ndx, false);
 
    // Now we just need to mark each ancestor invisible again
-   for (Recipe * ancestor : descendant->ancestors()) {
+   for (auto ancestor : descendant->ancestors()) {
       QModelIndex aIndex = findElement(ancestor, node);
       setShowChild(aIndex, false);
       emit dataChanged(aIndex, aIndex);
    }
+   return;
 }
 
 // more cleverness must happen. Wonder if I can figure it out.
@@ -1797,4 +1740,5 @@ void BtTreeModel::catchAncestors(bool showem) {
          showem ? showAncestors(ndxLocal) : hideAncestors(ndxLocal);
       }
    }
+   return;
 }

--- a/src/BtTreeModel.h
+++ b/src/BtTreeModel.h
@@ -1,6 +1,6 @@
 /*
  * BtTreeModel.h is part of Brewtarget, and is Copyright the following
- * authors 2009-2021
+ * authors 2009-2022
  * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  *
@@ -19,8 +19,10 @@
  */
 #ifndef BTTREEMODEL_H
 #define BTTREEMODEL_H
+#pragma once
 
 #include <memory>
+#include <optional>
 
 #include <QAbstractItemModel>
 #include <QList>
@@ -30,11 +32,12 @@
 #include <QSqlRelationalTableModel>
 #include <QVariant>
 
+#include "BtTreeItem.h"
+
 // Forward declarations
 class BrewNote;
 class BtFolder;
 class BtStringConst;
-class BtTreeItem;
 class BtTreeView;
 class Equipment;
 class Fermentable;
@@ -48,7 +51,6 @@ class Yeast;
 
 /*!
  * \class BtTreeModel
- *
  *
  * \brief Model for a tree of Recipes, Equipments, Fermentables, Hops, Miscs and Yeasts
  *
@@ -104,7 +106,10 @@ public:
    virtual QModelIndex parent(const QModelIndex & index) const;
 
    //! \brief Reimplemented from QAbstractItemModel
-   bool insertRow(int row, const QModelIndex & parent = QModelIndex(), QObject * victim = nullptr, int victimType = -1);
+   bool insertRow(int row,
+                  QModelIndex const & parent = QModelIndex(),
+                  QObject * victim = nullptr,
+                  std::optional<BtTreeItem::Type> victimType = std::nullopt);
    //! \brief Reimplemented from QAbstractItemModel
    virtual bool removeRows(int row, int count, const QModelIndex & parent = QModelIndex());
 
@@ -113,29 +118,17 @@ public:
    //! \brief returns the BtTreeItem at \c index
    BtTreeItem * item(const QModelIndex & index) const;
 
-   //! \brief Test type at \c index.
-   bool isRecipe(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isEquipment(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isFermentable(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isHop(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isMisc(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isYeast(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isBrewNote(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isStyle(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isFolder(const QModelIndex & index) const;
-   //! \brief Test type at \c index.
-   bool isWater(const QModelIndex & index) const;
+   /**
+    * \brief Test type at \c index.
+    *        Valid for \c Recipe, \c Equipment, \c Fermentable, \c Hop, \c Misc, \c Yeast, \c Style, \c BrewNote,
+    *        \c Water, \c BtFolder.
+    */
+   template<class T>
+   bool itemIs(QModelIndex const & index) const;
 
    //! \brief Gets the type of item at \c index
-   int type(const QModelIndex & index) const;
+   std::optional<BtTreeItem::Type> type(const QModelIndex & index) const;
+
    //! \brief Return the type mask for this tree. \sa BtTreeModel::TypeMasks
    int mask();
 
@@ -146,26 +139,15 @@ public:
    void deleteSelected(QModelIndexList victims);
 
    void copySelected(QList< QPair<QModelIndex, QString>> toBeCopied);
-   //! \brief Get Recipe at \c index.
-   Recipe * recipe(const QModelIndex & index) const;
-   //! \brief Get Equipment at \c index.
-   Equipment * equipment(const QModelIndex & index) const;
-   //! \brief Get Fermentable at \c index.
-   Fermentable * fermentable(const QModelIndex & index) const;
-   //! \brief Get Hop at \c index.
-   Hop * hop(const QModelIndex & index) const;
-   //! \brief Get Misc at \c index.
-   Misc * misc(const QModelIndex & index) const;
-   //! \brief Get Yeast at \c index.
-   Yeast * yeast(const QModelIndex & index) const;
-   //! \brief Get BrewNote at \c index.
-   BrewNote * brewNote(const QModelIndex & index) const;
-   //! \brief Get Style at \c index.
-   Style * style(const QModelIndex & index) const;
-   //! \brief Get folder at \c index
-   BtFolder * folder(const QModelIndex & index) const;
-   //! \brief Get folder at \c index
-   Water * water(const QModelIndex & index) const;
+
+   /**
+    * \brief Get T at \c index.
+    *        Valid for \c Recipe, \c Equipment, \c Fermentable, \c Hop, \c Misc, \c Yeast, \c Style, \c BrewNote,
+    *        \c Water, \c BtFolder.
+    */
+   template<class T>
+   T * getItem(QModelIndex const & index) const;
+
    //! \brief Get NamedEntity at \c index.
    NamedEntity * thing(const QModelIndex & index) const;
 
@@ -290,15 +272,13 @@ private:
    void addBrewNoteSubTree(Recipe * rec, int i, BtTreeItem * parent, bool recurse = true);
    //! \b flip the switch to show descendants
    void setShowChild(QModelIndex child, bool val);
-/*   //! \b link to recipes (this will get reverted later)
-   void makeAncestors(NamedEntity * ancestor, NamedEntity * descendant);
-   */
    void addAncestoralTree(Recipe * rec, int i, BtTreeItem * parent);
 
    BtTreeItem * rootItem;
    BtTreeView * parentTree;
    TypeMasks treeMask;
-   int _type, m_maxColumns;
+   BtTreeItem::Type itemType;
+   int m_maxColumns;
    QString _mimeType;
 
 };

--- a/src/BtTreeView.h
+++ b/src/BtTreeView.h
@@ -1,6 +1,6 @@
 /*
  * BtTreeView.h is part of Brewtarget, and is Copyright the following
- * authors 2009-2021
+ * authors 2009-2022
  * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  *
@@ -71,27 +71,14 @@ public:
 
    QModelIndex findElement(NamedEntity * thing);
 
-   //! \brief returns the recipe at \c index
-   Recipe * recipe(const QModelIndex & index) const;
-   //! \brief returns the equipment at \c index
-   Equipment * equipment(const QModelIndex & index) const;
-   //! \brief returns the fermentable at \c index
-   Fermentable * fermentable(const QModelIndex & index) const;
-   //! \brief returns the hop at \c index
-   Hop * hop(const QModelIndex & index) const;
-   //! \brief returns the misc at \c index
-   Misc * misc(const QModelIndex & index) const;
-   //! \brief returns the yeast at \c index
-   Yeast * yeast(const QModelIndex & index) const;
-   //! \brief returns the yeast at \c index
-   Style * style(const QModelIndex & index) const;
-   //! \brief returns the brewnote at \c index
-   BrewNote * brewNote(const QModelIndex & index) const;
-   //! \brief returns the water at \c index
-   Water * water(const QModelIndex & index) const;
+   /**
+    * \brief returns the item at \c index
+    *        Valid for \c Recipe, \c Equipment, \c Fermentable, \c Hop, \c Misc, \c Yeast, \c Style, \c BrewNote,
+    *        \c Water, \c BtFolder.
+    */
+   template<class T>
+   T * getItem(QModelIndex const & index) const;
 
-   //! \brief returns the folder at \c index
-   BtFolder * folder(const QModelIndex & index) const;
    //! \brief finds the index of the \c folder in the tree,but does not create
    QModelIndex findFolder(BtFolder * folder);
    //! \brief adds a folder to the tree
@@ -101,7 +88,7 @@ public:
    QString folderName(QModelIndex starter);
 
    //! \brief gets the type of the item at \c index.
-   int type(const QModelIndex & index);
+   std::optional<BtTreeItem::Type> type(QModelIndex const & index);
 
    //! \brief returns true if the recipe at ndx is showing its ancestors
    bool ancestorsAreShowing(QModelIndex ndx);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,8 +166,8 @@ SET( brewtarget_SRCS
     ${SRCDIR}/PersistentSettings.cpp
     ${SRCDIR}/PitchDialog.cpp
     ${SRCDIR}/PreInstruction.cpp
-    ${SRCDIR}/PrintAndPreviewDialog.cpp
     ${SRCDIR}/PrimingDialog.cpp
+    ${SRCDIR}/PrintAndPreviewDialog.cpp
     ${SRCDIR}/RadarChart.cpp
     ${SRCDIR}/RangedSlider.cpp
     ${SRCDIR}/RecipeExtrasWidget.cpp
@@ -182,6 +182,7 @@ SET( brewtarget_SRCS
     ${SRCDIR}/StyleRangeWidget.cpp
     ${SRCDIR}/StyleSortFilterProxyModel.cpp
     ${SRCDIR}/tableModels/BtTableModel.cpp
+    ${SRCDIR}/tableModels/BtTableModelInventory.cpp
     ${SRCDIR}/tableModels/FermentableTableModel.cpp
     ${SRCDIR}/tableModels/HopTableModel.cpp
     ${SRCDIR}/tableModels/MashStepTableModel.cpp
@@ -224,6 +225,10 @@ SET( brewtarget_SRCS
 # List of all the *.ui
 # TODO: can I somehow have a separate CMakeLists.txt
 # in the ui/ directory instead of here?
+#
+# You can recreate the body of this list by running the following from the bash prompt in the build directory:
+#    find ../ui -name '*.ui' | sort  | sed 's+^../ui+    ${SRCDIR}+'
+#
 SET( brewtarget_UIS
     ${UIDIR}/ancestorDialog.ui
     ${UIDIR}/brewDayScrollWidget.ui
@@ -336,8 +341,8 @@ SET( brewtarget_MOC_HEADERS
     ${SRCDIR}/OgAdjuster.h
     ${SRCDIR}/OptionDialog.h
     ${SRCDIR}/PitchDialog.h
-    ${SRCDIR}/PrintAndPreviewDialog.h
     ${SRCDIR}/PrimingDialog.h
+    ${SRCDIR}/PrintAndPreviewDialog.h
     ${SRCDIR}/RangedSlider.h
     ${SRCDIR}/RecipeExtrasWidget.h
     ${SRCDIR}/RecipeFormatter.h

--- a/src/FermentableDialog.cpp
+++ b/src/FermentableDialog.cpp
@@ -121,74 +121,69 @@ void FermentableDialog::retranslateUi()
 #endif // QT_NO_TOOLTIP
 }
 
-void FermentableDialog::removeFermentable()
-{
+void FermentableDialog::removeFermentable() {
    QModelIndexList selected = tableWidget->selectionModel()->selectedIndexes();
-   QModelIndex translated;
-   int row, size, i;
 
-   size = selected.size();
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return;
-
-   // Make sure only one row is selected.
-   row = selected[0].row();
-   for( i = 1; i < size; ++i )
-   {
-      if( selected[i].row() != row )
-         return;
    }
 
-   translated = fermTableProxy->mapToSource(selected[0]);
-   Fermentable* ferm = fermTableModel->getFermentable(translated.row());
+   // Make sure only one row is selected.
+   int row = selected[0].row();
+   for (int i = 1; i < size; ++i) {
+      if (selected[i].row() != row) {
+         return;
+      }
+   }
+
+   QModelIndex translated = fermTableProxy->mapToSource(selected[0]);
+   auto ferm = fermTableModel->getRow(translated.row());
    ObjectStoreWrapper::softDelete(*ferm);
    return;
 }
 
-void FermentableDialog::editSelected()
-{
+void FermentableDialog::editSelected() {
    QModelIndexList selected = tableWidget->selectionModel()->selectedIndexes();
-   QModelIndex translated;
-   int row, size, i;
 
-   size = selected.size();
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return;
-
-   // Make sure only one row is selected.
-   row = selected[0].row();
-   for( i = 1; i < size; ++i )
-   {
-      if( selected[i].row() != row )
-         return;
    }
 
-   translated = fermTableProxy->mapToSource(selected[0]);
-   Fermentable* ferm = fermTableModel->getFermentable(translated.row());
-   fermEdit->setFermentable(ferm);
+   // Make sure only one row is selected.
+   int row = selected[0].row();
+   for (int i = 1; i < size; ++i) {
+      if (selected[i].row() != row) {
+         return;
+      }
+   }
+
+   QModelIndex translated = fermTableProxy->mapToSource(selected[0]);
+   auto ferm = fermTableModel->getRow(translated.row());
+   fermEdit->setFermentable(ferm.get());
    fermEdit->show();
+   return;
 }
 
-void FermentableDialog::addFermentable(const QModelIndex& index)
-{
+void FermentableDialog::addFermentable(const QModelIndex& index) {
    QModelIndex translated;
 
    // If there is no provided index, get the selected index.
-   if( !index.isValid() )
-   {
+   if (!index.isValid()) {
       QModelIndexList selected = tableWidget->selectionModel()->selectedIndexes();
-      int row, size, i;
 
-      size = selected.size();
-      if( size == 0 )
+      int size = selected.size();
+      if (size == 0) {
          return;
+      }
 
       // Make sure only one row is selected.
-      row = selected[0].row();
-      for( i = 1; i < size; ++i )
-      {
-         if( selected[i].row() != row )
+      int row = selected[0].row();
+      for (int i = 1; i < size; ++i) {
+         if (selected[i].row() != row) {
             return;
+         }
       }
 
       translated = fermTableProxy->mapToSource(selected[0]);
@@ -204,7 +199,7 @@ void FermentableDialog::addFermentable(const QModelIndex& index)
          return;
    }
 
-   MainWindow::instance().addFermentableToRecipe(fermTableModel->getFermentable(translated.row()));
+   MainWindow::instance().addFermentableToRecipe(fermTableModel->getRow(translated.row()));
 
    return;
 }

--- a/src/FermentableSortFilterProxyModel.cpp
+++ b/src/FermentableSortFilterProxyModel.cpp
@@ -109,6 +109,6 @@ bool FermentableSortFilterProxyModel::filterAcceptsRow( int source_row, const QM
    return !filter
           ||
           (  sourceModel()->data(index).toString().contains(filterRegExp())
-             && model->getFermentable(source_row)->display()
+             && model->getRow(source_row)->display()
           );
 }

--- a/src/HopDialog.cpp
+++ b/src/HopDialog.cpp
@@ -121,8 +121,7 @@ void HopDialog::retranslateUi()
 #endif // QT_NO_TOOLTIP
 }
 
-void HopDialog::removeHop()
-{
+void HopDialog::removeHop() {
    QModelIndex modelIndex, viewIndex;
    QModelIndexList selected = tableWidget->selectionModel()->selectedIndexes();
    int row, size, i;
@@ -139,10 +138,11 @@ void HopDialog::removeHop()
          return;
    }
    modelIndex = hopTableProxy->mapToSource(selected[0]);
-   Hop *hop = hopTableModel->getHop(modelIndex.row());
+   auto hop = hopTableModel->getRow(modelIndex.row());
    if (hop) {
       ObjectStoreWrapper::softDelete(*hop);
    }
+   return;
 }
 
 void HopDialog::addHop(const QModelIndex& index)
@@ -178,7 +178,7 @@ void HopDialog::addHop(const QModelIndex& index)
          return;
    }
 
-   MainWindow::instance().addHopToRecipe(hopTableModel->getHop(translated.row()));
+   MainWindow::instance().addHopToRecipe(hopTableModel->getRow(translated.row()));
 
    return;
 }
@@ -202,9 +202,10 @@ void HopDialog::editSelected()
    }
 
    translated = hopTableProxy->mapToSource(selected.value(0));
-   Hop *hop = hopTableModel->getHop(translated.row());
-   hopEditor->setHop(hop);
+   auto hop = hopTableModel->getRow(translated.row());
+   hopEditor->setHop(hop.get());
    hopEditor->show();
+   return;
 }
 
 void HopDialog::newHop()

--- a/src/HopSortFilterProxyModel.cpp
+++ b/src/HopSortFilterProxyModel.cpp
@@ -90,6 +90,6 @@ bool HopSortFilterProxyModel::filterAcceptsRow( int source_row, const QModelInde
    return !filter
           ||
            ( sourceModel()->data(index).toString().contains(filterRegExp())
-             && model->getHop(source_row)->display()
+             && model->getRow(source_row)->display()
            );
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -115,6 +115,7 @@
 #include "PersistentSettings.h"
 #include "PitchDialog.h"
 #include "PrimingDialog.h"
+#include "PrintAndPreviewDialog.h"
 #include "RangedSlider.h"
 #include "RecipeFormatter.h"
 #include "RefractoDialog.h"
@@ -907,6 +908,7 @@ void MainWindow::setupTriggers() {
       connect( actionBackup_Database, &QAction::triggered, this, &MainWindow::backup );                                 // > File > Database > Backup
       connect( actionRestore_Database, &QAction::triggered, this, &MainWindow::restoreFromBackup );                     // > File > Database > Restore
    }
+   return;
 }
 
 // pushbuttons with a SIGNAL of clicked() should go in here.
@@ -1800,8 +1802,8 @@ void MainWindow::updateRecipeEfficiency() {
    return;
 }
 
-void MainWindow::addFermentableToRecipe(Fermentable* ferm) {
-   Q_ASSERT(nullptr != ferm);
+void MainWindow::addFermentableToRecipe(std::shared_ptr<Fermentable> ferm) {
+   Q_ASSERT(ferm);
    this->doOrRedoUpdate(
       newUndoableAddOrRemove(*this->recipeObs,
                              &Recipe::add<Fermentable>,
@@ -1814,8 +1816,8 @@ void MainWindow::addFermentableToRecipe(Fermentable* ferm) {
    return;
 }
 
-void MainWindow::addHopToRecipe(Hop *hop) {
-   Q_ASSERT(nullptr != hop);
+void MainWindow::addHopToRecipe(std::shared_ptr<Hop> hop) {
+   Q_ASSERT(hop);
    this->doOrRedoUpdate(
       newUndoableAddOrRemove(*this->recipeObs,
                              &Recipe::add<Hop>,
@@ -1827,8 +1829,8 @@ void MainWindow::addHopToRecipe(Hop *hop) {
    // triggered the necessary updates to hopTableModel.
 }
 
-void MainWindow::addMiscToRecipe(Misc* misc) {
-   Q_ASSERT(nullptr != misc);
+void MainWindow::addMiscToRecipe(std::shared_ptr<Misc> misc) {
+   Q_ASSERT(misc);
    this->doOrRedoUpdate(
       newUndoableAddOrRemove(*this->recipeObs,
                              &Recipe::add<Misc>,
@@ -1841,8 +1843,8 @@ void MainWindow::addMiscToRecipe(Misc* misc) {
    return;
 }
 
-void MainWindow::addYeastToRecipe(Yeast* yeast) {
-   Q_ASSERT(nullptr != yeast);
+void MainWindow::addYeastToRecipe(std::shared_ptr<Yeast> yeast) {
+   Q_ASSERT(yeast);
    this->doOrRedoUpdate(
       newUndoableAddOrRemove(*this->recipeObs,
                              &Recipe::add<Yeast>,
@@ -1961,163 +1963,139 @@ void MainWindow::editRedo()
    return;
 }
 
-Fermentable* MainWindow::selectedFermentable()
-{
+Fermentable* MainWindow::selectedFermentable() {
    QModelIndexList selected = fermentableTable->selectionModel()->selectedIndexes();
-   QModelIndex modelIndex, viewIndex;
-   int row, size, i;
 
-   size = selected.size();
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return nullptr;
-
-   // Make sure only one row is selected.
-   viewIndex = selected[0];
-   row = viewIndex.row();
-   for( i = 1; i < size; ++i )
-   {
-      if( selected[i].row() != row )
-         return nullptr;
    }
 
-   modelIndex = fermTableProxy->mapToSource(viewIndex);
-   Fermentable* ferm = fermTableModel->getFermentable(static_cast<unsigned int>(modelIndex.row()));
+   // Make sure only one row is selected.
+   QModelIndex viewIndex = selected[0];
+   int row = viewIndex.row();
+   for (int i = 1; i < size; ++i ) {
+      if (selected[i].row() != row) {
+         return nullptr;
+      }
+   }
 
-   return ferm;
+   QModelIndex modelIndex = fermTableProxy->mapToSource(viewIndex);
+   return fermTableModel->getRow(modelIndex.row()).get();
 }
 
-Hop* MainWindow::selectedHop()
-{
+Hop* MainWindow::selectedHop() {
    QModelIndexList selected = hopTable->selectionModel()->selectedIndexes();
-   QModelIndex modelIndex, viewIndex;
-   int row, size, i;
 
-   size = selected.size();
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return nullptr;
-
-   // Make sure only one row is selected.
-   viewIndex = selected[0];
-   row = viewIndex.row();
-   for( i = 1; i < size; ++i )
-   {
-      if( selected[i].row() != row )
-         return nullptr;
    }
 
-   modelIndex = hopTableProxy->mapToSource(viewIndex);
+   // Make sure only one row is selected.
+   QModelIndex viewIndex = selected[0];
+   int row = viewIndex.row();
+   for (int i = 1; i < size; ++i ) {
+      if (selected[i].row() != row) {
+         return nullptr;
+      }
+   }
 
-   Hop* h = hopTableModel->getHop(modelIndex.row());
-
-   return h;
+   QModelIndex modelIndex = hopTableProxy->mapToSource(viewIndex);
+   return hopTableModel->getRow(modelIndex.row()).get();
 }
 
-Misc* MainWindow::selectedMisc()
-{
+Misc* MainWindow::selectedMisc() {
    QModelIndexList selected = miscTable->selectionModel()->selectedIndexes();
-   QModelIndex modelIndex, viewIndex;
-   int row, size, i;
 
-   size = selected.size();
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return nullptr;
-
-   // Make sure only one row is selected.
-   viewIndex = selected[0];
-   row = viewIndex.row();
-   for( i = 1; i < size; ++i )
-   {
-      if( selected[i].row() != row )
-         return nullptr;
    }
 
-   modelIndex = miscTableProxy->mapToSource(viewIndex);
+   // Make sure only one row is selected.
+   QModelIndex viewIndex = selected[0];
+   int row = viewIndex.row();
+   for (int i = 1; i < size; ++i ) {
+      if (selected[i].row() != row) {
+         return nullptr;
+      }
+   }
 
-   Misc* m = miscTableModel->getMisc(static_cast<unsigned int>(modelIndex.row()));
-
-   return m;
+   QModelIndex modelIndex = miscTableProxy->mapToSource(viewIndex);
+   return miscTableModel->getRow(modelIndex.row()).get();
 }
 
-Yeast* MainWindow::selectedYeast()
-{
+Yeast* MainWindow::selectedYeast() {
    QModelIndexList selected = yeastTable->selectionModel()->selectedIndexes();
-   QModelIndex modelIndex, viewIndex;
-   int row, size, i;
 
-   size = selected.size();
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return nullptr;
-
-   // Make sure only one row is selected.
-   viewIndex = selected[0];
-   row = viewIndex.row();
-   for( i = 1; i < size; ++i )
-   {
-      if( selected[i].row() != row )
-         return nullptr;
    }
 
-   modelIndex = yeastTableProxy->mapToSource(viewIndex);
+   // Make sure only one row is selected.
+   QModelIndex viewIndex = selected[0];
+   int row = viewIndex.row();
+   for (int i = 1; i < size; ++i ) {
+      if (selected[i].row() != row) {
+         return nullptr;
+      }
+   }
 
-   Yeast* y = yeastTableModel->getYeast(static_cast<unsigned int>(modelIndex.row()));
-
-   return y;
-}
-
-void MainWindow::removeHop(Hop & itemToRemove) {
-   this->hopTableModel->remove(&itemToRemove);
-   return;
-}
-void MainWindow::removeFermentable(Fermentable & itemToRemove) {
-   this->fermTableModel->remove(&itemToRemove);
-   return;
-}
-void MainWindow::removeMisc(Misc & itemToRemove) {
-   this->miscTableModel->remove(&itemToRemove);
-   return;
-}
-void MainWindow::removeYeast(Yeast & itemToRemove) {
-   this->yeastTableModel->remove(&itemToRemove);
-   return;
+   QModelIndex modelIndex = yeastTableProxy->mapToSource(viewIndex);
+   return yeastTableModel->getRow(modelIndex.row()).get();
 }
 
-void MainWindow::removeMashStep(MashStep & itemToRemove) {
-   this->mashStepTableModel->remove(&itemToRemove);
+void MainWindow::removeHop(std::shared_ptr<Hop> itemToRemove) {
+   this->hopTableModel->remove(itemToRemove);
+   return;
+}
+void MainWindow::removeFermentable(std::shared_ptr<Fermentable> itemToRemove) {
+   this->fermTableModel->remove(itemToRemove);
+   return;
+}
+void MainWindow::removeMisc(std::shared_ptr<Misc> itemToRemove) {
+   this->miscTableModel->remove(itemToRemove);
+   return;
+}
+void MainWindow::removeYeast(std::shared_ptr<Yeast> itemToRemove) {
+   this->yeastTableModel->remove(itemToRemove);
    return;
 }
 
-void MainWindow::removeSelectedFermentable()
-{
+void MainWindow::removeMashStep(std::shared_ptr<MashStep> itemToRemove) {
+   this->mashStepTableModel->remove(itemToRemove);
+   return;
+}
+
+void MainWindow::removeSelectedFermentable() {
 
    QModelIndexList selected = fermentableTable->selectionModel()->selectedIndexes();
-   QModelIndex viewIndex, modelIndex;
-   QList<Fermentable *> itemsToRemove;
-   int size, i;
-
-   size = selected.size();
+   int size = selected.size();
 
    qDebug() << QString("MainWindow::removeSelectedFermentable() %1 items selected to remove").arg(size);
 
-   if( size == 0 )
+   if (size == 0) {
       return;
-
-   for(int i = 0; i < size; i++)
-   {
-      viewIndex = selected.at(i);
-      modelIndex = fermTableProxy->mapToSource(viewIndex);
-
-      itemsToRemove.append(fermTableModel->getFermentable(static_cast<unsigned int>(modelIndex.row())));
    }
 
-   for(i = 0; i < itemsToRemove.size(); i++)
-   {
+   QList< std::shared_ptr<Fermentable> > itemsToRemove;
+   for(int i = 0; i < size; i++) {
+      QModelIndex viewIndex = selected.at(i);
+      QModelIndex modelIndex = fermTableProxy->mapToSource(viewIndex);
+
+      itemsToRemove.append(fermTableModel->getRow(modelIndex.row()));
+   }
+
+   for (auto item : itemsToRemove) {
       this->doOrRedoUpdate(
          newUndoableAddOrRemove(*this->recipeObs,
                                 &Recipe::remove<Fermentable>,
-                                itemsToRemove.at(i),
+                                item,
                                 &Recipe::add<Fermentable>,
                                 &MainWindow::removeFermentable,
-                                static_cast<void (MainWindow::*)(Fermentable &)>(nullptr),
+                                static_cast<void (MainWindow::*)(std::shared_ptr<Fermentable>)>(nullptr),
                                 tr("Remove fermentable from recipe"))
       );
     }
@@ -2125,8 +2103,7 @@ void MainWindow::removeSelectedFermentable()
     return;
 }
 
-void MainWindow::editSelectedFermentable()
-{
+void MainWindow::editSelectedFermentable() {
    Fermentable* f = selectedFermentable();
    if( f == nullptr )
       return;
@@ -2135,8 +2112,7 @@ void MainWindow::editSelectedFermentable()
    fermEditor->show();
 }
 
-void MainWindow::editSelectedMisc()
-{
+void MainWindow::editSelectedMisc() {
    Misc* m = selectedMisc();
    if( m == nullptr )
       return;
@@ -2165,104 +2141,89 @@ void MainWindow::editSelectedYeast()
    yeastEditor->show();
 }
 
-void MainWindow::removeSelectedHop()
-{
+void MainWindow::removeSelectedHop() {
    QModelIndexList selected = hopTable->selectionModel()->selectedIndexes();
-   QModelIndex modelIndex, viewIndex;
-   QList<Hop *> itemsToRemove;
-   int size, i;
+   QList< std::shared_ptr<Hop> > itemsToRemove;
 
-   size = selected.size();
-
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return;
-
-   for(int i = 0; i < size; i++)
-   {
-      viewIndex = selected.at(i);
-      modelIndex = hopTableProxy->mapToSource(viewIndex);
-
-      itemsToRemove.append(hopTableModel->getHop(modelIndex.row()));
    }
 
-   for(i = 0; i < itemsToRemove.size(); i++)
-   {
+   for (int i = 0; i < size; i++) {
+      QModelIndex viewIndex = selected.at(i);
+      QModelIndex modelIndex = hopTableProxy->mapToSource(viewIndex);
+      itemsToRemove.append(hopTableModel->getRow(modelIndex.row()));
+   }
+
+   for (auto item : itemsToRemove) {
       this->doOrRedoUpdate(
          newUndoableAddOrRemove(*this->recipeObs,
                                  &Recipe::remove<Hop>,
-                                 itemsToRemove.at(i),
+                                 item,
                                  &Recipe::add<Hop>,
                                  &MainWindow::removeHop,
-                                 static_cast<void (MainWindow::*)(Hop &)>(nullptr),
+                                 static_cast<void (MainWindow::*)(std::shared_ptr<Hop>)>(nullptr),
                                  tr("Remove hop from recipe"))
       );
    }
 
 }
 
-void MainWindow::removeSelectedMisc()
-{
+
+void MainWindow::removeSelectedMisc() {
    QModelIndexList selected = miscTable->selectionModel()->selectedIndexes();
-   QModelIndex modelIndex, viewIndex;
-   QList<Misc *> itemsToRemove;
-   int size, i;
+   QList< std::shared_ptr<Misc> > itemsToRemove;
 
-   size = selected.size();
-
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return;
-
-   for(int i = 0; i < size; i++)
-   {
-      viewIndex = selected.at(i);
-      modelIndex = miscTableProxy->mapToSource(viewIndex);
-
-      itemsToRemove.append(miscTableModel->getMisc(static_cast<unsigned int>(modelIndex.row())));
    }
 
-   for(i = 0; i < itemsToRemove.size(); i++)
-   {
+   for (int i = 0; i < size; i++) {
+      QModelIndex viewIndex = selected.at(i);
+      QModelIndex modelIndex = miscTableProxy->mapToSource(viewIndex);
+
+      itemsToRemove.append(miscTableModel->getRow(modelIndex.row()));
+   }
+
+   for (auto item : itemsToRemove) {
       this->doOrRedoUpdate(
          newUndoableAddOrRemove(*this->recipeObs,
                                  &Recipe::remove<Misc>,
-                                 itemsToRemove.at(i),
+                                 item,
                                  &Recipe::add<Misc>,
                                  &MainWindow::removeMisc,
-                                 static_cast<void (MainWindow::*)(Misc &)>(nullptr),
+                                 static_cast<void (MainWindow::*)(std::shared_ptr<Misc>)>(nullptr),
                                  tr("Remove misc from recipe"))
       );
    }
 }
 
-void MainWindow::removeSelectedYeast()
-{
+void MainWindow::removeSelectedYeast() {
    QModelIndexList selected = yeastTable->selectionModel()->selectedIndexes();
-   QModelIndex modelIndex, viewIndex;
-   QList<Yeast *> itemsToRemove;
-   int size, i;
+   QList< std::shared_ptr<Yeast> > itemsToRemove;
 
-   size = selected.size();
-
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return;
-
-   for(int i = 0; i < size; i++)
-   {
-      viewIndex = selected.at(i);
-      modelIndex = yeastTableProxy->mapToSource(viewIndex);
-
-      itemsToRemove.append(yeastTableModel->getYeast(static_cast<unsigned int>(modelIndex.row())));
    }
 
-   for(i = 0; i < itemsToRemove.size(); i++)
-   {
+   for(int i = 0; i < size; i++) {
+      QModelIndex viewIndex = selected.at(i);
+      QModelIndex modelIndex = yeastTableProxy->mapToSource(viewIndex);
+
+      itemsToRemove.append(yeastTableModel->getRow(modelIndex.row()));
+   }
+
+   for (auto item : itemsToRemove) {
       this->doOrRedoUpdate(
          newUndoableAddOrRemove(*this->recipeObs,
                                  &Recipe::remove<Yeast>,
-                                 itemsToRemove.at(i),
+                                 item,
                                  &Recipe::add<Yeast>,
                                  &MainWindow::removeYeast,
-                                 static_cast<void (MainWindow::*)(Yeast &)>(nullptr),
+                                 static_cast<void (MainWindow::*)(std::shared_ptr<Yeast>)>(nullptr),
                                  tr("Remove yeast from recipe"))
       );
    }
@@ -2664,36 +2625,38 @@ void MainWindow::addMashStep() {
    return;
 }
 
-void MainWindow::removeSelectedMashStep()
-{
-   Mash* mash = recipeObs == nullptr ? nullptr : recipeObs->mash();
-   if( mash == nullptr )
+void MainWindow::removeSelectedMashStep() {
+   if (!this->recipeObs) {
       return;
-
-   QModelIndexList selected = mashStepTableWidget->selectionModel()->selectedIndexes();
-   int row, size, i;
-
-   size = selected.size();
-   if( size == 0 )
+   }
+   Mash* mash = this->recipeObs->mash();
+   if (!mash) {
       return;
-
-   // Make sure only one row is selected.
-   row = selected[0].row();
-   for( i = 1; i < size; ++i )
-   {
-      if( selected[i].row() != row )
-         return;
    }
 
-   MashStep* step = mashStepTableModel->getMashStep(static_cast<unsigned int>(row));
+   QModelIndexList selected = mashStepTableWidget->selectionModel()->selectedIndexes();
 
+   int size = selected.size();
+   if (size == 0) {
+      return;
+   }
+
+   // Make sure only one row is selected.
+   int row = selected[0].row();
+   for (int i = 1; i < size; ++i) {
+      if (selected[i].row() != row) {
+         return;
+      }
+   }
+
+   auto step = mashStepTableModel->getRow(row);
    this->doOrRedoUpdate(
       newUndoableAddOrRemove(*this->recipeObs->mash(),
                               &Mash::removeMashStep,
                               step,
                               &Mash::addMashStep,
                               &MainWindow::removeMashStep,
-                              static_cast<void (MainWindow::*)(MashStep&)>(nullptr),
+                              static_cast<void (MainWindow::*)(std::shared_ptr<MashStep>)>(nullptr),
                               tr("Remove mash step"))
    );
 
@@ -2772,9 +2735,8 @@ void MainWindow::editSelectedMashStep() {
       }
    }
 
-   MashStep* step = mashStepTableModel->getMashStep(static_cast<unsigned int>(row));
-   auto stepPointer = ObjectStoreWrapper::getSharedFromRaw(step);
-   mashStepEditor->setMashStep(stepPointer);
+   auto step = mashStepTableModel->getRow(static_cast<unsigned int>(row));
+   mashStepEditor->setMashStep(step);
    mashStepEditor->setVisible(true);
    return;
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2298,6 +2298,7 @@ void MainWindow::newRecipe()
             }
          }
       }
+   }
    setTreeSelection(treeView_recipe->findElement(newRec));
    setRecipe(newRec);
    return;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3018,6 +3018,7 @@ void MainWindow::exportSelected() {
                break;
          }
       }
+   }
 
    if (0 == count) {
       qDebug() << Q_FUNC_INFO << "Nothing selected was exportable to XML";

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -175,7 +175,7 @@ public slots:
    //! \brief Close a brewnote tab if we must (because of the BrewNote being deleted)
    void closeBrewNote(int brewNoteId, std::shared_ptr<QObject> object);
    //! \brief Add given Fermentable to the Recipe.
-   void addFermentableToRecipe(Fermentable* ferm);
+   void addFermentableToRecipe(std::shared_ptr<Fermentable> ferm);
    //! \brief Remove selected Fermentable(s) from the Recipe.
    void removeSelectedFermentable();
    //! \brief Edit selected Fermentable.
@@ -185,21 +185,21 @@ public slots:
    void showPitchDialog();
 
    //! \brief Add given Hop to the Recipe.
-   void addHopToRecipe(Hop *hop);
+   void addHopToRecipe(std::shared_ptr<Hop> hop);
    //! \brief Remove selected Hop(s) from the Recipe.
    void removeSelectedHop();
    //! \brief Edit selected Hop.
    void editSelectedHop();
 
    //! \brief Add given Misc to the Recipe.
-   void addMiscToRecipe(Misc* misc);
+   void addMiscToRecipe(std::shared_ptr<Misc> misc);
    //! \brief Remove selected Misc(s) from the Recipe.
    void removeSelectedMisc();
    //! \brief Edit selected Misc.
    void editSelectedMisc();
 
    //! \brief Add given Yeast to the Recipe.
-   void addYeastToRecipe(Yeast* yeast);
+   void addYeastToRecipe(std::shared_ptr<Yeast> yeast);
    //! \brief Remove selected Yeast(s) from the Recipe.
    void removeSelectedYeast();
    //! \brief Edit selected Yeast
@@ -339,13 +339,11 @@ private:
    //! No move assignment
    MainWindow & operator=(MainWindow &&) = delete;
 
-   void removeHop(Hop & itemToRemove);
-   void removeFermentable(Fermentable & itemToRemove);
-   void removeMisc(Misc & itemToRemove);
-   void removeYeast(Yeast & itemToRemove);
-   void removeMashStep(MashStep & itemToRemove);
-//   void removeWater(Water * itemToRemove);
-//   void removeSalt(Salt * itemToRemove);
+   void removeHop(std::shared_ptr<Hop> itemToRemove);
+   void removeFermentable(std::shared_ptr<Fermentable> itemToRemove);
+   void removeMisc(std::shared_ptr<Misc> itemToRemove);
+   void removeYeast(std::shared_ptr<Yeast> itemToRemove);
+   void removeMashStep(std::shared_ptr<MashStep> itemToRemove);
 
    Recipe* recipeObs;
    // TBD: (MY 2020-11-24) Not sure whether we need to store recipe style (since it ought to be available from the

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -637,7 +637,7 @@ double MashDesigner::getDecoctionAmount_l() {
    r = ((MC)*(tf-t1)) / ((m_w*c_w + m_g*c_g)*(maxTemp_c()-tf) + (m_w*c_w + m_g*c_g)*(tf-t1));
    if (r < 0 || r > 1) {
       //QMessageBox::critical(this, tr("Decoction error"), tr("Something went wrong in decoction calculation."));
-      //Brewken::log(Brewken::ERROR, QString("MashDesigner Decoction: r=%1").arg(r));
+      //Brewtarget::log(Brewtarget::ERROR, QString("MashDesigner Decoction: r=%1").arg(r));
       return 0;
    }
 

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -31,44 +31,43 @@
 #include "model/Fermentable.h"
 #include "PhysicalConstants.h"
 
-MashDesigner::MashDesigner(QWidget* parent) : QDialog(parent) {
+MashDesigner::MashDesigner(QWidget * parent) : QDialog     {parent},
+                                               recObs      {nullptr},
+                                               mash        {nullptr},
+                                               equip       {nullptr},
+                                               mashStep    {nullptr},
+                                               prevStep    {nullptr},
+                                               addedWater_l{0} {
    this->setupUi(this);
-
-   this->recObs = nullptr;
-   this->mash = nullptr;
-   this->equip = nullptr;
-   this->addedWater_l = 0;
-   this->mashStep = nullptr;
-   this->prevStep = nullptr;
 
    this->label_zeroVol->setText(Measurement::displayAmount(Measurement::Amount{0, Measurement::Units::liters}));
    this->label_zeroWort->setText(Measurement::displayAmount(Measurement::Amount{0, Measurement::Units::liters}));
 
    // Update temp slider when we move amount slider.
-   connect( horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTempSlider );
+   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTempSlider);
    // Update amount slider when we move temp slider.
-   connect( horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmtSlider );
+   connect(horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmtSlider);
    // Update tun fullness bar when either slider moves.
-   connect( horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateFullness );
-   connect( horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateFullness );
+   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateFullness);
+   connect(horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateFullness);
    // Update amount/temp text when sliders move.
-   connect( horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmt );
-   connect( horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTemp );
-   connect( horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmt );
-   connect( horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTemp );
+   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmt);
+   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTemp);
+   connect(horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmt);
+   connect(horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTemp);
    // Update collected wort when sliders move.
-   connect( horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateCollectedWort );
-   connect( horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateCollectedWort );
+   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateCollectedWort);
+   connect(horizontalSlider_temp, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateCollectedWort);
    // Save the target temp whenever it's changed.
-   connect( lineEdit_temp, &BtLineEdit::textModified, this, &MashDesigner::saveTargetTemp );
+   connect(lineEdit_temp, &BtLineEdit::textModified, this, &MashDesigner::saveTargetTemp);
    // Move to next step.
-   connect( pushButton_next, &QAbstractButton::clicked, this, &MashDesigner::proceed );
+   connect(pushButton_next, &QAbstractButton::clicked, this, &MashDesigner::proceed);
    // Do correct calcs when the mash step type is selected.
-   connect( comboBox_type, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, &MashDesigner::typeChanged );
+   connect(comboBox_type, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, &MashDesigner::typeChanged);
 
    // I still dislike this part. But I also need to "fix" the form
-   // connect( checkBox_batchSparge, SIGNAL(clicked()), this, SLOT(updateMaxAmt()) );
-   connect( pushButton_finish, &QAbstractButton::clicked, this, &MashDesigner::saveAndClose );
+   // connect(checkBox_batchSparge, SIGNAL(clicked()), this, SLOT(updateMaxAmt()));
+   connect(pushButton_finish, &QAbstractButton::clicked, this, &MashDesigner::saveAndClose);
 
    return;
 }
@@ -78,145 +77,134 @@ void MashDesigner::proceed()
    nextStep(++curStep);
 }
 
-void MashDesigner::setRecipe(Recipe* rec)
-{
-   recObs = rec;
-   if( isVisible() )
+void MashDesigner::setRecipe(Recipe* rec) {
+   this->recObs = rec;
+   if (isVisible()) {
       setVisible(false);
+   }
+   return;
 }
 
-void MashDesigner::show()
-{
+void MashDesigner::show() {
    // No point to run unless we have fermentables.
-   if( recObs && recObs->fermentables().size() == 0 )
-   {
+   if (this->recObs && this->recObs->fermentables().size() == 0) {
       QMessageBox::information(
          this,
          tr("No Fermentables"),
          tr("Your recipe must have fermentables to design a mash.")
-      );
+     );
       return;
    }
-   setVisible(nextStep(0));
+
+   this->setVisible(this->nextStep(0));
+   return;
 }
 
-void MashDesigner::saveAndClose()
-{
-   saveStep();
-   setVisible(false);
+void MashDesigner::saveAndClose() {
+   this->saveStep();
+   this->setVisible(false);
+   return;
 }
 
-bool MashDesigner::nextStep(int step)
-{
+bool MashDesigner::nextStep(int step) {
 
-   if( step == 0  && ! initializeMash() ) {
+   if (step == 0  && !this->initializeMash()) {
       return false;
    }
-   else if( step > 0 ) {
-      saveStep();
+
+   if (step > 0) {
+      this->saveStep();
    }
 
-   prevStep = mashStep;
-   if ( mashStep != nullptr ) {
+   this->prevStep = this->mashStep;
+   if (this->mashStep) {
       // NOTE: This needs to be changed. Assumes 1L of water is 1 kg.
-      MC += mashStep->infuseAmount_l() * HeatCalculations::Cw_calGC;
-      addedWater_l += mashStep->infuseAmount_l();
+      this->MC += this->mashStep->infuseAmount_l() * HeatCalculations::Cw_calGC;
+      this->addedWater_l += this->mashStep->infuseAmount_l();
 
-      if( prevStep == nullptr ) // If the last step is null, we need to add the influence of the tun.
-         MC += mash->tunSpecificHeat_calGC() * mash->tunWeight_kg();
+      if (!this->prevStep) {
+         // If the last step is null, we need to add the influence of the tun.
+         this->MC += this->mash->tunSpecificHeat_calGC() * this->mash->tunWeight_kg();
+      }
    }
 
    // If we have a step number, and the step is smaller than the current
    // number of mashsteps. How can this happen? When you get into
    // the mash designer, the first thing it does is clear all the steps.
-   if ( step >= 0 && step < mash->mashSteps().size() )
-      mashStep = mash->mashSteps()[step];
-   else {
-      // .:TODO:. Change to shared_ptr as potential memory leak
-      mashStep = new MashStep("");
+   if (step >= 0 && step < this->mash->mashSteps().size()) {
+      this->mashStep = this->mash->mashSteps()[step];
+   } else {
+      this->mashStep = std::make_shared<MashStep>("");
    }
 
    // Clear out some of the fields.
-   lineEdit_name->clear();
-   lineEdit_temp->clear();
-   lineEdit_time->clear();
+   this->lineEdit_name->clear();
+   this->lineEdit_temp->clear();
+   this->lineEdit_time->clear();
 
-   horizontalSlider_amount->setValue(0); // Least amount of water.
+   this->horizontalSlider_amount->setValue(0); // Least amount of water.
+
    // Update max amount here, instead of later. Cause later makes no sense.
-   updateMaxAmt();
+   this->updateMaxAmt();
 
    return true;
 }
 
 void MashDesigner::saveStep() {
-   MashStep::Type type = static_cast<MashStep::Type>(comboBox_type->currentIndex());
+   this->mashStep->setName(this->lineEdit_name->text());
+   this->mashStep->setType(static_cast<MashStep::Type>(comboBox_type->currentIndex()));
    // Bound the target temperature to what can be achieved
-   double temp = this->bound_temp_c(lineEdit_temp->toSI().quantity);
-
-   this->mashStep->setName(lineEdit_name->text());
-   this->mashStep->setType(type);
-   this->mashStep->setStepTemp_c(temp);
+   this->mashStep->setStepTemp_c(this->bound_temp_c(this->lineEdit_temp->toSI().quantity));
    this->mashStep->setStepTime_min(lineEdit_time->toSI().quantity);
 
    // finish a few things -- this may be premature optimization
    if (isInfusion()) {
-      this->mashStep->setInfuseAmount_l( selectedAmount_l() );
-      temp = selectedTemp_c();
-      this->mashStep->setInfuseTemp_c( temp );
+      this->mashStep->setInfuseAmount_l(selectedAmount_l());
+      this->mashStep->setInfuseTemp_c(this->selectedTemp_c());
    }
 
-   if (this->mashStep->key() < 0) {
-      this->mashStep->setMashId(this->mash->key());
-      ObjectStoreWrapper::insert(*this->mashStep);
-   }
+   // Mash::addMashStep() will ensure the mash step is stored in the DB and has the correct mash ID etc
+   this->mash->addMashStep(this->mashStep);
    return;
 }
 
-double MashDesigner::stepTemp_c()
-{
+double MashDesigner::stepTemp_c() {
    return lineEdit_temp->toSI().quantity;
 }
 
-bool MashDesigner::heating()
-{
-   // Returns true if the current step is hottern than the previous step
-   return stepTemp_c() >= ((prevStep) ? prevStep->stepTemp_c() : mash->grainTemp_c());
+bool MashDesigner::heating() {
+   // Returns true if the current step is hotter than the previous step
+   return stepTemp_c() >= (this->prevStep ? this->prevStep->stepTemp_c() : this->mash->grainTemp_c());
 }
 
-double MashDesigner::boilingTemp_c()
-{
+double MashDesigner::boilingTemp_c() {
    // Returns the equipment boiling point if available, otherwise 100.0
-   if (recObs && recObs->equipment())
+   if (recObs && recObs->equipment()) {
       return recObs->equipment()->boilingPoint_c();
-   else
-      return 100;
+   }
+   return 100;
 }
 
-double MashDesigner::maxTemp_c()
-{
+double MashDesigner::maxTemp_c() {
    return (heating())? boilingTemp_c() : tempFromVolume_c(maxAmt_l());
 }
 
-double MashDesigner::minTemp_c()
-{
+double MashDesigner::minTemp_c() {
    return (heating())? tempFromVolume_c(maxAmt_l()) : 0.0;
 }
 
-double MashDesigner::bound_temp_c(double temp_c)
-{
+double MashDesigner::bound_temp_c(double temp_c) {
    // Returns the closest achievable temperature to temp_c
    return (heating()) ? std::min(temp_c, maxTemp_c()) : std::max(temp_c, minTemp_c());
 }
 
 // The mash volume up to and not including the step currently being edited.
-double MashDesigner::mashVolume_l()
-{
+double MashDesigner::mashVolume_l() {
    return grain_kg/PhysicalConstants::grainDensity_kgL + addedWater_l;
 }
 
-double MashDesigner::minAmt_l()
-{
-   double minVol_l = volFromTemp_l( (heating())? maxTemp_c() : minTemp_c() );
+double MashDesigner::minAmt_l() {
+   double minVol_l = volFromTemp_l((heating())? maxTemp_c() : minTemp_c());
 
    // Sanity checks
    // TODO: If minVol_l > maxAmt_l(), change the target temp?
@@ -226,44 +214,40 @@ double MashDesigner::minAmt_l()
 }
 
 // However much more we can add at this step.
-double MashDesigner::maxAmt_l()
-{
+double MashDesigner::maxAmt_l() {
    double amt = 0;
 
-   if ( equip == nullptr )
+   if (equip == nullptr) {
       return amt;
+   }
 
    // However much more we can fit in the tun.
-   if( ! isSparge() )
-   {
+   if (!isSparge()) {
       amt = equip->tunVolume_l() - mashVolume_l();
-   }
-   else
-   {
+   } else {
       amt = equip->tunVolume_l() - grainVolume_l();
    }
 
-   amt = std::min(amt, recObs->targetTotalMashVol_l() - addedWater_l);
-
-   return amt;
+   return std::min(amt, recObs->targetTotalMashVol_l() - addedWater_l);
 }
 
 // Returns the required volume of water to infuse if the strike water is
 // at temp_c degrees Celsius.
-double MashDesigner::volFromTemp_l( double temp_c )
-{
-   if( mashStep == nullptr || mash == nullptr )
+double MashDesigner::volFromTemp_l(double temp_c) {
+   if (!this->mashStep || !this->mash) {
       return 0.0;
+   }
 
    double tw = temp_c;
    // Final temp is target temp.
    double tf = stepTemp_c();
    // Initial temp is the last step's temp if the last step exists, otherwise the grain temp.
-   double t1 = (prevStep==nullptr)? mash->grainTemp_c() : prevStep->stepTemp_c();
+   double t1 = (!this->prevStep) ? mash->grainTemp_c() : this->prevStep->stepTemp_c();
    double mt = mash->tunSpecificHeat_calGC();
    double ct = mash->tunWeight_kg();
 
-   double mw = 1/(HeatCalculations::Cw_calGC * (tw-tf)) * (MC*(tf-t1) + ((prevStep==nullptr)? mt*ct*(tf-mash->tunTemp_c()) : 0) );
+   double mw = 1/(HeatCalculations::Cw_calGC * (tw - tf)) *
+      (MC * (tf - t1) + ((!this->prevStep) ? mt * ct * (tf - this->mash->tunTemp_c()) : 0));
 
    // Sanity check for unlikely edge cases
    mw = std::max(0., mw);
@@ -274,53 +258,58 @@ double MashDesigner::volFromTemp_l( double temp_c )
 
 // Returns the required temp of strike water required if
 // the volume of strike water is vol_l liters.
-double MashDesigner::tempFromVolume_c( double vol_l )
-{
-   if( mashStep == nullptr || mash == nullptr )
+double MashDesigner::tempFromVolume_c(double vol_l) {
+   if (!this->mashStep || !this->mash) {
       return 0.0;
+   }
 
    double absorption_LKg;
-   if( equip != nullptr )
-      absorption_LKg = equip->grainAbsorption_LKg();
-   else
+   if (this->equip) {
+      absorption_LKg = this->equip->grainAbsorption_LKg();
+   } else {
       absorption_LKg = PhysicalConstants::grainAbsorption_Lkg;
+   }
 
    double tf = stepTemp_c();
 
    // NOTE: This needs to be changed. Assumes 1L = 1 kg.
    double mw = vol_l;
-   if( mw <= 0 )
+   if (mw <= 0) {
       return 0.0;
+   }
    double cw = HeatCalculations::Cw_calGC;
    // Initial temp is the last step's temp if the last step exists, otherwise the grain temp.
-   double t1 = (prevStep==nullptr)? mash->grainTemp_c() : prevStep->stepTemp_c();
+   double t1 = (!this->prevStep) ? this->mash->grainTemp_c() : this->prevStep->stepTemp_c();
    // When batch sparging, you lose about 10C from previous step.
-   if( isSparge() )
-      t1 = (prevStep==nullptr)? mash->grainTemp_c() : prevStep->stepTemp_c() - 10;
-   double mt = mash->tunSpecificHeat_calGC();
-   double ct = mash->tunWeight_kg();
+   if (isSparge()) {
+      t1 = (!this->prevStep) ? this->mash->grainTemp_c() : this->prevStep->stepTemp_c() - 10;
+   }
+   double mt = this->mash->tunSpecificHeat_calGC();
+   double ct = this->mash->tunWeight_kg();
 
    double batchMC = grain_kg * HeatCalculations::Cgrain_calGC
                     + absorption_LKg * grain_kg * HeatCalculations::Cw_calGC
-                    + mash->tunWeight_kg() * mash->tunSpecificHeat_calGC();
+                    + this->mash->tunWeight_kg() * this->mash->tunSpecificHeat_calGC();
 
-   double tw = 1/(mw*cw) * ( (isSparge()? batchMC : MC) * (tf-t1) + ((prevStep==nullptr)? mt*ct*(tf-mash->tunTemp_c()) : 0) ) + tf;
+   double tw = 1 / (mw * cw) * (
+      (this->isSparge() ? batchMC : MC) * (tf - t1) + (!this->prevStep ? mt * ct * (tf - this->mash->tunTemp_c()) : 0)
+   ) + tf;
 
    // Sanity check this value
-   tw = std::min( tw, boilingTemp_c() );  // Can't add water above boiling
-   tw = std::max( tw, 0.0 );  // (Probably) won't add water below freezing
+   tw = std::min(tw, boilingTemp_c());  // Can't add water above boiling
+   tw = std::max(tw, 0.0);  // (Probably) won't add water below freezing
 
    return tw;
 }
 
 // How many liters of grain are in the tun.
-double MashDesigner::grainVolume_l()
-{
+double MashDesigner::grainVolume_l() {
    return grain_kg / PhysicalConstants::grainDensity_kgL;
 }
 
 // After this, mash and equip are non-null iff we return true.
 bool MashDesigner::initializeMash() {
+   qDebug() << Q_FUNC_INFO << "Observing" << this->recObs;
    if (this->recObs == nullptr) {
       return false;
    }
@@ -333,16 +322,16 @@ bool MashDesigner::initializeMash() {
       return false;
    }
 
-   bool ok;
+   bool ok = false;
    QString dialogText = QInputDialog::getText(
-                                        this,
-                                        tr("Tun Temp"),
-                                        tr("Enter the temperature of the tun before your first infusion."),
-                                        QLineEdit::Normal, //default,
-                                        QString(),
-                                        &ok
-                                       //don't need the widget pointer - default is parent
-                                              );
+      this,
+      tr("Tun Temp"),
+      tr("Enter the temperature of the tun before your first infusion."),
+      QLineEdit::Normal, //default,
+      QString(),
+      &ok
+      //don't need the widget pointer - default is parent
+  );
 
    //if user hits cancel, cancel out of the dialog and quit the mashDesigner
    //edited jazzbeerman (dcavanagh) 8/20/10
@@ -350,11 +339,12 @@ bool MashDesigner::initializeMash() {
       return false;
    }
 
-   this->mash = recObs->mash();
+   this->mash = this->recObs->getMash();
    if (this->mash == nullptr) {
-      // .:TODO:. Change to shared_ptr as potential memory leak
-      this->mash = new Mash("");
+      qDebug() << Q_FUNC_INFO << "Create new Mash";
+      this->mash = std::make_shared<Mash>("");
    } else {
+      qDebug() << Q_FUNC_INFO << "Clear all steps of existing Mash";
       this->mash->removeAllMashSteps();
    }
 
@@ -365,8 +355,8 @@ bool MashDesigner::initializeMash() {
 
    this->curStep = 0;
    this->addedWater_l = 0;
-   this->mashStep = nullptr;
-   this->prevStep = nullptr;
+   this->mashStep.reset();
+   this->prevStep.reset();
 
    this->MC = recObs->grainsInMash_kg() * HeatCalculations::Cgrain_calGC;
    this->grain_kg = recObs->grainsInMash_kg();
@@ -382,6 +372,7 @@ bool MashDesigner::initializeMash() {
    this->horizontalSlider_amount->setValue(0); // As thick as possible initially.
 
    if (this->mash->key() < 0) {
+      qDebug() << Q_FUNC_INFO << "Add new Mash to Recipe";
       ObjectStoreWrapper::insert(*mash);
       this->recObs->setMash(mash);
    }
@@ -389,7 +380,7 @@ bool MashDesigner::initializeMash() {
 }
 
 void MashDesigner::updateFullness() {
-   if (this->mashStep == nullptr) {
+   if (!this->mashStep) {
       return;
    }
 
@@ -400,7 +391,7 @@ void MashDesigner::updateFullness() {
 
    double vol_l;
    if (!isSparge()) {
-      vol_l = mashVolume_l() + ( isInfusion() ? selectedAmount_l() : 0);
+      vol_l = mashVolume_l() + (isInfusion() ? selectedAmount_l() : 0);
    } else {
       vol_l = grainVolume_l() + selectedAmount_l();
    }
@@ -414,41 +405,61 @@ void MashDesigner::updateFullness() {
 
    this->progressBar_fullness->setValue(static_cast<int>(ratio*progressBar_fullness->maximum()));
    this->label_mashVol->setText(Measurement::displayAmount(Measurement::Amount{vol_l, Measurement::Units::liters}));
-   this->label_thickness->setText(Measurement::displayThickness( (addedWater_l + (isInfusion() ? selectedAmount_l() : 0) )/grain_kg ));
+   this->label_thickness->setText(Measurement::displayThickness((addedWater_l + (isInfusion() ? selectedAmount_l() : 0))/grain_kg));
    return;
 }
 
-double MashDesigner::waterFromMash_l()
-{
-   double waterAdded_l = mash->totalMashWater_l();
-   double absorption_lKg;
-
-   if ( recObs == nullptr )
+double MashDesigner::waterFromMash_l() {
+   if (this->recObs == nullptr) {
       return 0.0;
+   }
 
-   if( equip )
+   double waterAdded_l = this->mash->totalMashWater_l();
+
+   // A newly-created mash step will not yet have been added to the mash
+   if (this->mashStep && this->mashStep->getMashId() <= 0) {
+      if (this->isInfusion()) {
+         waterAdded_l += this->mashStep->infuseAmount_l();
+      }
+   }
+
+   double absorption_lKg;
+   if (equip) {
       absorption_lKg = equip->grainAbsorption_LKg();
-   else
+   } else {
       absorption_lKg = PhysicalConstants::grainAbsorption_Lkg;
+   }
 
-   return (waterAdded_l - absorption_lKg * recObs->grainsInMash_kg());
+   qDebug() <<
+      Q_FUNC_INFO << "waterAdded_l=" << waterAdded_l << ", absorption_lKg=" << absorption_lKg << "grainsInMash_kg=" <<
+      this->recObs->grainsInMash_kg();
+
+   return (waterAdded_l - absorption_lKg * this->recObs->grainsInMash_kg());
 }
 
 void MashDesigner::updateCollectedWort() {
-   if( recObs == nullptr )
+   qDebug() << Q_FUNC_INFO;
+   if (recObs == nullptr) {
       return;
+   }
 
-   // double wort_l = recObs->wortFromMash_l();
-   double wort_l = waterFromMash_l();
+   // double wort_l = this->recObs->wortFromMash_l();
+   double wort_l = this->waterFromMash_l();
+   double targetCollectedWort_l = this->recObs->targetCollectedWortVol_l();
 
-   double ratio = wort_l / recObs->targetCollectedWortVol_l();
-   if( ratio < 0 )
+   double ratio = wort_l / targetCollectedWort_l;
+   qDebug() <<
+      Q_FUNC_INFO << "waterFromMash=" << wort_l << "Liters, targetCollectedWort=" << targetCollectedWort_l << "Litres, "
+      "Unadjusted ratio=" << ratio;
+   if (ratio < 0) {
      ratio = 0;
-   if( ratio > 1 )
+   } else if (ratio > 1) {
      ratio = 1;
+   }
 
-   label_wort->setText(Measurement::displayAmount(Measurement::Amount{wort_l, Measurement::Units::liters}));
-   progressBar_wort->setValue( static_cast<int>(ratio * progressBar_wort->maximum() ));
+   this->label_wort->setText(Measurement::displayAmount(Measurement::Amount{wort_l, Measurement::Units::liters}));
+   this->progressBar_wort->setValue(static_cast<int>(ratio * this->progressBar_wort->maximum()));
+   return;
 }
 
 void MashDesigner::updateMinAmt() {
@@ -476,8 +487,7 @@ double MashDesigner::selectedAmount_l() {
    return amt;
 }
 
-double MashDesigner::selectedTemp_c()
-{
+double MashDesigner::selectedTemp_c() {
    double ratio = horizontalSlider_temp->sliderPosition() / static_cast<double>(horizontalSlider_temp->maximum());
    double minT = minTemp_c();
    double maxT = maxTemp_c();
@@ -486,83 +496,84 @@ double MashDesigner::selectedTemp_c()
    return T;
 }
 
-void MashDesigner::updateTempSlider()
-{
-   if( mashStep == nullptr )
+void MashDesigner::updateTempSlider() {
+   if (!this->mashStep) {
       return;
+   }
 
-   if( isInfusion() )
-   {
-      double temp = tempFromVolume_c( selectedAmount_l() );
+   if (isInfusion()) {
+      double temp = tempFromVolume_c(selectedAmount_l());
 
       double ratio = (temp-minTemp_c()) / (maxTemp_c() - minTemp_c());
       horizontalSlider_temp->setValue(static_cast<int>(ratio*horizontalSlider_temp->maximum()));
 
-      if( mashStep != nullptr )
-         mashStep->setInfuseTemp_c( temp );
-   }
-   else if( isDecoction() )
-   {
+      if (this->mashStep) {
+         this->mashStep->setInfuseTemp_c(temp);
+      }
+   } else if (isDecoction()) {
       horizontalSlider_temp->setValue(horizontalSlider_temp->maximum());
-   }
-   else
+   } else {
       horizontalSlider_temp->setValue(static_cast<int>(0.5*horizontalSlider_temp->maximum()));
+   }
+   return;
 }
 
-void MashDesigner::updateAmtSlider()
-{
-   if( mashStep == nullptr )
+void MashDesigner::updateAmtSlider() {
+   if (!this->mashStep) {
       return;
+   }
 
-   if( isInfusion() )
-   {
-      double vol = volFromTemp_l( selectedTemp_c() );
+   if (isInfusion()) {
+      double vol = volFromTemp_l(selectedTemp_c());
       double ratio = (vol - minAmt_l()) / (maxAmt_l() - minAmt_l());
 
       horizontalSlider_amount->setValue(static_cast<int>(ratio*horizontalSlider_amount->maximum()));
-      if( mashStep != nullptr )
-         mashStep->setInfuseAmount_l(vol);
+      if (this->mashStep) {
+         this->mashStep->setInfuseAmount_l(vol);
+      }
    }
-   else
+   else {
       horizontalSlider_amount->setValue(static_cast<int>(0.5*horizontalSlider_amount->maximum()));
+   }
+   return;
 }
 
-void MashDesigner::updateAmt()
-{
-   if( mashStep == nullptr )
+void MashDesigner::updateAmt() {
+   if (!this->mashStep) {
       return;
+   }
 
-   if( isInfusion() )
-   {
+   if (this->isInfusion()) {
       double vol = horizontalSlider_amount->sliderPosition() / static_cast<double>(horizontalSlider_amount->maximum())* (maxAmt_l() - minAmt_l()) + minAmt_l();
 
       label_amt->setText(Measurement::displayAmount(Measurement::Amount{vol, Measurement::Units::liters}));
 
-      if( mashStep != nullptr )
-         mashStep->setInfuseAmount_l( vol );
-   }
-   else if( isDecoction() )
-      label_amt->setText(Measurement::displayAmount(Measurement::Amount{mashStep->decoctionAmount_l(), Measurement::Units::liters}));
-   else
+      if (this->mashStep) {
+         this->mashStep->setInfuseAmount_l(vol);
+      }
+   } else if (isDecoction()) {
+      label_amt->setText(Measurement::displayAmount(Measurement::Amount{this->mashStep->decoctionAmount_l(), Measurement::Units::liters}));
+   } else {
       label_amt->setText(Measurement::displayAmount(Measurement::Amount{0, Measurement::Units::liters}));
+   }
+   return;
 }
 
 void MashDesigner::updateTemp() {
-
-   if (mashStep == nullptr) {
+   if (!this->mashStep) {
       return;
    }
 
    if (isInfusion())  {
       double temp = horizontalSlider_temp->sliderPosition() / static_cast<double>(horizontalSlider_temp->maximum()) * (maxTemp_c() - minTemp_c()) + minTemp_c();
       double maxT = maxTemp_c();
-      if ( temp > maxT )
+      if (temp > maxT)
          temp = maxT;
 
       label_temp->setText(Measurement::displayAmount(Measurement::Amount{temp, Measurement::Units::celsius}));
 
-      if (mashStep != nullptr) {
-         mashStep->setInfuseTemp_c(temp);
+      if (this->mashStep) {
+         this->mashStep->setInfuseTemp_c(temp);
       }
    } else if (isDecoction()) {
       label_temp->setText(Measurement::displayAmount(Measurement::Amount{maxTemp_c(), Measurement::Units::celsius}));
@@ -572,36 +583,35 @@ void MashDesigner::updateTemp() {
 }
 
 void MashDesigner::saveTargetTemp() {
-   double temp = stepTemp_c();
-
-   temp = bound_temp_c(temp);
+   double temp = this->bound_temp_c(this->stepTemp_c());
 
    // be nice and reset the field so it displays in proper units
-   lineEdit_temp->setText(temp);
-   if (mashStep != nullptr) {
-      mashStep->setStepTemp_c(temp);
+   this->lineEdit_temp->setText(temp);
+   if (this->mashStep) {
+      this->mashStep->setStepTemp_c(temp);
    }
 
-   if (isDecoction()) {
-      if (mashStep != nullptr) {
-         mashStep->setDecoctionAmount_l(getDecoctionAmount_l());
+   if (this->isDecoction()) {
+      if (this->mashStep) {
+         this->mashStep->setDecoctionAmount_l(this->getDecoctionAmount_l());
       }
 
-      updateAmtSlider();
-      updateAmt();
-      updateTempSlider();
-      updateTemp();
+      this->updateAmtSlider();
+      this->updateAmt();
+      this->updateTempSlider();
+      this->updateTemp();
    }
 
-   updateMinAmt();
-   updateMaxAmt();
-   updateMinTemp();
-   updateMaxTemp();
-   updateAmt();
-   updateTempSlider();
-   updateTemp();
-   updateFullness();
-   updateCollectedWort();
+   this->updateMinAmt();
+   this->updateMaxAmt();
+   this->updateMinTemp();
+   this->updateMaxTemp();
+   this->updateAmt();
+   this->updateTempSlider();
+   this->updateTemp();
+   this->updateFullness();
+   this->updateCollectedWort();
+   return;
 }
 
 double MashDesigner::getDecoctionAmount_l() {
@@ -609,13 +619,13 @@ double MashDesigner::getDecoctionAmount_l() {
    double c_w, c_g;
    double tf, t1;
 
-   if( prevStep == nullptr ) {
+   if (!this->prevStep) {
       QMessageBox::critical(this, tr("Decoction error"), tr("The first mash step cannot be a decoction."));
       qCritical() << "MashDesigner: First step not a decoction.";
       return 0;
    }
    tf = stepTemp_c();
-   t1 = prevStep->stepTemp_c();
+   t1 = this->prevStep->stepTemp_c();
 
    m_w = addedWater_l; // NOTE: this is bad. Assumes 1L = 1 kg.
    m_g = grain_kg;
@@ -625,94 +635,83 @@ double MashDesigner::getDecoctionAmount_l() {
 
    // r is the ratio of water and grain to take out for decoction.
    r = ((MC)*(tf-t1)) / ((m_w*c_w + m_g*c_g)*(maxTemp_c()-tf) + (m_w*c_w + m_g*c_g)*(tf-t1));
-   if( r < 0 || r > 1 ) {
-      //QMessageBox::critical(this, tr("Decoction error"), tr("Something went wrong in decoction calculation.") );
-      //Brewtarget::log(Brewtarget::ERROR, QString("MashDesigner Decoction: r=%1").arg(r));
+   if (r < 0 || r > 1) {
+      //QMessageBox::critical(this, tr("Decoction error"), tr("Something went wrong in decoction calculation."));
+      //Brewken::log(Brewken::ERROR, QString("MashDesigner Decoction: r=%1").arg(r));
       return 0;
    }
 
    return r*mashVolume_l();
 }
 
-bool MashDesigner::isBatchSparge() const
-{
-   MashStep::Type _type = type();
-   return (_type == MashStep::batchSparge);
+bool MashDesigner::isBatchSparge() const {
+   MashStep::Type stepType = type();
+   return (stepType == MashStep::batchSparge);
 }
 
-bool MashDesigner::isFlySparge() const
-{
-   MashStep::Type _type = type();
-   return (_type == MashStep::flySparge);
+bool MashDesigner::isFlySparge() const {
+   MashStep::Type stepType = type();
+   return (stepType == MashStep::flySparge);
 }
 
-bool MashDesigner::isSparge() const
-{
-   return ( isBatchSparge() || isFlySparge() );
+bool MashDesigner::isSparge() const {
+   return (isBatchSparge() || isFlySparge());
 }
 
-bool MashDesigner::isInfusion() const
-{
-   MashStep::Type _type = type();
-   return ( _type == MashStep::Infusion || isSparge() );
+bool MashDesigner::isInfusion() const {
+   MashStep::Type stepType = type();
+   return (stepType == MashStep::Infusion || isSparge());
 }
 
-bool MashDesigner::isDecoction() const
-{
-   MashStep::Type _type = type();
-   return ( _type == MashStep::Decoction );
+bool MashDesigner::isDecoction() const {
+   MashStep::Type stepType = type();
+   return (stepType == MashStep::Decoction);
 }
 
-bool MashDesigner::isTemperature() const
-{
-   MashStep::Type _type = type();
-   return ( _type == MashStep::Temperature );
+bool MashDesigner::isTemperature() const {
+   MashStep::Type stepType = type();
+   return (stepType == MashStep::Temperature);
 }
 
-MashStep::Type MashDesigner::type() const
-{
+MashStep::Type MashDesigner::type() const {
    int curIdx = comboBox_type->currentIndex();
    return static_cast<MashStep::Type>(curIdx);
 }
 
-void MashDesigner::typeChanged()
-{
-   MashStep::Type _type = type();
+void MashDesigner::typeChanged() {
+   MashStep::Type stepType = type();
 
-   if( mashStep != nullptr )
-      mashStep->setType(_type);
+   if (this->mashStep) {
+      this->mashStep->setType(stepType);
+   }
 
    // fly sparge is the end of the line. No more steps can be added after
-   if ( isFlySparge() )
-   {
+   if (isFlySparge()) {
       // more will happen here, but I need to understand a few things
       pushButton_next->setEnabled(false);
-   }
-   else if ( ! pushButton_next->isEnabled() )
+   } else if (! pushButton_next->isEnabled()) {
       pushButton_next->setEnabled(true);
+   }
 
-   if( isInfusion() )
-   {
+   if (isInfusion()) {
       horizontalSlider_amount->setEnabled(true);
       horizontalSlider_temp->setEnabled(true);
       updateMaxAmt();
-   }
-   else if( isDecoction() )
-   {
+   } else if (isDecoction()) {
       horizontalSlider_amount->setEnabled(false);
       horizontalSlider_temp->setEnabled(false);
 
-      if( mashStep != nullptr )
-         mashStep->setDecoctionAmount_l( getDecoctionAmount_l() );
+      if (this->mashStep) {
+         this->mashStep->setDecoctionAmount_l(getDecoctionAmount_l());
+      }
 
       updateAmtSlider();
       updateAmt();
       updateTempSlider();
       updateTemp();
-   }
-   else if( isTemperature() )
-   {
+   } else if (isTemperature()) {
       horizontalSlider_amount->setEnabled(false);
       horizontalSlider_temp->setEnabled(false);
    }
+   return;
 }

--- a/src/MashDesigner.h
+++ b/src/MashDesigner.h
@@ -20,6 +20,7 @@
  */
 #ifndef MASHDESIGNER_H
 #define MASHDESIGNER_H
+#pragma once
 
 #include <QDialog>
 #include <QWidget>
@@ -35,8 +36,7 @@
  *
  * \brief View/controller dialog that gives you more control over mash design than MashWizard does.
  */
-class MashDesigner : public QDialog, public Ui::mashDesigner
-{
+class MashDesigner : public QDialog, public Ui::mashDesigner {
    Q_OBJECT
 public:
    MashDesigner(QWidget* parent = nullptr);
@@ -95,10 +95,10 @@ private:
 
 
    Recipe* recObs;
-   Mash* mash;
+   std::shared_ptr<Mash> mash;
    Equipment* equip;
-   MashStep* mashStep;
-   MashStep* prevStep;
+   std::shared_ptr<MashStep> mashStep;
+   std::shared_ptr<MashStep> prevStep;
    double addedWater_l;
    double grain_kg;
    double MC;

--- a/src/MashWizard.cpp
+++ b/src/MashWizard.cpp
@@ -36,8 +36,7 @@
 #include "model/MashStep.h"
 #include "PhysicalConstants.h"
 
-MashWizard::MashWizard(QWidget* parent) : QDialog(parent)
-{
+MashWizard::MashWizard(QWidget* parent) : QDialog(parent) {
    setupUi(this);
    bGroup = new QButtonGroup();
    recObs = nullptr;
@@ -54,25 +53,23 @@ MashWizard::MashWizard(QWidget* parent) : QDialog(parent)
    return;
 }
 
-void MashWizard::toggleSpinBox(QAbstractButton* button)
-{
+void MashWizard::toggleSpinBox(QAbstractButton* button) {
    if ( button == radioButton_noSparge ) {
       widget_batches->setEnabled(false);
       widget_mashThickness->setEnabled(false);
-   }
-   else if ( button == radioButton_flySparge ) {
+   } else if ( button == radioButton_flySparge ) {
       widget_batches->setEnabled(false);
       widget_mashThickness->setEnabled(true);
-   }
-   else {
+   } else {
       widget_batches->setEnabled(true);
       widget_mashThickness->setEnabled(true);
    }
+   return;
 }
 
-void MashWizard::setRecipe(Recipe* rec)
-{
+void MashWizard::setRecipe(Recipe* rec) {
    recObs = rec;
+   return;
 }
 
 void MashWizard::show()
@@ -91,8 +88,8 @@ void MashWizard::show()
    Measurement::getThicknessUnits(&volumeUnit,&weightUnit);
    label_mashThickness->setText(tr("Mash thickness (%1/%2)").arg(volumeUnit->name, weightUnit->name));
 
-   MashStep * firstStep = recObs->mash()->mashSteps().first();
-   MashStep * lastStep  = recObs->mash()->mashSteps().last();
+   auto firstStep = recObs->mash()->mashSteps().first();
+   auto lastStep  = recObs->mash()->mashSteps().last();
 
    // Recalculate the mash thickness
    double thickNum = firstStep->infuseAmount_l()/recObs->grainsInMash_kg();
@@ -104,17 +101,15 @@ void MashWizard::show()
       radioButton_noSparge->setChecked(true);
       widget_batches->setEnabled(false);
       widget_mashThickness->setEnabled(false);
-   }
-   else if ( lastStep->type() == MashStep::flySparge ) {
+   } else if ( lastStep->type() == MashStep::flySparge ) {
       radioButton_flySparge->setChecked(true);
       widget_batches->setEnabled(false);
       widget_mashThickness->setEnabled(true);
-   }
-   else {
+   } else {
       int countSteps = 0;
-      QList<MashStep*> steps = recObs->mash()->mashSteps();
-      foreach( MashStep* step, steps) {
-         if ( step->isSparge() ) {
+      auto steps = recObs->mash()->mashSteps();
+      for(auto step : steps) {
+         if (step->isSparge()) {
             countSteps++;
          }
       }
@@ -125,6 +120,7 @@ void MashWizard::show()
    }
 
    setVisible(true);
+   return;
 }
 
 double MashWizard::calcDecoctionAmount( MashStep* step, Mash* mash, double waterMass, double grainMass, double lastTemp, double boiling)
@@ -177,27 +173,26 @@ void MashWizard::wizardry() {
       lauterDeadspace = recObs->equipment()->lauterDeadspace_l();
    }
 
-   QList<MashStep*> steps = mash->mashSteps();
-   QList<MashStep*> tmp;
+   auto steps = mash->mashSteps();
+   decltype(steps) tmp;
 
    // We ensured that there was at least one mash step when we displayed the thickness dialog in show().
-   MashStep* mashStep = steps.at(0);
-   if ( mashStep == nullptr ) {
+   auto mashStep = steps.at(0);
+   if (!mashStep) {
       qCritical() << "MashWizard::wizardry(): first mash step was null.";
       return;
    }
 
    // Ensure first mash step is an infusion.
-   if ( ! mashStep->isInfusion() && ! mashStep->isSparge() ) {
+   if (!mashStep->isInfusion() && !mashStep->isSparge()) {
       QMessageBox::information(this, tr("First step"), tr("Your first mash step must be an infusion."));
       return;
    }
 
    // Find any batch sparges and remove them
-   for (int i = 0; i < steps.size(); ++i) {
-      MashStep* step = steps[i];
+   for (auto step : steps) {
       if (step->isSparge()) {
-         mash->removeMashStep(ObjectStoreWrapper::getSharedFromRaw(step));
+         mash->removeMashStep(step);
       } else {
          tmp.append(step);
       }
@@ -208,8 +203,7 @@ void MashWizard::wizardry() {
    if ( bGroup->checkedButton() != radioButton_noSparge ) {
       thickNum = doubleSpinBox_thickness->value();
       thickness_LKg = thickNum * volumeUnit->toSI(1).quantity / weightUnit->toSI(1).quantity;
-   }
-   else {
+   } else {
       // not sure I like this. Why is this here and not somewhere later?
       if (steps.size() == 1 ) {
          mashStep->setInfuseAmount_l(recObs->targetTotalMashVol_l());
@@ -376,7 +370,7 @@ void MashWizard::wizardry() {
             newMashStep->setStepTime_min(15);
             newMashStep->setMashId(mash->key());
             ObjectStoreWrapper::insert(newMashStep);
-            steps.append(newMashStep.get());
+            steps.append(newMashStep);
             newMashStep->setStepNumber(steps.size());
             emit newMashStep->changed(
                newMashStep->metaObject()->property(
@@ -397,7 +391,7 @@ void MashWizard::wizardry() {
          newMashStep->setStepTime_min(15);
          newMashStep->setMashId(mash->key());
          ObjectStoreWrapper::insert(newMashStep);
-         steps.append(newMashStep.get());
+         steps.append(newMashStep);
          newMashStep->setStepNumber(steps.size());
          emit newMashStep->changed(
             newMashStep->metaObject()->property(

--- a/src/MiscDialog.cpp
+++ b/src/MiscDialog.cpp
@@ -137,7 +137,7 @@ void MiscDialog::removeMisc()
          return;
    }
 
-   Misc* m = miscTableModel->getMisc(miscTableProxy->mapToSource(selected[0]).row());
+   auto m = miscTableModel->getRow(miscTableProxy->mapToSource(selected[0]).row());
    ObjectStoreWrapper::softDelete(*m);
    return;
 }
@@ -177,7 +177,7 @@ void MiscDialog::addMisc(const QModelIndex& index)
          return;
    }
 
-   MainWindow::instance().addMiscToRecipe(miscTableModel->getMisc(translated.row()));
+   MainWindow::instance().addMiscToRecipe(miscTableModel->getRow(translated.row()));
 
    return;
 }
@@ -199,9 +199,10 @@ void MiscDialog::editSelected()
          return;
    }
 
-   Misc* m = miscTableModel->getMisc(miscTableProxy->mapToSource(selected[0]).row());
-   miscEdit->setMisc(m);
+   auto m = miscTableModel->getRow(miscTableProxy->mapToSource(selected[0]).row());
+   miscEdit->setMisc(m.get());
    miscEdit->show();
+   return;
 }
 
 void MiscDialog::newMisc()

--- a/src/MiscSortFilterProxyModel.cpp
+++ b/src/MiscSortFilterProxyModel.cpp
@@ -73,6 +73,6 @@ bool MiscSortFilterProxyModel::filterAcceptsRow( int source_row, const QModelInd
    return !filter
           ||
           (  sourceModel()->data(index).toString().contains(filterRegExp())
-             && model->getMisc(source_row)->display()
+             && model->getRow(source_row)->display()
           );
 }

--- a/src/NamedMashEditor.cpp
+++ b/src/NamedMashEditor.cpp
@@ -242,8 +242,8 @@ void NamedMashEditor::removeMashStep() {
    if ( !justOne(selected) )
       return;
 
-   MashStep* step = mashStepTableModel->getMashStep(selected[0].row());
-   this->mashObs->removeMashStep(ObjectStoreWrapper::getSharedFromRaw(step));
+   auto step = mashStepTableModel->getRow(selected[0].row());
+   this->mashObs->removeMashStep(step);
    return;
 }
 
@@ -301,22 +301,24 @@ void NamedMashEditor::fromEquipment(const QString& name)
    }
 }
 
-void NamedMashEditor::removeMash()
-{
-   if ( ! mashObs )
+void NamedMashEditor::removeMash() {
+   if (!this->mashObs) {
       return;
+   }
 
-   int newMash = mashComboBox->currentIndex() - 1;
+   int newMash = this->mashComboBox->currentIndex() - 1;
 
    // I *think* we want to disconnect the mash first?
-   disconnect(mashObs, 0, this, 0);
+   disconnect(this->mashObs, 0, this, 0);
    // Delete the mashsteps
-   QList<MashStep*> steps = mashObs->mashSteps();
-   for (auto step : steps) {
+   // .:TBD:. Mash should be responsible for deleting its steps.  This is already correctly handled for hard delete, but
+   // not for soft delete.
+   for (auto step : this->mashObs->mashSteps()) {
       ObjectStoreWrapper::softDelete(*step);
    }
-   // and delete the mash itself
+   // Delete the mash itself
    ObjectStoreWrapper::softDelete(*this->mashObs);
-   setMash(mashListModel->at(newMash));
+
+   this->setMash(this->mashListModel->at(newMash));
    return;
 }

--- a/src/RecipeFormatter.cpp
+++ b/src/RecipeFormatter.cpp
@@ -21,8 +21,15 @@
 #include "RecipeFormatter.h"
 
 #include <QClipboard>
+#include <QDebug>
+#include <QHBoxLayout>
+#include <QObject>
+#include <QPrintDialog>
 #include <QPrinter>
+#include <QPushButton>
 #include <QStringList>
+#include <QTextDocument>
+#include <QVBoxLayout>
 
 #include "Html.h"
 #include "Localization.h"
@@ -838,16 +845,12 @@ public:
    }
 
    QString buildMashTableHtml() {
-      if (this->rec == nullptr || this->rec->mash() == nullptr) {
+      if (!this->rec || !this->rec->mash()) {
          return "";
       }
 
-      MashStep* ms;
-      Mash* m = rec->mash();
-      QList<MashStep*> mashSteps = m->mashSteps();
-      int size = mashSteps.size();
-
-      if (size <= 0) {
+      auto mashSteps = this->rec->mash()->mashSteps();
+      if (mashSteps.size() == 0) {
          return "";
       }
 
@@ -869,22 +872,21 @@ public:
                .arg(tr("Temp"))
                .arg(tr("Target Temp"))
                .arg(tr("Time"));
-      for (int ii = 0; ii < size; ++ii) {
+      for (auto step : mashSteps) {
          QString tmp = "<tr>";
-         ms = mashSteps[ii];
          tmp += QString("<td>%1</td><td>%2</td><td>%3</td><td>%4</td><td>%5</td><td>%6</td>")
-               .arg(ms->name())
-               .arg(ms->typeStringTr());
+               .arg(step->name())
+               .arg(step->typeStringTr());
 
-         if (ms->isInfusion()) {
-            tmp = tmp.arg(Measurement::displayAmount(Measurement::Amount{ms->infuseAmount_l(), Measurement::Units::liters},
+         if (step->isInfusion()) {
+            tmp = tmp.arg(Measurement::displayAmount(Measurement::Amount{step->infuseAmount_l(), Measurement::Units::liters},
                                                      PersistentSettings::Sections::mashStepTableModel,
                                                      PropertyNames::MashStep::infuseAmount_l))
-                     .arg(Measurement::displayAmount(Measurement::Amount{ms->infuseTemp_c(), Measurement::Units::celsius},
+                     .arg(Measurement::displayAmount(Measurement::Amount{step->infuseTemp_c(), Measurement::Units::celsius},
                                                      PersistentSettings::Sections::mashStepTableModel,
                                                      PropertyNames::MashStep::infuseTemp_c));
-         } else if (ms->isDecoction()) {
-            tmp = tmp.arg( Measurement::displayAmount(Measurement::Amount{ms->decoctionAmount_l(), Measurement::Units::liters},
+         } else if (step->isDecoction()) {
+            tmp = tmp.arg( Measurement::displayAmount(Measurement::Amount{step->decoctionAmount_l(), Measurement::Units::liters},
                                                       PersistentSettings::Sections::mashStepTableModel,
                                                       PropertyNames::MashStep::decoctionAmount_l))
                   .arg("---");
@@ -892,10 +894,10 @@ public:
             tmp = tmp.arg( "---" ).arg("---");
          }
 
-         tmp = tmp.arg( Measurement::displayAmount(Measurement::Amount{ms->stepTemp_c(), Measurement::Units::celsius},
+         tmp = tmp.arg( Measurement::displayAmount(Measurement::Amount{step->stepTemp_c(), Measurement::Units::celsius},
                                                    PersistentSettings::Sections::mashStepTableModel,
                                                    PropertyNames::MashStep::stepTemp_c) );
-         tmp = tmp.arg( Measurement::displayAmount(Measurement::Amount{ms->stepTime_min(), Measurement::Units::minutes},
+         tmp = tmp.arg( Measurement::displayAmount(Measurement::Amount{step->stepTime_min(), Measurement::Units::minutes},
                                                    PersistentSettings::Sections::mashStepTableModel,
                                                    PropertyNames::Misc::time,
                                                    0) );
@@ -909,18 +911,13 @@ public:
    }
 
    QString buildMashTableTxt() {
-      if (this->rec == nullptr) {
+      if (!this->rec || !this->rec->mash()) {
          return "";
       }
 
       QString ret = "";
 
-      Mash* mash = rec->mash();
-
-      QList<MashStep*> mashSteps;
-      if ( mash ) {
-         mashSteps = mash->mashSteps();
-      }
+      auto mashSteps = this->rec->mash()->mashSteps();
 
       int size = mashSteps.size();
       if (size > 0) {
@@ -933,19 +930,18 @@ public:
          targets.append(tr("Target"));
          times.append(tr("Time"));
 
-         for(int ii = 0; ii < size; ++ii) {
-            MashStep* s = mashSteps[ii];
-            names.append(s->name());
-            types.append(s->typeStringTr());
-            if ( s->isInfusion() ) {
-               amounts.append(Measurement::displayAmount(Measurement::Amount{s->infuseAmount_l(), Measurement::Units::liters},
+         for (auto step : mashSteps) {
+            names.append(step->name());
+            types.append(step->typeStringTr());
+            if ( step->isInfusion() ) {
+               amounts.append(Measurement::displayAmount(Measurement::Amount{step->infuseAmount_l(), Measurement::Units::liters},
                                                          PersistentSettings::Sections::mashStepTableModel,
                                                          PropertyNames::MashStep::infuseAmount_l));
-               temps.append(Measurement::displayAmount(Measurement::Amount{s->infuseTemp_c(), Measurement::Units::celsius},
+               temps.append(Measurement::displayAmount(Measurement::Amount{step->infuseTemp_c(), Measurement::Units::celsius},
                                                        PersistentSettings::Sections::mashStepTableModel,
                                                        PropertyNames::MashStep::infuseTemp_c));
-            } else if( s->isDecoction() ) {
-               amounts.append(Measurement::displayAmount(Measurement::Amount{s->decoctionAmount_l(), Measurement::Units::liters},
+            } else if( step->isDecoction() ) {
+               amounts.append(Measurement::displayAmount(Measurement::Amount{step->decoctionAmount_l(), Measurement::Units::liters},
                                                          PersistentSettings::Sections::mashStepTableModel,
                                                          PropertyNames::MashStep::decoctionAmount_l));
                temps.append("---");
@@ -953,10 +949,10 @@ public:
                amounts.append( "---" );
                temps.append("---");
             }
-            targets.append(Measurement::displayAmount(Measurement::Amount{s->stepTemp_c(), Measurement::Units::celsius},
+            targets.append(Measurement::displayAmount(Measurement::Amount{step->stepTemp_c(), Measurement::Units::celsius},
                                                       PersistentSettings::Sections::mashStepTableModel,
                                                       PropertyNames::MashStep::stepTemp_c));
-            times.append(Measurement::displayAmount(Measurement::Amount{s->stepTime_min(), Measurement::Units::minutes},
+            times.append(Measurement::displayAmount(Measurement::Amount{step->stepTime_min(), Measurement::Units::minutes},
                                                     PersistentSettings::Sections::mashStepTableModel,
                                                     PropertyNames::Misc::time,
                                                     0));
@@ -1183,7 +1179,7 @@ void RecipeFormatter::setRecipe(Recipe* recipe) {
 
 
 
-QString RecipeFormatter::getHtmlFormat( QList<Recipe*> recipes ) {
+QString RecipeFormatter::getHtmlFormat(QList<Recipe*> recipes) {
    Recipe *current = this->pimpl->rec;
 
    QString hDoc = this->pimpl->buildHtmlHeader();
@@ -1233,10 +1229,10 @@ QString RecipeFormatter::getHtmlFormat() {
 QString RecipeFormatter::buildHtmlHeader() {
    return this->pimpl->buildHtmlHeader();
 }
+
 QString RecipeFormatter::buildHtmlFooter() {
    return this->pimpl->buildHtmlFooter();
 }
-
 
 QString RecipeFormatter::getBBCodeFormat() {
    if (this->pimpl->rec == nullptr) {

--- a/src/ScaleRecipeTool.cpp
+++ b/src/ScaleRecipeTool.cpp
@@ -45,7 +45,7 @@ ScaleRecipeTool::ScaleRecipeTool(QWidget* parent) :
 
 void ScaleRecipeTool::accept() {
    int row = field("equipComboBox").toInt();
-   QModelIndex equipProxyNdx( equipSortProxyModel->index(row, 0) );
+   QModelIndex equipProxyNdx( equipSortProxyModel->index(row, 0));
    QModelIndex equipNdx = equipSortProxyModel->mapToSource(equipProxyNdx);
 
    Equipment* selectedEquip = equipListModel->at(equipNdx.row());
@@ -60,12 +60,10 @@ void ScaleRecipeTool::setRecipe(Recipe* rec)
    recObs = rec;
 }
 
-void ScaleRecipeTool::scale(Equipment* equip, double newEff)
-{
-   if( recObs == nullptr || equip == nullptr )
+void ScaleRecipeTool::scale(Equipment* equip, double newEff) {
+   if (!this->recObs || !equip ) {
       return;
-
-   int i, size;
+   }
 
    // Calculate volume ratio
    double currentBatchSize_l = recObs->batchSize_l();
@@ -77,87 +75,46 @@ void ScaleRecipeTool::scale(Equipment* equip, double newEff)
    double effRatio = oldEfficiency / newEff;
 
    this->recObs->setEquipment(equip);
-   recObs->setBatchSize_l(newBatchSize_l);
-   recObs->setBoilSize_l(equip->boilSize_l());
-   recObs->setEfficiency_pct(newEff);
-   recObs->setBoilTime_min(equip->boilTime_min());
+   this->recObs->setBatchSize_l(newBatchSize_l);
+   this->recObs->setBoilSize_l(equip->boilSize_l());
+   this->recObs->setEfficiency_pct(newEff);
+   this->recObs->setBoilTime_min(equip->boilTime_min());
 
-   QList<Fermentable*> ferms = recObs->fermentables();
-   size = ferms.size();
-   for( i = 0; i < size; ++i )
-   {
-      Fermentable* ferm = ferms[i];
-      // NOTE: why the hell do we need this?
-      if( ferm == nullptr )
-         continue;
-
-      if( !ferm->isSugar() && !ferm->isExtract() ) {
+   for (auto ferm : this->recObs->fermentables()) {
+      if (!ferm->isSugar() && !ferm->isExtract()) {
          ferm->setAmount_kg(ferm->amount_kg() * effRatio * volRatio);
       } else {
          ferm->setAmount_kg(ferm->amount_kg() * volRatio);
       }
    }
 
-   QList<Hop*> hops = recObs->hops();
-   size = hops.size();
-   for( i = 0; i < size; ++i )
-   {
-      Hop* hop = hops[i];
-      // NOTE: why the hell do we need this?
-      if( hop == nullptr )
-         continue;
-
+   for (auto hop : this->recObs->hops()) {
       hop->setAmount_kg(hop->amount_kg() * volRatio);
    }
 
-   QList<Misc*> miscs = recObs->miscs();
-   size = miscs.size();
-   for( i = 0; i < size; ++i )
-   {
-      Misc* misc = miscs[i];
-      // NOTE: why the hell do we need this?
-      if( misc == nullptr )
-         continue;
-
-      misc->setAmount( misc->amount() * volRatio );
+   for (auto misc : this->recObs->miscs()) {
+      misc->setAmount( misc->amount() * volRatio);
    }
 
-   QList<Water*> waters = recObs->waters();
-   size = waters.size();
-   for( i = 0; i < size; ++i )
-   {
-      Water* water = waters[i];
-      // NOTE: why the hell do we need this?
-      if( water == nullptr )
-         continue;
-
+   for (auto water : this->recObs->waters()) {
       water->setAmount(water->amount() * volRatio);
    }
 
-   Mash* mash = recObs->mash();
-   if( mash == nullptr )
-      return;
-
-   QList<MashStep*> mashSteps = mash->mashSteps();
-   size = mashSteps.size();
-   for( i = 0; i < size; ++i )
-   {
-      MashStep* step = mashSteps[i];
-      // NOTE: why the hell do we need this?
-      if( step == nullptr )
-         continue;
-
-      // Reset all these to zero so that the user
-      // will know to re-run the mash wizard.
-      step->setDecoctionAmount_l(0);
-      step->setInfuseAmount_l(0);
+   Mash* mash = this->recObs->mash();
+   if (mash) {
+      for (auto step : mash->mashSteps()) {
+         // Reset all these to zero so that the user
+         // will know to re-run the mash wizard.
+         step->setDecoctionAmount_l(0);
+         step->setInfuseAmount_l(0);
+      }
    }
 
    // I don't think I should scale the yeasts.
 
    // Let the user know what happened.
    QMessageBox::information(this, tr("Recipe Scaled"),
-             tr("The equipment and mash have been reset due to the fact that mash temperatures do not scale easily. Please re-run the mash wizard.") );
+             tr("The equipment and mash have been reset due to the fact that mash temperatures do not scale easily. Please re-run the mash wizard."));
 }
 
 // ScaleRecipeIntroPage =======================================================
@@ -185,7 +142,7 @@ void ScaleRecipeIntroPage::retranslateUi() {
       "This wizard will help you scale a recipe to another size or efficiency."
       "Select another equipment with the new batch size and/or efficiency and"
       "the wizard will scale the recipe ingredients automatically."
-   ));
+  ));
 }
 
 // ScaleRecipeEquipmentPage ===================================================
@@ -219,7 +176,7 @@ void ScaleRecipeEquipmentPage::retranslateUi() {
    setTitle(tr("Select Equipment"));
    setSubTitle(tr("The recipe will be scaled to match the batch size and "
                   "efficiency of the selected equipment"
-   ));
+  ));
 
    equipLabel->setText(tr("New Equipment"));
    effLabel->setText(tr("New Efficiency (%)"));

--- a/src/UiAmountWithUnits.cpp
+++ b/src/UiAmountWithUnits.cpp
@@ -68,7 +68,9 @@ std::optional<Measurement::SystemOfMeasurement> UiAmountWithUnits::getForcedSyst
 }
 
 void UiAmountWithUnits::setForcedSystemOfMeasurementViaString(QString systemOfMeasurementAsString) {
-   qDebug() << Q_FUNC_INFO << systemOfMeasurementAsString;
+   qDebug() <<
+      Q_FUNC_INFO << "Measurement system" << systemOfMeasurementAsString << "for" << this->configSection << ">" <<
+      this->editField;
    this->setForcedSystemOfMeasurement(Measurement::getFromUniqueName(systemOfMeasurementAsString));
    return;
 }
@@ -88,7 +90,8 @@ std::optional<Measurement::UnitSystem::RelativeScale> UiAmountWithUnits::getForc
 }
 
 void UiAmountWithUnits::setForcedRelativeScaleViaString(QString relativeScaleAsString) {
-   qDebug() << Q_FUNC_INFO << relativeScaleAsString;
+   qDebug() <<
+      Q_FUNC_INFO << "Scale" << relativeScaleAsString << "for" << this->configSection << ">" << this->editField;
    this->setForcedRelativeScale(Measurement::UnitSystem::getScaleFromUniqueName(relativeScaleAsString));
    return;
 }
@@ -196,7 +199,7 @@ void UiAmountWithUnits::textOrUnitsChanged(PreviousScaleInfo previousScaleInfo) 
    QString correctedText;
 
    QString rawValue = this->getWidgetText();
-   qDebug() << Q_FUNC_INFO << "rawValue" << rawValue;
+   qDebug() << Q_FUNC_INFO << "rawValue:" << rawValue;
 
    if (rawValue.isEmpty()) {
       return;

--- a/src/UiAmountWithUnits.h
+++ b/src/UiAmountWithUnits.h
@@ -168,8 +168,6 @@ protected:
     *        If \c fieldType is not a \c Measurement::PhysicalQuantity, this will be \c nullptr
     */
    Measurement::Unit const * units;
-//   std::optional<Measurement::SystemOfMeasurement> forcedSystemOfMeasurement;
-//   std::optional<Measurement::UnitSystem::RelativeScale> forcedRelativeScale;
    QString editField;
    QString configSection;
 };

--- a/src/UndoableAddOrRemove.h
+++ b/src/UndoableAddOrRemove.h
@@ -61,13 +61,13 @@ public:
     * \param parent This is for grouping updates together.
     */
    explicit UndoableAddOrRemove(UU & updatee,
-                       std::shared_ptr<VV> (UU::*doer)(std::shared_ptr<VV>),
-                       std::shared_ptr<VV> whatToAddOrRemove,
-                       std::shared_ptr<VV> (UU::*undoer)(std::shared_ptr<VV>),
-                       void (MainWindow::*doCallback)(VV &),
-                       void (MainWindow::*undoCallback)(VV &),
-                       QString const & description,
-                       QUndoCommand * parent = nullptr) :
+                                std::shared_ptr<VV> (UU::*doer)(std::shared_ptr<VV>),
+                                std::shared_ptr<VV> whatToAddOrRemove,
+                                std::shared_ptr<VV> (UU::*undoer)(std::shared_ptr<VV>),
+                                void (MainWindow::*doCallback)(std::shared_ptr<VV>),
+                                void (MainWindow::*undoCallback)(std::shared_ptr<VV>),
+                                QString const & description,
+                                QUndoCommand * parent = nullptr) :
       QUndoCommand(parent),
       updatee(updatee),
       doer(doer),
@@ -142,7 +142,7 @@ private:
             this->whatToAddOrRemove->metaObject()->className() << "#" << this->whatToAddOrRemove->key();
 
          if (this->doCallback != nullptr) {
-            (MainWindow::instance().*(this->doCallback))(*this->whatToAddOrRemove);
+            (MainWindow::instance().*(this->doCallback))(this->whatToAddOrRemove);
          }
 
          // In this implementation "Do" and "Redo" are identical, but it's nonetheless useful for debugging purposes to
@@ -159,7 +159,7 @@ private:
             this->whatToAddOrRemove->key();
 
          if (this->undoCallback != nullptr) {
-            (MainWindow::instance().*(this->undoCallback))(*this->whatToAddOrRemove);
+            (MainWindow::instance().*(this->undoCallback))(this->whatToAddOrRemove);
          }
       }
 
@@ -175,8 +175,8 @@ private:
    std::shared_ptr<VV> (UU::*doer)(std::shared_ptr<VV>);
    std::shared_ptr<VV> whatToAddOrRemove;
    std::shared_ptr<VV> (UU::*undoer)(std::shared_ptr<VV>);
-   void (MainWindow::*doCallback)(VV &);
-   void (MainWindow::*undoCallback)(VV &);
+   void (MainWindow::*doCallback)(std::shared_ptr<VV>);
+   void (MainWindow::*undoCallback)(std::shared_ptr<VV>);
    bool everDone;
 };
 
@@ -191,8 +191,8 @@ UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemove(UU & updatee,
                                                      std::shared_ptr<VV> (UU::*doer)(std::shared_ptr<VV>),
                                                      std::shared_ptr<VV> whatToAddOrRemove,
                                                      std::shared_ptr<VV> (UU::*undoer)(std::shared_ptr<VV>),
-                                                     void (MainWindow::*doCallback)(VV &),
-                                                     void (MainWindow::*undoCallback)(VV &),
+                                                     void (MainWindow::*doCallback)(std::shared_ptr<VV>),
+                                                     void (MainWindow::*undoCallback)(std::shared_ptr<VV>),
                                                      QString const & description,
                                                      QUndoCommand * parent = nullptr) {
    return new UndoableAddOrRemove<UU, VV>(updatee,
@@ -213,8 +213,8 @@ UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemove(UU & updatee,
                                                      std::shared_ptr<VV> (UU::*doer)(std::shared_ptr<VV>),
                                                      VV * const whatToAddOrRemove,
                                                      std::shared_ptr<VV> (UU::*undoer)(std::shared_ptr<VV>),
-                                                     void (MainWindow::*doCallback)(VV &),
-                                                     void (MainWindow::*undoCallback)(VV &),
+                                                     void (MainWindow::*doCallback)(std::shared_ptr<VV>),
+                                                     void (MainWindow::*undoCallback)(std::shared_ptr<VV>),
                                                      QString const & description,
                                                      QUndoCommand * parent = nullptr) {
    return new UndoableAddOrRemove<UU, VV>(updatee,
@@ -243,8 +243,8 @@ UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemove(UU & updatee,
                                           doer,
                                           whatToAddOrRemove,
                                           undoer,
-                                          static_cast<void (MainWindow::*)(VV &)>(nullptr),
-                                          static_cast<void (MainWindow::*)(VV &)>(nullptr),
+                                          static_cast<void (MainWindow::*)(std::shared_ptr<VV>)>(nullptr),
+                                          static_cast<void (MainWindow::*)(std::shared_ptr<VV>)>(nullptr),
                                           description,
                                           parent);
 }
@@ -263,8 +263,8 @@ UndoableAddOrRemove<UU, VV> * newUndoableAddOrRemove(UU & updatee,
                                           doer,
                                           ObjectStoreWrapper::getSharedFromRaw(whatToAddOrRemove),
                                           undoer,
-                                          static_cast<void (MainWindow::*)(VV &)>(nullptr),
-                                          static_cast<void (MainWindow::*)(VV &)>(nullptr),
+                                          static_cast<void (MainWindow::*)(std::shared_ptr<VV>)>(nullptr),
+                                          static_cast<void (MainWindow::*)(std::shared_ptr<VV>)>(nullptr),
                                           description,
                                           parent);
 }

--- a/src/UndoableAddOrRemoveList.h
+++ b/src/UndoableAddOrRemoveList.h
@@ -57,8 +57,8 @@ public:
                            std::shared_ptr<VV> (UU::*doer)(std::shared_ptr<VV>),
                            QList<VV *> listToAddOrRemove,
                            std::shared_ptr<VV> (UU::*undoer)(std::shared_ptr<VV>),
-                           void (MainWindow::*doCallback)(VV &),
-                           void (MainWindow::*undoCallback)(VV &),
+                           void (MainWindow::*doCallback)(std::shared_ptr<VV>),
+                           void (MainWindow::*undoCallback)(std::shared_ptr<VV>),
                            QString const & description,
                            QUndoCommand * parent = nullptr) : QUndoCommand(parent) {
       // Parent class handles storing description and making it accessible to the undo stack etc - we just have to give
@@ -104,8 +104,8 @@ UndoableAddOrRemoveList<UU, VV> * newUndoableAddOrRemoveList(UU & updatee,
                                                              std::shared_ptr<VV> (UU::*doer)(std::shared_ptr<VV>),
                                                              QList<VV *> listToAddOrRemove,
                                                              std::shared_ptr<VV> (UU::*undoer)(std::shared_ptr<VV>),
-                                                             void (MainWindow::*doCallback)(VV &),
-                                                             void (MainWindow::*undoCallback)(VV &),
+                                                             void (MainWindow::*doCallback)(std::shared_ptr<VV>),
+                                                             void (MainWindow::*undoCallback)(std::shared_ptr<VV>),
                                                              QString const & description,
                                                              QUndoCommand * parent = nullptr) {
    return new UndoableAddOrRemoveList<UU, VV>(updatee,
@@ -134,8 +134,8 @@ UndoableAddOrRemoveList<UU, VV> * newUndoableAddOrRemoveList(UU & updatee,
                                               doer,
                                               listToAddOrRemove,
                                               undoer,
-                                              static_cast<void (MainWindow::*)(VV &)>(nullptr),
-                                              static_cast<void (MainWindow::*)(VV &)>(nullptr),
+                                              static_cast<void (MainWindow::*)(std::shared_ptr<VV>)>(nullptr),
+                                              static_cast<void (MainWindow::*)(std::shared_ptr<VV>)>(nullptr),
                                               description,
                                               parent);
 }

--- a/src/WaterDialog.h
+++ b/src/WaterDialog.h
@@ -49,8 +49,7 @@ class Salt;
  *
  * .:TBD:. This class (and associated UI files etc) might better be called Water Chemistry Dialog
  */
-class WaterDialog : public QDialog, public Ui::waterDialog
-{
+class WaterDialog : public QDialog, public Ui::waterDialog {
    Q_OBJECT
 
 public:

--- a/src/YeastDialog.cpp
+++ b/src/YeastDialog.cpp
@@ -135,7 +135,7 @@ void YeastDialog::removeYeast() {
    // We need to translate from the view's index to the model's index.  The
    // proxy model does the heavy lifting, as long as we do the call.
    QModelIndex translated = yeastTableProxy->mapToSource(selected[0]);
-   Yeast *yeast = yeastTableModel->getYeast(translated.row());
+   auto yeast = yeastTableModel->getRow(translated.row());
    ObjectStoreWrapper::softDelete(*yeast);
    return;
 }
@@ -175,34 +175,31 @@ void YeastDialog::addYeast(const QModelIndex& index)
    }
 
    // Adds a copy of yeast.
-   MainWindow::instance().addYeastToRecipe(yeastTableModel->getYeast(translated.row()));
+   MainWindow::instance().addYeastToRecipe(yeastTableModel->getRow(translated.row()));
 
    return;
 }
 
-void YeastDialog::editSelected()
-{
+void YeastDialog::editSelected() {
    QModelIndexList selected = tableWidget->selectionModel()->selectedIndexes();
-   QModelIndex translated;
-
-   int row, size, i;
-
-   size = selected.size();
-   if( size == 0 )
+   int size = selected.size();
+   if (size == 0) {
       return;
+   }
 
    // Make sure only one row is selected.
-   row = selected[0].row();
+   int row = selected[0].row();
 
-   for( i = 1; i < size; ++i )
-   {
-      if( selected[i].row() != row )
+   for (int i = 1; i < size; ++i ) {
+      if (selected[i].row() != row ) {
          return;
+      }
    }
-   translated = yeastTableProxy->mapToSource(selected[0]);
-   Yeast *yeast = yeastTableModel->getYeast(translated.row());
-   yeastEditor->setYeast(yeast);
+   QModelIndex translated = yeastTableProxy->mapToSource(selected[0]);
+   auto yeast = yeastTableModel->getRow(translated.row());
+   yeastEditor->setYeast(yeast.get());
    yeastEditor->show();
+   return;
 }
 
 void YeastDialog::newYeast()

--- a/src/YeastSortFilterProxyModel.cpp
+++ b/src/YeastSortFilterProxyModel.cpp
@@ -67,5 +67,5 @@ bool YeastSortFilterProxyModel::filterAcceptsRow( int source_row, const QModelIn
    QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
 
    return !filter ||
-          (sourceModel()->data(index).toString().contains(filterRegExp()) && model->getYeast(source_row)->display());
+          (sourceModel()->data(index).toString().contains(filterRegExp()) && model->getRow(source_row)->display());
 }

--- a/src/database/ObjectStore.cpp
+++ b/src/database/ObjectStore.cpp
@@ -1,6 +1,6 @@
 /*
  * database/ObjectStore.cpp is part of Brewtarget, and is copyright the following
- * authors 2021:
+ * authors 2021-2022:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify

--- a/src/database/ObjectStore.cpp
+++ b/src/database/ObjectStore.cpp
@@ -603,7 +603,6 @@ public:
          BtSqlQuery sqlQuery{connection};
          sqlQuery.prepare(queryString);
          QVariant propertyBindValue{object.property(*propertyName)};
-         // Enums need to be converted to strings first
          auto fieldDefn = std::find_if(
             this->primaryTable.tableFields.begin(),
             this->primaryTable.tableFields.end(),
@@ -612,7 +611,23 @@ public:
          // It's a coding error if we're trying to update a property that's not in the field definitions
          Q_ASSERT(fieldDefn != this->primaryTable.tableFields.end());
          if (fieldDefn->fieldType == ObjectStore::Enum) {
+            // Enums need to be converted to strings first
             propertyBindValue = QVariant{enumToString(*fieldDefn, propertyBindValue)};
+         } else if (fieldDefn->foreignKeyTo) {
+            //
+            // If the columns if a foreign key and the caller is setting it to a non-positive value then we actually
+            // need to store NULL in the DB.  (In the code we store foreign key IDs as ints, and use -1 to mean null.
+            // In the DB we need to store NULL explicitly because, if we try to store -1, we'll get a foreign key
+            // constraint violation as the DB is unable to find a row in the related table with primary key -1.)
+            //
+            // Firstly, we assert it's a coding error if we've created a foreign key column that's not an int.  For the
+            // moment at least, we don't support other types of primary/foreign key.
+            //
+            Q_ASSERT(ObjectStore::FieldType::Int == fieldDefn->fieldType);
+            if (propertyBindValue.toInt() <= 0) {
+               qDebug() << Q_FUNC_INFO << "Treating" << propertyBindValue << "foreign key value as NULL";
+               propertyBindValue = QVariant(QVariant::Int);
+            }
          }
          sqlQuery.bindValue(QString{":%1"}.arg(*columnToUpdateInDb), propertyBindValue);
          sqlQuery.bindValue(QString{":%1"}.arg(*primaryKeyColumn), primaryKey);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,8 +37,31 @@
 #include "Logging.h"
 #include "PersistentSettings.h"
 
-void importFromXml(const QString & filename);
-void createBlankDb(const QString & filename);
+namespace {
+   /*!
+   * \brief Imports the content of an xml file to the database.
+   *
+   * Use at your own risk.
+   */
+   void importFromXml(const QString & filename) {
+
+      QString errorMessage;
+      QTextStream errorMessageAsStream{&errorMessage};
+      if (!BeerXML::getInstance().importFromXML(filename, errorMessageAsStream)) {
+         qCritical() << "Unable to import" << filename << "Error: " << errorMessage;
+         exit(1);
+      }
+      Database::instance().unload();
+      PersistentSettings::insert(PersistentSettings::Names::converted, QDate().currentDate().toString());
+      exit(0);
+   }
+
+   //! \brief Creates a blank database using the given filename.
+   void createBlankDb(const QString & filename) {
+      Database::instance().createBlank(filename);
+      exit(0);
+   }
+}
 
 int main(int argc, char **argv) {
    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
@@ -189,28 +212,4 @@ int main(int argc, char **argv) {
             QApplication::tr("The application encountered a fatal error."));
    }
    return EXIT_FAILURE;
-}
-
-/*!
- * \brief Imports the content of an xml file to the database.
- *
- * Use at your own risk.
- */
-void importFromXml(const QString & filename) {
-
-   QString errorMessage;
-   QTextStream errorMessageAsStream{&errorMessage};
-   if (!BeerXML::getInstance().importFromXML(filename, errorMessageAsStream)) {
-      qCritical() << "Unable to import" << filename << "Error: " << errorMessage;
-      exit(1);
-   }
-   Database::instance().unload();
-   PersistentSettings::insert(PersistentSettings::Names::converted, QDate().currentDate().toString());
-   exit(0);
-}
-
-//! \brief Creates a blank database using the given filename.
-void createBlankDb(const QString & filename) {
-    Database::instance().createBlank(filename);
-    exit(0);
 }

--- a/src/measurement/PhysicalQuantity.cpp
+++ b/src/measurement/PhysicalQuantity.cpp
@@ -19,7 +19,6 @@
 #include "measurement/PhysicalQuantity.h"
 
 #include <QDebug>
-#include <QString>
 
 #include "utils/EnumStringMapping.h"
 

--- a/src/measurement/PhysicalQuantity.h
+++ b/src/measurement/PhysicalQuantity.h
@@ -20,7 +20,7 @@
 #define MEASUREMENT_PHYSICALQUANTITY_H
 #pragma once
 
-class QString;
+#include <QString>
 
 namespace Measurement {
    /**

--- a/src/measurement/PhysicalQuantity.h
+++ b/src/measurement/PhysicalQuantity.h
@@ -104,4 +104,15 @@ namespace Measurement {
     */
    QString getDisplayName(PhysicalQuantity physicalQuantity);
 }
+
+/**
+ * \brief Convenience function for logging
+ */
+template<class S>
+S & operator<<(S & stream, Measurement::PhysicalQuantity const physicalQuantity) {
+   stream <<
+      "PhysicalQuantity #" << static_cast<int>(physicalQuantity) << ": (" <<
+      Measurement::getDisplayName(physicalQuantity) << ")";
+   return stream;
+}
 #endif

--- a/src/measurement/UnitSystem.cpp
+++ b/src/measurement/UnitSystem.cpp
@@ -235,18 +235,14 @@ Measurement::Amount Measurement::UnitSystem::qstringToSI(QString qstr, Unit cons
       if (unitToUse) {
          qDebug() << Q_FUNC_INFO << this->uniqueName << ":" << unitName << "interpreted as" << unitToUse->name;
       } else {
-         qDebug() << Q_FUNC_INFO << this->uniqueName << ":" << unitName << "not recognised";
+         qDebug() <<
+            Q_FUNC_INFO << this->uniqueName << ":" << unitName << "not recognised for" << this->pimpl->physicalQuantity;
       }
    }
 
    if (!unitToUse) {
+      qDebug() << Q_FUNC_INFO << "Defaulting to" << defUnit;
       unitToUse = &defUnit;
-   }
-
-   // It is possible for unitToUse to be NULL at this point, so make sure we handle that case
-   if (!unitToUse) {
-      qDebug() << Q_FUNC_INFO << this->uniqueName << ": Couldn't determine units";
-      return Amount{-1.0, Measurement::Unit::getCanonicalUnit(this->pimpl->physicalQuantity)};
    }
 
    Measurement::Amount siAmount = unitToUse->toSI(amt);

--- a/src/model/Mash.h
+++ b/src/model/Mash.h
@@ -72,7 +72,7 @@ class Mash : public NamedEntity {
 public:
    Mash(QString name = "");
    Mash(NamedParameterBundle const & namedParameterBundle);
-   Mash(Mash const& other);
+   Mash(Mash const & other);
 
    virtual ~Mash();
 
@@ -97,7 +97,7 @@ public:
    //! \brief The total mash time in minutes. Calculated.
    Q_PROPERTY( double totalTime READ totalTime /*NOTIFY changed*/ /*changedTotalTime*/ STORED false )
    //! \brief The individual mash steps.
-   Q_PROPERTY( QList<MashStep*> mashSteps  READ mashSteps /*WRITE*/ /*NOTIFY changed*/ /*changedTotalTime*/ STORED false )
+   Q_PROPERTY( QList< std::shared_ptr<MashStep> > mashSteps  READ mashSteps /*WRITE*/ /*NOTIFY changed*/ /*changedTotalTime*/ STORED false )
 
    /**
     * \brief Connect MashStep changed signals to their parent Mashes.
@@ -141,7 +141,7 @@ public:
    bool hasSparge() const;
 
    // Relational getters
-   QList<MashStep*> mashSteps() const;
+   QList< std::shared_ptr<MashStep> > mashSteps() const;
 
    /*!
     * \brief Swap MashSteps \c ms1 and \c ms2

--- a/src/model/NamedEntity.h
+++ b/src/model/NamedEntity.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <type_traits>
 
 #include <QDateTime>
 #include <QDebug>
@@ -405,5 +406,45 @@ private:
    NamedEntityModifyingMarker(NamedEntityModifyingMarker &&) = delete;
    NamedEntityModifyingMarker & operator=(NamedEntityModifyingMarker &&) = delete;
 };
+
+/**
+ * \brief Convenience function for logging
+ */
+template<class S>
+S & operator<<(S & stream, NamedEntity const & namedEntity) {
+   stream << namedEntity.metaObject()->className() << " #" << namedEntity.key();
+   return stream;
+}
+
+template<class S>
+S & operator<<(S & stream, NamedEntity const * namedEntity) {
+   if (namedEntity) {
+      stream << *namedEntity;
+   } else {
+      stream << "Null";
+   }
+   return stream;
+}
+
+/**
+ * \brief Convenience function for logging, including coping with null pointers
+ *
+ *        std::is_base_of<NamedEntity, NE>::value is \c true if NE is \c NamedEntity or a subclass thereof
+ *        std::enable_if_t<condition> is only defined if condition is true
+ *        Thus std::enable_if_t<std::is_base_of<NamedEntity, NE>::value> is only defined if NE is \c NamedEntity or a
+ *        subclass thereof.  This means this template should not be instantiated for any other classes.
+ *
+ *        .:TODO:. This isn't quite working yet!
+ */
+template<class S, class NE,
+         std::enable_if_t<std::is_base_of<NamedEntity, NE>::value> >
+S & operator<<(S & stream, NE const * namedEntity) {
+   if (namedEntity) {
+      stream << *namedEntity;
+   } else {
+      stream << "Null " << NE::staticMetaObject.metaObject()->className();
+   }
+   return stream;
+}
 
 #endif

--- a/src/model/Recipe.h
+++ b/src/model/Recipe.h
@@ -437,6 +437,7 @@ public:
    QList<double> IBUs();
 
    // Relational getters
+   template<typename NE> QList< std::shared_ptr<NE> > getAll() const;
    QList<Hop *> hops() const;
    QVector<int> getHopIds() const;
    QList<Instruction *> instructions() const;
@@ -453,6 +454,7 @@ public:
    QVector<int> getSaltIds() const;
    QList<BrewNote *> brewNotes() const;
    QList<Recipe *> ancestors() const;
+   std::shared_ptr<Mash> getMash() const;
    Mash * mash() const;
    int getMashId() const;
    Equipment * equipment() const;
@@ -464,6 +466,7 @@ public:
 
    // Relational setters
    void setEquipment(Equipment * equipment);
+   void setMash(std::shared_ptr<Mash> mash);
    void setMash(Mash * var);
    void setStyle(Style * style);
 
@@ -503,7 +506,7 @@ public:
    //! \brief Formats the fermentables for instructions
    QList<QString> getReagents(QList<Fermentable *> ferms);
    //! \brief Formats the mashsteps for instructions
-   QList<QString> getReagents(QList<MashStep *> msteps);
+   QList<QString> getReagents(QList< std::shared_ptr<MashStep> >);
    //! \brief Formats the hops for instructions
    QList<QString> getReagents(QList<Hop *> hops, bool firstWort = false);
    //! \brief Formats the salts for instructions

--- a/src/tableModels/BtTableModel.cpp
+++ b/src/tableModels/BtTableModel.cpp
@@ -30,6 +30,17 @@
 #include "utils/OptionalToStream.h"
 #include "widgets/UnitAndScalePopUpMenu.h"
 
+BtTableModelRecipeObserver::BtTableModelRecipeObserver(QTableView * parent,
+                                                       bool editable,
+                                                       std::initializer_list<std::pair<int const, ColumnInfo> > columnIdToInfo) :
+   BtTableModel{parent, editable, columnIdToInfo},
+   recObs{nullptr} {
+   return;
+}
+
+BtTableModelRecipeObserver::~BtTableModelRecipeObserver() = default;
+
+//======================================================================================================================
 BtTableModel::BtTableModel(QTableView * parent,
                            bool editable,
                            std::initializer_list<std::pair<int const, BtTableModel::ColumnInfo> > columnIdToInfo) :

--- a/src/tableModels/BtTableModel.h
+++ b/src/tableModels/BtTableModel.h
@@ -23,6 +23,7 @@
 #include <optional>
 
 #include <QAbstractTableModel>
+#include <QDebug>
 #include <QHeaderView>
 #include <QMap>
 #include <QMenu>

--- a/src/tableModels/BtTableModel.h
+++ b/src/tableModels/BtTableModel.h
@@ -32,6 +32,99 @@
 #include "BtFieldType.h"
 #include "measurement/UnitSystem.h"
 
+class Recipe;
+class NamedEntity;
+
+/**
+ * \class BtTableModelData
+ *
+ * \brief Unfortunately we can't template \c BtTableModel because it inherits from a \c QObject and the Qt meta-object
+ *        compiler (moc) can't handle templated classes in QObject-derived classes (though it is fine with templated
+ *        member functions in such classes, as long as the are not signals or slots).  We might one day look at
+ *        https://github.com/woboq/verdigris, which overcomes these limitations, but, for now, we live within Qt's
+ *        limitations and try to pull out as much common code as possible using a limited form of multiple inheritance.
+ *
+ *              QObject
+ *                   \
+ *                   ...
+ *                     \
+ *              QAbstractTableModel
+ *                           \
+ *                            \
+ *                          BtTableModel               BtTableModelData
+ *                                /   \                /     /     /
+ *                               /     \              /     /     /
+ *                              /      MashStepTableModel  /     /
+ *                             /                          /     /
+ *                            /                          /     /
+ *                         BtTableModelRecipeObserver   /     /
+ *                              \       \              /     /
+ *                               \       \            /     /
+ *                                \      SaltTableModel    /
+ *                                 \    WaterTableModel   /
+ *                                  \                    /
+ *                                   \                  /
+ *                         BtTableModelInventory       /
+ *                                    \               /
+ *                                     \             /
+ *                                FermentableTableModel
+ *                                    HopTableModel
+ *                                   MiscTableModel
+ *                                   YeastTableModel
+ *
+ *        (I did start trying to do something clever with a common base class to try to expose functions from
+ *        \c BtTableModelData to the implementation of \c BtTableModel / \c BtTableModelRecipeObserver /
+ *        \c BtTableModelInventory, but it quickly starts getting more complicated than it's worth IMHO because (a)
+ *        \c BtTableModelData is templated but a common base class cannot be and (b) templated functions cannot be virtual.)
+ */
+template<class NE>
+class BtTableModelData {
+protected:
+   BtTableModelData() : rows{} {
+      return;
+   }
+public:
+   /**
+    * \brief Return the \c i-th row in the model.
+    *        Returns \c nullptr on failure.
+    */
+   std::shared_ptr<NE> getRow(int ii) {
+      if (!(this->rows.isEmpty())) {
+         if (ii >= 0 && ii < this->rows.size()) {
+            return this->rows[ii];
+         }
+         qWarning() << Q_FUNC_INFO << "index out of range (" << ii << "/" << this->rows.size() << ")";
+      } else {
+         qWarning() << Q_FUNC_INFO << "this->rows is empty (" << ii << "/" << this->rows.size() << ")";
+      }
+      return nullptr;
+   }
+
+   /**
+    * \brief Remove duplicates and non-displayable items from the supplied list
+    */
+   QList< std::shared_ptr<NE> > removeDuplicates(QList< std::shared_ptr<NE> > items, Recipe const * recipe = nullptr) {
+      decltype(items) tmp;
+
+      for (auto ii : items) {
+         if (!recipe && (ii->deleted() || !ii->display())) {
+               continue;
+         }
+         if (!this->rows.contains(ii) ) {
+            tmp.append(ii);
+         }
+      }
+      return tmp;
+   }
+
+protected:
+   virtual std::shared_ptr<NamedEntity> getRowAsNamedEntity(int ii) {
+      return std::static_pointer_cast<NamedEntity>(this->getRow(ii));
+   }
+
+
+   QList< std::shared_ptr<NE> > rows;
+};
 
 /*!
  * \class BtTableModel
@@ -82,9 +175,19 @@ public slots:
 protected:
    QTableView* parentTableWidget;
    bool editable;
-
 private:
    QMap<int, ColumnInfo> columnIdToInfo;
+
 };
 
+class BtTableModelRecipeObserver : public BtTableModel {
+public:
+   BtTableModelRecipeObserver(QTableView * parent,
+                              bool editable,
+                              std::initializer_list<std::pair<int const, ColumnInfo> > columnIdToInfo);
+   ~BtTableModelRecipeObserver();
+
+protected:
+   Recipe* recObs;
+};
 #endif

--- a/src/tableModels/BtTableModelInventory.cpp
+++ b/src/tableModels/BtTableModelInventory.cpp
@@ -1,0 +1,38 @@
+/*
+ * tableModels/BtTableModelInventory.cpp is part of Brewtarget, and is copyright the following
+ * authors 2021-2022:
+ * - Matt Young <mfsy@yahoo.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "tableModels/BtTableModelInventory.h"
+
+BtTableModelInventory::BtTableModelInventory(QTableView * parent,
+                                             bool editable,
+                                             std::initializer_list<std::pair<int const, ColumnInfo> > columnIdToInfo) :
+   BtTableModelRecipeObserver{parent, editable, columnIdToInfo},
+   inventoryEditable{false} {
+   return;
+}
+
+BtTableModelInventory::~BtTableModelInventory() = default;
+
+void BtTableModelInventory::setInventoryEditable(bool var) {
+   this->inventoryEditable = var;
+   return;
+}
+
+bool BtTableModelInventory::isInventoryEditable() const {
+   return this->inventoryEditable;
+}

--- a/src/tableModels/BtTableModelInventory.h
+++ b/src/tableModels/BtTableModelInventory.h
@@ -1,0 +1,49 @@
+/*
+ * tableModels/BtTableModelInventory.h is part of Brewtarget, and is copyright the following
+ * authors 2021-2022:
+ * - Matt Young <mfsy@yahoo.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef TABLEMODELS_BTTABLEMODELINVENTORY_H
+#define TABLEMODELS_BTTABLEMODELINVENTORY_H
+#pragma once
+
+#include "tableModels/BtTableModel.h"
+
+/**
+ * \class BtTableModelInventory
+ *
+ * \brief Extends \c BtTableModel to add support for inventory
+ */
+class BtTableModelInventory : public BtTableModelRecipeObserver {
+public:
+   BtTableModelInventory(QTableView * parent,
+                         bool editable,
+                         std::initializer_list<std::pair<int const, ColumnInfo> > columnIdToInfo);
+   ~BtTableModelInventory();
+
+   /*!
+    * \brief True if the inventory column should be editable, false otherwise.
+    *
+    * The default is that the inventory column is not editable
+    */
+   void setInventoryEditable(bool var);
+   bool isInventoryEditable() const;
+
+private:
+   bool inventoryEditable;
+};
+
+#endif

--- a/src/tableModels/FermentableTableModel.cpp
+++ b/src/tableModels/FermentableTableModel.cpp
@@ -52,7 +52,7 @@
 
 //=====================CLASS FermentableTableModel==============================
 FermentableTableModel::FermentableTableModel(QTableView* parent, bool editable) :
-   BtTableModel{
+   BtTableModelInventory{
       parent,
       editable,
       {{FERMNAMECOL,      {tr("Name"),      NonPhysicalQuantity::String,          ""            }},
@@ -64,12 +64,10 @@ FermentableTableModel::FermentableTableModel(QTableView* parent, bool editable) 
        {FERMYIELDCOL,     {tr("Yield %"),   NonPhysicalQuantity::Percentage,      ""            }},
        {FERMCOLORCOL,     {tr("Color"),     Measurement::PhysicalQuantity::Color, "color_srm"   }}}
    },
-   _inventoryEditable(false),
-   recObs(nullptr),
+   BtTableModelData<Fermentable>{},
    displayPercentages(false),
    totalFermMass_kg(0) {
 
-   fermObs.clear();
    // for units and scales
    setObjectName("fermentableTable");
 
@@ -98,7 +96,7 @@ void FermentableTableModel::observeRecipe(Recipe* rec) {
       qDebug() << Q_FUNC_INFO << "Observe Recipe #" << this->recObs->key() << "(" << this->recObs->name() << ")";
 
       connect(this->recObs, &NamedEntity::changed, this, &FermentableTableModel::changed);
-      this->addFermentables( recObs->fermentables() );
+      this->addFermentables(this->recObs->getAll<Fermentable>());
    }
    return;
 }
@@ -111,7 +109,7 @@ void FermentableTableModel::observeDatabase(bool val) {
       this->removeAll();
       connect(&ObjectStoreTyped<Fermentable>::getInstance(), &ObjectStoreTyped<Fermentable>::signalObjectInserted, this, &FermentableTableModel::addFermentable);
       connect(&ObjectStoreTyped<Fermentable>::getInstance(), &ObjectStoreTyped<Fermentable>::signalObjectDeleted,  this, &FermentableTableModel::removeFermentable);
-      addFermentables( ObjectStoreTyped<Fermentable>::getInstance().getAllRaw() );
+      this->addFermentables(ObjectStoreWrapper::getAll<Fermentable>());
    } else {
       disconnect(&ObjectStoreTyped<Fermentable>::getInstance(), nullptr, this, nullptr);
       this->removeAll();
@@ -119,11 +117,11 @@ void FermentableTableModel::observeDatabase(bool val) {
 }
 
 void FermentableTableModel::addFermentable(int fermId) {
-   Fermentable * ferm = ObjectStoreWrapper::getByIdRaw<Fermentable>(fermId);
+   auto ferm = ObjectStoreWrapper::getById<Fermentable>(fermId);
    qDebug() << Q_FUNC_INFO << ferm->name();
 
    // Check to see if it's already in the list
-   if (this->fermObs.contains(ferm)) {
+   if (this->rows.contains(ferm)) {
       return;
    }
 
@@ -143,44 +141,31 @@ void FermentableTableModel::addFermentable(int fermId) {
       }
    }
 
-   int size = fermObs.size();
-   beginInsertRows( QModelIndex(), size, size );
-   fermObs.append(ferm);
-   connect( ferm, &NamedEntity::changed, this, &FermentableTableModel::changed );
-   totalFermMass_kg += ferm->amount_kg();
+   int size = this->rows.size();
+   beginInsertRows(QModelIndex(), size, size);
+   this->rows.append(ferm);
+   connect(ferm.get(), &NamedEntity::changed, this, &FermentableTableModel::changed);
+   this->totalFermMass_kg += ferm->amount_kg();
    //reset(); // Tell everybody that the table has changed.
    endInsertRows();
    return;
 }
 
-void FermentableTableModel::addFermentables(QList<Fermentable*> ferms) {
-   qDebug() << Q_FUNC_INFO << QString("Add up to %1 fermentables to existing list of %2").arg(ferms.size()).arg(this->fermObs.size());
+void FermentableTableModel::addFermentables(QList<std::shared_ptr<Fermentable> > ferms) {
+   qDebug() << Q_FUNC_INFO << "Add up to " << ferms.size() << " fermentables to existing list of " << this->rows.size();
 
-   QList<Fermentable*> tmp;
-
-   for (auto ii : ferms) {
-//      qDebug() <<
-//         Q_FUNC_INFO << "Fermentable #" << ii->key() << (ii->deleted() ? "" : "not") << "deleted, display=" << (ii->display() ? "on" : "off");
-      if ( recObs == nullptr  && ( ii->deleted() || !ii->display() ) ) {
-
-            continue;
-      }
-      if( !fermObs.contains(ii) ) {
-         tmp.append(ii);
-      }
-   }
+   auto tmp = this->removeDuplicates(ferms, this->recObs);
 
    qDebug() << Q_FUNC_INFO << QString("After de-duping, adding %1 fermentables").arg(tmp.size());
 
-   int size = fermObs.size();
+   int size = this->rows.size();
    if (size+tmp.size()) {
       beginInsertRows( QModelIndex(), size, size+tmp.size()-1 );
-      fermObs.append(tmp);
+      this->rows.append(tmp);
 
-      for(QList<Fermentable*>::iterator i = tmp.begin(); i != tmp.end(); i++ )
-      {
-         connect( *i, &NamedEntity::changed, this, &FermentableTableModel::changed );
-         totalFermMass_kg += (*i)->amount_kg();
+      for (auto ferm : tmp) {
+         connect(ferm.get(), &NamedEntity::changed, this, &FermentableTableModel::changed);
+         totalFermMass_kg += ferm->amount_kg();
       }
 
       endInsertRows();
@@ -188,19 +173,18 @@ void FermentableTableModel::addFermentables(QList<Fermentable*> ferms) {
 }
 
 void FermentableTableModel::removeFermentable(int fermId, std::shared_ptr<QObject> object) {
-   this->remove(std::static_pointer_cast<Fermentable>(object).get());
+   this->remove(std::static_pointer_cast<Fermentable>(object));
    return;
 }
 
-bool FermentableTableModel::remove(Fermentable * ferm) {
-   int i = fermObs.indexOf(ferm);
-   if( i >= 0 )
-   {
-      beginRemoveRows( QModelIndex(), i, i );
-      disconnect(ferm, nullptr, this, nullptr);
-      fermObs.removeAt(i);
+bool FermentableTableModel::remove(std::shared_ptr<Fermentable> ferm) {
+   int rowNum = this->rows.indexOf(ferm);
+   if (rowNum >= 0)  {
+      beginRemoveRows( QModelIndex(), rowNum, rowNum);
+      disconnect(ferm.get(), nullptr, this, nullptr);
+      this->rows.removeAt(rowNum);
 
-      totalFermMass_kg -= ferm->amount_kg();
+      this->totalFermMass_kg -= ferm->amount_kg();
       //reset(); // Tell everybody the table has changed.
       endRemoveRows();
 
@@ -210,98 +194,91 @@ bool FermentableTableModel::remove(Fermentable * ferm) {
    return false;
 }
 
-void FermentableTableModel::removeAll()
-{
-   if (fermObs.size())
-   {
-      beginRemoveRows( QModelIndex(), 0, fermObs.size()-1 );
-      while( !fermObs.isEmpty() )
-      {
-         disconnect( fermObs.takeLast(), nullptr, this, nullptr );
+void FermentableTableModel::removeAll() {
+
+   int size = this->rows.size();
+   if (size > 0) {
+      beginRemoveRows(QModelIndex(), 0, size - 1);
+      while (!this->rows.empty()) {
+         disconnect(this->rows.takeLast().get(), nullptr, this, nullptr );
       }
       endRemoveRows();
    }
    // I think we need to zero this out
-   totalFermMass_kg = 0;
+   this->totalFermMass_kg = 0;
+   return;
 }
 
-void FermentableTableModel::updateTotalGrains()
-{
-   int i, size;
-
-   totalFermMass_kg = 0;
-
-   size = fermObs.size();
-   for( i = 0; i < size; ++i )
-      totalFermMass_kg += fermObs[i]->amount_kg();
+void FermentableTableModel::updateTotalGrains() {
+   this->totalFermMass_kg = 0;
+   for (auto ferm : this->rows) {
+      totalFermMass_kg += ferm->amount_kg();
+   }
+   return;
 }
 
-void FermentableTableModel::setDisplayPercentages(bool var)
-{
-   displayPercentages = var;
+void FermentableTableModel::setDisplayPercentages(bool var) {
+   this->displayPercentages = var;
+   return;
 }
 
 void FermentableTableModel::changedInventory(int invKey, BtStringConst const & propertyName) {
 
    if (propertyName == PropertyNames::Inventory::amount) {
-      for( int i = 0; i < fermObs.size(); ++i ) {
-         Fermentable* holdmybeer = fermObs.at(i);
-         if ( invKey == holdmybeer->inventoryId() ) {
-            emit dataChanged( QAbstractItemModel::createIndex(i,FERMINVENTORYCOL),
-                              QAbstractItemModel::createIndex(i,FERMINVENTORYCOL) );
+      for (int ii = 0; ii < this->rows.size(); ++ii) {
+         if (invKey == this->rows.at(ii)->inventoryId()) {
+            emit dataChanged(QAbstractItemModel::createIndex(ii, FERMINVENTORYCOL),
+                             QAbstractItemModel::createIndex(ii, FERMINVENTORYCOL));
          }
       }
    }
    return;
 }
 
-void FermentableTableModel::changed(QMetaProperty prop, QVariant /*val*/)
-{
-   qDebug() << QString("FermentableTableModel::changed() %1").arg(prop.name());
-
-   int i;
+void FermentableTableModel::changed(QMetaProperty prop, QVariant /*val*/) {
+   qDebug() << Q_FUNC_INFO << prop.name();
 
    // Is sender one of our fermentables?
    Fermentable* fermSender = qobject_cast<Fermentable*>(sender());
-   if( fermSender )
-   {
-      i = fermObs.indexOf(fermSender);
-      if( i < 0 )
+   if (fermSender) {
+      auto spFermSender = ObjectStoreWrapper::getSharedFromRaw(fermSender);
+      int ii = this->rows.indexOf(spFermSender);
+      if (ii < 0) {
          return;
+      }
 
-      updateTotalGrains();
-      emit dataChanged( QAbstractItemModel::createIndex(i, 0),
-                        QAbstractItemModel::createIndex(i, FERMNUMCOLS-1));
-      if( displayPercentages && rowCount() > 0 )
-         emit headerDataChanged( Qt::Vertical, 0, rowCount()-1 );
+      this->updateTotalGrains();
+      emit dataChanged(QAbstractItemModel::createIndex(ii, 0), QAbstractItemModel::createIndex(ii, FERMNUMCOLS - 1));
+      if (displayPercentages && rowCount() > 0) {
+         emit headerDataChanged(Qt::Vertical, 0, rowCount() - 1);
+      }
       return;
    }
 
    // See if our recipe gained or lost fermentables.
    Recipe* recSender = qobject_cast<Recipe*>(sender());
-   if( recSender && recSender == recObs && prop.name() == PropertyNames::Recipe::fermentableIds )
-   {
-      removeAll();
-      addFermentables( recObs->fermentables() );
-      return;
+   if (recSender && recSender == recObs && prop.name() == PropertyNames::Recipe::fermentableIds) {
+      this->removeAll();
+      this->addFermentables(this->recObs->getAll<Fermentable>());
    }
+
+   return;
 }
 
-int FermentableTableModel::rowCount(QModelIndex const & /*parent*/) const
-{
-   return fermObs.size();
+int FermentableTableModel::rowCount(QModelIndex const & /*parent*/) const {
+   return this->rows.size();
 }
 
 QVariant FermentableTableModel::data(QModelIndex const & index, int role) const {
    // Ensure the row is OK
-   if (index.row() >= static_cast<int>(fermObs.size() )) {
+   if (index.row() >= static_cast<int>(this->rows.size())) {
       qCritical() << Q_FUNC_INFO << "Bad model index. row = " << index.row();
       return QVariant();
    }
 
-   Fermentable* row = this->fermObs[index.row()];
-   if (row == nullptr) {
-      // This is probably a coding error
+   auto row = this->rows[index.row()];
+   if (!row) {
+      // This is almost certainly a coding error
       qCritical() << Q_FUNC_INFO << "Null pointer at row" << index.row();
       return QVariant();
    }
@@ -389,7 +366,7 @@ QVariant FermentableTableModel::headerData( int section, Qt::Orientation orienta
    if (displayPercentages && orientation == Qt::Vertical && role == Qt::DisplayRole) {
       double perMass = 0.0;
       if (totalFermMass_kg > 0.0 ) {
-         perMass = fermObs[section]->amount_kg()/totalFermMass_kg;
+         perMass = this->rows[section]->amount_kg()/totalFermMass_kg;
       }
       return QVariant( QString("%1%").arg( static_cast<double>(100.0) * perMass, 0, 'f', 0 ) );
    }
@@ -397,30 +374,28 @@ QVariant FermentableTableModel::headerData( int section, Qt::Orientation orienta
    return QVariant();
 }
 
-Qt::ItemFlags FermentableTableModel::flags(const QModelIndex& index ) const
-{
-   Qt::ItemFlags defaults = Qt::ItemIsEnabled;
-   int col = index.column();
-   Fermentable* row = fermObs[index.row()];
+Qt::ItemFlags FermentableTableModel::flags(const QModelIndex& index ) const {
+   Qt::ItemFlags constexpr defaults = Qt::ItemIsEnabled;
+   auto row = this->rows[index.row()];
 
-   switch(col)
-   {
+   int col = index.column();
+   switch (col) {
       case FERMISMASHEDCOL:
          // Ensure that being mashed and being a late addition are mutually exclusive.
-         if( !row->addAfterBoil() )
+         if (!row->addAfterBoil()) {
             return (defaults | Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled);
-         else
-            return Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled;
+         }
+         return Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled;
       case FERMAFTERBOIL:
          // Ensure that being mashed and being a late addition are mutually exclusive.
-         if( !row->isMashed() )
+         if (!row->isMashed()) {
             return (defaults | Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled);
-         else
-            return Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled;
+         }
+         return Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled;
       case FERMNAMECOL:
          return (defaults | Qt::ItemIsSelectable);
       case FERMINVENTORYCOL:
-         return (defaults | (_inventoryEditable ? Qt::ItemIsEditable : Qt::NoItemFlags));
+         return (defaults | (this->isInventoryEditable() ? Qt::ItemIsEditable : Qt::NoItemFlags));
       default:
          return (defaults | Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) );
    }
@@ -428,12 +403,12 @@ Qt::ItemFlags FermentableTableModel::flags(const QModelIndex& index ) const
 
 
 bool FermentableTableModel::setData(QModelIndex const & index, QVariant const & value, int role) {
-   if (index.row() >= static_cast<int>(this->fermObs.size())) {
+   if (index.row() >= static_cast<int>(this->rows.size())) {
       return false;
    }
 
    bool retVal = false;
-   Fermentable* row = fermObs[index.row()];
+   auto row = this->rows[index.row()];
 
    int const column = index.column();
    switch (column) {
@@ -543,10 +518,6 @@ bool FermentableTableModel::setData(QModelIndex const & index, QVariant const & 
    return retVal;
 }
 
-Fermentable* FermentableTableModel::getFermentable(unsigned int i) {
-   return fermObs.at(static_cast<int>(i));
-}
-
 //======================CLASS FermentableItemDelegate===========================
 
 FermentableItemDelegate::FermentableItemDelegate(QObject* parent) : QItemDelegate(parent) {
@@ -556,7 +527,7 @@ FermentableItemDelegate::FermentableItemDelegate(QObject* parent) : QItemDelegat
 QWidget* FermentableItemDelegate::createEditor(QWidget *parent,
                                                QStyleOptionViewItem const & option,
                                                QModelIndex const & index) const {
-   if( index.column() == FERMTYPECOL )
+   if (index.column() == FERMTYPECOL )
    {
       QComboBox *box = new QComboBox(parent);
 
@@ -573,7 +544,7 @@ QWidget* FermentableItemDelegate::createEditor(QWidget *parent,
       return box;
    }
 
-   if( index.column() == FERMISMASHEDCOL )
+   if (index.column() == FERMISMASHEDCOL )
    {
       QComboBox* box = new QComboBox(parent);
       QListWidget* list = new QListWidget(parent);
@@ -605,7 +576,7 @@ QWidget* FermentableItemDelegate::createEditor(QWidget *parent,
       return box;
    }
 
-   if( index.column() == FERMAFTERBOIL )
+   if (index.column() == FERMAFTERBOIL )
    {
       QComboBox* box = new QComboBox(parent);
 
@@ -626,7 +597,7 @@ void FermentableItemDelegate::setEditorData(QWidget *editor, const QModelIndex &
 {
    int col = index.column();
 
-   if( col == FERMTYPECOL || col == FERMISMASHEDCOL || col == FERMAFTERBOIL)
+   if (col == FERMTYPECOL || col == FERMISMASHEDCOL || col == FERMAFTERBOIL)
    {
       QComboBox* box = static_cast<QComboBox*>(editor);
       int ndx = index.model()->data(index, Qt::UserRole).toInt();
@@ -645,7 +616,7 @@ void FermentableItemDelegate::setModelData(QWidget *editor, QAbstractItemModel *
 {
    int col = index.column();
 
-   if( col == FERMTYPECOL || col == FERMISMASHEDCOL || col == FERMAFTERBOIL )
+   if (col == FERMTYPECOL || col == FERMISMASHEDCOL || col == FERMAFTERBOIL )
    {
       QComboBox* box = qobject_cast<QComboBox*>(editor);
       int value = box->currentIndex();
@@ -655,7 +626,7 @@ void FermentableItemDelegate::setModelData(QWidget *editor, QAbstractItemModel *
       if ( value != ndx )
          model->setData(index, value, Qt::EditRole);
    }
-   else if( col == FERMISMASHEDCOL || col == FERMAFTERBOIL )
+   else if (col == FERMISMASHEDCOL || col == FERMAFTERBOIL )
    {
       QComboBox* box = qobject_cast<QComboBox*>(editor);
       int value = box->currentIndex();

--- a/src/tableModels/FermentableTableModel.h
+++ b/src/tableModels/FermentableTableModel.h
@@ -35,7 +35,7 @@
 #include <QWidget>
 
 #include "measurement/Unit.h"
-#include "tableModels/BtTableModel.h"
+#include "tableModels/BtTableModelInventory.h"
 
 // Forward declarations.
 class BtStringConst;
@@ -50,7 +50,7 @@ enum{FERMNAMECOL, FERMTYPECOL, FERMAMOUNTCOL, FERMINVENTORYCOL, FERMISMASHEDCOL,
  *
  * \brief A table model for a list of fermentables.
  */
-class FermentableTableModel : public BtTableModel {
+class FermentableTableModel : public BtTableModelInventory, public BtTableModelData<Fermentable> {
    Q_OBJECT
 
 public:
@@ -61,20 +61,14 @@ public:
    void observeRecipe(Recipe* rec);
    //! \brief If true, we model the database's list of fermentables.
    void observeDatabase(bool val);
+private:
    //! \brief Watch all the \b ferms for changes.
-   void addFermentables(QList<Fermentable*> ferms);
+   void addFermentables(QList<std::shared_ptr< Fermentable> > ferms);
+public:
    //! \brief Clear the model.
    void removeAll();
-   //! \brief Return the \c i-th fermentable in the model.
-   Fermentable* getFermentable(unsigned int i);
    //! \brief True if you want to display percent of each grain in the row header.
    void setDisplayPercentages( bool var );
-   /*!
-    * \brief True if the inventory column should be editable, false otherwise.
-    *
-    * The default is that the inventory column is not editable
-    */
-   void setInventoryEditable( bool var ) { _inventoryEditable = var; }
 
    //! \brief Reimplemented from QAbstractTableModel.
    virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;
@@ -88,7 +82,7 @@ public:
    virtual bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole );
 
    //! \returns true if "ferm" is successfully found and removed.
-   bool remove(Fermentable * ferm);
+   bool remove(std::shared_ptr<Fermentable> ferm);
 
 public slots:
    //! \brief Watch \b ferm for changes.
@@ -107,12 +101,8 @@ private:
    void updateTotalGrains();
 
 private:
-   bool _inventoryEditable;
-   QList<Fermentable*> fermObs;
-   Recipe* recObs;
    bool displayPercentages;
    double totalFermMass_kg;
-
 };
 
 /*!

--- a/src/tableModels/HopTableModel.cpp
+++ b/src/tableModels/HopTableModel.cpp
@@ -47,7 +47,7 @@
 #include "utils/BtStringConst.h"
 
 HopTableModel::HopTableModel(QTableView * parent, bool editable) :
-   BtTableModel{
+   BtTableModelInventory{
       parent,
       editable,
       {{HOPNAMECOL,      {tr("Name"),      NonPhysicalQuantity::String,          ""                                                 }},
@@ -58,22 +58,9 @@ HopTableModel::HopTableModel(QTableView * parent, bool editable) :
        {HOPUSECOL,       {tr("Use"),       NonPhysicalQuantity::String,          ""                                                 }},
        {HOPTIMECOL,      {tr("Time"),      Measurement::PhysicalQuantity::Time,  *PropertyNames::Hop::time_min                      }}}
    },
-   colFlags(HOPNUMCOLS),
-   _inventoryEditable(false),
-   recObs(nullptr),
    showIBUs(false) {
-   this->hopObs.clear();
+   this->rows.clear();
    this->setObjectName("hopTable");
-
-   for (int i = 0; i < HOPNUMCOLS; ++i) {
-      if (i == HOPNAMECOL) {
-         colFlags[i] = Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled;
-      } else if (i == HOPINVENTORYCOL) {
-         colFlags[i] = Qt::ItemIsEnabled;
-      } else
-         colFlags[i] = Qt::ItemIsSelectable | (editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled |
-                       Qt::ItemIsEnabled;
-   }
 
    QHeaderView * headerView = parentTableWidget->horizontalHeader();
    headerView->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -88,7 +75,7 @@ HopTableModel::HopTableModel(QTableView * parent, bool editable) :
 }
 
 HopTableModel::~HopTableModel() {
-   this->hopObs.clear();
+   this->rows.clear();
    return;
 }
 
@@ -101,7 +88,7 @@ void HopTableModel::observeRecipe(Recipe * rec) {
    this->recObs = rec;
    if (this->recObs) {
       connect(this->recObs, &NamedEntity::changed, this, &HopTableModel::changed);
-      this->addHops(this->recObs->hops());
+      this->addHops(this->recObs->getAll<Hop>());
    }
 }
 
@@ -115,12 +102,12 @@ void HopTableModel::observeDatabase(bool val) {
               &ObjectStoreTyped<Hop>::signalObjectDeleted,
               this,
               &HopTableModel::removeHop);
-      this->addHops(ObjectStoreTyped<Hop>::getInstance().getAllRaw());
+      this->addHops(ObjectStoreWrapper::getAll<Hop>());
    } else {
       removeAll();
       disconnect(&ObjectStoreTyped<Hop>::getInstance(), nullptr, this, nullptr);
-
    }
+   return;
 }
 
 void HopTableModel::addHop(int hopId) {
@@ -132,57 +119,54 @@ void HopTableModel::addHop(int hopId) {
       return;
    }
 
-   // .:TODO:. For the moment at least, the rest of this class uses raw pointers, but would be good to refactor to use
-   // shared pointers.
-   Hop * hop = hopAdded.get();
-   if (this->hopObs.contains(hop)) {
+   if (this->rows.contains(hopAdded)) {
       return;
    }
 
    // If we are observing the database, ensure that the item is undeleted and
    // fit to display.
-   if (this->recObs == nullptr && (hop->deleted() || !hop->display())) {
+   if (this->recObs == nullptr && (hopAdded->deleted() || !hopAdded->display())) {
       return;
    }
 
    // If we are watching a Recipe and the new Hop does not belong to it then there is nothing for us to do
    if (this->recObs) {
-      Recipe * recipeOfNewHop = hop->getOwningRecipe();
+      Recipe * recipeOfNewHop = hopAdded->getOwningRecipe();
       if (recipeOfNewHop && this->recObs->key() != recipeOfNewHop->key()) {
          qDebug() <<
-            Q_FUNC_INFO << "Ignoring signal about new Hop #" << hop->key() << "as it belongs to Recipe #" <<
+            Q_FUNC_INFO << "Ignoring signal about new Hop #" << hopAdded->key() << "as it belongs to Recipe #" <<
             recipeOfNewHop->key() << "and we are watching Recipe #" << this->recObs->key();
          return;
       }
    }
 
-   int size = hopObs.size();
+   int size = this->rows.size();
    beginInsertRows(QModelIndex(), size, size);
-   hopObs.append(hop);
-   connect(hop, &NamedEntity::changed, this, &HopTableModel::changed);
+   this->rows.append(hopAdded);
+   connect(hopAdded.get(), &NamedEntity::changed, this, &HopTableModel::changed);
    endInsertRows();
    return;
 }
 
-void HopTableModel::addHops(QList<Hop *> hops) {
-   QList<Hop *> tmp;
+void HopTableModel::addHops(QList< std::shared_ptr<Hop> > hops) {
+   decltype(hops) tmp;
 
    for (auto hop : hops) {
       if (recObs == nullptr && (hop->deleted() || !hop->display())) {
          continue;
       }
-      if (!hopObs.contains(hop)) {
+      if (!this->rows.contains(hop)) {
          tmp.append(hop);
       }
    }
 
-   int size = hopObs.size();
+   int size = this->rows.size();
    if (size + tmp.size()) {
       beginInsertRows(QModelIndex(), size, size + tmp.size() - 1);
-      hopObs.append(tmp);
+      this->rows.append(tmp);
 
       for (auto hop : tmp) {
-         connect(hop, &NamedEntity::changed, this, &HopTableModel::changed);
+         connect(hop.get(), &NamedEntity::changed, this, &HopTableModel::changed);
       }
 
       endInsertRows();
@@ -190,12 +174,12 @@ void HopTableModel::addHops(QList<Hop *> hops) {
    return;
 }
 
-bool HopTableModel::remove(Hop * hop) {
-   int i = hopObs.indexOf(hop);
+bool HopTableModel::remove(std::shared_ptr<Hop> hop) {
+   int i = this->rows.indexOf(hop);
    if (i >= 0) {
       beginRemoveRows(QModelIndex(), i, i);
-      disconnect(hop, nullptr, this, nullptr);
-      hopObs.removeAt(i);
+      disconnect(hop.get(), nullptr, this, nullptr);
+      this->rows.removeAt(i);
       //reset(); // Tell everybody the table has changed.
       endRemoveRows();
 
@@ -206,7 +190,7 @@ bool HopTableModel::remove(Hop * hop) {
 }
 
 void HopTableModel::removeHop(int hopId, std::shared_ptr<QObject> object) {
-   this->remove(std::static_pointer_cast<Hop>(object).get());
+   this->remove(std::static_pointer_cast<Hop>(object));
    return;
 }
 
@@ -215,10 +199,10 @@ void HopTableModel::setShowIBUs(bool var) {
 }
 
 void HopTableModel::removeAll() {
-   if (hopObs.size()) {
-      beginRemoveRows(QModelIndex(), 0, hopObs.size() - 1);
-      while (!hopObs.isEmpty()) {
-         disconnect(hopObs.takeLast(), nullptr, this, nullptr);
+   if (this->rows.size()) {
+      beginRemoveRows(QModelIndex(), 0, this->rows.size() - 1);
+      while (!this->rows.isEmpty()) {
+         disconnect(this->rows.takeLast().get(), nullptr, this, nullptr);
       }
       endRemoveRows();
    }
@@ -226,15 +210,10 @@ void HopTableModel::removeAll() {
 
 void HopTableModel::changedInventory(int invKey, BtStringConst const & propertyName) {
    if (propertyName == PropertyNames::Inventory::amount) {
-///      double newAmount = ObjectStoreWrapper::getById<InventoryHop>()->getAmount();
-      for (int i = 0; i < hopObs.size(); ++i) {
-         Hop * holdmybeer = hopObs.at(i);
-
-         if (invKey == holdmybeer->inventoryId()) {
-/// No need to update amount as it's only stored in one place (the inventory object) now
-///            holdmybeer->setInventoryAmount(newAmount);
-            emit dataChanged(QAbstractItemModel::createIndex(i, HOPINVENTORYCOL),
-                             QAbstractItemModel::createIndex(i, HOPINVENTORYCOL));
+      for (int ii = 0; ii < this->rows.size(); ++ii) {
+         if (invKey == this->rows.at(ii)->inventoryId()) {
+            emit dataChanged(QAbstractItemModel::createIndex(ii, HOPINVENTORYCOL),
+                             QAbstractItemModel::createIndex(ii, HOPINVENTORYCOL));
          }
       }
    }
@@ -242,19 +221,19 @@ void HopTableModel::changedInventory(int invKey, BtStringConst const & propertyN
 }
 
 void HopTableModel::changed(QMetaProperty prop, QVariant /*val*/) {
-   int i;
 
    // Find the notifier in the list
    Hop * hopSender = qobject_cast<Hop *>(sender());
    if (hopSender) {
-      i = hopObs.indexOf(hopSender);
-      if (i < 0) {
+      auto spHopSender = ObjectStoreWrapper::getSharedFromRaw(hopSender);
+      int ii = this->rows.indexOf(spHopSender);
+      if (ii < 0) {
          return;
       }
 
-      emit dataChanged(QAbstractItemModel::createIndex(i, 0),
-                       QAbstractItemModel::createIndex(i, HOPNUMCOLS - 1));
-      emit headerDataChanged(Qt::Vertical, i, i);
+      emit dataChanged(QAbstractItemModel::createIndex(ii, 0),
+                       QAbstractItemModel::createIndex(ii, HOPNUMCOLS - 1));
+      emit headerDataChanged(Qt::Vertical, ii, ii);
       return;
    }
 
@@ -263,7 +242,7 @@ void HopTableModel::changed(QMetaProperty prop, QVariant /*val*/) {
    if (recSender && recSender == recObs) {
       if (QString(prop.name()) == PropertyNames::Recipe::hopIds) {
          removeAll();
-         addHops(recObs->hops());
+         this->addHops(recObs->getAll<Hop>());
       }
       if (rowCount() > 0) {
          emit headerDataChanged(Qt::Vertical, 0, rowCount() - 1);
@@ -273,19 +252,19 @@ void HopTableModel::changed(QMetaProperty prop, QVariant /*val*/) {
 }
 
 int HopTableModel::rowCount(const QModelIndex & /*parent*/) const {
-   return hopObs.size();
+   return this->rows.size();
 }
 
 QVariant HopTableModel::data(const QModelIndex & index, int role) const {
 
 
    // Ensure the row is ok.
-   if (index.row() >= static_cast<int>(hopObs.size())) {
+   if (index.row() >= static_cast<int>(this->rows.size())) {
       qWarning() << Q_FUNC_INFO << "Bad model index. row =" << index.row();
       return QVariant();
    }
 
-   Hop * row = hopObs[index.row()];
+   auto row = this->rows[index.row()];
 
    int const column = index.column();
    switch (column) {
@@ -361,20 +340,26 @@ QVariant HopTableModel::headerData(int section, Qt::Orientation orientation, int
 
 Qt::ItemFlags HopTableModel::flags(const QModelIndex & index) const {
    int col = index.column();
-
-   return colFlags[col];
+   switch (col) {
+      case HOPNAMECOL:
+         return Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled;
+      case HOPINVENTORYCOL:
+         return Qt::ItemIsEnabled | (this->isInventoryEditable() ? Qt::ItemIsEditable : Qt::NoItemFlags);
+      default:
+         return Qt::ItemIsSelectable | (this->editable ? Qt::ItemIsEditable : Qt::NoItemFlags) | Qt::ItemIsDragEnabled |
+                       Qt::ItemIsEnabled;
+   }
 }
 
 bool HopTableModel::setData(const QModelIndex & index, const QVariant & value, int role) {
-   Hop * row;
    bool retVal = false;
    double amt;
 
-   if (index.row() >= static_cast<int>(hopObs.size()) || role != Qt::EditRole) {
+   if (index.row() >= static_cast<int>(this->rows.size()) || role != Qt::EditRole) {
       return false;
    }
 
-   row = hopObs[index.row()];
+   auto row = this->rows[index.row()];
 
    int const column = index.column();
    switch (column) {
@@ -471,18 +456,6 @@ bool HopTableModel::setData(const QModelIndex & index, const QVariant & value, i
    }
 
    return retVal;
-}
-
-// Returns null on failure.
-Hop * HopTableModel::getHop(int i) {
-   if (!(hopObs.isEmpty())) {
-      if (i >= 0 && i < hopObs.size()) {
-         return hopObs[i];
-      }
-   } else {
-      qWarning() << Q_FUNC_INFO << "this->hopObs is empty (" << i << "/" << hopObs.size() << ")";
-   }
-   return nullptr;
 }
 
 //==========================CLASS HopItemDelegate===============================

--- a/src/tableModels/HopTableModel.h
+++ b/src/tableModels/HopTableModel.h
@@ -33,7 +33,7 @@
 
 #include "model/Hop.h"
 #include "model/Recipe.h"
-#include "tableModels/BtTableModel.h"
+#include "tableModels/BtTableModelInventory.h"
 
 class BtStringConst;
 class HopTableModel;
@@ -46,7 +46,7 @@ enum{HOPNAMECOL, HOPALPHACOL, HOPAMOUNTCOL, HOPINVENTORYCOL, HOPFORMCOL, HOPUSEC
  *
  * \brief Model class for a list of hops.
  */
-class HopTableModel : public BtTableModel {
+class HopTableModel : public BtTableModelInventory, public BtTableModelData<Hop> {
    Q_OBJECT
 
 public:
@@ -60,18 +60,9 @@ public:
    //! \brief Show ibus in the vertical header.
    void setShowIBUs( bool var );
    //! \brief Watch all the \c hops for changes.
-   void addHops(QList<Hop*> hops);
-   //! \brief Return the \c i-th hop in the model.
-   Hop* getHop(int i);
+   void addHops(QList< std::shared_ptr<Hop> > hops);
    //! \brief Clear the model.
    void removeAll();
-
-   /*!
-    * \brief True if the inventory column should be editable, false otherwise.
-    *
-    * The default is that the inventory column is not editable
-    */
-   void setInventoryEditable( bool var ) { _inventoryEditable = var; colFlags[HOPINVENTORYCOL] = Qt::ItemIsEnabled | (_inventoryEditable ? Qt::ItemIsEditable : Qt::NoItemFlags); }
 
    //! \brief Reimplemented from QAbstractTableModel.
    virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;
@@ -85,7 +76,7 @@ public:
    virtual bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole );
 
    //! \returns true if "hop" is successfully found and removed.
-   bool remove(Hop* hop);
+   bool remove(std::shared_ptr<Hop> hop);
 
 public slots:
    void changed(QMetaProperty, QVariant);
@@ -95,10 +86,6 @@ public slots:
    void removeHop(int hopId, std::shared_ptr<QObject> object);
 
 private:
-   QVector<Qt::ItemFlags> colFlags;
-   bool _inventoryEditable;
-   QList<Hop*> hopObs;
-   Recipe* recObs;
    bool showIBUs; // True if you want to show the IBU contributions in the table rows.
 };
 

--- a/src/tableModels/MashStepTableModel.h
+++ b/src/tableModels/MashStepTableModel.h
@@ -21,6 +21,7 @@
  */
 #ifndef TABLEMODELS_MASHSTEPTABLEMODEL_H
 #define TABLEMODELS_MASHSTEPTABLEMODEL_H
+#pragma once
 
 #include <QItemDelegate>
 #include <QMetaProperty>
@@ -44,20 +45,20 @@ enum{ MASHSTEPNAMECOL, MASHSTEPTYPECOL, MASHSTEPAMOUNTCOL, MASHSTEPTEMPCOL, MASH
  *
  * \brief Model for the list of mash steps in a mash.
  */
-class MashStepTableModel : public BtTableModel {
+class MashStepTableModel : public BtTableModel, public BtTableModelData<MashStep> {
    Q_OBJECT
 
 public:
    MashStepTableModel(QTableView* parent = nullptr);
    virtual ~MashStepTableModel();
 
-   //! Set the mash whose mash steps we want to model.
-   void setMash( Mash* m );
+   /**
+    * \brief Set the mash whose mash steps we want to model or reload steps from an existing mash after they were
+    *        changed.
+    */
+   void setMash(Mash * m);
 
    Mash * getMash() const;
-
-   //! \returns the mash step at model index \b i.
-   MashStep* getMashStep(unsigned int i);
 
    //! Reimplemented from QAbstractTableModel.
    virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;
@@ -71,14 +72,9 @@ public:
    virtual bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole );
 
    //! \returns true if mashStep is successfully found and removed.
-   bool remove(MashStep * MashStep);
+   bool remove(std::shared_ptr<MashStep> MashStep);
 
 public slots:
-   //! \brief Add a MashStep to the model.
-   void addMashStep(int mashStep);
-
-   void removeMashStep(int mashStepId, std::shared_ptr<QObject> object);
-
    void moveStepUp(int i);
    void moveStepDown(int i);
    void mashChanged();
@@ -86,9 +82,8 @@ public slots:
 
 private:
    Mash* mashObs;
-   QList<MashStep*> steps;
 
-   void reorderMashStep(MashStep *step, int current);
+   void reorderMashStep(std::shared_ptr<MashStep> step, int current);
 };
 
 /*!

--- a/src/tableModels/MiscTableModel.h
+++ b/src/tableModels/MiscTableModel.h
@@ -36,7 +36,7 @@
 #include <QWidget>
 
 #include "measurement/Unit.h"
-#include "tableModels/BtTableModel.h"
+#include "tableModels/BtTableModelInventory.h"
 
 
 // Forward declarations.
@@ -53,7 +53,7 @@ enum{MISCNAMECOL, MISCTYPECOL, MISCUSECOL, MISCTIMECOL, MISCAMOUNTCOL, MISCINVEN
  *
  * \brief Table model for a list of miscs.
  */
-class MiscTableModel : public BtTableModel {
+class MiscTableModel : public BtTableModelInventory, public BtTableModelData<Misc> {
    Q_OBJECT
 
 public:
@@ -65,18 +65,9 @@ public:
    //! \brief If true, we model the database's list of miscs.
    void observeDatabase(bool val);
    //! \brief Add \c miscs to the model.
-   void addMiscs(QList<Misc*> miscs);
-   //! \returns the \c Misc at model index \b i.
-   Misc* getMisc(unsigned int i);
+   void addMiscs(QList<std::shared_ptr<Misc> > miscs);
    //! \brief Clear the model.
    void removeAll();
-
-   /*!
-    * \brief True if the inventory column should be editable, false otherwise.
-    *
-    * The default is that the inventory column is not editable
-    */
-   void setInventoryEditable( bool var ) { _inventoryEditable = var; }
 
    //! \brief Reimplemented from QAbstractTableModel
    virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;
@@ -88,7 +79,7 @@ public:
    virtual Qt::ItemFlags flags(const QModelIndex& index ) const;
    //! \brief Reimplemented from QAbstractTableModel
    virtual bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole );
-   bool remove(Misc * misc);
+   bool remove(std::shared_ptr<Misc> misc);
 
 public slots:
    //! \brief Add a misc to the model.
@@ -100,11 +91,6 @@ private slots:
    //! \brief Catch changes to Recipe, Database, and Misc.
    void changed(QMetaProperty, QVariant);
    void changedInventory(int invKey, BtStringConst const & propertyName);
-
-private:
-   bool _inventoryEditable;
-   QList<Misc*> miscObs;
-   Recipe* recObs;
 };
 
 /*!

--- a/src/tableModels/SaltTableModel.h
+++ b/src/tableModels/SaltTableModel.h
@@ -51,15 +51,17 @@ enum{ SALTNAMECOL,
  *
  * \brief Table model for salts.
  */
-class SaltTableModel : public BtTableModel {
+class SaltTableModel : public BtTableModelRecipeObserver, public BtTableModelData<Salt> {
    Q_OBJECT
 
 public:
    SaltTableModel(QTableView* parent = nullptr);
    ~SaltTableModel();
    void observeRecipe(Recipe* rec);
-   void addSalt(Salt* salt);
-   void addSalts(QList<Salt*> salts);
+private:
+   void addSalt(std::shared_ptr<Salt> salt);
+public:
+   void addSalts(QList<std::shared_ptr<Salt> > salts);
    void removeAll();
 
    //! Reimplemented from QAbstractTableModel.
@@ -90,19 +92,15 @@ public:
 
 public slots:
    void changed(QMetaProperty,QVariant);
-   void removeSalt(Salt* salt);
+   void remove(std::shared_ptr<Salt> salt);
    void catchSalt();
 
 signals:
    void newTotals();
 
 private:
-   QList<Salt*> saltObs;
-   Recipe* m_rec;
    double spargePct;
-
-   double multiplier(Salt *s) const;
-
+   double multiplier(Salt & salt) const;
 };
 
 /*!

--- a/src/tableModels/WaterTableModel.h
+++ b/src/tableModels/WaterTableModel.h
@@ -50,14 +50,14 @@ enum{ WATERNAMECOL, WATERAMOUNTCOL, WATERCALCIUMCOL, WATERBICARBONATECOL,
  *
  * \brief Table model for waters.
  */
-class WaterTableModel : public BtTableModel {
+class WaterTableModel : public BtTableModelRecipeObserver, public BtTableModelData<Water> {
    Q_OBJECT
 
 public:
-   WaterTableModel(WaterTableWidget* parent=0);
+   WaterTableModel(WaterTableWidget* parent = nullptr);
    virtual ~WaterTableModel();
 
-   void addWaters(QList<Water*> waters);
+   void addWaters(QList<std::shared_ptr<Water> > waters);
    void observeRecipe(Recipe* rec);
    void observeDatabase(bool val);
    void removeAll();
@@ -77,10 +77,6 @@ public slots:
    void changed(QMetaProperty,QVariant);
    void addWater(int waterId);
    void removeWater(int waterId, std::shared_ptr<QObject> object);
-
-private:
-   QList<Water*> waterObs;
-   Recipe* recObs;
 };
 
 /*!

--- a/src/tableModels/YeastTableModel.h
+++ b/src/tableModels/YeastTableModel.h
@@ -35,7 +35,7 @@
 #include <QWidget>
 
 #include "measurement/Unit.h"
-#include "tableModels/BtTableModel.h"
+#include "tableModels/BtTableModelInventory.h"
 
 // Forward declarations.
 class BtStringConst;
@@ -51,7 +51,7 @@ enum{ YEASTNAMECOL, YEASTLABCOL, YEASTPRODIDCOL, YEASTTYPECOL, YEASTFORMCOL, YEA
  *
  * \brief Table model for yeasts.
  */
-class YeastTableModel : public BtTableModel {
+class YeastTableModel : public BtTableModelInventory, public BtTableModelData<Yeast> {
    Q_OBJECT
 
 public:
@@ -63,18 +63,9 @@ public:
    //! \brief If true, we model the database's list of yeasts.
    void observeDatabase(bool val);
    //! \brief Add \c yeasts to the model.
-   void addYeasts(QList<Yeast*> yeasts);
-   //! \brief Get the yeast at model index \c i.
-   Yeast* getYeast(unsigned int i);
+   void addYeasts(QList<std::shared_ptr<Yeast> > yeasts);
    //! \brief Clear the model.
    void removeAll();
-
-   /*!
-    * \brief True if the inventory column should be editable, false otherwise.
-    *
-    * The default is that the inventory column is not editable
-    */
-   void setInventoryEditable( bool var ) { _inventoryEditable = var; }
 
    //! \brief Reimplemented from QAbstractTableModel.
    virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;
@@ -87,7 +78,7 @@ public:
    //! \brief Reimplemented from QAbstractTableModel.
    virtual bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole );
 
-   void remove(Yeast * yeast);
+   void remove(std::shared_ptr<Yeast> yeast);
 
 public slots:
    //! \brief Add a \c yeast to the model.
@@ -99,11 +90,6 @@ private slots:
    //! \brief Catch changes to Recipe, Database, and Yeast.
    void changed(QMetaProperty, QVariant);
    void changedInventory(int invKey, BtStringConst const & propertyName);
-
-private:
-   bool _inventoryEditable;
-   QList<Yeast*> yeastObs;
-   Recipe* recObs;
 };
 
 /*!

--- a/src/xml/XmlMashRecord.cpp
+++ b/src/xml/XmlMashRecord.cpp
@@ -33,11 +33,11 @@ void XmlMashRecord::subRecordToXml(XmlRecord::FieldDefinition const & fieldDefin
    // We assert that MashStep is the only complex record inside a Mash
    Q_ASSERT(fieldDefinition.propertyName == PropertyNames::Mash::mashSteps);
 
-   QList<MashStep *> children = mash.mashSteps();
+   auto children = mash.mashSteps();
    if (children.empty()) {
       this->writeNone(subRecord, mash, out, indentLevel, indentString);
    } else {
-      for (MashStep * child : children) {
+      for (auto child : children) {
          subRecord.toXml(*child, out, indentLevel, indentString);
       }
    }

--- a/ui/waterDialog.ui
+++ b/ui/waterDialog.ui
@@ -508,7 +508,7 @@
    <extends>QLabel</extends>
    <header>BtLabel.h</header>
    <slots>
-    <signal>labelChanged(Unit::unitDisplay,Unit::unitScale)</signal>
+    <signal>changedSystemOfMeasurementOrScale(PreviousScaleInfo)</signal>
    </slots>
   </customwidget>
   <customwidget>
@@ -572,7 +572,7 @@
    <sender>label_totalcacl2</sender>
    <signal>changedSystemOfMeasurementOrScale(PreviousScaleInfo)</signal>
    <receiver>btDigit_totalcacl2</receiver>
-   <slot>displayChanged(Measurement::SystemOfMeasurement, std::optional&lt;Measurement::UnitSystem::RelativeScale&gt;)</slot>
+   <slot>displayChanged(PreviousScaleInfo)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>70</x>
@@ -588,7 +588,7 @@
    <sender>label_totalcaco3</sender>
    <signal>changedSystemOfMeasurementOrScale(PreviousScaleInfo)</signal>
    <receiver>btDigit_totalcaco3</receiver>
-   <slot>displayChanged(Measurement::SystemOfMeasurement, std::optional&lt;Measurement::UnitSystem::RelativeScale&gt;)</slot>
+   <slot>displayChanged(PreviousScaleInfo)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>70</x>
@@ -604,7 +604,7 @@
    <sender>label_totalcaso4</sender>
    <signal>changedSystemOfMeasurementOrScale(PreviousScaleInfo)</signal>
    <receiver>btDigit_totalcaso4</receiver>
-   <slot>displayChanged(Measurement::SystemOfMeasurement, std::optional&lt;Measurement::UnitSystem::RelativeScale&gt;)</slot>
+   <slot>displayChanged(PreviousScaleInfo)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>70</x>
@@ -620,7 +620,7 @@
    <sender>label_totalmgso4</sender>
    <signal>changedSystemOfMeasurementOrScale(PreviousScaleInfo)</signal>
    <receiver>btDigit_totalmgso4</receiver>
-   <slot>displayChanged(Measurement::SystemOfMeasurement, std::optional&lt;Measurement::UnitSystem::RelativeScale&gt;)</slot>
+   <slot>displayChanged(PreviousScaleInfo)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>251</x>
@@ -636,7 +636,7 @@
    <sender>label_totalnacl</sender>
    <signal>changedSystemOfMeasurementOrScale(PreviousScaleInfo)</signal>
    <receiver>btDigit_totalnacl</receiver>
-   <slot>displayChanged(Measurement::SystemOfMeasurement, std::optional&lt;Measurement::UnitSystem::RelativeScale&gt;)</slot>
+   <slot>displayChanged(PreviousScaleInfo)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>251</x>
@@ -652,7 +652,7 @@
    <sender>label_totalnahco3</sender>
    <signal>changedSystemOfMeasurementOrScale(PreviousScaleInfo)</signal>
    <receiver>btDigit_totalnahco3</receiver>
-   <slot>displayChanged(Measurement::SystemOfMeasurement, std::optional&lt;Measurement::UnitSystem::RelativeScale&gt;)</slot>
+   <slot>displayChanged(PreviousScaleInfo)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>251</x>


### PR DESCRIPTION
There were a few places where we were still trying to do things directly with `MashStep` objects rather than just giving them to the owning Mash and letting all the logic be centralised in `Mash::addMashStep()`.  Similarly, part of the original bug was trying to grab some info from a newly-created `MashStep` before it had been added to the Mash.  We now just wait for the Mash to tell us about changes to its MashSteps, per comment in `src/tableModels/MashStepTableModel.cpp`

Switched more of the code to use shared pointers which removes some memory leaks and makes undelete work even on things that have been "hard" deleted (because the shared pointer keeps the object in existence even after it was removed from the `ObjectStore`).

Tried to remove some of the duplicated code from the files in the tableModels directory, though there are some limitations about what we can do here with the Qt MOC not being able to handle C++ templates (see comment in `tableModels/BtTableModel.h`