### PR TITLE
Update actions for Node.js upgrade

### DIFF
--- a/.github/workflows/linux-ubuntu.yml
+++ b/.github/workflows/linux-ubuntu.yml
@@ -28,7 +28,7 @@ jobs:
         #
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload Linux Packages (Installers)
         if: ${{ success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: brewtarget-${{matrix.os}}
           path: |
@@ -117,7 +117,7 @@ jobs:
 
       - name: Recover Debris Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-results-${{matrix.os}}
           path: build

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
           version: 5.9.5
 
@@ -84,7 +84,7 @@ jobs:
 
     - name: Upload Mac Packages (Installers)
       if: ${{ success() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: brewtarget-dev-mac
         path: |
@@ -106,7 +106,7 @@ jobs:
 
     - name: Recover Debris Artifacts (aka build output)
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-results
         path: ${{github.workspace}}/build
@@ -114,7 +114,7 @@ jobs:
 
     - name: Recover DiagnosticReports (if any)
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: DiagnosticReports
         path: /Library/Logs/DiagnosticReports
@@ -122,7 +122,7 @@ jobs:
 
     - name: Recover Cores (if any)
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: cores
         path: /cores

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
         ]
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: temp
           fetch-depth: 0
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload Windows binaries (installers)
         if: ${{ success()}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: brewtarget-dev-${{ matrix.msystem }}
           path: |
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload error info from failed build
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.msystem }}-build
           path: C:/_/build/


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ but, in short, we need to use newer versions of some of our workflow actions as the version of Node.js that they run against is out of support and will be upgraded by GitHub in the near future.