### PR TITLE
Translations now including .ui files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -738,27 +738,27 @@ set(filesToInstall_icons ${repoDir}/images/brewtarget.svg)
 # binary .qm files will be generated and shipped.  Note that src/OptionDialog.cpp controls which languages are shown to
 # the user as options for the UI
 set(translationSourceFiles ${repoDir}/translations/bt_ca.ts # Catalan
-                                ${repoDir}/translations/bt_cs.ts # Czech
-                                ${repoDir}/translations/bt_de.ts # German
-                                ${repoDir}/translations/bt_en.ts # English
-                                ${repoDir}/translations/bt_el.ts # Greek
-                                ${repoDir}/translations/bt_es.ts # Spanish
-                                ${repoDir}/translations/bt_et.ts # Estonian
-                                ${repoDir}/translations/bt_eu.ts # Basque
-                                ${repoDir}/translations/bt_fr.ts # French
-                                ${repoDir}/translations/bt_gl.ts # Galician
-                                ${repoDir}/translations/bt_nb.ts # Norwegian Bokmal
-                                ${repoDir}/translations/bt_it.ts # Italian
-                                ${repoDir}/translations/bt_lv.ts # Latvian
-                                ${repoDir}/translations/bt_nl.ts # Dutch
-                                ${repoDir}/translations/bt_pl.ts # Polish
-                                ${repoDir}/translations/bt_pt.ts # Portuguese
-                                ${repoDir}/translations/bt_hu.ts # Hungarian
-                                ${repoDir}/translations/bt_ru.ts # Russian
-                                ${repoDir}/translations/bt_sr.ts # Serbian
-                                ${repoDir}/translations/bt_sv.ts # Swedish
-                                ${repoDir}/translations/bt_tr.ts # Turkish
-                                ${repoDir}/translations/bt_zh.ts) # Chinese
+                           ${repoDir}/translations/bt_cs.ts # Czech
+                           ${repoDir}/translations/bt_de.ts # German
+                           ${repoDir}/translations/bt_en.ts # English
+                           ${repoDir}/translations/bt_el.ts # Greek
+                           ${repoDir}/translations/bt_es.ts # Spanish
+                           ${repoDir}/translations/bt_et.ts # Estonian
+                           ${repoDir}/translations/bt_eu.ts # Basque
+                           ${repoDir}/translations/bt_fr.ts # French
+                           ${repoDir}/translations/bt_gl.ts # Galician
+                           ${repoDir}/translations/bt_nb.ts # Norwegian Bokmal
+                           ${repoDir}/translations/bt_it.ts # Italian
+                           ${repoDir}/translations/bt_lv.ts # Latvian
+                           ${repoDir}/translations/bt_nl.ts # Dutch
+                           ${repoDir}/translations/bt_pl.ts # Polish
+                           ${repoDir}/translations/bt_pt.ts # Portuguese
+                           ${repoDir}/translations/bt_hu.ts # Hungarian
+                           ${repoDir}/translations/bt_ru.ts # Russian
+                           ${repoDir}/translations/bt_sr.ts # Serbian
+                           ${repoDir}/translations/bt_sv.ts # Swedish
+                           ${repoDir}/translations/bt_tr.ts # Turkish
+                           ${repoDir}/translations/bt_zh.ts) # Chinese
 
 set(filesToInstall_windowsIcon ${repoDir}/win/icon.rc)
 
@@ -792,6 +792,11 @@ set(filesToInstall_sounds ${repoDir}/data/sounds/45minLeft.wav
                           ${repoDir}/data/sounds/startBurner.wav
                           ${repoDir}/data/sounds/startChill.wav
                           ${repoDir}/data/sounds/stirMash.wav)
+
+# We mostly don't need to explicitly specify the .ui files because AUTOUIC will find them all for us.  However, I
+# haven't found a way to connect AUTOUIC with the translation stuff below, so grab a list of all the .ui files here for
+# that.
+file(GLOB_RECURSE filesToCompile_ui "${repoDir}/ui/*.ui")
 
 set(filesToInstall_macPropertyList "${repoDir}/mac/Info.plist")
 
@@ -832,6 +837,8 @@ include(src/CMakeLists.txt)
 set_property(SOURCE ${translationSourceFiles} PROPERTY OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/translations)
 # The qt5_create_translation understands what to do with each file name by its extension thus .cpp and .ui files are
 # used to update the .ts files.  The list of generated .qm files ends up in the QM_FILES variable.
+message(STATUS "Pulling strings to translate from " "${filesToCompile_cpp} ${filesToCompile_ui}")
+message(STATUS "translationSourceFiles " "${translationSourceFiles}")
 qt5_create_translation(QM_FILES ${translationSourceFiles} ${filesToCompile_cpp} ${filesToCompile_ui})
 
 # Add a target for the QM_FILES so that we can add

--- a/translations/bt_ca.ts
+++ b/translations/bt_ca.ts
@@ -530,6 +530,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Recepta</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Existències</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Fermentables</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Llúpols</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Llevat</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Resultats</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancel·lar</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2005,13 +2100,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">mínim</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2453,15 +2541,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2767,80 +2855,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Desconegut</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">Normal</translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Existències</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Nom</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Quantitat</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alfa %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -3003,6 +3017,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Desconegut</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Normal</translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Existències</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nom</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Quantitat</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3785,8 +3873,36 @@ El volum final al primari és de %1.</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancel·lar</translation>
+        <translation type="unfinished">Cancel·lar</translation>
     </message>
 </context>
 <context>
@@ -3799,12 +3915,56 @@ El volum final al primari és de %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Inicia</translation>
+        <translation type="unfinished">Inicia</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Para</translation>
+        <translation type="unfinished">Para</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4250,54 +4410,73 @@ El volum final al primari és de %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Diàleg</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Genera Instruccions</translation>
+        <translation>Genera Instruccions</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Afegiu una fase</translation>
+        <translation>Afegiu una fase</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Nom del pas nou</translation>
+        <translation>Nom del pas nou</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Pas número</translation>
+        <translation>Pas número</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">El número és la posició on en el pas s&apos;ha de col·locar</translation>
+        <translation>El número és la posició on en el pas s&apos;ha de col·locar</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Afegeix el pas nou</translation>
+        <translation>Afegeix el pas nou</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Mou els passos</translation>
+        <translation>Mou els passos</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Moure el pas seleccionat cap amunt</translation>
+        <translation>Moure el pas seleccionat cap amunt</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Moure el pas seleccionat cap avall</translation>
+        <translation>Moure el pas seleccionat cap avall</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Esborrar el pas seleccionat</translation>
+        <translation>Esborrar el pas seleccionat</translation>
     </message>
 </context>
 <context>
@@ -4367,27 +4546,27 @@ El volum final al primari és de %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Abans de bullir</translation>
+        <translation>Abans de bullir</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Densitat estimada</translation>
+        <translation>Densitat estimada</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Densitat abans de bullir</translation>
+        <translation>Densitat abans de bullir</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volum</translation>
+        <translation>Volum</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Volum de most resultant</translation>
+        <translation>Volum de most resultant</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Temp. aigua</translation>
+        <translation>Temp. aigua</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4395,59 +4574,59 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Temperatura final</translation>
+        <translation>Temperatura final</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Temperatura del macerat</translation>
+        <translation>Temperatura del macerat</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Després de bullir</translation>
+        <translation>Després de bullir</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Desnsitat després de bulir</translation>
+        <translation>Desnsitat després de bulir</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Volum després de l&apos;ebullició</translation>
+        <translation>Volum després de l&apos;ebullició</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Volum de most en el recipient d&apos;ebullició després de bullir</translation>
+        <translation>Volum de most en el recipient d&apos;ebullició després de bullir</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Volum de most transferit al fermentador</translation>
+        <translation>Volum de most transferit al fermentador</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volum en el fermentador</translation>
+        <translation>Volum en el fermentador</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Temp. Sembrat</translation>
+        <translation> Temp. Sembrat</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Temperatura del most cuan s&apos;afegeix el llevat</translation>
+        <translation>Temperatura del most cuan s&apos;afegeix el llevat</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Post-fermentació</translation>
+        <translation>Post-fermentació</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Densitat Final</translation>
+        <translation>Densitat Final</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Volum de cervesa en barril / ampolles</translation>
+        <translation>Volum de cervesa en barril / ampolles</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4463,11 +4642,11 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">DI prevista</translation>
+        <translation>DI prevista</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Brewhouse Eficiència</translation>
+        <translation>Brewhouse Eficiència</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4479,7 +4658,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">ABV projectat</translation>
+        <translation>ABV projectat</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4487,15 +4666,59 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>yyyy-dd-MM</source>
-        <translation type="vanished">aaaa-dd-MM</translation>
+        <translation>aaaa-dd-MM</translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4514,14 +4737,182 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Pèrdues al filtrar</translation>
+        <translation>Pèrdues al filtrar</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Editor d&apos;equip</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Posar com Defecte</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Lot</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nom</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Temps</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Càlcul volum abans de l&apos;ebullició</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Temps d&apos;ebullició</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Tassa d&apos;evaporació (per hora)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Aigua agregada al final</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Aigua agregada a l&apos;olla</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Absorció per defecte</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Punt d&apos;ebullició</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Volum del macerador</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Equip nou</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Editor de fermentables</translation>
+        <translation>Editor de fermentables</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4529,31 +4920,31 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipus</translation>
+        <translation>Tipus</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Gra</translation>
+        <translation>Gra</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Sucre</translation>
+        <translation>Sucre</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Extracte</translation>
+        <translation>Extracte</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Extracte sec</translation>
+        <translation>Extracte sec</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Adjunt</translation>
+        <translation>Adjunt</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4565,43 +4956,43 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Rendiment relatiu a la glucosa</translation>
+        <translation>Rendiment relatiu a la glucosa</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Color Lovibond</translation>
+        <translation>Color Lovibond</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Després d&apos;ebullició</translation>
+        <translation>Després d&apos;ebullició</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">L&apos;ingredient s&apos;afegeix després de bullir.</translation>
+        <translation>L&apos;ingredient s&apos;afegeix després de bullir.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origen</translation>
+        <translation>Origen</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Proveïdor</translation>
+        <translation>Proveïdor</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Diferència Gruixut/Fi (%)</translation>
+        <translation>Diferència Gruixut/Fi (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Diferència de rendiment entre gra gruixut i fi</translation>
+        <translation>Diferència de rendiment entre gra gruixut i fi</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Humitat (%)</translation>
+        <translation>Humitat (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Percentatge d&apos;humitat per massa</translation>
+        <translation>Percentatge d&apos;humitat per massa</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4613,43 +5004,43 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Proteïnes (%)</translation>
+        <translation>Proteïnes (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Percentatge de proteïnes per massa</translation>
+        <translation>Percentatge de proteïnes per massa</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Màxim per Lot (%)</translation>
+        <translation>Màxim per Lot (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Percentatge màxim recomanat del total</translation>
+        <translation>Percentatge màxim recomanat del total</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Maceració recomanada</translation>
+        <translation>Maceració recomanada</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Es recomana que es maceri</translation>
+        <translation>Es recomana que es maceri</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Macerat</translation>
+        <translation>Macerat</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Si està en la maceració</translation>
+        <translation>Si està en la maceració</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Amargor (IBU*gal/lb)</translation>
+        <translation>Amargor (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Amargor dels extractes de llúpol</translation>
+        <translation>Amargor dels extractes de llúpol</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4661,22 +5052,70 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Existències</translation>
+        <translation>Existències</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantitat en estoc</translation>
+        <translation>Quantitat en estoc</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Color</translation>
+        <translation>Color</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Rendiment %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extres</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Editor de Llúpols</translation>
+        <translation>Editor de Llúpols</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4684,7 +5123,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4692,7 +5131,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Percentatge d&apos;alfa-àcids per massa</translation>
+        <translation>Percentatge d&apos;alfa-àcids per massa</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4700,59 +5139,59 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Ús</translation>
+        <translation>Ús</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maceració</translation>
+        <translation>Maceració</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Primera most</translation>
+        <translation>Primera most</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Bullit</translation>
+        <translation>Bullit</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">«Dry Hop»</translation>
+        <translation>«Dry Hop»</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Temps</translation>
+        <translation>Temps</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipus</translation>
+        <translation>Tipus</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Amargor</translation>
+        <translation>Amargor</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Ambdós</translation>
+        <translation>Ambdós</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Flor</translation>
+        <translation>Flor</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pèl·let</translation>
+        <translation>Pèl·let</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">«Plug»</translation>
+        <translation>«Plug»</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4760,19 +5199,19 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Percentatge àcids beta per massa</translation>
+        <translation>Percentatge àcids beta per massa</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Índex d&apos;estabilitat/emmagatzematge del llúpol</translation>
+        <translation>Índex d&apos;estabilitat/emmagatzematge del llúpol</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origen</translation>
+        <translation>Origen</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4780,7 +5219,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulene</translation>
+        <translation>Humulene</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4796,7 +5235,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulone</translation>
+        <translation>Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4804,7 +5243,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcene</translation>
+        <translation>Myrcene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4820,65 +5259,121 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Existències</translation>
+        <translation>Existències</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantitat en estoc</translation>
+        <translation>Quantitat en estoc</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extres</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Mostra un temporitzador</translation>
+        <translation>Mostra un temporitzador</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Mostra un temporitzador</translation>
+        <translation>Mostra un temporitzador</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Marcar aquest pas com a complert</translation>
+        <translation>Marcar aquest pas com a complert</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Pas complet</translation>
+        <translation>Pas complet</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Receptes</translation>
+        <translation>Receptes</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Estils</translation>
+        <translation>Estils</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Fermentables</translation>
+        <translation>Fermentables</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Llúpols</translation>
+        <translation>Llúpols</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Ingredients extres</translation>
+        <translation>Ingredients extres</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Llevats</translation>
+        <translation>Llevats</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Recepta</translation>
+        <translation>Recepta</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4886,11 +5381,11 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Nom de la recepta</translation>
+        <translation>Nom de la recepta</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Ebullició desitjada</translation>
+        <translation>Ebullició desitjada</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4906,7 +5401,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">L&apos;eficiència d&apos;extracció que esperes</translation>
+        <translation>L&apos;eficiència d&apos;extracció que esperes</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4918,7 +5413,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Lot desitjat</translation>
+        <translation>Lot desitjat</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4926,7 +5421,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Equip</translation>
+        <translation>Equip</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4934,163 +5429,163 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Densitat d&apos;ebullició</translation>
+        <translation>Densitat d&apos;ebullició</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">DF</translation>
+        <translation>DF</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Amargor (IBU)</translation>
+        <translation>Amargor (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Color</translation>
+        <translation>Color</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU per Densitat</translation>
+        <translation>IBU per Densitat</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Calories/12oz</translation>
+        <translation>Calories/12oz</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extres</translation>
+        <translation>Extres</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Dia d&apos;elaboració</translation>
+        <translation>Dia d&apos;elaboració</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Afegir un fermentable</translation>
+        <translation>Afegir un fermentable</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Elimina fermentable seleccionat</translation>
+        <translation>Elimina fermentable seleccionat</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Edita fermentable seleccionat</translation>
+        <translation>Edita fermentable seleccionat</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Afegeix llúpol</translation>
+        <translation>Afegeix llúpol</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Elimina llúpol seleccionat</translation>
+        <translation>Elimina llúpol seleccionat</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Edita llúpol seleccionat</translation>
+        <translation>Edita llúpol seleccionat</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Ingredients extres</translation>
+        <translation>Ingredients extres</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Afegeix ingredient extra</translation>
+        <translation>Afegeix ingredient extra</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Elimina ingredient extra seleccionat</translation>
+        <translation>Elimina ingredient extra seleccionat</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Edita ingredient extra seleccionat</translation>
+        <translation>Edita ingredient extra seleccionat</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Llevat</translation>
+        <translation>Llevat</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Afegeix llevat</translation>
+        <translation>Afegeix llevat</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Elimina llevat seleccionat</translation>
+        <translation>Elimina llevat seleccionat</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Edita llevat seleccionat</translation>
+        <translation>Edita llevat seleccionat</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maceració</translation>
+        <translation>Maceració</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Afegeix una fase a la maceració</translation>
+        <translation>Afegeix una fase a la maceració</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Elimina la fase seleccionada</translation>
+        <translation>Elimina la fase seleccionada</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Edita la fase seleccionada</translation>
+        <translation>Edita la fase seleccionada</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Edita les característiques de la maceració</translation>
+        <translation>Edita les característiques de la maceració</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Edita maceració</translation>
+        <translation>Edita maceració</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Dissenyador</translation>
+        <translation>Dissenyador</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Executa l&apos;assistent de maceració</translation>
+        <translation>Executa l&apos;assistent de maceració</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Giny</translation>
+        <translation>Giny</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Maceracions</translation>
+        <translation>Maceracions</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Mou cap a dalt la fase de maceració</translation>
+        <translation>Mou cap a dalt la fase de maceració</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Mou cap abaix la fase de maceració</translation>
+        <translation>Mou cap abaix la fase de maceració</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Desa aquest perfil de maceració</translation>
+        <translation>Desa aquest perfil de maceració</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Desa maceració</translation>
+        <translation>Desa maceració</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Quant a</translation>
+        <translation>&amp;Quant a</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Fitxer</translation>
+        <translation>&amp;Fitxer</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5102,27 +5597,27 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Base de dades</translation>
+        <translation>&amp;Base de dades</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Mostra</translation>
+        <translation>&amp;Mostra</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">E&amp;ines</translation>
+        <translation>E&amp;ines</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Barra d&apos;eines</translation>
+        <translation>Barra d&apos;eines</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">Quant a &amp;Brewtarget</translation>
+        <translation>Quant a &amp;Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Quant a Brewtarget</translation>
+        <translation>Quant a Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5130,19 +5625,19 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Fermentables</translation>
+        <translation>&amp;Fermentables</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">Ll&amp;úpols</translation>
+        <translation>Ll&amp;úpols</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+U</translation>
+        <translation>Ctrl+U</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5150,31 +5645,31 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+X</translation>
+        <translation>Ctrl+X</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Llevats</translation>
+        <translation>&amp;Llevats</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+L</translation>
+        <translation>Ctrl+L</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Equips</translation>
+        <translation>&amp;Equips</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">Es&amp;tils</translation>
+        <translation>Es&amp;tils</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5182,7 +5677,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+S</translation>
+        <translation>Ctrl+S</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5194,55 +5689,55 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Manual</translation>
+        <translation>&amp;Manual</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Escala la recepta</translation>
+        <translation>&amp;Escala la recepta</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Recepta copiada com a &amp;text</translation>
+        <translation>Recepta copiada com a &amp;text</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">Ajuda per corregir la &amp;DI</translation>
+        <translation>Ajuda per corregir la &amp;DI</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Conversor d&apos;unitats</translation>
+        <translation>&amp;Conversor d&apos;unitats</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Còpia de seguretat de la base de dades</translation>
+        <translation>Còpia de seguretat de la base de dades</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Recupera base de dades</translation>
+        <translation>Recupera base de dades</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Copia la recepta</translation>
+        <translation>&amp;Copia la recepta</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Calculadora del «&amp;priming»</translation>
+        <translation>Calculadora del «&amp;priming»</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">Eina per a &amp;refractometres</translation>
+        <translation>Eina per a &amp;refractometres</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">Calculadora de &amp;llevat</translation>
+        <translation>Calculadora de &amp;llevat</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Uneix les bases de dades</translation>
+        <translation>Uneix les bases de dades</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Seleccionar una base de dades per combinar-la amb la actual.</translation>
+        <translation>Seleccionar una base de dades per combinar-la amb la actual.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5262,19 +5757,19 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">Còpia de seguretat</translation>
+        <translation>Còpia de seguretat</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Desa totes les receptes, ingredient, etc… a la carpeta de còpies de seguretat</translation>
+        <translation>Desa totes les receptes, ingredient, etc… a la carpeta de còpies de seguretat</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Recupera</translation>
+        <translation>&amp;Recupera</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Recupera receptes, ingredients, etc… des de una còpia de seguretat anterior</translation>
+        <translation>Recupera receptes, ingredients, etc… des de una còpia de seguretat anterior</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5286,7 +5781,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">Recepta nova</translation>
+        <translation>Recepta nova</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5294,46 +5789,162 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Mostra els temporitzadors</translation>
+        <translation>Mostra els temporitzadors</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Desa</translation>
+        <translation>Desa</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Esborrar la selecció</translation>
+        <translation>Esborrar la selecció</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Esborrar recepta</translation>
+        <translation>Esborrar recepta</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Maceracions</translation>
+        <translation>&amp;Maceracions</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Maceracions</translation>
+        <translation>Maceracions</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
         <translation type="vanished">Calculadora d&apos;aigua a afegir</translation>
     </message>
     <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Export to &amp;BBCode</source>
-        <translation type="vanished">Exporta a &amp;BBCode</translation>
+        <translation>Exporta a &amp;BBCode</translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Lot</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Ebullició</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Elabora-la!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Dissenyador de maceració</translation>
+        <translation>Dissenyador de maceració</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5349,7 +5960,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Temps</translation>
+        <translation>Temps</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5357,275 +5968,311 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Segueix</translation>
+        <translation>Segueix</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Acaba</translation>
+        <translation>Acaba</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Quantitat d&apos;infusió/decocció</translation>
+        <translation>Quantitat d&apos;infusió/decocció</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">mínim</translation>
+        <translation>mínim</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">màxim</translation>
+        <translation>màxim</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Temp. d&apos;infusió</translation>
+        <translation>Temp. d&apos;infusió</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Most extret</translation>
+        <translation>Most extret</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">vol</translation>
+        <translation>vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Capacitat de maceració</translation>
+        <translation>Capacitat de maceració</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">tunVol</translation>
+        <translation>tunVol</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">viscositat</translation>
+        <translation>viscositat</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Editor de maceració</translation>
+        <translation>Editor de maceració</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temp. inicial del gra</translation>
+        <translation>Temp. inicial del gra</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temp. de rentat</translation>
+        <translation>Temp. de rentat</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Temp. desitjada del rentat</translation>
+        <translation>Temp. desitjada del rentat</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH del rentat</translation>
+        <translation>pH del rentat</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Macerador</translation>
+        <translation>Macerador</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temp. inicial del macerador</translation>
+        <translation>Temp. inicial del macerador</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Aconseguir els paràmetres de l&apos;equip de la recepta.</translation>
+        <translation>Aconseguir els paràmetres de l&apos;equip de la recepta.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Del equip</translation>
+        <translation>Del equip</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Massa</translation>
+        <translation>Massa</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Calor específic</translation>
+        <translation>Calor específic</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Calor específic del macerador (cal/(g*K))</translation>
+        <translation>Calor específic del macerador (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Editor de fase de maceració</translation>
+        <translation>Editor de fase de maceració</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipus</translation>
+        <translation>Tipus</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infusió</translation>
+        <translation>Infusió</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Decocció</translation>
+        <translation>Decocció</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Desitjada</translation>
+        <translation>Desitjada</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Desitjada en aquest pas</translation>
+        <translation>Desitjada en aquest pas</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Quantitat d&apos;aigua</translation>
+        <translation>Quantitat d&apos;aigua</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Quantitat d&apos;aigua per fer la infusió</translation>
+        <translation>Quantitat d&apos;aigua per fer la infusió</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Temp. de la infusió</translation>
+        <translation>Temp. de la infusió</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Temperatura de l&apos;aigua de la infusió</translation>
+        <translation>Temperatura de l&apos;aigua de la infusió</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Quantitat de la decocció</translation>
+        <translation>Quantitat de la decocció</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Quantitat de líquid de la maceració per a la decocció</translation>
+        <translation>Quantitat de líquid de la maceració per a la decocció</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Temps</translation>
+        <translation>Temps</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Temps per fer el pas</translation>
+        <translation>Temps per fer el pas</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Lapse entre temparatures</translation>
+        <translation>Lapse entre temparatures</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Lapse de temps</translation>
+        <translation>Lapse de temps</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Temperatura final</translation>
+        <translation>Temperatura final</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Temp. fial final del pas</translation>
+        <translation>Temp. fial final del pas</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Batch Sparge</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Assistent de la maceració</translation>
+        <translation>Assistent de la maceració</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Gruix (L/kg)</translation>
+        <translation>Gruix (L/kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Viscositat de la maceració (no introduir unitats)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Editor d&apos;ingredients extres</translation>
+        <translation>Editor d&apos;ingredients extres</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipus</translation>
+        <translation>Tipus</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Especie</translation>
+        <translation>Especie</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Clarificador</translation>
+        <translation>Clarificador</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Agent per a aigua</translation>
+        <translation>Agent per a aigua</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Herba</translation>
+        <translation>Herba</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Sabor</translation>
+        <translation>Sabor</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Altres</translation>
+        <translation>Altres</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Ús</translation>
+        <translation>Ús</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Ebullició</translation>
+        <translation>Ebullició</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maceració</translation>
+        <translation>Maceració</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Primari</translation>
+        <translation>Primari</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Secundari</translation>
+        <translation>Secundari</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Embotellar</translation>
+        <translation>Embotellar</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Temps</translation>
+        <translation>Temps</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5633,15 +6280,15 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Marcar si la quantitat es mesura en Kg en comptes de L.</translation>
+        <translation>Marcar si la quantitat es mesura en Kg en comptes de L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">La quantitat és massa?</translation>
+        <translation>La quantitat és massa?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Marcar si la quantitat es mesura en massa en comptes de volum</translation>
+        <translation>Marcar si la quantitat es mesura en massa en comptes de volum</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5657,192 +6304,220 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Existències</translation>
+        <translation>Existències</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantitat en estoc</translation>
+        <translation>Quantitat en estoc</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Editor de maceracions amb nom</translation>
+        <translation>Editor de maceracions amb nom</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maceració</translation>
+        <translation>Maceració</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Elimina estil seleccionat</translation>
+        <translation>Elimina estil seleccionat</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temp. inicial del gra</translation>
+        <translation>Temp. inicial del gra</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temp. de rentat</translation>
+        <translation>Temp. de rentat</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Temp. desitjada del rentat</translation>
+        <translation>Temp. desitjada del rentat</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH del rentat</translation>
+        <translation>pH del rentat</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Macerador</translation>
+        <translation>Macerador</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temp. inicial macerador</translation>
+        <translation>Temp. inicial macerador</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">De l&apos;equip</translation>
+        <translation>De l&apos;equip</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Macerador</translation>
+        <translation>Macerador</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Macer. calor específic</translation>
+        <translation>Macer. calor específic</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Calor específic del macerador (cal/(g*K))</translation>
+        <translation>Calor específic del macerador (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Afegieix una fase a la maceració</translation>
+        <translation>Afegieix una fase a la maceració</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Elimina la fase seleccionada</translation>
+        <translation>Elimina la fase seleccionada</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Mou cap a dalt la fase de maceració</translation>
+        <translation>Mou cap a dalt la fase de maceració</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Mou cap abaix la fase de maceració</translation>
+        <translation>Mou cap abaix la fase de maceració</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Ajustar el Volum per obtenir la DI</translation>
+        <translation>Ajustar el Volum per obtenir la DI</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrada</translation>
+        <translation>Entrada</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Densitat</translation>
+        <translation>Densitat</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Densitat mesurada abans de bullir</translation>
+        <translation>Densitat mesurada abans de bullir</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temp.</translation>
+        <translation>Temp.</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Temperatura al mesurar la densitat</translation>
+        <translation>Temperatura al mesurar la densitat</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Temperatura de calibrat</translation>
+        <translation>Temperatura de calibrat</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temperatura a la que està calibrat el hidròmetre</translation>
+        <translation>Temperatura a la que està calibrat el hidròmetre</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-o-</translation>
+        <translation>-o-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (percentatge per massa de sacarosa equivalent)</translation>
+        <translation>Plato (percentatge per massa de sacarosa equivalent)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Volum abans de bullir</translation>
+        <translation>Volum abans de bullir</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Volum mesurat abans de bullir</translation>
+        <translation>Volum mesurat abans de bullir</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultats</translation>
+        <translation>Resultats</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">DI sense correcció</translation>
+        <translation>DI sense correcció</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">DI si es bull com tenim planificat</translation>
+        <translation>DI si es bull com tenim planificat</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Afegir al bullir</translation>
+        <translation>Afegir al bullir</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Quantitat d&apos;aigua que necessites afegir a la ebullició per arribar a la DI planificada (o bullir si és negativa)</translation>
+        <translation>Quantitat d&apos;aigua que necessites afegir a la ebullició per arribar a la DI planificada (o bullir si és negativa)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Mida lot final</translation>
+        <translation>Mida lot final</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Mida estimada després de la correcció</translation>
+        <translation>Mida estimada després de la correcció</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Opcions</translation>
+        <translation>Opcions</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Unitats</translation>
+        <translation>Unitats</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Massa</translation>
+        <translation>Massa</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5858,7 +6533,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5870,11 +6545,11 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volum</translation>
+        <translation>Volum</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Densitat</translation>
+        <translation>Densitat</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5886,7 +6561,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Color</translation>
+        <translation>Color</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5898,7 +6573,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Fórmules</translation>
+        <translation>Fórmules</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5914,7 +6589,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5926,7 +6601,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Ajustaments IBU</translation>
+        <translation>Ajustaments IBU</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5962,7 +6637,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Llenguatge</translation>
+        <translation>Llenguatge</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5972,7 +6647,7 @@ El volum final al primari és de %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Coneixes un altre idioma?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    O potser t&apos;agradaria millorar una traducció? Ajuda&apos;ns i
@@ -5982,7 +6657,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Data</translation>
+        <translation>Data</translation>
     </message>
     <message>
         <source>mm-dd-YYYY</source>
@@ -5999,6 +6674,42 @@ El volum final al primari és de %1.</translation>
     <message>
         <source>Noonan&apos;s approximation</source>
         <translation type="vanished">Aproximació de Noonan</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6081,6 +6792,54 @@ El volum final al primari és de %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6089,418 +6848,418 @@ El volum final al primari és de %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Calculadora de Llevat</translation>
+        <translation>Calculadora de Llevat</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrades</translation>
+        <translation>Entrades</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Volum de most</translation>
+        <translation>Volum de most</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Per a ales, 0.75-1. Pera a lagers, 1.5-2.</translation>
+        <translation>Per a ales, 0.75-1. Pera a lagers, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Sembra ((M cel·l.)/(mL*P)</translation>
+        <translation>Sembra ((M cel·l.)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Mètode d&apos;aireig</translation>
+        <translation>Mètode d&apos;aireig</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Data de producció del llevat</translation>
+        <translation>Data de producció del llevat</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Viabilitat del llevat</translation>
+        <translation>Viabilitat del llevat</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Cap</translation>
+        <translation>Cap</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 At Start</translation>
+        <translation>O2 At Start</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Stir Plate</translation>
+        <translation>Stir Plate</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">dd/MM/yyyy</translation>
+        <translation>dd/MM/yyyy</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">TextLabel</translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Calcular la viabilitat de la Data</translation>
+        <translation>Calcular la viabilitat de la Data</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># Vials/Smack Packs Pitched</translation>
+        <translation># Vials/Smack Packs Pitched</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultats</translation>
+        <translation>Resultats</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Mils de milions de cèl·lules que es requereixen</translation>
+        <translation>Mils de milions de cèl·lules que es requereixen</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Vials/Smack Packs w/o Starter</translation>
+        <translation># Vials/Smack Packs w/o Starter</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Llevat sec</translation>
+        <translation>Llevat sec</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Volum del starter</translation>
+        <translation>Volum del starter</translation>
     </message>
     <message>
         <source>Volume of wort</source>
-        <translation type="vanished">Volum de most</translation>
+        <translation>Volum de most</translation>
     </message>
     <message>
         <source>Starting gravity of the wort</source>
-        <translation type="vanished">Densitat inicial del most</translation>
+        <translation>Densitat inicial del most</translation>
     </message>
     <message>
         <source>Aeration method</source>
-        <translation type="vanished">Mètode d&apos;aeració</translation>
+        <translation>Mètode d&apos;aeració</translation>
     </message>
     <message>
         <source>Production date (Best By date less three months)</source>
-        <translation type="vanished">Data de producció (data recomanada menys 3 mesos)</translation>
+        <translation>Data de producció (data recomanada menys 3 mesos)</translation>
     </message>
     <message>
         <source>Estimated viability of the yeast</source>
-        <translation type="vanished">Viabilitat estimada del llevat</translation>
+        <translation>Viabilitat estimada del llevat</translation>
     </message>
     <message>
         <source>Desired pitch rate</source>
-        <translation type="vanished">Quantitat a sembrar</translation>
+        <translation>Quantitat a sembrar</translation>
     </message>
     <message>
         <source>Number of vials/smack packs added to starter</source>
-        <translation type="vanished">Nombre de vials/paquets afegits a a l&apos;estàrter</translation>
+        <translation>Nombre de vials/paquets afegits a a l&apos;estàrter</translation>
     </message>
     <message>
         <source>How much yeast you will need</source>
-        <translation type="vanished">Quant llevat et caldrà</translation>
+        <translation>Quant llevat et caldrà</translation>
     </message>
     <message>
         <source>How many smack packs or vials required to reach pitch rate</source>
-        <translation type="vanished">La quantitat de paquets o vials necessaris per assolir la quantitat a sembrar</translation>
+        <translation>La quantitat de paquets o vials necessaris per assolir la quantitat a sembrar</translation>
     </message>
     <message>
         <source>Amount of dry yeast needed to reach pitch rate</source>
-        <translation type="vanished">Quantitat de llevat sec per obtenir la quantitat a sembrar</translation>
+        <translation>Quantitat de llevat sec per obtenir la quantitat a sembrar</translation>
     </message>
     <message>
         <source>Starter size to reach pitch rate</source>
-        <translation type="vanished">Mida de l&apos;estàrter per assolir la quantitat a sembrar</translation>
+        <translation>Mida de l&apos;estàrter per assolir la quantitat a sembrar</translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Calculador de priming</translation>
+        <translation>Calculador de priming</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrades</translation>
+        <translation>Entrades</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Volum de cervesa</translation>
+        <translation>Volum de cervesa</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Quantitat de cervesa per fer el priming</translation>
+        <translation>Quantitat de cervesa per fer el priming</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Temperatura de la cervesa</translation>
+        <translation>Temperatura de la cervesa</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Temperatura de la cervesa</translation>
+        <translation>Temperatura de la cervesa</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Volums desitjats</translation>
+        <translation>Volums desitjats</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Quantitat de CO2 que es vol(1 L CO2 @ STP per L de cervesa)</translation>
+        <translation>Quantitat de CO2 que es vol(1 L CO2 @ STP per L de cervesa)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glucosa Monohidrat</translation>
+        <translation>Glucosa Monohidrat</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Glucosa Deshidratada</translation>
+        <translation>Glucosa Deshidratada</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sacarosa</translation>
+        <translation>Sacarosa</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Extracte de malta sec</translation>
+        <translation>Extracte de malta sec</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultats</translation>
+        <translation>Resultats</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Primer amb</translation>
+        <translation>Primer amb</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Quina quantitat de l&apos;ingredient per al priming vol usar</translation>
+        <translation>Quina quantitat de l&apos;ingredient per al priming vol usar</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Cerveser</translation>
+        <translation>Cerveser</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Ajudant</translation>
+        <translation>Ajudant</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Nota de tast</translation>
+        <translation>Nota de tast</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Fermentació primària (dies)</translation>
+        <translation>Fermentació primària (dies)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Temperatura primària</translation>
+        <translation>Temperatura primària</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Fermentació secundària (dies)</translation>
+        <translation>Fermentació secundària (dies)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Temperatura secundària</translation>
+        <translation>Temperatura secundària</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Fermentació terciària (dies)</translation>
+        <translation>Fermentació terciària (dies)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Temperatura terciària</translation>
+        <translation>Temperatura terciària</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Fermentació en ampolla/barril (dies)</translation>
+        <translation>Fermentació en ampolla/barril (dies)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Temperatura ampolla/barril</translation>
+        <translation>Temperatura ampolla/barril</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Data primera elaboració</translation>
+        <translation>Data primera elaboració</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Volum de CO2</translation>
+        <translation>Volum de CO2</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Notes de tasts</translation>
+        <translation>Notes de tasts</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Eina per a refractometres</translation>
+        <translation>Eina per a refractometres</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Entrades</translation>
+        <translation>Entrades</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Plato inicial</translation>
+        <translation>Plato inicial</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">DI (20C)</translation>
+        <translation>DI (20C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Plato actual</translation>
+        <translation>Plato actual</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Resultats</translation>
+        <translation>Resultats</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">Densitat (20C)</translation>
+        <translation>Densitat (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">ABW</translation>
+        <translation>ABW</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Índex refractor</translation>
+        <translation>Índex refractor</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Extracte real (Plato)</translation>
+        <translation>Extracte real (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">DI (20C)</translation>
+        <translation>DI (20C)</translation>
     </message>
     <message>
         <source>Measured original plato</source>
-        <translation type="vanished">Platos inicials obtinguts</translation>
+        <translation>Platos inicials obtinguts</translation>
     </message>
     <message>
         <source>Measured original gravity</source>
-        <translation type="vanished">Densitat inicial obtinguda</translation>
+        <translation>Densitat inicial obtinguda</translation>
     </message>
     <message>
         <source>Current measured plato</source>
-        <translation type="vanished">Platos actuals obtinguts</translation>
+        <translation>Platos actuals obtinguts</translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Calculadora d&apos;aigua a afegir</translation>
+        <translation>Calculadora d&apos;aigua a afegir</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Infusió inicial</translation>
+        <translation>Infusió inicial</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Temp. original del gra</translation>
+        <translation>Temp. original del gra</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Temp. de macerat desitjada</translation>
+        <translation>Temp. de macerat desitjada</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Pes del gra</translation>
+        <translation>Pes del gra</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Volum d&apos;aigua</translation>
+        <translation>Volum d&apos;aigua</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">Infusió</translation>
+        <translation>Infusió</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Volum total d&apos;aigua</translation>
+        <translation>Volum total d&apos;aigua</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Massa del gra</translation>
+        <translation>Massa del gra</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Temperatura de macerat actual</translation>
+        <translation>Temperatura de macerat actual</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Temperatura de l&apos;aigua per la infusió</translation>
+        <translation>Temperatura de l&apos;aigua per la infusió</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcula</translation>
+        <translation>Calcula</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Temperatura de l&apos;aigua a afegir</translation>
+        <translation>Temperatura de l&apos;aigua a afegir</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Volum a afegir</translation>
+        <translation>Volum a afegir</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Tingueu en compte que la calculadora suposa que el macerador ja està calent.</translation>
+        <translation>Tingueu en compte que la calculadora suposa que el macerador ja està calent.</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Editor d&apos;estils</translation>
+        <translation>Editor d&apos;estils</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Estil</translation>
+        <translation>Estil</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Elimina estil seleccionat</translation>
+        <translation>Elimina estil seleccionat</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6508,55 +7267,55 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Categoria</translation>
+        <translation>Categoria</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Número de categoria</translation>
+        <translation>Número de categoria</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Estil de lletra</translation>
+        <translation>Estil de lletra</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Guia d&apos;estil</translation>
+        <translation>Guia d&apos;estil</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipus</translation>
+        <translation>Tipus</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Tipus de beguda</translation>
+        <translation>Tipus de beguda</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Aiguamel</translation>
+        <translation>Aiguamel</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Blat</translation>
+        <translation>Blat</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Mixte</translation>
+        <translation>Mixte</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Sidra</translation>
+        <translation>Sidra</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6564,51 +7323,51 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Màxim</translation>
+        <translation>Màxim</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Mínim</translation>
+        <translation>Mínim</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">DF</translation>
+        <translation>DF</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBUs</translation>
+        <translation>IBUs</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Color (SRM)</translation>
+        <translation>Color (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Carb (vols)</translation>
+        <translation>Carb (vols)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV (pct)</translation>
+        <translation>ABV (pct)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Perfil</translation>
+        <translation>Perfil</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingredients</translation>
+        <translation>Ingredients</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Exemples</translation>
+        <translation>Exemples</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <source>New</source>
@@ -6622,6 +7381,50 @@ El volum final al primari és de %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Cancel·lar</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
@@ -6629,12 +7432,207 @@ El volum final al primari és de %1.</translation>
         <source>Timers</source>
         <translation type="vanished">Temporitzadors</translation>
     </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">Format</translation>
+        <translation type="unfinished">Format</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Para</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancel·lar</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6645,18 +7643,22 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Editor de Llevats</translation>
+        <translation>Editor de Llevats</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6664,51 +7666,51 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipus</translation>
+        <translation>Tipus</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Blat</translation>
+        <translation>Blat</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Vi</translation>
+        <translation>Vi</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Cava</translation>
+        <translation>Cava</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Líquid</translation>
+        <translation>Líquid</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Sec</translation>
+        <translation>Sec</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Pendent</translation>
+        <translation>Pendent</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Cultiu</translation>
+        <translation>Cultiu</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6716,91 +7718,91 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Marqueu si és en kilos i no en litres</translation>
+        <translation>Marqueu si és en kilos i no en litres</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Quantitat en massa?</translation>
+        <translation>Quantitat en massa?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Indica si la quantitat esta expressada en massa o volum</translation>
+        <translation>Indica si la quantitat esta expressada en massa o volum</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Lab</translation>
+        <translation>Lab</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">ID del producte</translation>
+        <translation>ID del producte</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Temperatura min</translation>
+        <translation>Temperatura min</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Temperatura min</translation>
+        <translation>Temperatura min</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Temperatura max</translation>
+        <translation>Temperatura max</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Temperatura max</translation>
+        <translation>Temperatura max</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Floculació</translation>
+        <translation>Floculació</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Baixa</translation>
+        <translation>Baixa</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Mitja</translation>
+        <translation>Mitja</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Alta</translation>
+        <translation>Alta</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Molt Alta</translation>
+        <translation>Molt Alta</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Atenuació (%)</translation>
+        <translation>Atenuació (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Atenuació aparent com un percentatge de punts de DI</translation>
+        <translation>Atenuació aparent com un percentatge de punts de DI</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Nombre de cultius</translation>
+        <translation>Nombre de cultius</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Cops que aquest llevats s&apos;ha tornat a cultivar</translation>
+        <translation>Cops que aquest llevats s&apos;ha tornat a cultivar</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Cultius màxims</translation>
+        <translation>Cultius màxims</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Nombre màxim de cultius</translation>
+        <translation>Nombre màxim de cultius</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Afegiu al secundari</translation>
+        <translation>Afegiu al secundari</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Comprova si cal afegir aquest llevat al secundari en lloc del primari</translation>
+        <translation>Comprova si cal afegir aquest llevat al secundari en lloc del primari</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6816,11 +7818,39 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Existències</translation>
+        <translation>Existències</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Quantitat en estoc</translation>
+        <translation>Quantitat en estoc</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extres</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_cs.ts
+++ b/translations/bt_cs.ts
@@ -490,6 +490,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Recept</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Sklad</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Suroviny</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Chmele</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Kvasnice</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Výstup</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Zrušit</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1965,13 +2060,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2413,15 +2501,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2727,80 +2815,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Neznámý</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Sklad</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Název</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Množství</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alfa %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2963,6 +2977,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Neznámý</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Sklad</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Název</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Množství</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3745,8 +3833,36 @@ Celkový objem pro hlavní kvašení je %1.</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Zrušit</translation>
+        <translation type="unfinished">Zrušit</translation>
     </message>
 </context>
 <context>
@@ -3759,12 +3875,56 @@ Celkový objem pro hlavní kvašení je %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Spustit</translation>
+        <translation type="unfinished">Spustit</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Zastavit</translation>
+        <translation type="unfinished">Zastavit</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4210,54 +4370,73 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialog</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Vygenerovat pokyny</translation>
+        <translation>Vygenerovat pokyny</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Přidat krok</translation>
+        <translation>Přidat krok</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Název kroku</translation>
+        <translation>Název kroku</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Číslo kroku</translation>
+        <translation>Číslo kroku</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Číslo, kam má být krok přidán</translation>
+        <translation>Číslo, kam má být krok přidán</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Přidat nový krok</translation>
+        <translation>Přidat nový krok</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Přesunout kroky</translation>
+        <translation>Přesunout kroky</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Přesunout zvolený nahoru</translation>
+        <translation>Přesunout zvolený nahoru</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Přesunout zvolený dolů</translation>
+        <translation>Přesunout zvolený dolů</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Odebrat zvolený krok</translation>
+        <translation>Odebrat zvolený krok</translation>
     </message>
 </context>
 <context>
@@ -4327,27 +4506,27 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Před chmelovarem</translation>
+        <translation>Před chmelovarem</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Hustota</translation>
+        <translation>Hustota</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Hustota před chmelovarem</translation>
+        <translation>Hustota před chmelovarem</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Objem</translation>
+        <translation>Objem</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Objem získaného díla</translation>
+        <translation>Objem získaného díla</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Teplota zapářky</translation>
+        <translation>Teplota zapářky</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4355,59 +4534,59 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Výsledná teplota</translation>
+        <translation>Výsledná teplota</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Teplota rmutu před odrmutováním</translation>
+        <translation>Teplota rmutu před odrmutováním</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Po chmelovaru</translation>
+        <translation>Po chmelovaru</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Počát. hustota</translation>
+        <translation>Počát. hustota</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Hustota po chmelovaru</translation>
+        <translation>Hustota po chmelovaru</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Objem po chmelovaru</translation>
+        <translation>Objem po chmelovaru</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Objem díla ve varné nádobě po chmelovaru</translation>
+        <translation>Objem díla ve varné nádobě po chmelovaru</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Objem díla přesouvanéhé do spilky</translation>
+        <translation>Objem díla přesouvanéhé do spilky</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Objem do spilky</translation>
+        <translation>Objem do spilky</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Teplota zakvašení</translation>
+        <translation> Teplota zakvašení</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Teplota díla, při které se přidají kvasnice</translation>
+        <translation>Teplota díla, při které se přidají kvasnice</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Po kvašení</translation>
+        <translation>Po kvašení</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Konečná hustota</translation>
+        <translation>Konečná hustota</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Objem piva do sudů/lahví</translation>
+        <translation>Objem piva do sudů/lahví</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4423,11 +4602,11 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Předpokl. počáteční hustota</translation>
+        <translation>Předpokl. počáteční hustota</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Varní výtěžnost pivovaru</translation>
+        <translation>Varní výtěžnost pivovaru</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4439,7 +4618,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Odhadovaný obsah alkoholu</translation>
+        <translation>Odhadovaný obsah alkoholu</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4447,11 +4626,59 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Obsah alkoholu</translation>
+        <translation>Obsah alkoholu</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Poznámky</translation>
+        <translation>Poznámky</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4470,14 +4697,182 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Mrtvý objem zcezovačky</translation>
+        <translation>Mrtvý objem zcezovačky</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Editor vybavení</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Vybavení</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Nastavit jako Výchozí</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Objem várky</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Název</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Čas</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Vypočít. obj. před chmelovarem</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Délka chmelovaru</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Odpar (za hodinu)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Přilití vody po chmelovaru</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Přilití vody před chmelovarem</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Výchozí nasákavost</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Bod varu vody</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Objem rmutovací pánve</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Poznámky</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Nové vybavení</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Editor surovin</translation>
+        <translation>Editor surovin</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4485,31 +4880,31 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Druh</translation>
+        <translation>Druh</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Slad</translation>
+        <translation>Slad</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Cukr</translation>
+        <translation>Cukr</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Výtažek</translation>
+        <translation>Výtažek</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Sušený výtažek</translation>
+        <translation>Sušený výtažek</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Surogát</translation>
+        <translation>Surogát</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4521,43 +4916,43 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Výtěžnost ve srovnání s glukózou</translation>
+        <translation>Výtěžnost ve srovnání s glukózou</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Hodnota Lovibond/SRM</translation>
+        <translation>Hodnota Lovibond/SRM</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Přidat po chmelovaru</translation>
+        <translation>Přidat po chmelovaru</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Tato přísada se přidává po chmelovaru.</translation>
+        <translation>Tato přísada se přidává po chmelovaru.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Původ</translation>
+        <translation>Původ</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Dodavatel</translation>
+        <translation>Dodavatel</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Hrubý/jemný (%)</translation>
+        <translation>Hrubý/jemný (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Rozdíl vytěžnosti mezi hrubým a jemným meltím</translation>
+        <translation>Rozdíl vytěžnosti mezi hrubým a jemným meltím</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Vlhkost (%)</translation>
+        <translation>Vlhkost (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Hmotnostní procenta vlkhosti</translation>
+        <translation>Hmotnostní procenta vlkhosti</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4569,45 +4964,45 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Proteiny (%)</translation>
+        <translation>Proteiny (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Hmotnostní procenta proteinů</translation>
+        <translation>Hmotnostní procenta proteinů</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Maximum ve várce (%)</translation>
+        <translation>Maximum ve várce (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Maximální doporučený podíl na várce</translation>
+        <translation>Maximální doporučený podíl na várce</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Doporučeno rmutování</translation>
+        <translation>Doporučeno rmutování</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Je doporučeno tuto surovinu rmutovat</translation>
+        <translation>Je doporučeno tuto surovinu rmutovat</translation>
     </message>
     <message>
         <source>Is Mashed</source>
         <translatorcomment>Znamená to, že už je po rmutování?
 </translatorcomment>
-        <translation type="vanished">Je rmutovaná</translation>
+        <translation>Je rmutovaná</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Zaškrtněte pokud je přítomna ve rmutu</translation>
+        <translation>Zaškrtněte pokud je přítomna ve rmutu</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Hořkost (IBU*gal/lb)</translation>
+        <translation>Hořkost (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Hořkost předchmelených výtažků</translation>
+        <translation>Hořkost předchmelených výtažků</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4619,22 +5014,70 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Množství na skladě</translation>
+        <translation>Množství na skladě</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Množství na skladě</translation>
+        <translation>Množství na skladě</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Barva</translation>
+        <translation>Barva</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Vytěžnost %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Podrobnosti</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Poznámky</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Editor chmele</translation>
+        <translation>Editor chmele</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4642,7 +5085,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4650,7 +5093,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Hmotnostní procenta alfa hořkých kyselin</translation>
+        <translation>Hmotnostní procenta alfa hořkých kyselin</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4658,59 +5101,59 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Použití</translation>
+        <translation>Použití</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Vystírka (mash hop)</translation>
+        <translation>Vystírka (mash hop)</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Vyslazování (first wort)</translation>
+        <translation>Vyslazování (first wort)</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Chmelovar</translation>
+        <translation>Chmelovar</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aromatický</translation>
+        <translation>Aromatický</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Dry hopping</translation>
+        <translation>Dry hopping</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Čas</translation>
+        <translation>Čas</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Druh</translation>
+        <translation>Druh</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Hořký</translation>
+        <translation>Hořký</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Oboje</translation>
+        <translation>Oboje</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Hlávkový</translation>
+        <translation>Hlávkový</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Granulovaný</translation>
+        <translation>Granulovaný</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Lisovaný</translation>
+        <translation>Lisovaný</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4718,19 +5161,19 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Hmotnostní procenta beta hořkých kyselin</translation>
+        <translation>Hmotnostní procenta beta hořkých kyselin</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Index stability/skladovatelnosti chmele</translation>
+        <translation>Index stability/skladovatelnosti chmele</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Původ</translation>
+        <translation>Původ</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4738,7 +5181,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulin</translation>
+        <translation>Humulin</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4754,7 +5197,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Kohumulon</translation>
+        <translation>Kohumulon</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4762,7 +5205,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Mircen</translation>
+        <translation>Mircen</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4778,65 +5221,121 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Množství na skladě</translation>
+        <translation>Množství na skladě</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Množství na skladě</translation>
+        <translation>Množství na skladě</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Podrobnosti</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Poznámky</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulář</translation>
+        <translation>Formulář</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Zobrazit časovač</translation>
+        <translation>Zobrazit časovač</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Zobrazit časovač</translation>
+        <translation>Zobrazit časovač</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Označit krok jako provedený</translation>
+        <translation>Označit krok jako provedený</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Krok proveden</translation>
+        <translation>Krok proveden</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Recepty</translation>
+        <translation>Recepty</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Styly</translation>
+        <translation>Styly</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Suroviny</translation>
+        <translation>Suroviny</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Chmele</translation>
+        <translation>Chmele</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Přípravky</translation>
+        <translation>Přípravky</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Kvasnice</translation>
+        <translation>Kvasnice</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Recept</translation>
+        <translation>Recept</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4844,11 +5343,11 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Název receptu</translation>
+        <translation>Název receptu</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Objem várky před chmelovarem</translation>
+        <translation>Objem várky před chmelovarem</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4864,7 +5363,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Očekávaná varní výtěžnost</translation>
+        <translation>Očekávaná varní výtěžnost</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4876,7 +5375,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Požadovaná cílová velikost várky</translation>
+        <translation>Požadovaná cílová velikost várky</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4884,7 +5383,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Vybavení</translation>
+        <translation>Vybavení</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4892,163 +5391,163 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Počáteční hustota</translation>
+        <translation>Počáteční hustota</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Hustota před chmelovarem</translation>
+        <translation>Hustota před chmelovarem</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">Konečná hustota</translation>
+        <translation>Konečná hustota</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Obsah alkoholu</translation>
+        <translation>Obsah alkoholu</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Hořkost (IBU)</translation>
+        <translation>Hořkost (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Barva</translation>
+        <translation>Barva</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/hustota</translation>
+        <translation>IBU/hustota</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Kalorická hodnota (na 340 g)</translation>
+        <translation>Kalorická hodnota (na 340 g)</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Podrobnosti</translation>
+        <translation>Podrobnosti</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Varní list</translation>
+        <translation>Varní list</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Přidat surovinu</translation>
+        <translation>Přidat surovinu</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Odebrat zvolenou surovinu</translation>
+        <translation>Odebrat zvolenou surovinu</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Upravit zvolenou surovinu</translation>
+        <translation>Upravit zvolenou surovinu</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Přidat chmel</translation>
+        <translation>Přidat chmel</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Odebrat zvolený chmel</translation>
+        <translation>Odebrat zvolený chmel</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Upravit zvolený chmel</translation>
+        <translation>Upravit zvolený chmel</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Přípravky</translation>
+        <translation>Přípravky</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Přidat přípravek</translation>
+        <translation>Přidat přípravek</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Odebrat zvolený přípravek</translation>
+        <translation>Odebrat zvolený přípravek</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Upravit zvolený přípravek</translation>
+        <translation>Upravit zvolený přípravek</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Kvasnice</translation>
+        <translation>Kvasnice</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Přidat kvasnice</translation>
+        <translation>Přidat kvasnice</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Odebrat zvolené kvasnice</translation>
+        <translation>Odebrat zvolené kvasnice</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Upravit zvolené kvasnice</translation>
+        <translation>Upravit zvolené kvasnice</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Rmutování</translation>
+        <translation>Rmutování</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Přidat rmutovací krok</translation>
+        <translation>Přidat rmutovací krok</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Odebrat zvolený rmutovací krok</translation>
+        <translation>Odebrat zvolený rmutovací krok</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Upravit zvolený rmutovací krok</translation>
+        <translation>Upravit zvolený rmutovací krok</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Upravit možnosti rmutování</translation>
+        <translation>Upravit možnosti rmutování</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Upravit rmutování</translation>
+        <translation>Upravit rmutování</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Návrhář rmutování</translation>
+        <translation>Návrhář rmutování</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Spustit průvodce rmutováním</translation>
+        <translation>Spustit průvodce rmutováním</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Průvodce rmutováním</translation>
+        <translation>Průvodce rmutováním</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Rmutování</translation>
+        <translation>Rmutování</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Krok nahoru</translation>
+        <translation>Krok nahoru</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Krok dolů</translation>
+        <translation>Krok dolů</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Uložit tento rmutovací profil</translation>
+        <translation>Uložit tento rmutovací profil</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Uložit rmutování</translation>
+        <translation>Uložit rmutování</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Nápověda</translation>
+        <translation>&amp;Nápověda</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Soubor</translation>
+        <translation>&amp;Soubor</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5060,27 +5559,27 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Databáze</translation>
+        <translation>&amp;Databáze</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Zobrazit</translation>
+        <translation>&amp;Zobrazit</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">Nás&amp;troje</translation>
+        <translation>Nás&amp;troje</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">nástrojováLišta</translation>
+        <translation>nástrojováLišta</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">&amp;O aplikaci Brewtarget</translation>
+        <translation>&amp;O aplikaci Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">O aplikaci Brewtarget</translation>
+        <translation>O aplikaci Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5088,19 +5587,19 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Suroviny</translation>
+        <translation>&amp;Suroviny</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Chmele</translation>
+        <translation>&amp;Chmele</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5108,31 +5607,31 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Kvasnice</translation>
+        <translation>&amp;Kvasnice</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Vybavení</translation>
+        <translation>&amp;Vybavení</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">S&amp;tyly</translation>
+        <translation>S&amp;tyly</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5140,7 +5639,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5152,55 +5651,55 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Návod</translation>
+        <translation>&amp;Návod</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Změnit objem</translation>
+        <translation>&amp;Změnit objem</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">&amp;Recept do schránky jako text</translation>
+        <translation>&amp;Recept do schránky jako text</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">Ú&amp;prava objemu pro dosažení hustoty</translation>
+        <translation>Ú&amp;prava objemu pro dosažení hustoty</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Převody jednotek</translation>
+        <translation>&amp;Převody jednotek</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Zálohovat databázi</translation>
+        <translation>Zálohovat databázi</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Obnovit databázi</translation>
+        <translation>Obnovit databázi</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Kopírovat recept</translation>
+        <translation>&amp;Kopírovat recept</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">&amp;Výpočet kvasných cukrů</translation>
+        <translation>&amp;Výpočet kvasných cukrů</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">&amp;Nástroje pro refraktometr</translation>
+        <translation>&amp;Nástroje pro refraktometr</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">Vý&amp;počet rozkvašení kvasnic</translation>
+        <translation>Vý&amp;počet rozkvašení kvasnic</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Spojit databáze</translation>
+        <translation>Spojit databáze</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Vyberte jinou databázi pro spojení se současnou.</translation>
+        <translation>Vyberte jinou databázi pro spojení se současnou.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5220,19 +5719,19 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Zálohovat</translation>
+        <translation>&amp;Zálohovat</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Uložit všechny recepty, přísady a další do adresáře záloh</translation>
+        <translation>Uložit všechny recepty, přísady a další do adresáře záloh</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Obnovit</translation>
+        <translation>&amp;Obnovit</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Obnovit recepty, přísady a další z předchozí zálohy</translation>
+        <translation>Obnovit recepty, přísady a další z předchozí zálohy</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5244,7 +5743,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Nový recept</translation>
+        <translation>&amp;Nový recept</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5252,42 +5751,162 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Zobrazit časovač</translation>
+        <translation>Zobrazit časovač</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Uložit</translation>
+        <translation>Uložit</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Odstranit vybraný</translation>
+        <translation>Odstranit vybraný</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Odebrat recept</translation>
+        <translation>Odebrat recept</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Rmutovací schémata</translation>
+        <translation>&amp;Rmutovací schémata</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Rmutovací schémata</translation>
+        <translation>Rmutovací schémata</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
         <translation type="vanished">Výpočet nálevu</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Objem várky</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Původní objem</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Uvařit!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Návrhář rmutování</translation>
+        <translation>Návrhář rmutování</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5303,7 +5922,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Čas</translation>
+        <translation>Čas</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5311,275 +5930,311 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Další</translation>
+        <translation>Další</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Dokončit</translation>
+        <translation>Dokončit</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Infuzní/dekokční množství</translation>
+        <translation>Infuzní/dekokční množství</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Teplota infuze</translation>
+        <translation>Teplota infuze</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Celkový objem díla</translation>
+        <translation>Celkový objem díla</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">množství</translation>
+        <translation>množství</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Plnost nádoby</translation>
+        <translation>Plnost nádoby</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">objNád</translation>
+        <translation>objNád</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">hustota</translation>
+        <translation>hustota</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Editor rmutů</translation>
+        <translation>Editor rmutů</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Počáteční teplota sladu</translation>
+        <translation>Počáteční teplota sladu</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Teplota vyslazovací vody</translation>
+        <translation>Teplota vyslazovací vody</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Cílová teplota vyslazovací vody</translation>
+        <translation>Cílová teplota vyslazovací vody</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH sladiny</translation>
+        <translation>pH sladiny</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Poznámky</translation>
+        <translation>Poznámky</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Pánev</translation>
+        <translation>Pánev</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Počáteční teplota</translation>
+        <translation>Počáteční teplota</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Získat následující parametry z vybavení receptu.</translation>
+        <translation>Získat následující parametry z vybavení receptu.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Z vybavení</translation>
+        <translation>Z vybavení</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Hmotnost kádě</translation>
+        <translation>Hmotnost kádě</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Spec. teplo kádě</translation>
+        <translation>Spec. teplo kádě</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Specifické teplo kádě (kalorií/(g*K))</translation>
+        <translation>Specifické teplo kádě (kalorií/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Editor rmutovacích kroků</translation>
+        <translation>Editor rmutovacích kroků</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Druh</translation>
+        <translation>Druh</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infuze</translation>
+        <translation>Infuze</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Teplota</translation>
+        <translation>Teplota</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Dekokce</translation>
+        <translation>Dekokce</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Cílová teplota</translation>
+        <translation>Cílová teplota</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Cílová teplota tohoto kroku</translation>
+        <translation>Cílová teplota tohoto kroku</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Infuzní množství</translation>
+        <translation>Infuzní množství</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Množství vody pro infuzi</translation>
+        <translation>Množství vody pro infuzi</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Teplota infuze</translation>
+        <translation>Teplota infuze</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Teplota infuzní vody</translation>
+        <translation>Teplota infuzní vody</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Dekokční množ.</translation>
+        <translation>Dekokční množ.</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Množství rmutu pro dekokci</translation>
+        <translation>Množství rmutu pro dekokci</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Čas</translation>
+        <translation>Čas</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Čas pro provedení kroku</translation>
+        <translation>Čas pro provedení kroku</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Prodleva</translation>
+        <translation>Prodleva</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Čas pro odpočinek</translation>
+        <translation>Čas pro odpočinek</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Konečná teplota</translation>
+        <translation>Konečná teplota</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Konečná teplota tohoto kroku</translation>
+        <translation>Konečná teplota tohoto kroku</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Vyslazení</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Průvodce rmutováním</translation>
+        <translation>Průvodce rmutováním</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Tloušťka rmutu (L/kg)</translation>
+        <translation>Tloušťka rmutu (L/kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Tloušťka rmutu (nezadávejte jednotky)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Editor přípravků</translation>
+        <translation>Editor přípravků</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Druh</translation>
+        <translation>Druh</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Koření</translation>
+        <translation>Koření</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Čeření</translation>
+        <translation>Čeření</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Úprava vody</translation>
+        <translation>Úprava vody</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Bylina</translation>
+        <translation>Bylina</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Příchuť</translation>
+        <translation>Příchuť</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Jiný</translation>
+        <translation>Jiný</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Použití</translation>
+        <translation>Použití</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Chmelovar</translation>
+        <translation>Chmelovar</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Rmutování</translation>
+        <translation>Rmutování</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Hlavní kvašení</translation>
+        <translation>Hlavní kvašení</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Dokvašování</translation>
+        <translation>Dokvašování</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Stáčení</translation>
+        <translation>Stáčení</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Čas</translation>
+        <translation>Čas</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5587,15 +6242,15 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Zaškrtněte, pokud se množství přísady vyjadřuje v kg místo l.</translation>
+        <translation>Zaškrtněte, pokud se množství přísady vyjadřuje v kg místo l.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Množství je v kg?</translation>
+        <translation>Množství je v kg?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Zaškrtněte pokud je zadané množství v hmostnostních a ne objemových jednotkách</translation>
+        <translation>Zaškrtněte pokud je zadané množství v hmostnostních a ne objemových jednotkách</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5611,192 +6266,220 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Množství na skladě</translation>
+        <translation>Množství na skladě</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Množství na skladě</translation>
+        <translation>Množství na skladě</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Poznámky</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Editor pojmenovaných rmutovacích schémat</translation>
+        <translation>Editor pojmenovaných rmutovacích schémat</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Rmutovací schéma</translation>
+        <translation>Rmutovací schéma</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Odstranit vybraný styl</translation>
+        <translation>Odstranit vybraný styl</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Počáteční teplota sladu</translation>
+        <translation>Počáteční teplota sladu</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Teplota vyslazovací vody</translation>
+        <translation>Teplota vyslazovací vody</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Cílová teplota vyslazovací vody</translation>
+        <translation>Cílová teplota vyslazovací vody</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH sladiny</translation>
+        <translation>pH sladiny</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Poznámky</translation>
+        <translation>Poznámky</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Káď</translation>
+        <translation>Káď</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Počáteční teplota kádě</translation>
+        <translation>Počáteční teplota kádě</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Z vybavení</translation>
+        <translation>Z vybavení</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Hmotnost kádě</translation>
+        <translation>Hmotnost kádě</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Spec. teplo kádě</translation>
+        <translation>Spec. teplo kádě</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Specifické teplo kádě (kalorií/(g*K))</translation>
+        <translation>Specifické teplo kádě (kalorií/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Přidat rmutovací krok</translation>
+        <translation>Přidat rmutovací krok</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Odebrat zvolený rmutovací krok</translation>
+        <translation>Odebrat zvolený rmutovací krok</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Krok nahoru</translation>
+        <translation>Krok nahoru</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Krok dolů</translation>
+        <translation>Krok dolů</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Úprava objemu pro dosažení hustoty</translation>
+        <translation>Úprava objemu pro dosažení hustoty</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Vstup</translation>
+        <translation>Vstup</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Hustota</translation>
+        <translation>Hustota</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Změřená hustota před chmelovarem</translation>
+        <translation>Změřená hustota před chmelovarem</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Tepl.</translation>
+        <translation>Tepl.</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Teplota vzorku při měření hustoty</translation>
+        <translation>Teplota vzorku při měření hustoty</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Kalibr. tepl.</translation>
+        <translation>Kalibr. tepl.</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Teplota, na kterou je hydrometr kalibrován</translation>
+        <translation>Teplota, na kterou je hydrometr kalibrován</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-n.-</translation>
+        <translation>-n.-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (hmotnostní procenta sacharozy)</translation>
+        <translation>Plato (hmotnostní procenta sacharozy)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Objem před chmelovarem</translation>
+        <translation>Objem před chmelovarem</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Změřený objem před chmelovarem</translation>
+        <translation>Změřený objem před chmelovarem</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Výstup</translation>
+        <translation>Výstup</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">Původní hustota bez kor.</translation>
+        <translation>Původní hustota bez kor.</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">Hustota, které by bylo dosaženo, pokud byste vařili podle plánu</translation>
+        <translation>Hustota, které by bylo dosaženo, pokud byste vařili podle plánu</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Množství pro přidání</translation>
+        <translation>Množství pro přidání</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Množství vody, které musíte přidat pro dosažení požadované hustoty</translation>
+        <translation>Množství vody, které musíte přidat pro dosažení požadované hustoty</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Celkový objem várky</translation>
+        <translation>Celkový objem várky</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Odhadovaný objem várky po korekci</translation>
+        <translation>Odhadovaný objem várky po korekci</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Spočítat</translation>
+        <translation>Spočítat</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Možnosti</translation>
+        <translation>Možnosti</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Jednotky</translation>
+        <translation>Jednotky</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Hmotnost</translation>
+        <translation>Hmotnost</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5812,7 +6495,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Teplota</translation>
+        <translation>Teplota</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5824,11 +6507,11 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Objem</translation>
+        <translation>Objem</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Hustota</translation>
+        <translation>Hustota</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5840,7 +6523,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Barva</translation>
+        <translation>Barva</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5852,7 +6535,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Vzorce</translation>
+        <translation>Vzorce</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5868,7 +6551,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5880,7 +6563,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Úpravy IBU</translation>
+        <translation>Úpravy IBU</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5916,7 +6599,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Jazyk</translation>
+        <translation>Jazyk</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5926,17 +6609,53 @@ Celkový objem pro hlavní kvašení je %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Rozumíte dalšímu jazyku?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
-   Nebo máte zájem vylepšit překlad? Pomozte nám a 
+   Nebo máte zájem vylepšit překlad? Pomozte nám a
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   poskytněte překlad&lt;/a&gt; aby vaši přátelé mohli používat BrewTarget!
 &lt;/qt&gt;</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Datum</translation>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6019,6 +6738,54 @@ Celkový objem pro hlavní kvašení je %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6027,350 +6794,418 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Výpočet rozkvašení kvasnic</translation>
+        <translation>Výpočet rozkvašení kvasnic</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Vstup</translation>
+        <translation>Vstup</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Objem díla</translation>
+        <translation>Objem díla</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Hustota mladiny</translation>
+        <translation>Hustota mladiny</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Pro ejly 0,75. Pro ležáky 1,5-2.</translation>
+        <translation>Pro ejly 0,75. Pro ležáky 1,5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Rychl. množení (M buňek)/(mL*P)</translation>
+        <translation>Rychl. množení (M buňek)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Způsob provzdušnění</translation>
+        <translation>Způsob provzdušnění</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Datum výroby kvasnic</translation>
+        <translation>Datum výroby kvasnic</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Životaschopnost kvasnic</translation>
+        <translation>Životaschopnost kvasnic</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Žádný</translation>
+        <translation>Žádný</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">Kyslík na začátku</translation>
+        <translation>Kyslík na začátku</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Míchadlo</translation>
+        <translation>Míchadlo</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">MM/dd/yyyy</translation>
+        <translation>MM/dd/yyyy</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">TextovýPopis</translation>
+        <translation>TextovýPopis</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Spočítat životaschopnost ze zadaného data</translation>
+        <translation>Spočítat životaschopnost ze zadaného data</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished">Použito balíčků</translation>
+        <translation>Použito balíčků</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Výstup</translation>
+        <translation>Výstup</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Žádaný počet miliard kvasinek</translation>
+        <translation>Žádaný počet miliard kvasinek</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished">Balíčků bez rozkvašení</translation>
+        <translation>Balíčků bez rozkvašení</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Sušené kvasnice</translation>
+        <translation>Sušené kvasnice</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Počáteční objem</translation>
+        <translation>Počáteční objem</translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Výpočet kvasných cukrů</translation>
+        <translation>Výpočet kvasných cukrů</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Vstup</translation>
+        <translation>Vstup</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Množství piva</translation>
+        <translation>Množství piva</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Množství piva pro přidání kvasných cukrů</translation>
+        <translation>Množství piva pro přidání kvasných cukrů</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Teplota piva</translation>
+        <translation>Teplota piva</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Teplota piva</translation>
+        <translation>Teplota piva</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Požadované nasycení</translation>
+        <translation>Požadované nasycení</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Kolik objemů (volumes) CO2, chcete získat (1l CO2 na l piva)</translation>
+        <translation>Kolik objemů (volumes) CO2, chcete získat (1l CO2 na l piva)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Monohydrát glukózy (kukuřičný cukr)</translation>
+        <translation>Monohydrát glukózy (kukuřičný cukr)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Bezvodá glukóza</translation>
+        <translation>Bezvodá glukóza</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sacharóza (řepný cukr)</translation>
+        <translation>Sacharóza (řepný cukr)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Sušený sladový výtažek</translation>
+        <translation>Sušený sladový výtažek</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Výstup</translation>
+        <translation>Výstup</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Přidejte</translation>
+        <translation>Přidejte</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Kolik přísady přidat</translation>
+        <translation>Kolik přísady přidat</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Spočítat</translation>
+        <translation>Spočítat</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulář</translation>
+        <translation>Formulář</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Sládek</translation>
+        <translation>Sládek</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Asistent sládka</translation>
+        <translation>Asistent sládka</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Hodnocení ochutnávky</translation>
+        <translation>Hodnocení ochutnávky</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Délka hlav. kvašení (dny)</translation>
+        <translation>Délka hlav. kvašení (dny)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Teplota hlavního kvašení</translation>
+        <translation>Teplota hlavního kvašení</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Délka dokvašování</translation>
+        <translation>Délka dokvašování</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Teplota dokvašování</translation>
+        <translation>Teplota dokvašování</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Délka ležení (dny)</translation>
+        <translation>Délka ležení (dny)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Teplota ležení</translation>
+        <translation>Teplota ležení</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">V lahvi/KEGu (dny)</translation>
+        <translation>V lahvi/KEGu (dny)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Teplota lahve/KEGu</translation>
+        <translation>Teplota lahve/KEGu</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Poprvé uvařeno</translation>
+        <translation>Poprvé uvařeno</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Nasycení</translation>
+        <translation>Nasycení</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Poznámky k chuti</translation>
+        <translation>Poznámky k chuti</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Poznámky</translation>
+        <translation>Poznámky</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Nástroje pro refraktometr</translation>
+        <translation>Nástroje pro refraktometr</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Vstupy</translation>
+        <translation>Vstupy</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Původní Plato</translation>
+        <translation>Původní Plato</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">Hustota (20C)</translation>
+        <translation>Hustota (20C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Aktuální Plato</translation>
+        <translation>Aktuální Plato</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Spočítat</translation>
+        <translation>Spočítat</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Výstupy</translation>
+        <translation>Výstupy</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">Hustota (20C)</translation>
+        <translation>Hustota (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Obsah alk. (obj.)</translation>
+        <translation>Obsah alk. (obj.)</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">Obsah alk. (hm.)</translation>
+        <translation>Obsah alk. (hm.)</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Index lomu</translation>
+        <translation>Index lomu</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Skutečný extrakt (P.)</translation>
+        <translation>Skutečný extrakt (P.)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">Pův. hustota (20C)</translation>
+        <translation>Pův. hustota (20C)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Výpočet nálevu</translation>
+        <translation>Výpočet nálevu</translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Teplota sladu</translation>
+        <translation>Teplota sladu</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Cílová teplota rmutu</translation>
+        <translation>Cílová teplota rmutu</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Hmožnost sladu</translation>
+        <translation>Hmožnost sladu</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Objem vody</translation>
+        <translation>Objem vody</translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Celkový objem vody</translation>
+        <translation>Celkový objem vody</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Hmotnost sladu</translation>
+        <translation>Hmotnost sladu</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Skutečná teplota rmutu</translation>
+        <translation>Skutečná teplota rmutu</translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Vypočítat</translation>
+        <translation>Vypočítat</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Teplota nálevu</translation>
+        <translation>Teplota nálevu</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Množství k přidání</translation>
+        <translation>Množství k přidání</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Pozn.: Tato kalkulačka uvažuje předehřátou rmutovací pánev.</translation>
+        <translation>Pozn.: Tato kalkulačka uvažuje předehřátou rmutovací pánev.</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Editor stylů</translation>
+        <translation>Editor stylů</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Styl</translation>
+        <translation>Styl</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Odstranit vybraný styl</translation>
+        <translation>Odstranit vybraný styl</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6378,55 +7213,55 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Kategorie</translation>
+        <translation>Kategorie</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Číslo kategorie</translation>
+        <translation>Číslo kategorie</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Písmeno stylu</translation>
+        <translation>Písmeno stylu</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Katalog stylů</translation>
+        <translation>Katalog stylů</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Druh</translation>
+        <translation>Druh</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Druh nápoje</translation>
+        <translation>Druh nápoje</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Ležák</translation>
+        <translation>Ležák</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Medovina</translation>
+        <translation>Medovina</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Pšenice</translation>
+        <translation>Pšenice</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Mix</translation>
+        <translation>Mix</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Cider</translation>
+        <translation>Cider</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6434,51 +7269,51 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Maximálně</translation>
+        <translation>Maximálně</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Minimálně</translation>
+        <translation>Minimálně</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Počát. hustota</translation>
+        <translation>Počát. hustota</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">Konečná hustota</translation>
+        <translation>Konečná hustota</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Barva (SRM)</translation>
+        <translation>Barva (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Nasycení (obj.)</translation>
+        <translation>Nasycení (obj.)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">Alkohol (%)</translation>
+        <translation>Alkohol (%)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Profil</translation>
+        <translation>Profil</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Přísady</translation>
+        <translation>Přísady</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Příklady</translation>
+        <translation>Příklady</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Poznámky</translation>
+        <translation>Poznámky</translation>
     </message>
     <message>
         <source>New</source>
@@ -6492,12 +7327,258 @@ Celkový objem pro hlavní kvašení je %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Zrušit</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
     <message>
         <source>Timers</source>
         <translation type="vanished">Časovače</translation>
+    </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Zastavit</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Zrušit</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6508,18 +7589,22 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Poznámky</translation>
+        <translation>Poznámky</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Editor kvasnic</translation>
+        <translation>Editor kvasnic</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6527,51 +7612,51 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Název</translation>
+        <translation>Název</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Druh</translation>
+        <translation>Druh</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Ležák</translation>
+        <translation>Ležák</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Pšenice</translation>
+        <translation>Pšenice</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Víno</translation>
+        <translation>Víno</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Šampaňské</translation>
+        <translation>Šampaňské</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Druh</translation>
+        <translation>Druh</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Tekuté</translation>
+        <translation>Tekuté</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Sušené</translation>
+        <translation>Sušené</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Agar</translation>
+        <translation>Agar</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Kultura</translation>
+        <translation>Kultura</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6579,91 +7664,91 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Zaškrtněte, pokud je objem v kg místo l.</translation>
+        <translation>Zaškrtněte, pokud je objem v kg místo l.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Možství je hmotnost?</translation>
+        <translation>Možství je hmotnost?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Zaškrtněte, pokud je zadané množství hmotnostní, nikoli objemové</translation>
+        <translation>Zaškrtněte, pokud je zadané množství hmotnostní, nikoli objemové</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Laboratoř</translation>
+        <translation>Laboratoř</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">ID produktu</translation>
+        <translation>ID produktu</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Min. teplota</translation>
+        <translation>Min. teplota</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Min. teplota</translation>
+        <translation>Min. teplota</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Max. teplota</translation>
+        <translation>Max. teplota</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Maximální teplota</translation>
+        <translation>Maximální teplota</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Flokulace</translation>
+        <translation>Flokulace</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Nízká</translation>
+        <translation>Nízká</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Střední</translation>
+        <translation>Střední</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Vysoká</translation>
+        <translation>Vysoká</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Velmi vysoké</translation>
+        <translation>Velmi vysoké</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Prokvašení (%)</translation>
+        <translation>Prokvašení (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Zdánlivé prokvašení v procentech bodů hustoty</translation>
+        <translation>Zdánlivé prokvašení v procentech bodů hustoty</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Počet použití</translation>
+        <translation>Počet použití</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Kolikrát byly již kvasnice použity</translation>
+        <translation>Kolikrát byly již kvasnice použity</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Max. počet použití</translation>
+        <translation>Max. počet použití</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Maximální počet použití</translation>
+        <translation>Maximální počet použití</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Přidat při dokvašování</translation>
+        <translation>Přidat při dokvašování</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Zaškrtněte, pokud přidáváte tyto kvasnice do dokvašování místo hlavního kvašení</translation>
+        <translation>Zaškrtněte, pokud přidáváte tyto kvasnice do dokvašování místo hlavního kvašení</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6676,6 +7761,42 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     <message>
         <source>Default Amount</source>
         <translation type="vanished">Výchozí množství</translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Podrobnosti</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Poznámky</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_de.ts
+++ b/translations/bt_de.ts
@@ -522,6 +522,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Rezept</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Lagerbestand</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Hopfen</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Hefe</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Ausgabe</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbruch</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1989,13 +2084,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2437,15 +2525,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2751,80 +2839,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">unbekannt</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">Normal</translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Lagerbestand</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Name</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Menge</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alpha %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2987,6 +3001,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">unbekannt</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Normal</translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Lagerbestand</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Menge</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3769,8 +3857,36 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Abbruch</translation>
+        <translation type="unfinished">Abbruch</translation>
     </message>
 </context>
 <context>
@@ -3783,12 +3899,56 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Start</translation>
+        <translation type="unfinished">Start</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Stopp</translation>
+        <translation type="unfinished">Stopp</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4234,54 +4394,73 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Form</translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Erzeuge Anweisungen</translation>
+        <translation>Erzeuge Anweisungen</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Schritt einfügen</translation>
+        <translation>Schritt einfügen</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Name des neuen Schritts</translation>
+        <translation>Name des neuen Schritts</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Schritt #</translation>
+        <translation>Schritt #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Die Stelle an welcher der neue Schritt platziert werden soll</translation>
+        <translation>Die Stelle an welcher der neue Schritt platziert werden soll</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Den neuen Schritt einfügen</translation>
+        <translation>Den neuen Schritt einfügen</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Schritte verschieben</translation>
+        <translation>Schritte verschieben</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Bewege ausgewählten Schritt nach oben</translation>
+        <translation>Bewege ausgewählten Schritt nach oben</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Bewege ausgewählten Schritt nach unten</translation>
+        <translation>Bewege ausgewählten Schritt nach unten</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Den derzeitig gewählten Schritt entfernen</translation>
+        <translation>Den derzeitig gewählten Schritt entfernen</translation>
     </message>
 </context>
 <context>
@@ -4351,87 +4530,91 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Vorkochen</translation>
+        <translation>Vorkochen</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Pfannevollwürzekonzentration</translation>
+        <translation>Pfannevollwürzekonzentration</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volumen</translation>
+        <translation>Volumen</translation>
+    </message>
+    <message>
+        <source>Volume of wort collected</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Einmaischtemperatur</translation>
+        <translation>Einmaischtemperatur</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Endtemperatur</translation>
+        <translation>Endtemperatur</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Temperatur der Maische vorm Abmaischen</translation>
+        <translation>Temperatur der Maische vorm Abmaischen</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Nachkochen</translation>
+        <translation>Nachkochen</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Stammwürze</translation>
+        <translation>Stammwürze</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Stammwürzegehalt</translation>
+        <translation>Stammwürzegehalt</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Nachkochvolumen</translation>
+        <translation>Nachkochvolumen</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Volumen der Würze in der Sudpfanne nach dem Kochen</translation>
+        <translation>Volumen der Würze in der Sudpfanne nach dem Kochen</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Menge der Würze in den Gärbehälter</translation>
+        <translation>Menge der Würze in den Gärbehälter</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volumen im Fermenter</translation>
+        <translation>Volumen im Fermenter</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Anstelltemperatur</translation>
+        <translation> Anstelltemperatur</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Temperatur der Würze wenn die Hefe zugegeben wird</translation>
+        <translation>Temperatur der Würze wenn die Hefe zugegeben wird</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Nachgärung</translation>
+        <translation>Nachgärung</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Restextrakt</translation>
+        <translation>Restextrakt</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Volumen an Bier in Ausschank-Fass/Flasche</translation>
+        <translation>Volumen an Bier in Ausschank-Fass/Flasche</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Geplante Stammwürze</translation>
+        <translation>Geplante Stammwürze</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Sudhausausbeute</translation>
+        <translation>Sudhausausbeute</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4443,7 +4626,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Geplanter Alkoholgehalt</translation>
+        <translation>Geplanter Alkoholgehalt</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4451,11 +4634,59 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notizen</translation>
+        <translation>Notizen</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4474,14 +4705,182 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Läutertotraum</translation>
+        <translation>Läutertotraum</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Ausstattungs-Editor</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Ausstattung</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Als Standard setzen</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Ausschlagmenge</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Zeit</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Berechne Pfannevollwürzekonzentration</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Kochzeit</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Verdampfungsrate (pro Stunde)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Standardabsorption</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Siedepunkt von Wasser</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Volumen des Maischbottichs</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Neue Ausstattung</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Gärgut-Editor</translation>
+        <translation>Gärgut-Editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4489,31 +4888,31 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Korn</translation>
+        <translation>Korn</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Zucker</translation>
+        <translation>Zucker</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Extrakt</translation>
+        <translation>Extrakt</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Trockenextrakt</translation>
+        <translation>Trockenextrakt</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Zusatz</translation>
+        <translation>Zusatz</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4525,39 +4924,43 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Ertrag im Vergleich zur Glukose</translation>
+        <translation>Ertrag im Vergleich zur Glukose</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Lovibond Einschätzung</translation>
+        <translation>Lovibond Einschätzung</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Nach dem Kochen zugeben</translation>
+        <translation>Nach dem Kochen zugeben</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Diese Zutat wird nach dem Kochen hinzugefügt.</translation>
+        <translation>Diese Zutat wird nach dem Kochen hinzugefügt.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Ursprung</translation>
+        <translation>Ursprung</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Lieferant</translation>
+        <translation>Lieferant</translation>
+    </message>
+    <message>
+        <source>Coarse/Fine Diff (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Ausbeute-Unterschied zwischen grober und feiner Mahlstärke</translation>
+        <translation>Ausbeute-Unterschied zwischen grober und feiner Mahlstärke</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Feuchtigkeit (%)</translation>
+        <translation>Feuchtigkeit (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Feuchtigkeit [%/w]</translation>
+        <translation>Feuchtigkeit [%/w]</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4569,43 +4972,43 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Eiweiß (%)</translation>
+        <translation>Eiweiß (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Eiweiß Prozent der Masse</translation>
+        <translation>Eiweiß Prozent der Masse</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Max. in Schüttung (%)</translation>
+        <translation>Max. in Schüttung (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Empfohlener maximaler Anteil an gesamtem Mahlgut</translation>
+        <translation>Empfohlener maximaler Anteil an gesamtem Mahlgut</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Maischen empfohlen</translation>
+        <translation>Maischen empfohlen</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Empfiehlt dies zum Maischen</translation>
+        <translation>Empfiehlt dies zum Maischen</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Ist Gemaischt</translation>
+        <translation>Ist Gemaischt</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Anhaken, wenn es sich in der Maische befindet</translation>
+        <translation>Anhaken, wenn es sich in der Maische befindet</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Bitterkeit (IBU*gal/lb)</translation>
+        <translation>Bitterkeit (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Bitterkeit der ungehopften Extrakte</translation>
+        <translation>Bitterkeit der ungehopften Extrakte</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4617,22 +5020,70 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Menge im Lager</translation>
+        <translation>Menge im Lager</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Menge im Lager</translation>
+        <translation>Menge im Lager</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Farbe</translation>
+        <translation>Farbe</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Ausbeute %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Hopfen-Editor</translation>
+        <translation>Hopfen-Editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4640,7 +5091,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4648,7 +5099,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Alphasäuren in Prozent der Masse</translation>
+        <translation>Alphasäuren in Prozent der Masse</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4656,59 +5107,59 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Verwende</translation>
+        <translation>Verwende</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maische</translation>
+        <translation>Maische</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Vorderwürze</translation>
+        <translation>Vorderwürze</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Kochen</translation>
+        <translation>Kochen</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Stopfhopfen</translation>
+        <translation>Stopfhopfen</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Zeit</translation>
+        <translation>Zeit</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Bitterung</translation>
+        <translation>Bitterung</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Beide</translation>
+        <translation>Beide</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Form</translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Blatt</translation>
+        <translation>Blatt</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellet</translation>
+        <translation>Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Niederdruckpellet</translation>
+        <translation>Niederdruckpellet</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4716,19 +5167,19 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Beta-Säuren in Prozent der Masse</translation>
+        <translation>Beta-Säuren in Prozent der Masse</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Hopfen Stabilität/Lagerungs Index</translation>
+        <translation>Hopfen Stabilität/Lagerungs Index</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Ursprung</translation>
+        <translation>Ursprung</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4736,7 +5187,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">α-Humulene</translation>
+        <translation>α-Humulene</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4752,7 +5203,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulone</translation>
+        <translation>Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4760,7 +5211,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcene</translation>
+        <translation>Myrcene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4776,65 +5227,121 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Menge im Lager</translation>
+        <translation>Menge im Lager</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Menge im Lager</translation>
+        <translation>Menge im Lager</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">von</translation>
+        <translation>von</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Eine Stoppuhr zeigen</translation>
+        <translation>Eine Stoppuhr zeigen</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Eine Stoppuhr zeigen</translation>
+        <translation>Eine Stoppuhr zeigen</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Diesen Schritt als fertig markieren</translation>
+        <translation>Diesen Schritt als fertig markieren</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Schritt ist fertig</translation>
+        <translation>Schritt ist fertig</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Rezepte</translation>
+        <translation>Rezepte</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Stile</translation>
+        <translation>Stile</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Gärgüter</translation>
+        <translation>Gärgüter</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Hopfen</translation>
+        <translation>Hopfen</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Sonstiges</translation>
+        <translation>Sonstiges</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Hefen</translation>
+        <translation>Hefen</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Rezept</translation>
+        <translation>Rezept</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4842,11 +5349,11 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Name des Rezepts</translation>
+        <translation>Name des Rezepts</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Geplante Ausschlagmenge</translation>
+        <translation>Geplante Ausschlagmenge</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4862,7 +5369,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Die erwartete Effizient beim extrahieren</translation>
+        <translation>Die erwartete Effizient beim extrahieren</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4874,7 +5381,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Geplante Ausschlagmenge</translation>
+        <translation>Geplante Ausschlagmenge</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4882,7 +5389,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Ausstattung</translation>
+        <translation>Ausstattung</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4890,163 +5397,163 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Stammwürze</translation>
+        <translation>Stammwürze</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Pfannevollwürzekonz.</translation>
+        <translation>Pfannevollwürzekonz.</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Bitterkeit (IBU)</translation>
+        <translation>Bitterkeit (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Farbe</translation>
+        <translation>Farbe</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Kalorien/12oz</translation>
+        <translation>Kalorien/12oz</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extras</translation>
+        <translation>Extras</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Brautag</translation>
+        <translation>Brautag</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Ein Gärgut zugeben</translation>
+        <translation>Ein Gärgut zugeben</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Das gewählte Gärgut entfernen</translation>
+        <translation>Das gewählte Gärgut entfernen</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">ausgewähltes Gärgut bearbeiten</translation>
+        <translation>ausgewähltes Gärgut bearbeiten</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Hopfen zugeben</translation>
+        <translation>Hopfen zugeben</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Den ausgewählten Hopfen entfernen</translation>
+        <translation>Den ausgewählten Hopfen entfernen</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">ausgewählten Hopfen bearbeiten</translation>
+        <translation>ausgewählten Hopfen bearbeiten</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Sonstiges</translation>
+        <translation>Sonstiges</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">eine sonstige Zutat hinzufügen</translation>
+        <translation>eine sonstige Zutat hinzufügen</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">ausgewählte sonstige Zutat entfernen</translation>
+        <translation>ausgewählte sonstige Zutat entfernen</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">ausgewählte sonstige Zutat bearbeiten</translation>
+        <translation>ausgewählte sonstige Zutat bearbeiten</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Hefe</translation>
+        <translation>Hefe</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Hefe zugeben</translation>
+        <translation>Hefe zugeben</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">ausgewählte Hefe entfernen</translation>
+        <translation>ausgewählte Hefe entfernen</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">ausgewählte Hefe bearbeiten</translation>
+        <translation>ausgewählte Hefe bearbeiten</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maische</translation>
+        <translation>Maische</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Maischschritt zufügen</translation>
+        <translation>Maischschritt zufügen</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">ausgewählten Maischschritt entfernen</translation>
+        <translation>ausgewählten Maischschritt entfernen</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">ausgewählten Maischschritt bearbeiten</translation>
+        <translation>ausgewählten Maischschritt bearbeiten</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Bearbeite Maisch-Eigenschaften</translation>
+        <translation>Bearbeite Maisch-Eigenschaften</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Maische bearbeiten</translation>
+        <translation>Maische bearbeiten</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Maisch Designer</translation>
+        <translation>Maisch Designer</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Maisch-Assistent aufrufen</translation>
+        <translation>Maisch-Assistent aufrufen</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Maische-Assistent</translation>
+        <translation>Maische-Assistent</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Maischen</translation>
+        <translation>Maischen</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Maischschritt hoch</translation>
+        <translation>Maischschritt hoch</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Maischschritt runter</translation>
+        <translation>Maischschritt runter</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Dieses Maische-Profil speichern</translation>
+        <translation>Dieses Maische-Profil speichern</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Maische speichern</translation>
+        <translation>Maische speichern</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Über</translation>
+        <translation>&amp;Über</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Datei</translation>
+        <translation>&amp;Datei</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5058,27 +5565,27 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Datenbank</translation>
+        <translation>&amp;Datenbank</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Betrachten</translation>
+        <translation>&amp;Betrachten</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Werkzeuge</translation>
+        <translation>&amp;Werkzeuge</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Werkzeugleiste</translation>
+        <translation>Werkzeugleiste</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">Über &amp;Brewtarget</translation>
+        <translation>Über &amp;Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Über Brewtarget</translation>
+        <translation>Über Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5086,19 +5593,19 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Gärgüter</translation>
+        <translation>&amp;Gärgüter</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Strg+F</translation>
+        <translation>Strg+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Hopfen</translation>
+        <translation>&amp;Hopfen</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Strg+H</translation>
+        <translation>Strg+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5106,31 +5613,31 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Strg+M</translation>
+        <translation>Strg+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Hefen</translation>
+        <translation>&amp;Hefen</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Strg+Y</translation>
+        <translation>Strg+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Ausstattungen</translation>
+        <translation>&amp;Ausstattungen</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Strg+E</translation>
+        <translation>Strg+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Stile</translation>
+        <translation>&amp;Stile</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Strg+T</translation>
+        <translation>Strg+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5138,7 +5645,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Strg+Q</translation>
+        <translation>Strg+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5150,55 +5657,55 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Handbuch</translation>
+        <translation>&amp;Handbuch</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">Rezept &amp;skalieren</translation>
+        <translation>Rezept &amp;skalieren</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Rezept in die Zwischenablage als &amp;Text</translation>
+        <translation>Rezept in die Zwischenablage als &amp;Text</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">Stammwürze K&amp;orrekturhilfe</translation>
+        <translation>Stammwürze K&amp;orrekturhilfe</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">Einheiten umre&amp;chnen</translation>
+        <translation>Einheiten umre&amp;chnen</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Backup Datenbank</translation>
+        <translation>Backup Datenbank</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Datenbank wiederherstellen</translation>
+        <translation>Datenbank wiederherstellen</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">Rezept kopieren &amp;c</translation>
+        <translation>Rezept kopieren &amp;c</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Speiserechner</translation>
+        <translation>Speiserechner</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">Refraktiometer-Werkzeuge</translation>
+        <translation>Refraktiometer-Werkzeuge</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">&amp;Anstellverhältnis-Rechner</translation>
+        <translation>&amp;Anstellverhältnis-Rechner</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Datenbanken vereinigen</translation>
+        <translation>Datenbanken vereinigen</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Wählen Sie eine Datenbank aus um sie mit der aktuellen zusammenzuführen.</translation>
+        <translation>Wählen Sie eine Datenbank aus um sie mit der aktuellen zusammenzuführen.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5218,19 +5725,19 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Backup</translation>
+        <translation>&amp;Backup</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Speichere alle Rezepte, Zutaten, etc. in einen Sicherungs-Ordner</translation>
+        <translation>Speichere alle Rezepte, Zutaten, etc. in einen Sicherungs-Ordner</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">Wiede&amp;rherstellen</translation>
+        <translation>Wiede&amp;rherstellen</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Stelle Rezepte, Zutaten, etc. von einer Sicherungskopie wieder her.</translation>
+        <translation>Stelle Rezepte, Zutaten, etc. von einer Sicherungskopie wieder her.</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5242,7 +5749,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Neues Rezept</translation>
+        <translation>&amp;Neues Rezept</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5250,42 +5757,162 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Eieruhr zeigen</translation>
+        <translation>Eieruhr zeigen</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Speichern</translation>
+        <translation>Speichern</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Auswahl löschen</translation>
+        <translation>Auswahl löschen</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Rezept löschen</translation>
+        <translation>Rezept löschen</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Maischen</translation>
+        <translation>&amp;Maischen</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Maischen</translation>
+        <translation>Maischen</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
         <translation type="vanished">Einmaischwasser-Rechner</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Ausschlagmenge</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Kochgröße</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Dieses brauen!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Maischedesigner</translation>
+        <translation>Maischedesigner</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5301,7 +5928,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Zeit</translation>
+        <translation>Zeit</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5309,271 +5936,307 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Nächster</translation>
+        <translation>Nächster</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Fertigstellen</translation>
+        <translation>Fertigstellen</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Aufguß/Absud Menge</translation>
+        <translation>Aufguß/Absud Menge</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Aufgußtemperatur</translation>
+        <translation>Aufgußtemperatur</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Ausschlagmenge</translation>
+        <translation>Ausschlagmenge</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">Vol</translation>
+        <translation>Vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Bottichfülle</translation>
+        <translation>Bottichfülle</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">Bottichvolumen</translation>
+        <translation>Bottichvolumen</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">spez. Volumen</translation>
+        <translation>spez. Volumen</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Maisch-Editor</translation>
+        <translation>Maisch-Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Anfängliche Getreidetemp.</translation>
+        <translation>Anfängliche Getreidetemp.</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Anschwänztemp.</translation>
+        <translation>Anschwänztemp.</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Geplante Anschwänztemp.</translation>
+        <translation>Geplante Anschwänztemp.</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Anschwänz pH</translation>
+        <translation>Anschwänz pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notizen</translation>
+        <translation>Notizen</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Bottich</translation>
+        <translation>Bottich</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Anfängliche Bottichtemp.</translation>
+        <translation>Anfängliche Bottichtemp.</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Dei Folgenden Parameter von der Ausrüstung im Rezept übernehmen.</translation>
+        <translation>Dei Folgenden Parameter von der Ausrüstung im Rezept übernehmen.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Von Ausrüstung</translation>
+        <translation>Von Ausrüstung</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Bottichmasse</translation>
+        <translation>Bottichmasse</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Maischbottich sp. Wärme</translation>
+        <translation>Maischbottich sp. Wärme</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Maischbottich spez. Wärme (cal/(g*K))</translation>
+        <translation>Maischbottich spez. Wärme (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Maischschritt-Editor</translation>
+        <translation>Maischschritt-Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Aufguß</translation>
+        <translation>Aufguß</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatur</translation>
+        <translation>Temperatur</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Absud</translation>
+        <translation>Absud</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Zieltemp.</translation>
+        <translation>Zieltemp.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Zieltemperatur dieses Schrittes</translation>
+        <translation>Zieltemperatur dieses Schrittes</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Ausgussmenge</translation>
+        <translation>Ausgussmenge</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Menge an Wasser für den Aufguss</translation>
+        <translation>Menge an Wasser für den Aufguss</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Aufgußtemp.</translation>
+        <translation>Aufgußtemp.</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Temperatur des Aufgußwassers</translation>
+        <translation>Temperatur des Aufgußwassers</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Absudmenge</translation>
+        <translation>Absudmenge</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Maischmenge zum absuden</translation>
+        <translation>Maischmenge zum absuden</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Zeit</translation>
+        <translation>Zeit</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Zeit um den Schritt durchzuführen</translation>
+        <translation>Zeit um den Schritt durchzuführen</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Temperatur-Anstiegszeit</translation>
+        <translation>Temperatur-Anstiegszeit</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Verzögerung</translation>
+        <translation>Verzögerung</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Endtemp.</translation>
+        <translation>Endtemp.</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Endtemperatur dieses Schrittes</translation>
+        <translation>Endtemperatur dieses Schrittes</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Schrittweise Anschwänzen</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Maische-Assistent</translation>
+        <translation>Maische-Assistent</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Maischdichte  (L/kg)</translation>
+        <translation>Maischdichte  (L/kg)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Sonstiges-Editor</translation>
+        <translation>Sonstiges-Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Gewürz</translation>
+        <translation>Gewürz</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Schönung</translation>
+        <translation>Schönung</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Wasserzusatzmittel</translation>
+        <translation>Wasserzusatzmittel</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Gewürz</translation>
+        <translation>Gewürz</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Andere</translation>
+        <translation>Andere</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Verwendung</translation>
+        <translation>Verwendung</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Kochen</translation>
+        <translation>Kochen</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maische</translation>
+        <translation>Maische</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Hauptgärung</translation>
+        <translation>Hauptgärung</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Nachgärung</translation>
+        <translation>Nachgärung</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Abfüllung</translation>
+        <translation>Abfüllung</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Zeit</translation>
+        <translation>Zeit</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5581,15 +6244,15 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Anhaken, wenn Menge in kg statt L angegeben wird.</translation>
+        <translation>Anhaken, wenn Menge in kg statt L angegeben wird.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Mengenangabe ist Gewicht</translation>
+        <translation>Mengenangabe ist Gewicht</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Angehakt, wenn die Mengenangabe in Gewicht anstatt Volumen erfolgt</translation>
+        <translation>Angehakt, wenn die Mengenangabe in Gewicht anstatt Volumen erfolgt</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5605,184 +6268,220 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Menge im Lager</translation>
+        <translation>Menge im Lager</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Menge im Lager</translation>
+        <translation>Menge im Lager</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mash</source>
-        <translation type="vanished">Maische</translation>
+        <translation>Maische</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Ausgewählten Stil entfernen</translation>
+        <translation>Ausgewählten Stil entfernen</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Anfängliche Getreidetemp.</translation>
+        <translation>Anfängliche Getreidetemp.</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Anschwänztemp.</translation>
+        <translation>Anschwänztemp.</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Geplante Anschwänztemp.</translation>
+        <translation>Geplante Anschwänztemp.</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Anschwänz pH</translation>
+        <translation>Anschwänz pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notizen</translation>
+        <translation>Notizen</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Bottich</translation>
+        <translation>Bottich</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Anfängliche Bottichtemp.</translation>
+        <translation>Anfängliche Bottichtemp.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Von Ausrüstung</translation>
+        <translation>Von Ausrüstung</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Bottichmasse</translation>
+        <translation>Bottichmasse</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Maischbottich sp. Wärme</translation>
+        <translation>Maischbottich sp. Wärme</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Maischbottich spez. Wärme (cal/(g*K))</translation>
+        <translation>Maischbottich spez. Wärme (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Maischschritt hinzufügen</translation>
+        <translation>Maischschritt hinzufügen</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">ausgewählten Maischschritt entfernen</translation>
+        <translation>ausgewählten Maischschritt entfernen</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Maischschritt hoch</translation>
+        <translation>Maischschritt hoch</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Maischschritt runter</translation>
+        <translation>Maischschritt runter</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Volumen anpassen um Stammwürze zu erreichen</translation>
+        <translation>Volumen anpassen um Stammwürze zu erreichen</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Eingabe</translation>
+        <translation>Eingabe</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Gemessene Pfannevollwürzekonzentration</translation>
+        <translation>Gemessene Pfannevollwürzekonzentration</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temp.</translation>
+        <translation>Temp.</translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Kalibrierte Temperatur</translation>
+        <translation>Kalibrierte Temperatur</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temperatur, bei welcher das Hydrometer kalibriert ist.</translation>
+        <translation>Temperatur, bei welcher das Hydrometer kalibriert ist.</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-oder-</translation>
+        <translation>-oder-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (Prozent der Masse bei entsrechender Saccharose)</translation>
+        <translation>Plato (Prozent der Masse bei entsrechender Saccharose)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Vorkochvolumen</translation>
+        <translation>Vorkochvolumen</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Gemessenes Pfannevollwürzevolumen</translation>
+        <translation>Gemessenes Pfannevollwürzevolumen</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Ausgabe</translation>
+        <translation>Ausgabe</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">Stammwürze ohne Korrektur</translation>
+        <translation>Stammwürze ohne Korrektur</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">Stammwürze wenn Sie wie geplant kochen</translation>
+        <translation>Stammwürze wenn Sie wie geplant kochen</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Dem Sud hinzufügen</translation>
+        <translation>Dem Sud hinzufügen</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Menge an Wasser welches Sie hinzufügen müssen um die geplante Stammwürzekonzentration zu erreichen (oder verkochen müssen wenn negativ)</translation>
+        <translation>Menge an Wasser welches Sie hinzufügen müssen um die geplante Stammwürzekonzentration zu erreichen (oder verkochen müssen wenn negativ)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Brauziel</translation>
+        <translation>Brauziel</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Geschätzte Auschlagmenge nach Korrektur</translation>
+        <translation>Geschätzte Auschlagmenge nach Korrektur</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Berechne</translation>
+        <translation>Berechne</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Optionen</translation>
+        <translation>Optionen</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Einheiten</translation>
+        <translation>Einheiten</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Gewicht</translation>
+        <translation>Gewicht</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5798,7 +6497,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatur</translation>
+        <translation>Temperatur</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5810,11 +6509,11 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volumen</translation>
+        <translation>Volumen</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Dichte</translation>
+        <translation>Dichte</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5826,7 +6525,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Farbe</translation>
+        <translation>Farbe</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5838,7 +6537,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Berechnungen</translation>
+        <translation>Berechnungen</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5854,7 +6553,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5866,7 +6565,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">IBU Korrekturen</translation>
+        <translation>IBU Korrekturen</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5898,7 +6597,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Sprache</translation>
+        <translation>Sprache</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5908,7 +6607,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Know another language?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Or, would you like to improve a translation? Help us out and
@@ -5918,7 +6617,43 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Datum</translation>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6001,6 +6736,54 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6009,338 +6792,418 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Anstellverhältnis-Rechner</translation>
+        <translation>Anstellverhältnis-Rechner</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Eingabe</translation>
+        <translation>Eingabe</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Würzevolumen</translation>
+        <translation>Würzevolumen</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Stammwürze</translation>
+        <translation>Stammwürze</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Für Ales, 0.75-1. Für Lager, 1.5-2.</translation>
+        <translation>Für Ales, 0.75-1. Für Lager, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Anstellverhältnis (Mio. Zellen)/(ml*P)</translation>
+        <translation>Anstellverhältnis (Mio. Zellen)/(ml*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Berlüftungsmethode</translation>
+        <translation>Berlüftungsmethode</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Produktionsdatum der Hefe</translation>
+        <translation>Produktionsdatum der Hefe</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Hefe-Lebendigkeit</translation>
+        <translation>Hefe-Lebendigkeit</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Keine</translation>
+        <translation>Keine</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 am Start</translation>
+        <translation>O2 am Start</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Rührplatte</translation>
+        <translation>Rührplatte</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">MM/tt/jjjj</translation>
+        <translation>MM/tt/jjjj</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">TextLabel</translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Berechne Lebendigkeit vom Datum</translation>
+        <translation>Berechne Lebendigkeit vom Datum</translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Ausgabe</translation>
+        <translation>Ausgabe</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Millionen Hefezellen die benötigt werden</translation>
+        <translation>Millionen Hefezellen die benötigt werden</translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Trockenhefe</translation>
+        <translation>Trockenhefe</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Startervolumen</translation>
+        <translation>Startervolumen</translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Speiserechner</translation>
+        <translation>Speiserechner</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Eingabe</translation>
+        <translation>Eingabe</translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Menge an Bier zur Nachgärung</translation>
+        <translation>Menge an Bier zur Nachgärung</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Bier Temperatur</translation>
+        <translation>Bier Temperatur</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Temp. des Bieres</translation>
+        <translation>Temp. des Bieres</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Gewünschte Volumina</translation>
+        <translation>Gewünschte Volumina</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Wieviele Volumen CO2 möchten sie haben (1 Liter CO2 @ STP pro Liter Bier)</translation>
+        <translation>Wieviele Volumen CO2 möchten sie haben (1 Liter CO2 @ STP pro Liter Bier)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glukose-Monohydrat (Maiszucker)</translation>
+        <translation>Glukose-Monohydrat (Maiszucker)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Wasserfreie Glukose</translation>
+        <translation>Wasserfreie Glukose</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Saccharose (Rohrzucker)</translation>
+        <translation>Saccharose (Rohrzucker)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Trockenmalzextrakt</translation>
+        <translation>Trockenmalzextrakt</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Ausgabe</translation>
+        <translation>Ausgabe</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Karboniserung mi</translation>
+        <translation>Karboniserung mi</translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Berechne</translation>
+        <translation>Berechne</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formular</translation>
+        <translation>Formular</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Brauer</translation>
+        <translation>Brauer</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Brauhelfer</translation>
+        <translation>Brauhelfer</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Geschmacksbeurteilung</translation>
+        <translation>Geschmacksbeurteilung</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Dauer der Hauptgärung (Tage)</translation>
+        <translation>Dauer der Hauptgärung (Tage)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Temperatur der Hauptgärung (Tage)</translation>
+        <translation>Temperatur der Hauptgärung (Tage)</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Dauer der Nachgärung (Tage)</translation>
+        <translation>Dauer der Nachgärung (Tage)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Temperatur der Nachgärung (Tage)</translation>
+        <translation>Temperatur der Nachgärung (Tage)</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Reifungszeit (Tage)</translation>
+        <translation>Reifungszeit (Tage)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Reifungstemperatur</translation>
+        <translation>Reifungstemperatur</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Zeit in Flaschen/Fass (Tage)</translation>
+        <translation>Zeit in Flaschen/Fass (Tage)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Temperatur in Flaschen/Fass</translation>
+        <translation>Temperatur in Flaschen/Fass</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Datum des ersten Brauens</translation>
+        <translation>Datum des ersten Brauens</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">tt MMM jjjj</translation>
+        <translation>tt MMM jjjj</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Karbonisierung</translation>
+        <translation>Karbonisierung</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Geschmacksnotizen</translation>
+        <translation>Geschmacksnotizen</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notizen</translation>
+        <translation>Notizen</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Refraktiometer-Werkzeuge</translation>
+        <translation>Refraktiometer-Werkzeuge</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Eingaben</translation>
+        <translation>Eingaben</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Stammwürzegehalt (Plato)</translation>
+        <translation>Stammwürzegehalt (Plato)</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">OG (20 C)</translation>
+        <translation>OG (20 C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Aktueller Plato</translation>
+        <translation>Aktueller Plato</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Berechne</translation>
+        <translation>Berechne</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Ausgaben</translation>
+        <translation>Ausgaben</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">SG (20C)</translation>
+        <translation>SG (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">ABW</translation>
+        <translation>ABW</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Refraktionsindex</translation>
+        <translation>Refraktionsindex</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Wahrer Restextrakt (Plato)</translation>
+        <translation>Wahrer Restextrakt (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">OG (20 C)</translation>
+        <translation>OG (20 C)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Einmaischwasser-Rechner</translation>
+        <translation>Einmaischwasser-Rechner</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Anfänglicher Aufguss</translation>
+        <translation>Anfänglicher Aufguss</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Ursprüngliche Malz-Temperatur</translation>
+        <translation>Ursprüngliche Malz-Temperatur</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Zieltemperatur der Maische</translation>
+        <translation>Zieltemperatur der Maische</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Gewicht des Getreides</translation>
+        <translation>Gewicht des Getreides</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Wasservolumen</translation>
+        <translation>Wasservolumen</translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Gesamtvolumen des Wassers</translation>
+        <translation>Gesamtvolumen des Wassers</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Getreidegewicht</translation>
+        <translation>Getreidegewicht</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Aktuelle Maischetemperatur</translation>
+        <translation>Aktuelle Maischetemperatur</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Temperatur des Aufgusswassers</translation>
+        <translation>Temperatur des Aufgusswassers</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Berechnen</translation>
+        <translation>Berechnen</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Einmaischtemperatur</translation>
+        <translation>Einmaischtemperatur</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Zuzugebendes Volumen</translation>
+        <translation>Zuzugebendes Volumen</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Hinweis: Diese Berechnung setzt einen vorgeheizten Maischottich voraus.</translation>
+        <translation>Hinweis: Diese Berechnung setzt einen vorgeheizten Maischottich voraus.</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Style</source>
-        <translation type="vanished">Stil</translation>
+        <translation>Stil</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Ausgewählten Stil entfernen</translation>
+        <translation>Ausgewählten Stil entfernen</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6348,43 +7211,55 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Kategory</translation>
+        <translation>Kategory</translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Getränketyp</translation>
+        <translation>Getränketyp</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Met</translation>
+        <translation>Met</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Wiezen</translation>
+        <translation>Wiezen</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Gemischt</translation>
+        <translation>Gemischt</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Cider</translation>
+        <translation>Cider</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6392,51 +7267,51 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Max</translation>
+        <translation>Max</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Min.</translation>
+        <translation>Min.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBUs</translation>
+        <translation>IBUs</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Farbe (SRM)</translation>
+        <translation>Farbe (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Karbohydrate (Vol.)</translation>
+        <translation>Karbohydrate (Vol.)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Profil</translation>
+        <translation>Profil</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingredienzen</translation>
+        <translation>Ingredienzen</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Beispiele</translation>
+        <translation>Beispiele</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notizen</translation>
+        <translation>Notizen</translation>
     </message>
     <message>
         <source>New</source>
@@ -6450,6 +7325,50 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Abbruch</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
@@ -6457,23 +7376,229 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
         <source>Timers</source>
         <translation type="vanished">Eieruhren</translation>
     </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Stopp</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbruch</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>waterEditor</name>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notizen</translation>
+        <translation>Notizen</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Hefe-Editor</translation>
+        <translation>Hefe-Editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6481,51 +7606,51 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Name</translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Weizenbier</translation>
+        <translation>Weizenbier</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Wein</translation>
+        <translation>Wein</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Champagner</translation>
+        <translation>Champagner</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Form</translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Flüssig</translation>
+        <translation>Flüssig</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Trocken</translation>
+        <translation>Trocken</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Schrägagar</translation>
+        <translation>Schrägagar</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Kultur</translation>
+        <translation>Kultur</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6533,91 +7658,91 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Anhaken, wenn Mengenangabe in kg antatt L</translation>
+        <translation>Anhaken, wenn Mengenangabe in kg antatt L</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Mengenangabe ist Gewicht</translation>
+        <translation>Mengenangabe ist Gewicht</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Angehakt, wenn die Mengenangabe in Gewicht anstatt Volumen erfolgt</translation>
+        <translation>Angehakt, wenn die Mengenangabe in Gewicht anstatt Volumen erfolgt</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Labor</translation>
+        <translation>Labor</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">Produktnummer</translation>
+        <translation>Produktnummer</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Min Temp</translation>
+        <translation>Min Temp</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">minimale Temperatur</translation>
+        <translation>minimale Temperatur</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">max Temp</translation>
+        <translation>max Temp</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Maximale Temperatur</translation>
+        <translation>Maximale Temperatur</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Ausflockung</translation>
+        <translation>Ausflockung</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Niedrig</translation>
+        <translation>Niedrig</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Mittel</translation>
+        <translation>Mittel</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Hoch</translation>
+        <translation>Hoch</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Sehr Hoch</translation>
+        <translation>Sehr Hoch</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Vergärungsgrad (%)</translation>
+        <translation>Vergärungsgrad (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">scheinbarer Vergärungsgrad in Prozent</translation>
+        <translation>scheinbarer Vergärungsgrad in Prozent</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Führung Nr.</translation>
+        <translation>Führung Nr.</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Die Führung in der sich die Hefe befindet</translation>
+        <translation>Die Führung in der sich die Hefe befindet</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Max Führungen</translation>
+        <translation>Max Führungen</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Maximale Anzahl der Führungen für die Hefe</translation>
+        <translation>Maximale Anzahl der Führungen für die Hefe</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Zur Nachgärung hinzufügen</translation>
+        <translation>Zur Nachgärung hinzufügen</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Wenn angehakt, diese Hefe zur Nachgärung verwenden anstatt zur Hauptgärung</translation>
+        <translation>Wenn angehakt, diese Hefe zur Nachgärung verwenden anstatt zur Hauptgärung</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6633,11 +7758,39 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Menge im Lager</translation>
+        <translation>Menge im Lager</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Menge im Lager</translation>
+        <translation>Menge im Lager</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_el.ts
+++ b/translations/bt_el.ts
@@ -490,6 +490,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Συνταγή</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Ευρετήριο ειδών</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Ζυμώσιμα</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Μαγιά</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Ακύρωση</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1965,13 +2060,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">ελαχ.</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2413,15 +2501,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2727,80 +2815,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Άγνωστο</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Ευρετήριο ειδών</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Ποσότητα</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alpha %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2963,6 +2977,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Άγνωστο</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Ευρετήριο ειδών</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Ποσότητα</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3745,8 +3833,36 @@ The final volume in the primary is %1.</source>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Ακύρωση</translation>
+        <translation type="unfinished">Ακύρωση</translation>
     </message>
 </context>
 <context>
@@ -3759,12 +3875,56 @@ The final volume in the primary is %1.</source>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Έναρξη</translation>
+        <translation type="unfinished">Έναρξη</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Διακοπή</translation>
+        <translation type="unfinished">Διακοπή</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4210,54 +4370,73 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Πλαίσιο διαλόγου</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Μορφή</translation>
+        <translation>Μορφή</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Δημιουργία οδηγιών</translation>
+        <translation>Δημιουργία οδηγιών</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Εισάγετε βήμα</translation>
+        <translation>Εισάγετε βήμα</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Ονομασία νέου βήματος</translation>
+        <translation>Ονομασία νέου βήματος</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Βήμα #</translation>
+        <translation>Βήμα #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Σειρά  στην οποία θα μπει το νέο βήμα</translation>
+        <translation>Σειρά  στην οποία θα μπει το νέο βήμα</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Εισάγετε νέο βήμα</translation>
+        <translation>Εισάγετε νέο βήμα</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Μετακίνηση βήματος</translation>
+        <translation>Μετακίνηση βήματος</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Μετακίνηση του επιλεγμένου βήματος πάνω</translation>
+        <translation>Μετακίνηση του επιλεγμένου βήματος πάνω</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Μετακίνηση του επιλεγμένου βήματος κάτω</translation>
+        <translation>Μετακίνηση του επιλεγμένου βήματος κάτω</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Διαγραφή του επιλεγμένου βήματος</translation>
+        <translation>Διαγραφή του επιλεγμένου βήματος</translation>
     </message>
 </context>
 <context>
@@ -4327,27 +4506,27 @@ The final volume in the primary is %1.</source>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Πριν τον βρασμό</translation>
+        <translation>Πριν τον βρασμό</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Πυκνότητα πριν το βρασμό</translation>
+        <translation>Πυκνότητα πριν το βρασμό</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Όγκος</translation>
+        <translation>Όγκος</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Όγκος γλεύκους που συλλέχτηκε</translation>
+        <translation>Όγκος γλεύκους που συλλέχτηκε</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Strike Temp</translation>
+        <translation>Strike Temp</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4355,59 +4534,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Τελική Θερμοκρασία</translation>
+        <translation>Τελική Θερμοκρασία</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Θερμοκρασία σακχαροποίησης πριν το τέλος</translation>
+        <translation>Θερμοκρασία σακχαροποίησης πριν το τέλος</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">μετά τον βρασμό</translation>
+        <translation>μετά τον βρασμό</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">πυκνότητα μετά τον βρασμό</translation>
+        <translation>πυκνότητα μετά τον βρασμό</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Όγκος μετά τον βρασμό</translation>
+        <translation>Όγκος μετά τον βρασμό</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Όγκος στο καζάνι μετά τον βρασμό</translation>
+        <translation>Όγκος στο καζάνι μετά τον βρασμό</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Όγκος γλεύκους που μεταφέρθηκε στον κάδο ζύμωσης</translation>
+        <translation>Όγκος γλεύκους που μεταφέρθηκε στον κάδο ζύμωσης</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Όγκος στον κάδο ζύμωσης</translation>
+        <translation>Όγκος στον κάδο ζύμωσης</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Θερμοκρασία ρίψης της μαγιάς</translation>
+        <translation> Θερμοκρασία ρίψης της μαγιάς</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Θερμοκρασία του γλέυκους κατά την ρίψη της μαγιάς</translation>
+        <translation>Θερμοκρασία του γλέυκους κατά την ρίψη της μαγιάς</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Μετά την ζύμωση</translation>
+        <translation>Μετά την ζύμωση</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Τελική πυκνότητα</translation>
+        <translation>Τελική πυκνότητα</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Όγκος μπύρας σε μποτίλιες</translation>
+        <translation>Όγκος μπύρας σε μποτίλιες</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4423,11 +4602,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Προβλεπόμενη OG</translation>
+        <translation>Προβλεπόμενη OG</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Απόδοση εξοπλισμού</translation>
+        <translation>Απόδοση εξοπλισμού</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4439,7 +4618,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Προβλεπόμενοι ABV</translation>
+        <translation>Προβλεπόμενοι ABV</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4447,11 +4626,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Σημειώσεις</translation>
+        <translation>Σημειώσεις</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4470,14 +4697,182 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Νεκρός χώρος στο Lauter</translation>
+        <translation>Νεκρός χώρος στο Lauter</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Επεξεργασία εξοπλισμού</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Εξοπλισμός</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Ορισμός ως Προεπιλογή</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Όγκος παρτίδας</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Χρόνος</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Υπολογισμός όγκου πριν το βρασμό</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Διάρκεια βρασμού</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Ποσοστό εξάτμισης (ανα ώρα)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">τελική προσθήκη νερού</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Συμπηρωματική ποσότητα νερού την μαρμίτα</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Μέση απορρόφηση</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Σημείο βρασμού του νερού</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Όγκος σκεύους σακχαροποίησης</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Σημειώσεις</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Νέος εξοπλισμός</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Διόρθωση Ζυμώσιμων</translation>
+        <translation>Διόρθωση Ζυμώσιμων</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4485,31 +4880,31 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Τύπος</translation>
+        <translation>Τύπος</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Σιτηρά</translation>
+        <translation>Σιτηρά</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Σάκχαρα</translation>
+        <translation>Σάκχαρα</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Υγρή Βύνη</translation>
+        <translation>Υγρή Βύνη</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Ξηρή Βύνη</translation>
+        <translation>Ξηρή Βύνη</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Πρόσθετα</translation>
+        <translation>Πρόσθετα</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4521,43 +4916,43 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Απόδοση σε σύγκριση με  γλυκόζη</translation>
+        <translation>Απόδοση σε σύγκριση με  γλυκόζη</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Βαθμοί Lovibond</translation>
+        <translation>Βαθμοί Lovibond</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Προσθήκη μετά τον βρασμό</translation>
+        <translation>Προσθήκη μετά τον βρασμό</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Αυτό το συστατικό προστίθεται μετά το βράσιμο</translation>
+        <translation>Αυτό το συστατικό προστίθεται μετά το βράσιμο</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Προέλευση</translation>
+        <translation>Προέλευση</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Προμηθευτής</translation>
+        <translation>Προμηθευτής</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Χοντροκομμένο/Ψιλοκομμένο Διαφορά (%)</translation>
+        <translation>Χοντροκομμένο/Ψιλοκομμένο Διαφορά (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Διαφορά απόδοσης μεταξύ χοντροαλεσμένου και ψιλοαλεσμένου</translation>
+        <translation>Διαφορά απόδοσης μεταξύ χοντροαλεσμένου και ψιλοαλεσμένου</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Υγρασία (%)</translation>
+        <translation>Υγρασία (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Ποσοστό υγρασίας κατά μάζα</translation>
+        <translation>Ποσοστό υγρασίας κατά μάζα</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4569,43 +4964,43 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Πρωτεΐνες</translation>
+        <translation>Πρωτεΐνες</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Ποσοστό πρωτεΐνης με βάση την μάζα</translation>
+        <translation>Ποσοστό πρωτεΐνης με βάση την μάζα</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Μέγιστη ποσότητα ανά παρτίδα (%)</translation>
+        <translation>Μέγιστη ποσότητα ανά παρτίδα (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Μεγιστη συνιστόμενη ποσότητα</translation>
+        <translation>Μεγιστη συνιστόμενη ποσότητα</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Προτείνεται κατά την σακχαροποίηση</translation>
+        <translation>Προτείνεται κατά την σακχαροποίηση</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Πρότείνεται να σακχαροποιήται</translation>
+        <translation>Πρότείνεται να σακχαροποιήται</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Σακχαροποιήται</translation>
+        <translation>Σακχαροποιήται</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Σημειώστε αν πρέπει να βρίσκεται κατά την σακχαροποίηση</translation>
+        <translation>Σημειώστε αν πρέπει να βρίσκεται κατά την σακχαροποίηση</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Πικράδα (IBU*gal/lb)</translation>
+        <translation>Πικράδα (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Βαθμός πικρότητας εκχυλισμάτων</translation>
+        <translation>Βαθμός πικρότητας εκχυλισμάτων</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4617,22 +5012,70 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Ποσότητα στο ευρετήριο</translation>
+        <translation>Ποσότητα στο ευρετήριο</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Ποσότητα στο ευρετήριο</translation>
+        <translation>Ποσότητα στο ευρετήριο</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Χρώμα</translation>
+        <translation>Χρώμα</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Απόδοση %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Πρόσθετα</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Σημειώσεις</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Επεξεργασία λυκίσκου</translation>
+        <translation>Επεξεργασία λυκίσκου</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4640,7 +5083,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4648,7 +5091,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Alpha οξέα σε ποσοστό επί της μάζας</translation>
+        <translation>Alpha οξέα σε ποσοστό επί της μάζας</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4656,59 +5099,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Χρήση</translation>
+        <translation>Χρήση</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Στο σκεύος σακχαροποίησης</translation>
+        <translation>Στο σκεύος σακχαροποίησης</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Πρίν το βράσιμο</translation>
+        <translation>Πρίν το βράσιμο</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Στο Βράσιμο</translation>
+        <translation>Στο Βράσιμο</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Για άρωμα</translation>
+        <translation>Για άρωμα</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">στον κάδο ζύμωσης</translation>
+        <translation>στον κάδο ζύμωσης</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Χρόνος</translation>
+        <translation>Χρόνος</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Είδος</translation>
+        <translation>Είδος</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Πικράδα</translation>
+        <translation>Πικράδα</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Και τα δύο</translation>
+        <translation>Και τα δύο</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Μορφή</translation>
+        <translation>Μορφή</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">σε φύλλα</translation>
+        <translation>σε φύλλα</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Σφαιρίδια</translation>
+        <translation>Σφαιρίδια</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Ανθός</translation>
+        <translation>Ανθός</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4716,19 +5159,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Οξέα Beta  ως πσοστό επι της μάζας</translation>
+        <translation>Οξέα Beta  ως πσοστό επι της μάζας</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Σταθερότητα λυκίσκου/Αποθήκευση</translation>
+        <translation>Σταθερότητα λυκίσκου/Αποθήκευση</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Προέλευση</translation>
+        <translation>Προέλευση</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4736,7 +5179,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulene</translation>
+        <translation>Humulene</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4752,7 +5195,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulone</translation>
+        <translation>Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4760,7 +5203,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcene</translation>
+        <translation>Myrcene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4776,65 +5219,121 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Ποσότητα στο ευρετήριο</translation>
+        <translation>Ποσότητα στο ευρετήριο</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Ποσότητα στο ευρετήριο</translation>
+        <translation>Ποσότητα στο ευρετήριο</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Πρόσθετα</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Σημειώσεις</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Μορφή</translation>
+        <translation>Μορφή</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Χρονόμετρο</translation>
+        <translation>Χρονόμετρο</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Εμφάνιση χρονομέτρου</translation>
+        <translation>Εμφάνιση χρονομέτρου</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">ανήγγειλε αυτό το βήμα ώς ολοκληρωμένο</translation>
+        <translation>ανήγγειλε αυτό το βήμα ώς ολοκληρωμένο</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Το βήμα ολοκληρώθηκε</translation>
+        <translation>Το βήμα ολοκληρώθηκε</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Συνταγές</translation>
+        <translation>Συνταγές</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Στυλ</translation>
+        <translation>Στυλ</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Ζυμώσιμα</translation>
+        <translation>Ζυμώσιμα</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Λυκίσκοι</translation>
+        <translation>Λυκίσκοι</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Διάφορα</translation>
+        <translation>Διάφορα</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Μαγιές</translation>
+        <translation>Μαγιές</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Συνταγή</translation>
+        <translation>Συνταγή</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4842,11 +5341,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Ονομασία συνταγής</translation>
+        <translation>Ονομασία συνταγής</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Όγκος που επιθυμούμε</translation>
+        <translation>Όγκος που επιθυμούμε</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4862,7 +5361,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Πσοστό απόδοσης που περιμένουμε</translation>
+        <translation>Πσοστό απόδοσης που περιμένουμε</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4874,7 +5373,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Μέγεθος παρτίδας που επιθυμούμε</translation>
+        <translation>Μέγεθος παρτίδας που επιθυμούμε</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4882,7 +5381,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Εξοπλισμός</translation>
+        <translation>Εξοπλισμός</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4890,163 +5389,163 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">SG βρασμού</translation>
+        <translation>SG βρασμού</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Πικρότητα (IBU)</translation>
+        <translation>Πικρότητα (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Χρώμα</translation>
+        <translation>Χρώμα</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Θερμίδες/12 ουγγιές</translation>
+        <translation>Θερμίδες/12 ουγγιές</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Πρόσθετα</translation>
+        <translation>Πρόσθετα</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Μέρα ζυθοποίησης</translation>
+        <translation>Μέρα ζυθοποίησης</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Προσθέστε ζυμώσιμα</translation>
+        <translation>Προσθέστε ζυμώσιμα</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Αφαιρέστε το επιλεγμένο ζυμώσιμο</translation>
+        <translation>Αφαιρέστε το επιλεγμένο ζυμώσιμο</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Επεξεργαστείτε  το επιλεγμένο ζυμώσιμο</translation>
+        <translation>Επεξεργαστείτε  το επιλεγμένο ζυμώσιμο</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Προσθέστε λυκίσκο</translation>
+        <translation>Προσθέστε λυκίσκο</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Αφαιρέστε τον επιλεγμένο λυκίσκο</translation>
+        <translation>Αφαιρέστε τον επιλεγμένο λυκίσκο</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">επεξεργαστείτε τον επιλεγμένο λυκίσκο</translation>
+        <translation>επεξεργαστείτε τον επιλεγμένο λυκίσκο</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Διάφορα</translation>
+        <translation>Διάφορα</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">προσθέστε διαφ.</translation>
+        <translation>προσθέστε διαφ.</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Αφαιρέστε τα επιλεγμένα διαφ.</translation>
+        <translation>Αφαιρέστε τα επιλεγμένα διαφ.</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Επεξεργαστείτε τα επιλεγμένα διαφ.</translation>
+        <translation>Επεξεργαστείτε τα επιλεγμένα διαφ.</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Μαγιά</translation>
+        <translation>Μαγιά</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Προσθέστε μαγιά</translation>
+        <translation>Προσθέστε μαγιά</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Αφαιρέστε την επιλεγμένη μαγιά</translation>
+        <translation>Αφαιρέστε την επιλεγμένη μαγιά</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Επεξεργαστείτε την επιλεγμένη μαγιά</translation>
+        <translation>Επεξεργαστείτε την επιλεγμένη μαγιά</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Σκεύος σακχαροποίησης</translation>
+        <translation>Σκεύος σακχαροποίησης</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Νέο βήμα σακχαροποίησης</translation>
+        <translation>Νέο βήμα σακχαροποίησης</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Αφαιρέστε το επιλεγμένο βήμα σακχ/σης</translation>
+        <translation>Αφαιρέστε το επιλεγμένο βήμα σακχ/σης</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Επεξεργαστέιτε το επιλεγμένο βήμα mash</translation>
+        <translation>Επεξεργαστέιτε το επιλεγμένο βήμα mash</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Ιδιότητες mash</translation>
+        <translation>Ιδιότητες mash</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Edit mash</translation>
+        <translation>Edit mash</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Περιγραφή</translation>
+        <translation>Περιγραφή</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Εκκίνηση του mash wizard</translation>
+        <translation>Εκκίνηση του mash wizard</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Mash wiz</translation>
+        <translation>Mash wiz</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Mashs</translation>
+        <translation>Mashs</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Βήμα σακχ/σης πάνω</translation>
+        <translation>Βήμα σακχ/σης πάνω</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">βήμα σακχ/σης  κάτω</translation>
+        <translation>βήμα σακχ/σης  κάτω</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Αποθήκευση αυτού του προφιλ σακχ/σης</translation>
+        <translation>Αποθήκευση αυτού του προφιλ σακχ/σης</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Αποθήκευση Mash</translation>
+        <translation>Αποθήκευση Mash</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Σχετικά</translation>
+        <translation>&amp;Σχετικά</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Αρχείο</translation>
+        <translation>&amp;Αρχείο</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5058,27 +5557,27 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Βάση δεδομένων</translation>
+        <translation>&amp;Βάση δεδομένων</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Προβολή</translation>
+        <translation>&amp;Προβολή</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Εργαλεία</translation>
+        <translation>&amp;Εργαλεία</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Γραμμή εργαλείων</translation>
+        <translation>Γραμμή εργαλείων</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">Σχετικά &amp;BrewTarget</translation>
+        <translation>Σχετικά &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Σχετικά με το Brewtarget</translation>
+        <translation>Σχετικά με το Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5086,19 +5585,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Ζυμώσιμα</translation>
+        <translation>&amp;Ζυμώσιμα</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Λυκίσκοι</translation>
+        <translation>&amp;Λυκίσκοι</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5106,31 +5605,31 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Μαγιές</translation>
+        <translation>&amp;Μαγιές</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Εξοπλισμός</translation>
+        <translation>&amp;Εξοπλισμός</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Στυλ</translation>
+        <translation>&amp;Στυλ</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5138,7 +5637,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5150,55 +5649,55 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">οδηγίες</translation>
+        <translation>οδηγίες</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Μετατροπή συνταγής</translation>
+        <translation>&amp;Μετατροπή συνταγής</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Συνταγή  στην επικόλληση  ως αρχείο &amp;Text</translation>
+        <translation>Συνταγή  στην επικόλληση  ως αρχείο &amp;Text</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">&amp;Βοήθημα διόρθωσης OG</translation>
+        <translation>&amp;Βοήθημα διόρθωσης OG</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Μετατροπή μονάδων μέτρησης</translation>
+        <translation>&amp;Μετατροπή μονάδων μέτρησης</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Αντίγραφο ασφαλείας βάσης δεδομένων</translation>
+        <translation>Αντίγραφο ασφαλείας βάσης δεδομένων</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Επαναφορά Βάσης Δεδομένων</translation>
+        <translation>Επαναφορά Βάσης Δεδομένων</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Αντιγραφή Συνταγής</translation>
+        <translation>&amp;Αντιγραφή Συνταγής</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Υπολογισμός ανθρακικού</translation>
+        <translation>Υπολογισμός ανθρακικού</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">&amp;Διαθλασίμετρο</translation>
+        <translation>&amp;Διαθλασίμετρο</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">&amp;Υπολογισμός starter</translation>
+        <translation>&amp;Υπολογισμός starter</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Συγχώνευση βάσεων δεδομένων</translation>
+        <translation>Συγχώνευση βάσεων δεδομένων</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Επιλέξτε μια άλλη βάση δεδομένων για συγχώνευση με την τρέχουσα</translation>
+        <translation>Επιλέξτε μια άλλη βάση δεδομένων για συγχώνευση με την τρέχουσα</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5218,19 +5717,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Αντίγραφο ασφαλείας</translation>
+        <translation>&amp;Αντίγραφο ασφαλείας</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Αποθηκευση όλων των συνταγών, συστατικών, κλπ σε αρχείο ασφαλείας</translation>
+        <translation>Αποθηκευση όλων των συνταγών, συστατικών, κλπ σε αρχείο ασφαλείας</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Επαναφορά</translation>
+        <translation>&amp;Επαναφορά</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">επαναφορά συνταγών, συστατικών, κλπ από προηγούμενο αντίγραφο ασφαλείας</translation>
+        <translation>επαναφορά συνταγών, συστατικών, κλπ από προηγούμενο αντίγραφο ασφαλείας</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5242,7 +5741,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Νέα Συνταγή</translation>
+        <translation>&amp;Νέα Συνταγή</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5250,42 +5749,162 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Εμφάνιση χρονόμετρων</translation>
+        <translation>Εμφάνιση χρονόμετρων</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Αποθήκευση</translation>
+        <translation>Αποθήκευση</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Διαγραφή επιλεγμένου</translation>
+        <translation>Διαγραφή επιλεγμένου</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Διαγραφή συνταγής</translation>
+        <translation>Διαγραφή συνταγής</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Mashs</translation>
+        <translation>&amp;Mashs</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Mashes</translation>
+        <translation>Mashes</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
         <translation type="vanished">Υπολογισμός Θερμοκρασίας νερού</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Όγκος παρτίδας</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Όγκος βρασμού</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Ζυθοποίησε!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Σχεδιασμός σακχ/σης</translation>
+        <translation>Σχεδιασμός σακχ/σης</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5301,7 +5920,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Χρόνος</translation>
+        <translation>Χρόνος</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5309,275 +5928,311 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Επόμενο</translation>
+        <translation>Επόμενο</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Λήξη</translation>
+        <translation>Λήξη</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Ποσότητα έγχυσης/decoction</translation>
+        <translation>Ποσότητα έγχυσης/decoction</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">ελαχ.</translation>
+        <translation>ελαχ.</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">μέγ.</translation>
+        <translation>μέγ.</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Θερμοκρασία έγχυσης</translation>
+        <translation>Θερμοκρασία έγχυσης</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Συνολικό γλεύκος</translation>
+        <translation>Συνολικό γλεύκος</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">vol</translation>
+        <translation>vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">σκεύος γεμάτο</translation>
+        <translation>σκεύος γεμάτο</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">όγκος σκεύους</translation>
+        <translation>όγκος σκεύους</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">πάχος</translation>
+        <translation>πάχος</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Επεξεργασία σακχαροποίησης</translation>
+        <translation>Επεξεργασία σακχαροποίησης</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Αρχική θερμοκρασία σιτηρών</translation>
+        <translation>Αρχική θερμοκρασία σιτηρών</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Θερμοκρασία ψεκασμού</translation>
+        <translation>Θερμοκρασία ψεκασμού</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Επιθυμητή θερμοκρασία ψεκασμού</translation>
+        <translation>Επιθυμητή θερμοκρασία ψεκασμού</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">PH ψεκασμού</translation>
+        <translation>PH ψεκασμού</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Σημειώσεις</translation>
+        <translation>Σημειώσεις</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">σκεύος σακχ/σης</translation>
+        <translation>σκεύος σακχ/σης</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Αρχική θερμοκρασία σκεύους</translation>
+        <translation>Αρχική θερμοκρασία σκεύους</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Συμπληρώστε τις παραμέτρους  από τον εξοπλισμό</translation>
+        <translation>Συμπληρώστε τις παραμέτρους  από τον εξοπλισμό</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Από τον εξοπλισμό</translation>
+        <translation>Από τον εξοπλισμό</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">μάζα σκεύους</translation>
+        <translation>μάζα σκεύους</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Tun sp. heat</translation>
+        <translation>Tun sp. heat</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Συγκεκριμένη θερμοκρασία σκεύους (cal/(g*K))</translation>
+        <translation>Συγκεκριμένη θερμοκρασία σκεύους (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">επεξεργασία βήματος σακχ/σης</translation>
+        <translation>επεξεργασία βήματος σακχ/σης</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Είδος</translation>
+        <translation>Είδος</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Έγχυση</translation>
+        <translation>Έγχυση</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Θερμοκρασία</translation>
+        <translation>Θερμοκρασία</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Decoction</translation>
+        <translation>Decoction</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Επιθυμητή θερμ.</translation>
+        <translation>Επιθυμητή θερμ.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Επιθυμητή θερμ. αυτού του βήματος</translation>
+        <translation>Επιθυμητή θερμ. αυτού του βήματος</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Ποσότητα έγχυσης</translation>
+        <translation>Ποσότητα έγχυσης</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Ποσότητα νερού για την έγχυση</translation>
+        <translation>Ποσότητα νερού για την έγχυση</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Θερμοκρασία έγχυσης</translation>
+        <translation>Θερμοκρασία έγχυσης</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">θερμοκρασία του προοριζόμενου για έγχυση νερού</translation>
+        <translation>θερμοκρασία του προοριζόμενου για έγχυση νερού</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Ποσότητα decoction</translation>
+        <translation>Ποσότητα decoction</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Ποσότητα γλεύκους για decoction</translation>
+        <translation>Ποσότητα γλεύκους για decoction</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Χρόνος</translation>
+        <translation>Χρόνος</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Ώρα για την διεξαγωγή του βήματος</translation>
+        <translation>Ώρα για την διεξαγωγή του βήματος</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Temp. lag time</translation>
+        <translation>Temp. lag time</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Lag time</translation>
+        <translation>Lag time</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Τελ. Θερμ.</translation>
+        <translation>Τελ. Θερμ.</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Τελική θερμ. αυτού του βήματος</translation>
+        <translation>Τελική θερμ. αυτού του βήματος</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">τμηματικός ψεκασμός</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Οδηγός Σακχαροποίησης</translation>
+        <translation>Οδηγός Σακχαροποίησης</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Πυκνότητα σακχαροποίησης (L/kg)</translation>
+        <translation>Πυκνότητα σακχαροποίησης (L/kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">πυκνότητα σακχαροποίησης. ( μην εισάγετε στοιχεία)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Επεξεργασία διαφόρων</translation>
+        <translation>Επεξεργασία διαφόρων</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Είδος</translation>
+        <translation>Είδος</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Μπαχαρικά</translation>
+        <translation>Μπαχαρικά</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Βελτιωτικά</translation>
+        <translation>Βελτιωτικά</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Ρυθμιστής νερού</translation>
+        <translation>Ρυθμιστής νερού</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Βότανα</translation>
+        <translation>Βότανα</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Άρωματικές Ύλες</translation>
+        <translation>Άρωματικές Ύλες</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">&apos;Αλλο</translation>
+        <translation>&apos;Αλλο</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Χρήση</translation>
+        <translation>Χρήση</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Στο Βράσιμο</translation>
+        <translation>Στο Βράσιμο</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Στο σκεύος σακχ/σης</translation>
+        <translation>Στο σκεύος σακχ/σης</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Κατά την πρώτη ζύμωση</translation>
+        <translation>Κατά την πρώτη ζύμωση</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">κατά την δεύτερη ζύμωση</translation>
+        <translation>κατά την δεύτερη ζύμωση</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Κατά την εμφιάλωση</translation>
+        <translation>Κατά την εμφιάλωση</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Χρόνος</translation>
+        <translation>Χρόνος</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5585,15 +6240,15 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Τσέκαρε το εαν το ποσό που αναγράφεται είναι σε κιλά αντί για λίτρα</translation>
+        <translation>Τσέκαρε το εαν το ποσό που αναγράφεται είναι σε κιλά αντί για λίτρα</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Το ποσό αναφέρεται σε βάρος;</translation>
+        <translation>Το ποσό αναφέρεται σε βάρος;</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Τσέκαρε το εαν το αναφερόμενο ποσό είναι βάρος αντί για όγκος</translation>
+        <translation>Τσέκαρε το εαν το αναφερόμενο ποσό είναι βάρος αντί για όγκος</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5609,192 +6264,220 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Ποσότητα στο ευρετήριο</translation>
+        <translation>Ποσότητα στο ευρετήριο</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Ποσότητα στο ευρετήριο</translation>
+        <translation>Ποσότητα στο ευρετήριο</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Σημειώσεις</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Named Mash Editor</translation>
+        <translation>Named Mash Editor</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Σακχαροποίηση</translation>
+        <translation>Σακχαροποίηση</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Διέγραψε το επιλεγμένο στυλ</translation>
+        <translation>Διέγραψε το επιλεγμένο στυλ</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Αρχική θερμοκρασία σιτηρών</translation>
+        <translation>Αρχική θερμοκρασία σιτηρών</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Θερμοκρασία ψεκασμού</translation>
+        <translation>Θερμοκρασία ψεκασμού</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Επιθυμητή θερμοκρασία ψεκασμού</translation>
+        <translation>Επιθυμητή θερμοκρασία ψεκασμού</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">PH ψεκασμού</translation>
+        <translation>PH ψεκασμού</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Σημειώσεις</translation>
+        <translation>Σημειώσεις</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">σκεύος σακχ/σης</translation>
+        <translation>σκεύος σακχ/σης</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Αρχική θερμοκρασία σκεύους</translation>
+        <translation>Αρχική θερμοκρασία σκεύους</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Από τον εξοπλισμό</translation>
+        <translation>Από τον εξοπλισμό</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">μάζα σκεύους</translation>
+        <translation>μάζα σκεύους</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Συγκ. Θερμ. σκ.</translation>
+        <translation>Συγκ. Θερμ. σκ.</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Συγκεκριμένη θερμοκρασία σκεύους (cal/(g*K))</translation>
+        <translation>Συγκεκριμένη θερμοκρασία σκεύους (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Νέο βήμα σακχ/σης</translation>
+        <translation>Νέο βήμα σακχ/σης</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Αφαιρέστε το επιλεγμένο βήμα σακχ/σης</translation>
+        <translation>Αφαιρέστε το επιλεγμένο βήμα σακχ/σης</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Βήμα σακχ/σης πάνω</translation>
+        <translation>Βήμα σακχ/σης πάνω</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">βήμα σακχ/σης  κάτω</translation>
+        <translation>βήμα σακχ/σης  κάτω</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Ρύθμιση όγκου για να συμπέσει με την OG</translation>
+        <translation>Ρύθμιση όγκου για να συμπέσει με την OG</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Εισαγωγή</translation>
+        <translation>Εισαγωγή</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Υπολογισμένη πυκνότητα προ του βρασμού</translation>
+        <translation>Υπολογισμένη πυκνότητα προ του βρασμού</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Θερμ.</translation>
+        <translation>Θερμ.</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Θερμοκρασία της SG</translation>
+        <translation>Θερμοκρασία της SG</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Θερμοκρασία ρύθμισης</translation>
+        <translation>Θερμοκρασία ρύθμισης</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">θερμοκρασία που είναι ρυθμισμένο το υδρόμετρο</translation>
+        <translation>θερμοκρασία που είναι ρυθμισμένο το υδρόμετρο</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-ή-</translation>
+        <translation>-ή-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (percent by mass of equivalent sucrose)</translation>
+        <translation>Plato (percent by mass of equivalent sucrose)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Όγκος προ-βρασμού</translation>
+        <translation>Όγκος προ-βρασμού</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">καταμετρημένος προ-βρασμού όγκος</translation>
+        <translation>καταμετρημένος προ-βρασμού όγκος</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Μετατροπή</translation>
+        <translation>Μετατροπή</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">OG  χωρίς διόρθωση</translation>
+        <translation>OG  χωρίς διόρθωση</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">OG εαν βράσατε κατά το σχέδιο</translation>
+        <translation>OG εαν βράσατε κατά το σχέδιο</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">προσθήκη στο βράσιμο</translation>
+        <translation>προσθήκη στο βράσιμο</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Ποσότητα νερού που απαιτείται για να επιτευχθεί η OG</translation>
+        <translation>Ποσότητα νερού που απαιτείται για να επιτευχθεί η OG</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Τελικός όγκος παρτίδας</translation>
+        <translation>Τελικός όγκος παρτίδας</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Προβλεπόμενος όγκος παρτίδας μετά την διόρθωση</translation>
+        <translation>Προβλεπόμενος όγκος παρτίδας μετά την διόρθωση</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Υπολογισμός</translation>
+        <translation>Υπολογισμός</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Επιλογές</translation>
+        <translation>Επιλογές</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Μονάδες</translation>
+        <translation>Μονάδες</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Βάρος</translation>
+        <translation>Βάρος</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5810,7 +6493,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Θερμοκρασία</translation>
+        <translation>Θερμοκρασία</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5822,11 +6505,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Όγκος</translation>
+        <translation>Όγκος</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Πυκνότητα</translation>
+        <translation>Πυκνότητα</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5838,7 +6521,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Χρώμα</translation>
+        <translation>Χρώμα</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5850,7 +6533,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Φόρμουλες</translation>
+        <translation>Φόρμουλες</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5866,7 +6549,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5878,7 +6561,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Προσαρμογή IBU</translation>
+        <translation>Προσαρμογή IBU</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5914,7 +6597,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Γλώσσα</translation>
+        <translation>Γλώσσα</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5924,7 +6607,7 @@ The final volume in the primary is %1.</source>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Γνωρίζεις κάποια άλλη γλώσσα;&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Ή, θα ήθελες να βελτιώσεις μια ήδη υπάρχουσα μετάφραση; Βοήθησε μας και
@@ -5934,7 +6617,43 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Ημερομηνία</translation>
+        <translation>Ημερομηνία</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6017,6 +6736,54 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6025,362 +6792,418 @@ The final volume in the primary is %1.</source>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Pitch Rate Calculator</translation>
+        <translation>Pitch Rate Calculator</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Εισαγωγή</translation>
+        <translation>Εισαγωγή</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Όγκος γλεύκους</translation>
+        <translation>Όγκος γλεύκους</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Για ales, 0.75-1. Για lagers, 1.5-2.</translation>
+        <translation>Για ales, 0.75-1. Για lagers, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Pitch Rate (M cells)/(mL*P)</translation>
+        <translation>Pitch Rate (M cells)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Μέθοδος αερισμού</translation>
+        <translation>Μέθοδος αερισμού</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Ημερομηνία παραγωγής μαγιάς</translation>
+        <translation>Ημερομηνία παραγωγής μαγιάς</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Βιωσιμότητα μαγιάς</translation>
+        <translation>Βιωσιμότητα μαγιάς</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Καμία</translation>
+        <translation>Καμία</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 στο ξεκίνημα</translation>
+        <translation>O2 στο ξεκίνημα</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">συσκευή ανάδευσης</translation>
+        <translation>συσκευή ανάδευσης</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">ΜΜ/ηη/εεεε</translation>
+        <translation>ΜΜ/ηη/εεεε</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">Ετικέτα</translation>
+        <translation>Ετικέτα</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Υπολογισμός βιωσιμότητας από την ημ/νια</translation>
+        <translation>Υπολογισμός βιωσιμότητας από την ημ/νια</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished">Φιαλίδια/πακέτα που χρησιμοποιήθηκαν</translation>
+        <translation>Φιαλίδια/πακέτα που χρησιμοποιήθηκαν</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Αποτέλεσμα</translation>
+        <translation>Αποτέλεσμα</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Δισ. κυττάρων μαγιάς που χρειάζονται</translation>
+        <translation>Δισ. κυττάρων μαγιάς που χρειάζονται</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished">Φιαλίδια/πακέτα χωρίς starter</translation>
+        <translation>Φιαλίδια/πακέτα χωρίς starter</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Ξηρή μαγιά</translation>
+        <translation>Ξηρή μαγιά</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Όγκος starter</translation>
+        <translation>Όγκος starter</translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Υπολογισμός CO2</translation>
+        <translation>Υπολογισμός CO2</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Εισαγωγή</translation>
+        <translation>Εισαγωγή</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Συνολικός όγκος μπύρας</translation>
+        <translation>Συνολικός όγκος μπύρας</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Ποσότητα μπύρας για γόμωση</translation>
+        <translation>Ποσότητα μπύρας για γόμωση</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Θερμοκρασία μπύρας</translation>
+        <translation>Θερμοκρασία μπύρας</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Θερμ. μπύρας</translation>
+        <translation>Θερμ. μπύρας</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Επιθυμητή ποσότητα CO2</translation>
+        <translation>Επιθυμητή ποσότητα CO2</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Πόσο όγκο  CO2 θέλετε; (1 L CO2 @ STP ανά L μπύρας)</translation>
+        <translation>Πόσο όγκο  CO2 θέλετε; (1 L CO2 @ STP ανά L μπύρας)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glucose Monohydrate (Δεξτρόζη)</translation>
+        <translation>Glucose Monohydrate (Δεξτρόζη)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Άνυδρη γλυκόζη</translation>
+        <translation>Άνυδρη γλυκόζη</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sucrose (κοινή ζάχαρη)</translation>
+        <translation>Sucrose (κοινή ζάχαρη)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Ξηρή βύνη</translation>
+        <translation>Ξηρή βύνη</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Αποτέλεσμα</translation>
+        <translation>Αποτέλεσμα</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Γόμωση με</translation>
+        <translation>Γόμωση με</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Πόσο υλικό για την γόμμωση θα χρησιμοποιήσετε</translation>
+        <translation>Πόσο υλικό για την γόμμωση θα χρησιμοποιήσετε</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Υπολογισμός</translation>
+        <translation>Υπολογισμός</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Μορφή</translation>
+        <translation>Μορφή</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Ζυθοποιός</translation>
+        <translation>Ζυθοποιός</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Βοηθός</translation>
+        <translation>Βοηθός</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">εκτίμηση γεύσης</translation>
+        <translation>εκτίμηση γεύσης</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Ωρίμανση στον αρχικό κάδο ζήμωσης  (ημέρες)</translation>
+        <translation>Ωρίμανση στον αρχικό κάδο ζήμωσης  (ημέρες)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Θερμοκρασία</translation>
+        <translation>Θερμοκρασία</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Ωρίμανση στον δεύτευρο κάδο  (ημέρες)</translation>
+        <translation>Ωρίμανση στον δεύτευρο κάδο  (ημέρες)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Θερμοκρασία</translation>
+        <translation>Θερμοκρασία</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Ωρίμανση στον τρίτο κάδο (ημέρες)</translation>
+        <translation>Ωρίμανση στον τρίτο κάδο (ημέρες)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Θερμοκρασία</translation>
+        <translation>Θερμοκρασία</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Παλάιωση σε φιάλες/βαρέλια</translation>
+        <translation>Παλάιωση σε φιάλες/βαρέλια</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Θερμοκρασία</translation>
+        <translation>Θερμοκρασία</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Ημ/νια αρχικής παρασκευής</translation>
+        <translation>Ημ/νια αρχικής παρασκευής</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">μμ ΜΜ ΕΕΕΕ</translation>
+        <translation>μμ ΜΜ ΕΕΕΕ</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Βαθμοί CO2</translation>
+        <translation>Βαθμοί CO2</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">σημειώσεις σχετικά με την γεύση</translation>
+        <translation>σημειώσεις σχετικά με την γεύση</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Σημειώσεις</translation>
+        <translation>Σημειώσεις</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Διαθλασίμετρο</translation>
+        <translation>Διαθλασίμετρο</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Εισαγωγή</translation>
+        <translation>Εισαγωγή</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Αρχική Plato</translation>
+        <translation>Αρχική Plato</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">OG (20 C)</translation>
+        <translation>OG (20 C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Τρέχουσα Plato</translation>
+        <translation>Τρέχουσα Plato</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Υπολογισμός</translation>
+        <translation>Υπολογισμός</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Αποτέλεσμα</translation>
+        <translation>Αποτέλεσμα</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">SG (20C)</translation>
+        <translation>SG (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">ABW</translation>
+        <translation>ABW</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">δείκτης διάθλασης</translation>
+        <translation>δείκτης διάθλασης</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Real Extract (Plato)</translation>
+        <translation>Real Extract (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">OG (20C)</translation>
+        <translation>OG (20C)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Υπολογισμός Θερμοκρασίας νερού</translation>
+        <translation>Υπολογισμός Θερμοκρασίας νερού</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Αρχική έγχυση</translation>
+        <translation>Αρχική έγχυση</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Αρχική θερμοκρασία σιτηρών</translation>
+        <translation>Αρχική θερμοκρασία σιτηρών</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Επιθυμητή θερμοκρασία χυλού</translation>
+        <translation>Επιθυμητή θερμοκρασία χυλού</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Βαρός σιτηρών</translation>
+        <translation>Βαρός σιτηρών</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Όγκος νερού</translation>
+        <translation>Όγκος νερού</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">έγχυση του χυλού</translation>
+        <translation>έγχυση του χυλού</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Ολικός όγκος νερού</translation>
+        <translation>Ολικός όγκος νερού</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Βάρος σιτηρών</translation>
+        <translation>Βάρος σιτηρών</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Ακριβής θερμοκρασία χυλού</translation>
+        <translation>Ακριβής θερμοκρασία χυλού</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Θερμοκρασία νερού έγχυσης</translation>
+        <translation>Θερμοκρασία νερού έγχυσης</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Υπολογισμός</translation>
+        <translation>Υπολογισμός</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Θερμοκρασία της αρχικής ποσότητας νερού</translation>
+        <translation>Θερμοκρασία της αρχικής ποσότητας νερού</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Ποσότητα για προσθήκη</translation>
+        <translation>Ποσότητα για προσθήκη</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Σημείωση: Το πρόγραμμα θεωρεί ότι το σκεύος σακχαροποίησης έχει  προθερμανθεί</translation>
+        <translation>Σημείωση: Το πρόγραμμα θεωρεί ότι το σκεύος σακχαροποίησης έχει  προθερμανθεί</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Επεξεργαστής στυλ</translation>
+        <translation>Επεξεργαστής στυλ</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Στυλ</translation>
+        <translation>Στυλ</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Διέγραψε το επιλεγμένο στυλ</translation>
+        <translation>Διέγραψε το επιλεγμένο στυλ</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6388,55 +7211,55 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Κατηγορία</translation>
+        <translation>Κατηγορία</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Αριθμός κατηγορίας</translation>
+        <translation>Αριθμός κατηγορίας</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Γράμμα στυλ</translation>
+        <translation>Γράμμα στυλ</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Οδηγός στυλ</translation>
+        <translation>Οδηγός στυλ</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Είδος</translation>
+        <translation>Είδος</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Τύπος αναψυκτικού</translation>
+        <translation>Τύπος αναψυκτικού</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Υδρόμελο</translation>
+        <translation>Υδρόμελο</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Σιτάρι</translation>
+        <translation>Σιτάρι</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Ανάμεικτη</translation>
+        <translation>Ανάμεικτη</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Μηλίτης</translation>
+        <translation>Μηλίτης</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6444,51 +7267,51 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Μεγ.</translation>
+        <translation>Μεγ.</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Ελαχ.</translation>
+        <translation>Ελαχ.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBUs</translation>
+        <translation>IBUs</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Χρώμα (SRM)</translation>
+        <translation>Χρώμα (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Ανθρακ. (ατμ)</translation>
+        <translation>Ανθρακ. (ατμ)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV (pct)</translation>
+        <translation>ABV (pct)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Προφίλ</translation>
+        <translation>Προφίλ</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Συστατικά</translation>
+        <translation>Συστατικά</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Παραδείγματα</translation>
+        <translation>Παραδείγματα</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Σημειώσεις</translation>
+        <translation>Σημειώσεις</translation>
     </message>
     <message>
         <source>New</source>
@@ -6502,6 +7325,50 @@ The final volume in the primary is %1.</source>
         <source>Cancel</source>
         <translation type="vanished">Ακύρωση</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
@@ -6509,12 +7376,207 @@ The final volume in the primary is %1.</source>
         <source>Timers</source>
         <translation type="vanished">Χρονόμετρα</translation>
     </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">Μορφή</translation>
+        <translation type="unfinished">Μορφή</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Διακοπή</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Ακύρωση</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6525,18 +7587,22 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Σημειώσεις</translation>
+        <translation>Σημειώσεις</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Επεξεργασία στοιχείων μαγιάς</translation>
+        <translation>Επεξεργασία στοιχείων μαγιάς</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6544,51 +7610,51 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Ονομασία</translation>
+        <translation>Ονομασία</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Είδος</translation>
+        <translation>Είδος</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Σταρένια</translation>
+        <translation>Σταρένια</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Κρασί</translation>
+        <translation>Κρασί</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Σαμπάνια</translation>
+        <translation>Σαμπάνια</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Μορφή</translation>
+        <translation>Μορφή</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Υγρή</translation>
+        <translation>Υγρή</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Ξηρή</translation>
+        <translation>Ξηρή</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">επικλινής</translation>
+        <translation>επικλινής</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Καλιέργεια</translation>
+        <translation>Καλιέργεια</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6596,91 +7662,91 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Έλεγχος εάν η ποσότητα είναι σε κιλά αντί για λίτρα</translation>
+        <translation>Έλεγχος εάν η ποσότητα είναι σε κιλά αντί για λίτρα</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Το ποσό αναφέρεται σε βάρος;</translation>
+        <translation>Το ποσό αναφέρεται σε βάρος;</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Τσέκαρε  εάν το νούμερο αναφέρεται σε βάρος αντί για όγκο</translation>
+        <translation>Τσέκαρε  εάν το νούμερο αναφέρεται σε βάρος αντί για όγκο</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Εργαστήριο/Εταιρία</translation>
+        <translation>Εργαστήριο/Εταιρία</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">Κωδικός προιόντος</translation>
+        <translation>Κωδικός προιόντος</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Ελαχ. Θερμ.</translation>
+        <translation>Ελαχ. Θερμ.</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Ελαχ. Θερμ.</translation>
+        <translation>Ελαχ. Θερμ.</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Μεγ. Θερμ.</translation>
+        <translation>Μεγ. Θερμ.</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Μεγ. Θερμ.</translation>
+        <translation>Μεγ. Θερμ.</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">κροκίδωση</translation>
+        <translation>κροκίδωση</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Χαμηλή</translation>
+        <translation>Χαμηλή</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Μεσαία</translation>
+        <translation>Μεσαία</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Υψηλή</translation>
+        <translation>Υψηλή</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Πολύ υψηλή</translation>
+        <translation>Πολύ υψηλή</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Ελάττωση</translation>
+        <translation>Ελάττωση</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Φαινομενική ελάττωση πυκνότητας ως πσοστό επί  OG βαθμών</translation>
+        <translation>Φαινομενική ελάττωση πυκνότητας ως πσοστό επί  OG βαθμών</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Φορές που επανακαλλιεργήθηκε</translation>
+        <translation>Φορές που επανακαλλιεργήθηκε</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Φορές που αυτή η μαγιά επανακαλλιεργήθηκε</translation>
+        <translation>Φορές που αυτή η μαγιά επανακαλλιεργήθηκε</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Μέγιστος αριθμός επανακαλλιεργιών</translation>
+        <translation>Μέγιστος αριθμός επανακαλλιεργιών</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Μέγιστος αριθμός επανακαλλιεργιών</translation>
+        <translation>Μέγιστος αριθμός επανακαλλιεργιών</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Προσθήκη στο δεύτερο κάδο ζύμωσης</translation>
+        <translation>Προσθήκη στο δεύτερο κάδο ζύμωσης</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Σε περίπτωση τσεκαρίσματος η μαγιά προστίθεται στο δεύτερο κάδο</translation>
+        <translation>Σε περίπτωση τσεκαρίσματος η μαγιά προστίθεται στο δεύτερο κάδο</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6696,11 +7762,39 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Ποσότητα στο ευρετήριο</translation>
+        <translation>Ποσότητα στο ευρετήριο</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Ποσότητα στο ευρετήριο</translation>
+        <translation>Ποσότητα στο ευρετήριο</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Πρόσθετα</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Σημειώσεις</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_en.ts
+++ b/translations/bt_en.ts
@@ -300,6 +300,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2016,15 +2111,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2286,80 +2381,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2522,6 +2543,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3295,6 +3390,41 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>TimerDialog</name>
+    <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TimerListDialog</name>
     <message>
         <source>Addition Timers</source>
@@ -3303,6 +3433,58 @@ The final volume in the primary is %1.</source>
 </context>
 <context>
     <name>TimerMainDialog</name>
+    <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>No Timers</source>
         <translation type="unfinished"></translation>
@@ -3703,9 +3885,1892 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>brewDayScrollWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generate Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The number where the new step should be placed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert the new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove currently selected step</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>brewNoteWidget</name>
+    <message>
+        <source>Preboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preboil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort collected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of mash before mash out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Post boil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort in BK after boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort transferred to fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume into fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> Pitch Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of wort when yeast is pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postferment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of beer into serving keg/bottles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewhouse efficiency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>equipmentEditor</name>
+    <message>
+        <source>Lauter deadspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>fermentableEditor</name>
+    <message>
+        <source>Fermentable Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sugar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjunct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield as compared to glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lovibond rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add After Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This ingredient is added post boil.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse/Fine Diff (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield difference between coarse and fine grind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max In Batch (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum recommended percentage of total grist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend this be mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is Mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if it is present in mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU*gal/lb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness of pre-hopped extracts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>hopEditor</name>
+    <message>
+        <source>Hop Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aroma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bittering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pellet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop Stability/Storage index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>instructionWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mark this step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mainWindow</name>
+    <message>
+        <source>Recipes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target boil size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The extraction efficiency you expect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target batch size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU/GU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calories/12oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Des</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invoke the mash wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash wiz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save this mash profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;BrewTarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Brewtarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Equipments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Scale Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe to Clipboard as &amp;Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;OG Correction Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Convert Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backup Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Copy Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pr&amp;iming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select another database to merge into the current one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save all recipes, ingredients, etc. to a backup folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore recipes, ingredients, etc. from a previous backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;New Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1.0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashDesigner</name>
+    <message>
+        <source>Mash Designer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion/Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Collected Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>vol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun Fullness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunVol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashEditor</name>
+    <message>
+        <source>Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Get following parameters from the recipe&apos;s equipment.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashStepEditor</name>
+    <message>
+        <source>Mash Step Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water to infuse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of infusion water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of mash to decoct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time to conduct the step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp. lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashWizard</name>
+    <message>
+        <source>Mash Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash thickness (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>miscEditor</name>
+    <message>
+        <source>Misc Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Herb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flavor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check it if the amount listed is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>namedMashEditor</name>
+    <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ogAdjuster</name>
+    <message>
+        <source>Adjust Volume to Hit OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured gravity pre-boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp to which the hydrometer is calibrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-or-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato (percent by mass of equivalent sucrose)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG w/o Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG if you boil as planned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated batch size after correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>optionsDialog</name>
     <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Formulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU Adjustments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;qt&gt;
+   &lt;b&gt;Know another language?&lt;/b&gt;
+   &lt;br&gt;&lt;br&gt;
+   Or, would you like to improve a translation? Help us out and
+  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
+  provide a translation&lt;/a&gt; so that your friends can use brewtarget!
+&lt;/qt&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3789,7 +5854,1016 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>pitchDialog</name>
+    <message>
+        <source>Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wort Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch Rate (M cells)/(mL*P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Production Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Viability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>O2 At Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stir Plate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MM/dd/yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate Viability From Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Billions of Yeast Cells Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>primingDialog</name>
+    <message>
+        <source>Priming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of beer to prime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beer Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp of the beer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Glucose Monohydrate (corn sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anhydrous Glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sucrose (table sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Malt Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prime with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>recipeExtrasWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asst. Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date First Brewed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dd MMM yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carbonation Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>refractoDialog</name>
+    <message>
+        <source>Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20 C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refractive Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Real Extract (Plato)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>strikeWaterDialog</name>
+    <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>styleEditor</name>
+    <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type of beverage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBUs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color (SRM)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carb (vols)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV (pct)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ingredients</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerListDialog</name>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterEditor</name>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>yeastEditor</name>
+    <message>
+        <source>Yeast Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Champagne</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Liquid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Culture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check it if the amount given is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flocculation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attenuation (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apparent attenuation as percentage of OG points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times Recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times this yeast has been recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked means add this yeast to secondary instead of primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_es.ts
+++ b/translations/bt_es.ts
@@ -530,6 +530,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Receta</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Inventario</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Fermentables</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Lúpulos</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Levadura</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Resultados</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2005,13 +2100,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2453,15 +2541,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2767,80 +2855,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Desconocido</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">Normal</translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Inventario</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Nombre</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alfa %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -3003,6 +3017,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Desconocido</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Normal</translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Inventario</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nombre</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidad</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3785,8 +3873,36 @@ El volumen final en el primario es %1.</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation type="unfinished">Cancelar</translation>
     </message>
 </context>
 <context>
@@ -3799,12 +3915,56 @@ El volumen final en el primario es %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Empezar</translation>
+        <translation type="unfinished">Empezar</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Detener</translation>
+        <translation type="unfinished">Detener</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4250,54 +4410,73 @@ El volumen final en el primario es %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialog</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulario</translation>
+        <translation>Formulario</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Generar Instrucciones</translation>
+        <translation>Generar Instrucciones</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Introducir un escalón</translation>
+        <translation>Introducir un escalón</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Nombre del nuevo escalón</translation>
+        <translation>Nombre del nuevo escalón</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Escalón #</translation>
+        <translation>Escalón #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">El número en donde el escalón debería estar colocado</translation>
+        <translation>El número en donde el escalón debería estar colocado</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Introducir el nuevo escalón</translation>
+        <translation>Introducir el nuevo escalón</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Mover escalones</translation>
+        <translation>Mover escalones</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Mover hacia arriba el escalón seleccionado</translation>
+        <translation>Mover hacia arriba el escalón seleccionado</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Mover hacia abajo el escalón seleccionado</translation>
+        <translation>Mover hacia abajo el escalón seleccionado</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Quitar el escalón seleccionado</translation>
+        <translation>Quitar el escalón seleccionado</translation>
     </message>
 </context>
 <context>
@@ -4367,27 +4546,27 @@ El volumen final en el primario es %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Antes de hervir</translation>
+        <translation>Antes de hervir</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Densidad</translation>
+        <translation>Densidad</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Densidad Pre-hervido</translation>
+        <translation>Densidad Pre-hervido</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volúmen</translation>
+        <translation>Volúmen</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Volumen de mosto conseguido</translation>
+        <translation>Volumen de mosto conseguido</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Temp. de Salto</translation>
+        <translation>Temp. de Salto</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4395,59 +4574,59 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Temp. Final</translation>
+        <translation>Temp. Final</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Temp. de la maceración antes del Mash Out (final del macerado)</translation>
+        <translation>Temp. de la maceración antes del Mash Out (final del macerado)</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Despúes de hervir</translation>
+        <translation>Despúes de hervir</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">D.I.</translation>
+        <translation>D.I.</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Densidad después de la ebullición</translation>
+        <translation>Densidad después de la ebullición</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Volumen después de hervir</translation>
+        <translation>Volumen después de hervir</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Volumen de mosto en la olla después del hervido</translation>
+        <translation>Volumen de mosto en la olla después del hervido</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Volumen del mosto tranferido al fermentador</translation>
+        <translation>Volumen del mosto tranferido al fermentador</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volumen en Fermentador</translation>
+        <translation>Volumen en Fermentador</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Temp Inicial</translation>
+        <translation> Temp Inicial</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Temp. del mosto antes de echar la levadura</translation>
+        <translation>Temp. del mosto antes de echar la levadura</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Despues de fermentar</translation>
+        <translation>Despues de fermentar</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Densidad Final</translation>
+        <translation>Densidad Final</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Volumen de cerveza en botellas o barrillito</translation>
+        <translation>Volumen de cerveza en botellas o barrillito</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4463,11 +4642,11 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">D.I. Prevista</translation>
+        <translation>D.I. Prevista</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Eficiencia total</translation>
+        <translation>Eficiencia total</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4479,7 +4658,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">APV Previsto</translation>
+        <translation>APV Previsto</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4487,11 +4666,59 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">APV</translation>
+        <translation>APV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4510,14 +4737,182 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Pérdida en la olla (turbio)</translation>
+        <translation>Pérdida en la olla (turbio)</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Editor de Equipo</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Establecer como predeterminado</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Tamaño del lote</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nombre</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Tiempo</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Calcular volumen pre-hervido</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Tiempo de hervido</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Tasa de evaporación (por hr)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Agua agregada al fin</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Agua agregada a la olla</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Absorción por defecto</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Punto de ebullición</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Volumen de olla de macerado</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notas</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Equipo nuevo</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Editor de Fermentables</translation>
+        <translation>Editor de Fermentables</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4525,31 +4920,31 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Grano</translation>
+        <translation>Grano</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Azúcar</translation>
+        <translation>Azúcar</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Extracto</translation>
+        <translation>Extracto</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Extracto Seco</translation>
+        <translation>Extracto Seco</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Adjunto</translation>
+        <translation>Adjunto</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4561,43 +4956,43 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Rendimiento relativo a la glucosa</translation>
+        <translation>Rendimiento relativo a la glucosa</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Color Lovibond</translation>
+        <translation>Color Lovibond</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Agregar despues de hervir</translation>
+        <translation>Agregar despues de hervir</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">El ingrediente se agrega despues de hervir.</translation>
+        <translation>El ingrediente se agrega despues de hervir.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origen</translation>
+        <translation>Origen</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Proveedor</translation>
+        <translation>Proveedor</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Dif. Grueso/Fino (%)</translation>
+        <translation>Dif. Grueso/Fino (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Diferencia de rendimiento entre grano grueso y fino</translation>
+        <translation>Diferencia de rendimiento entre grano grueso y fino</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Humedad (%)</translation>
+        <translation>Humedad (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Porcentaje de humedad por masa</translation>
+        <translation>Porcentaje de humedad por masa</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4609,43 +5004,43 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Proteinas (%)</translation>
+        <translation>Proteinas (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Porcentaje de proteinas por masa</translation>
+        <translation>Porcentaje de proteinas por masa</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Max. en Lote (%)</translation>
+        <translation>Max. en Lote (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Porcentaje máximo recomendado del total de la molienda</translation>
+        <translation>Porcentaje máximo recomendado del total de la molienda</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Maceración Recomendada</translation>
+        <translation>Maceración Recomendada</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Se recomienda que se macere</translation>
+        <translation>Se recomienda que se macere</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Macerado</translation>
+        <translation>Macerado</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Revisar si está en el macerado</translation>
+        <translation>Revisar si está en el macerado</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Amargor (IBU*gal/lb)</translation>
+        <translation>Amargor (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Amargor de los extractos con lúpulo</translation>
+        <translation>Amargor de los extractos con lúpulo</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4657,22 +5052,70 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Cantidad en inventario</translation>
+        <translation>Cantidad en inventario</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Cantidad en inventario</translation>
+        <translation>Cantidad en inventario</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Color</translation>
+        <translation>Color</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Potencial de extracto %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notas</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Editor de Lúpulos</translation>
+        <translation>Editor de Lúpulos</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4680,7 +5123,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4688,7 +5131,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Porcentaje de ácidos alfas por masa</translation>
+        <translation>Porcentaje de ácidos alfas por masa</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4696,59 +5139,59 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Uso</translation>
+        <translation>Uso</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maceración</translation>
+        <translation>Maceración</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">First Wort</translation>
+        <translation>First Wort</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Hervor</translation>
+        <translation>Hervor</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Dry Hop</translation>
+        <translation>Dry Hop</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tiempo</translation>
+        <translation>Tiempo</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Amargor</translation>
+        <translation>Amargor</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Los dos</translation>
+        <translation>Los dos</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Flor</translation>
+        <translation>Flor</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellet</translation>
+        <translation>Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Plug</translation>
+        <translation>Plug</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4756,19 +5199,19 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Ácidos betas por masa</translation>
+        <translation>Ácidos betas por masa</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">IEL</translation>
+        <translation>IEL</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Índice de estabilidad de lúpulos</translation>
+        <translation>Índice de estabilidad de lúpulos</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origen</translation>
+        <translation>Origen</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4776,7 +5219,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulene</translation>
+        <translation>Humulene</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4792,7 +5235,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulone</translation>
+        <translation>Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4800,7 +5243,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcene</translation>
+        <translation>Myrcene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4816,65 +5259,121 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Cantidad en inventario</translation>
+        <translation>Cantidad en inventario</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Cantidad en inventario</translation>
+        <translation>Cantidad en inventario</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notas</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Muestra minutero</translation>
+        <translation>Muestra minutero</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Muestra minutero</translation>
+        <translation>Muestra minutero</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Marcar como completado</translation>
+        <translation>Marcar como completado</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Paso Completado</translation>
+        <translation>Paso Completado</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Recetas</translation>
+        <translation>Recetas</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Estilos</translation>
+        <translation>Estilos</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Fermentables</translation>
+        <translation>Fermentables</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Lúpulos</translation>
+        <translation>Lúpulos</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Miscs</translation>
+        <translation>Miscs</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Levaduras</translation>
+        <translation>Levaduras</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Receta</translation>
+        <translation>Receta</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4882,11 +5381,11 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Nombre de la receta</translation>
+        <translation>Nombre de la receta</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Tamaño de hervor que deseas</translation>
+        <translation>Tamaño de hervor que deseas</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4902,7 +5401,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">La eficiencia de extracción que esperas</translation>
+        <translation>La eficiencia de extracción que esperas</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4914,7 +5413,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Tamaño de lote que deseas</translation>
+        <translation>Tamaño de lote que deseas</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4922,7 +5421,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Equipaje</translation>
+        <translation>Equipaje</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4930,163 +5429,163 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Densidad del hervor</translation>
+        <translation>Densidad del hervor</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">DF</translation>
+        <translation>DF</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">APV</translation>
+        <translation>APV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Amargor (IBU)</translation>
+        <translation>Amargor (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Color</translation>
+        <translation>Color</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU por Densidad</translation>
+        <translation>IBU por Densidad</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Calorías/12oz</translation>
+        <translation>Calorías/12oz</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extras</translation>
+        <translation>Extras</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Brewday</translation>
+        <translation>Brewday</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Agregar un fermentable</translation>
+        <translation>Agregar un fermentable</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Remover fermentable seleccionado</translation>
+        <translation>Remover fermentable seleccionado</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Editar fermentable seleccionado</translation>
+        <translation>Editar fermentable seleccionado</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Agregar lúpulo</translation>
+        <translation>Agregar lúpulo</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Remover lúpulo seleccionado</translation>
+        <translation>Remover lúpulo seleccionado</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Editar lúpulo seleccionado</translation>
+        <translation>Editar lúpulo seleccionado</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Misc</translation>
+        <translation>Misc</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Agregar misc</translation>
+        <translation>Agregar misc</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Remover misc seleccionado</translation>
+        <translation>Remover misc seleccionado</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Editor misc seleccionado</translation>
+        <translation>Editor misc seleccionado</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Levadura</translation>
+        <translation>Levadura</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Agregar levadura</translation>
+        <translation>Agregar levadura</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Remover levadura seleccionada</translation>
+        <translation>Remover levadura seleccionada</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Editar levadura seleccionada</translation>
+        <translation>Editar levadura seleccionada</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maceración</translation>
+        <translation>Maceración</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Agregar paso de maceración</translation>
+        <translation>Agregar paso de maceración</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Remover paso seleccionado</translation>
+        <translation>Remover paso seleccionado</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Editar paso seleccionado</translation>
+        <translation>Editar paso seleccionado</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Editar características de la maceración</translation>
+        <translation>Editar características de la maceración</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Editar maceración</translation>
+        <translation>Editar maceración</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Diseñador</translation>
+        <translation>Diseñador</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Ejecutar el asistente de maceración</translation>
+        <translation>Ejecutar el asistente de maceración</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Asistente</translation>
+        <translation>Asistente</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Maceraciones</translation>
+        <translation>Maceraciones</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Paso para arriba</translation>
+        <translation>Paso para arriba</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Paso para abajo</translation>
+        <translation>Paso para abajo</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Guardar esta perfil de maceración</translation>
+        <translation>Guardar esta perfil de maceración</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Guardar Maceración</translation>
+        <translation>Guardar Maceración</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Sobre</translation>
+        <translation>&amp;Sobre</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Archivo</translation>
+        <translation>&amp;Archivo</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5098,27 +5597,27 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Base de Datos</translation>
+        <translation>&amp;Base de Datos</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Ver</translation>
+        <translation>&amp;Ver</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Herramientas</translation>
+        <translation>&amp;Herramientas</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">toolBar</translation>
+        <translation>toolBar</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">Sobre &amp;Brewtarget</translation>
+        <translation>Sobre &amp;Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Sobre Brewtarget</translation>
+        <translation>Sobre Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5126,19 +5625,19 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Fermentables</translation>
+        <translation>&amp;Fermentables</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Lúpulos</translation>
+        <translation>&amp;Lúpulos</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+L</translation>
+        <translation>Ctrl+L</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5146,31 +5645,31 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">Le&amp;vaduras</translation>
+        <translation>Le&amp;vaduras</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+V</translation>
+        <translation>Ctrl+V</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Equipajes</translation>
+        <translation>&amp;Equipajes</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">Est&amp;ilos</translation>
+        <translation>Est&amp;ilos</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+I</translation>
+        <translation>Ctrl+I</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5178,7 +5677,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5190,55 +5689,55 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Manual</translation>
+        <translation>&amp;Manual</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Balancear la Receta</translation>
+        <translation>&amp;Balancear la Receta</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Receta al portapapeles como &amp;texto</translation>
+        <translation>Receta al portapapeles como &amp;texto</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">&amp;Ayuda para Corrección de DI</translation>
+        <translation>&amp;Ayuda para Corrección de DI</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Convertir unidades</translation>
+        <translation>&amp;Convertir unidades</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Reservar Base de Datos</translation>
+        <translation>Reservar Base de Datos</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Restituir Base de Datos</translation>
+        <translation>Restituir Base de Datos</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Copiar Receta</translation>
+        <translation>&amp;Copiar Receta</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Calculadora para &amp;Embotellar</translation>
+        <translation>Calculadora para &amp;Embotellar</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">&amp;Herramienta para Refractómetros</translation>
+        <translation>&amp;Herramienta para Refractómetros</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">Calculadora para &amp;Levadura</translation>
+        <translation>Calculadora para &amp;Levadura</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Unir Bases de Datos</translation>
+        <translation>Unir Bases de Datos</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Elegir otro base de datos para unir al actual.</translation>
+        <translation>Elegir otro base de datos para unir al actual.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5258,19 +5757,19 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Hacer copia de seguro</translation>
+        <translation>&amp;Hacer copia de seguro</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Guardar todas las recetas, ingredientes, etc. en una copia de seguro</translation>
+        <translation>Guardar todas las recetas, ingredientes, etc. en una copia de seguro</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Restituir</translation>
+        <translation>&amp;Restituir</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Restituir las recetas, ingredients, etc. de una copia de seguro</translation>
+        <translation>Restituir las recetas, ingredients, etc. de una copia de seguro</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5282,7 +5781,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Nueva receta</translation>
+        <translation>&amp;Nueva receta</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5290,38 +5789,158 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Mostrar minuteros</translation>
+        <translation>Mostrar minuteros</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Guardar</translation>
+        <translation>Guardar</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Borrar el seleccionado</translation>
+        <translation>Borrar el seleccionado</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Borrar receta</translation>
+        <translation>Borrar receta</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp; Macerados</translation>
+        <translation>&amp; Macerados</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Macerados</translation>
+        <translation>Macerados</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Tamaño del lote</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Tamaño del hervido</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">¡Elaborar cerveza!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Diseñador de Maceración</translation>
+        <translation>Diseñador de Maceración</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5337,7 +5956,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tiempo</translation>
+        <translation>Tiempo</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5345,275 +5964,311 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Seguir</translation>
+        <translation>Seguir</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Acabar</translation>
+        <translation>Acabar</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Cantidad de Infusión/Cocción</translation>
+        <translation>Cantidad de Infusión/Cocción</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Temp de Infusión</translation>
+        <translation>Temp de Infusión</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Caldo Extraído</translation>
+        <translation>Caldo Extraído</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">vol</translation>
+        <translation>vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Llenura de la cuba</translation>
+        <translation>Llenura de la cuba</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">tunVol</translation>
+        <translation>tunVol</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">thickness</translation>
+        <translation>thickness</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Editor de Maceración</translation>
+        <translation>Editor de Maceración</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temp. inicial del grano</translation>
+        <translation>Temp. inicial del grano</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temp. del lavado</translation>
+        <translation>Temp. del lavado</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Temp. deseado del lavado</translation>
+        <translation>Temp. deseado del lavado</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH del lavado</translation>
+        <translation>pH del lavado</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Cuba</translation>
+        <translation>Cuba</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temp. inicial</translation>
+        <translation>Temp. inicial</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Conseguir los parametros del equipaje de la receta.</translation>
+        <translation>Conseguir los parametros del equipaje de la receta.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Del Equipaje</translation>
+        <translation>Del Equipaje</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Masa</translation>
+        <translation>Masa</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Calor específico</translation>
+        <translation>Calor específico</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Calor específico de la cuba (cal/(g*K))</translation>
+        <translation>Calor específico de la cuba (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Editor de pasos de la maceracíon</translation>
+        <translation>Editor de pasos de la maceracíon</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infusión</translation>
+        <translation>Infusión</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Cocción</translation>
+        <translation>Cocción</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Temp. deseado</translation>
+        <translation>Temp. deseado</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Temp deseado del paso</translation>
+        <translation>Temp deseado del paso</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Cantidad de agua</translation>
+        <translation>Cantidad de agua</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Cantidad del agua para infusar</translation>
+        <translation>Cantidad del agua para infusar</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Temp de la infusión</translation>
+        <translation>Temp de la infusión</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Temperatura del agua de la infusión</translation>
+        <translation>Temperatura del agua de la infusión</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Cantidad de la cocción</translation>
+        <translation>Cantidad de la cocción</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Cantidad de la maceración para cocer</translation>
+        <translation>Cantidad de la maceración para cocer</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tiempo</translation>
+        <translation>Tiempo</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Tiempo para hacer el paso</translation>
+        <translation>Tiempo para hacer el paso</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Lapso de la temp.</translation>
+        <translation>Lapso de la temp.</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Tiempo del lapso</translation>
+        <translation>Tiempo del lapso</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Temp. final</translation>
+        <translation>Temp. final</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Temp. final del paso</translation>
+        <translation>Temp. final del paso</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Llavado lote entero</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Asistente de la maceración</translation>
+        <translation>Asistente de la maceración</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Grosor (L/kg)</translation>
+        <translation>Grosor (L/kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Grosor de la maceración (no ingresar ningún unidad)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Editor de miscs</translation>
+        <translation>Editor de miscs</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Especia</translation>
+        <translation>Especia</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Aclarador</translation>
+        <translation>Aclarador</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Agente para Agua</translation>
+        <translation>Agente para Agua</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Hierba</translation>
+        <translation>Hierba</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Sabor</translation>
+        <translation>Sabor</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Otro</translation>
+        <translation>Otro</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Uso</translation>
+        <translation>Uso</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Hervor</translation>
+        <translation>Hervor</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maceración</translation>
+        <translation>Maceración</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Primario</translation>
+        <translation>Primario</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Secundario</translation>
+        <translation>Secundario</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Embotellar</translation>
+        <translation>Embotellar</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tiempo</translation>
+        <translation>Tiempo</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5621,15 +6276,15 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Marcar si la cantidad se mide por masa en vez de volumen</translation>
+        <translation>Marcar si la cantidad se mide por masa en vez de volumen</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">¿Cantidad es masa?</translation>
+        <translation>¿Cantidad es masa?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Marcar si la cantidad se mide por masa en vez de volumen</translation>
+        <translation>Marcar si la cantidad se mide por masa en vez de volumen</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5645,192 +6300,220 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Cantidad en inventario</translation>
+        <translation>Cantidad en inventario</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Cantidad en inventario</translation>
+        <translation>Cantidad en inventario</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notas</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Editor de Macerados</translation>
+        <translation>Editor de Macerados</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maceración</translation>
+        <translation>Maceración</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Eliminar el estilo seleccionado</translation>
+        <translation>Eliminar el estilo seleccionado</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temp. inicial del grano</translation>
+        <translation>Temp. inicial del grano</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temp. del lavado</translation>
+        <translation>Temp. del lavado</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Temp. deseado del lavado</translation>
+        <translation>Temp. deseado del lavado</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH del lavado</translation>
+        <translation>pH del lavado</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Cuba</translation>
+        <translation>Cuba</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temp. inicial de la cuba</translation>
+        <translation>Temp. inicial de la cuba</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Desde Equipo</translation>
+        <translation>Desde Equipo</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Masa del Macerador</translation>
+        <translation>Masa del Macerador</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Calor específico</translation>
+        <translation>Calor específico</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Calor específico de la cuba (cal/(g*K))</translation>
+        <translation>Calor específico de la cuba (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Agregar paso de maceración</translation>
+        <translation>Agregar paso de maceración</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Remover paso seleccionado</translation>
+        <translation>Remover paso seleccionado</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Subir Paso</translation>
+        <translation>Subir Paso</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Bajar Paso</translation>
+        <translation>Bajar Paso</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Ajustar el Volumen para alcanzar la DI</translation>
+        <translation>Ajustar el Volumen para alcanzar la DI</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Introducir</translation>
+        <translation>Introducir</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Densidad</translation>
+        <translation>Densidad</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Densidad medida antes del hervor</translation>
+        <translation>Densidad medida antes del hervor</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temp</translation>
+        <translation>Temp</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Temp de la medida de la densidad</translation>
+        <translation>Temp de la medida de la densidad</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Temp del calibrado</translation>
+        <translation>Temp del calibrado</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temp al cual está calibrado el hidrometro</translation>
+        <translation>Temp al cual está calibrado el hidrometro</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-o-</translation>
+        <translation>-o-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (porciento por masa de sacarosa equivalente)</translation>
+        <translation>Plato (porciento por masa de sacarosa equivalente)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Volumen pre-hervor</translation>
+        <translation>Volumen pre-hervor</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Volumen medido antes del hervor</translation>
+        <translation>Volumen medido antes del hervor</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultados</translation>
+        <translation>Resultados</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">DI sin corrección</translation>
+        <translation>DI sin corrección</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">DI si se hierve como planeado</translation>
+        <translation>DI si se hierve como planeado</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Agregar al hervor</translation>
+        <translation>Agregar al hervor</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Cantidad de agua que necesitas agregar al hervor para alcanzar la DI planeada (o hervir si está negativa)</translation>
+        <translation>Cantidad de agua que necesitas agregar al hervor para alcanzar la DI planeada (o hervir si está negativa)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Tamaño de lote final</translation>
+        <translation>Tamaño de lote final</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Tamaño estimado después de la corrección</translation>
+        <translation>Tamaño estimado después de la corrección</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Opciones</translation>
+        <translation>Opciones</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Unidades</translation>
+        <translation>Unidades</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Masa</translation>
+        <translation>Masa</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5846,7 +6529,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5858,11 +6541,11 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volumen</translation>
+        <translation>Volumen</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Densidad</translation>
+        <translation>Densidad</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5874,7 +6557,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Color</translation>
+        <translation>Color</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5886,7 +6569,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Formulas</translation>
+        <translation>Formulas</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5902,7 +6585,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">Amargor</translation>
+        <translation>Amargor</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5914,7 +6597,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Ajustes de IBUs</translation>
+        <translation>Ajustes de IBUs</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5950,7 +6633,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Lenguaje</translation>
+        <translation>Lenguaje</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5960,7 +6643,7 @@ El volumen final en el primario es %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;¿Conoces otra idioma?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    ¿O, te gustaría mejorar una traducción? ¡Ayudanos y
@@ -5970,7 +6653,43 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Fecha</translation>
+        <translation>Fecha</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6053,6 +6772,54 @@ El volumen final en el primario es %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6061,346 +6828,418 @@ El volumen final en el primario es %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Calculadora para Levadura</translation>
+        <translation>Calculadora para Levadura</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entradas</translation>
+        <translation>Entradas</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Volumen del Caldo</translation>
+        <translation>Volumen del Caldo</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Para ales, 0.75-1. Para lagers, 1.5-2.</translation>
+        <translation>Para ales, 0.75-1. Para lagers, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Tasa de Levadura</translation>
+        <translation>Tasa de Levadura</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Método de Airear</translation>
+        <translation>Método de Airear</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Fecha de Producción</translation>
+        <translation>Fecha de Producción</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Viabilidad</translation>
+        <translation>Viabilidad</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Ningun</translation>
+        <translation>Ningun</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 al Principio</translation>
+        <translation>O2 al Principio</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Placa Agitadora</translation>
+        <translation>Placa Agitadora</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">dd/MM/yyyy</translation>
+        <translation>dd/MM/yyyy</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">TextLabel</translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Calcular la Viabilidad de la Fecha</translation>
+        <translation>Calcular la Viabilidad de la Fecha</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># De Paquetes</translation>
+        <translation># De Paquetes</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultados</translation>
+        <translation>Resultados</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Mil Millones de Células Requisitas</translation>
+        <translation>Mil Millones de Células Requisitas</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># De Paquetes sin Cultura</translation>
+        <translation># De Paquetes sin Cultura</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Levadura Seca</translation>
+        <translation>Levadura Seca</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Volumen del Iniciador</translation>
+        <translation>Volumen del Iniciador</translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Production date (Best By date less three months)</source>
-        <translation type="vanished">Fecha de producción</translation>
+        <translation>Fecha de producción</translation>
     </message>
     <message>
         <source>Estimated viability of the yeast</source>
-        <translation type="vanished">Viabilidad estimada de la levadura</translation>
+        <translation>Viabilidad estimada de la levadura</translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>How much yeast you will need</source>
-        <translation type="vanished">Cantidad de levadura requisita</translation>
+        <translation>Cantidad de levadura requisita</translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Calculadora para Botellar</translation>
+        <translation>Calculadora para Botellar</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entradas</translation>
+        <translation>Entradas</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Volumen Coleccionado</translation>
+        <translation>Volumen Coleccionado</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Cantidad de cerveza</translation>
+        <translation>Cantidad de cerveza</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Temp de la cerveza</translation>
+        <translation>Temp de la cerveza</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Volúmenes Deseados</translation>
+        <translation>Volúmenes Deseados</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Cantidad de CO2 que se quiere (1 L CO2 @ STP por L de cerveza)</translation>
+        <translation>Cantidad de CO2 que se quiere (1 L CO2 @ STP por L de cerveza)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glucosa Monohidrato</translation>
+        <translation>Glucosa Monohidrato</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Glucosa Deshidratado</translation>
+        <translation>Glucosa Deshidratado</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sacarosa</translation>
+        <translation>Sacarosa</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Extracto Seco</translation>
+        <translation>Extracto Seco</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultados</translation>
+        <translation>Resultados</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Utilizar</translation>
+        <translation>Utilizar</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Cantidad de azúcar requisita</translation>
+        <translation>Cantidad de azúcar requisita</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Fabricante</translation>
+        <translation>Fabricante</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Asst. del Fabricante</translation>
+        <translation>Asst. del Fabricante</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Calificacción del Sabor</translation>
+        <translation>Calificacción del Sabor</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Días en el Primario</translation>
+        <translation>Días en el Primario</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Temp. del Primario</translation>
+        <translation>Temp. del Primario</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Dias en el Secundario</translation>
+        <translation>Dias en el Secundario</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Temp. del Secundario</translation>
+        <translation>Temp. del Secundario</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Dias en el Terciario</translation>
+        <translation>Dias en el Terciario</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Temp. del Terciario</translation>
+        <translation>Temp. del Terciario</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Dias en la Botella o Barrica</translation>
+        <translation>Dias en la Botella o Barrica</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Temp. de la Botella o Barrica</translation>
+        <translation>Temp. de la Botella o Barrica</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Fecha de Primera Fabricación</translation>
+        <translation>Fecha de Primera Fabricación</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Volúmenes de CO2</translation>
+        <translation>Volúmenes de CO2</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Notas del Sabor</translation>
+        <translation>Notas del Sabor</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Herramienta para Refractometros</translation>
+        <translation>Herramienta para Refractometros</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Entradas</translation>
+        <translation>Entradas</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Plato Inicial</translation>
+        <translation>Plato Inicial</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">DI (20C)</translation>
+        <translation>DI (20C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Plato Actual</translation>
+        <translation>Plato Actual</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Resultados</translation>
+        <translation>Resultados</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">Densidad (20C)</translation>
+        <translation>Densidad (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">APV</translation>
+        <translation>APV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">APM</translation>
+        <translation>APM</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Índice Refractor</translation>
+        <translation>Índice Refractor</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Extracto Real (Plato)</translation>
+        <translation>Extracto Real (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">DI (20C)</translation>
+        <translation>DI (20C)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Infusión Inicial</translation>
+        <translation>Infusión Inicial</translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Peso del Grano</translation>
+        <translation>Peso del Grano</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Volumen de Agua</translation>
+        <translation>Volumen de Agua</translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Volumen Total del Agua</translation>
+        <translation>Volumen Total del Agua</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Peso del Grano</translation>
+        <translation>Peso del Grano</translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Golpe de temperatura del agua</translation>
+        <translation>Golpe de temperatura del agua</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Volumen a añadir</translation>
+        <translation>Volumen a añadir</translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Editor de Estilos</translation>
+        <translation>Editor de Estilos</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Estilo</translation>
+        <translation>Estilo</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Remover estilo seleccionado</translation>
+        <translation>Remover estilo seleccionado</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6408,55 +7247,55 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Categoría</translation>
+        <translation>Categoría</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Número de Categoría</translation>
+        <translation>Número de Categoría</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Letra de Estilo</translation>
+        <translation>Letra de Estilo</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Guía de Estilos</translation>
+        <translation>Guía de Estilos</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Tipo de bebida</translation>
+        <translation>Tipo de bebida</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Mead</translation>
+        <translation>Mead</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Trigo</translation>
+        <translation>Trigo</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Mezclado</translation>
+        <translation>Mezclado</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Cider</translation>
+        <translation>Cider</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6464,51 +7303,51 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Max</translation>
+        <translation>Max</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Min</translation>
+        <translation>Min</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">DF</translation>
+        <translation>DF</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Color (SRM)</translation>
+        <translation>Color (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">CO2 (vol.)</translation>
+        <translation>CO2 (vol.)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">APV (%)</translation>
+        <translation>APV (%)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Perfil</translation>
+        <translation>Perfil</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingredientes</translation>
+        <translation>Ingredientes</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Ejemplos</translation>
+        <translation>Ejemplos</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
     </message>
     <message>
         <source>New</source>
@@ -6522,12 +7361,258 @@ El volumen final en el primario es %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Cancelar</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
     <message>
         <source>Timers</source>
         <translation type="vanished">Minuteros</translation>
+    </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Detener</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6538,18 +7623,22 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Editor de Levaduras</translation>
+        <translation>Editor de Levaduras</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6557,51 +7646,51 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nombre</translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Trigo</translation>
+        <translation>Trigo</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Vino</translation>
+        <translation>Vino</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Champán</translation>
+        <translation>Champán</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Liquida</translation>
+        <translation>Liquida</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Seca</translation>
+        <translation>Seca</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Slant</translation>
+        <translation>Slant</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Cultura</translation>
+        <translation>Cultura</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6609,91 +7698,91 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Si la cantidad es masa.</translation>
+        <translation>Si la cantidad es masa.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">¿Cantidad es masa?</translation>
+        <translation>¿Cantidad es masa?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Si la cantidad es masa</translation>
+        <translation>Si la cantidad es masa</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Lab</translation>
+        <translation>Lab</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">No. ID</translation>
+        <translation>No. ID</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Temp Min</translation>
+        <translation>Temp Min</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Temp min</translation>
+        <translation>Temp min</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Temp Max</translation>
+        <translation>Temp Max</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Temp. max</translation>
+        <translation>Temp. max</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Precipitado</translation>
+        <translation>Precipitado</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Bajo</translation>
+        <translation>Bajo</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Medio</translation>
+        <translation>Medio</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Alto</translation>
+        <translation>Alto</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Muy Alto</translation>
+        <translation>Muy Alto</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Atenuación (%)</translation>
+        <translation>Atenuación (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Atenucación aparente como un porcentaje de puntos de DI</translation>
+        <translation>Atenucación aparente como un porcentaje de puntos de DI</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Veces Reculturada</translation>
+        <translation>Veces Reculturada</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Numero de veces que la levadura ha sido reculturado</translation>
+        <translation>Numero de veces que la levadura ha sido reculturado</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Reculteraciónes Max</translation>
+        <translation>Reculteraciónes Max</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Reculteraciónes Max</translation>
+        <translation>Reculteraciónes Max</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Agregar al Secundario</translation>
+        <translation>Agregar al Secundario</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Que si se necesita agregarla al secundario</translation>
+        <translation>Que si se necesita agregarla al secundario</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6706,6 +7795,42 @@ El volumen final en el primario es %1.</translation>
     <message>
         <source>Default Amount</source>
         <translation type="vanished">Cantidad por defecto</translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notas</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_et.ts
+++ b/translations/bt_et.ts
@@ -351,6 +351,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2067,15 +2162,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2337,80 +2432,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2573,6 +2594,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3346,6 +3441,41 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>TimerDialog</name>
+    <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TimerListDialog</name>
     <message>
         <source>Addition Timers</source>
@@ -3354,6 +3484,58 @@ The final volume in the primary is %1.</source>
 </context>
 <context>
     <name>TimerMainDialog</name>
+    <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>No Timers</source>
         <translation type="unfinished"></translation>
@@ -3754,6 +3936,76 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>brewDayScrollWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generate Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The number where the new step should be placed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert the new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove currently selected step</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayWidget</name>
     <message>
         <source>Instructions</source>
@@ -3761,14 +4013,734 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
-    <name>hopEditor</name>
+    <name>brewNoteWidget</name>
+    <message>
+        <source>Preboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preboil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort collected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of mash before mash out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Post boil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort in BK after boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort transferred to fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume into fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> Pitch Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of wort when yeast is pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postferment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of beer into serving keg/bottles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewhouse efficiency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>equipmentEditor</name>
+    <message>
+        <source>Lauter deadspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Kestus</translation>
+        <translation type="unfinished">Kestus</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>fermentableEditor</name>
+    <message>
+        <source>Fermentable Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sugar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjunct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield as compared to glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lovibond rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add After Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This ingredient is added post boil.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse/Fine Diff (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield difference between coarse and fine grind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max In Batch (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum recommended percentage of total grist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend this be mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is Mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if it is present in mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU*gal/lb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness of pre-hopped extracts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>hopEditor</name>
+    <message>
+        <source>Hop Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aroma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>Kestus</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bittering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pellet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop Stability/Storage index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>instructionWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mark this step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step completed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
+    <message>
+        <source>Recipes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target boil size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The extraction efficiency you expect</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Style</source>
         <translation type="vanished">Õlletüüp</translation>
@@ -3777,41 +4749,1095 @@ The final volume in the primary is %1.</source>
         <source>Boil Time</source>
         <translation type="vanished">Keeduaeg</translation>
     </message>
+    <message>
+        <source>Target batch size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU/GU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calories/12oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Des</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invoke the mash wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash wiz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save this mash profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;BrewTarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Brewtarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Equipments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Scale Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe to Clipboard as &amp;Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;OG Correction Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Convert Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backup Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Copy Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pr&amp;iming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select another database to merge into the current one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save all recipes, ingredients, etc. to a backup folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore recipes, ingredients, etc. from a previous backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;New Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1.0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
+        <source>Mash Designer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Kestus</translation>
+        <translation>Kestus</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion/Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Collected Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>vol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun Fullness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunVol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashEditor</name>
+    <message>
+        <source>Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Get following parameters from the recipe&apos;s equipment.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
+        <source>Mash Step Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water to infuse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of infusion water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of mash to decoct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Kestus</translation>
+        <translation>Kestus</translation>
+    </message>
+    <message>
+        <source>Time to conduct the step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp. lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashWizard</name>
+    <message>
+        <source>Mash Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash thickness (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
+        <source>Misc Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Herb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flavor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Kestus</translation>
+        <translation>Kestus</translation>
+    </message>
+    <message>
+        <source>Check it if the amount listed is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>namedMashEditor</name>
+    <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ogAdjuster</name>
+    <message>
+        <source>Adjust Volume to Hit OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured gravity pre-boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp to which the hydrometer is calibrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-or-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato (percent by mass of equivalent sucrose)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG w/o Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG if you boil as planned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated batch size after correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Formulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
+    </message>
+    <message>
+        <source>IBU Adjustments</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;qt&gt;
+   &lt;b&gt;Know another language?&lt;/b&gt;
+   &lt;br&gt;&lt;br&gt;
+   Or, would you like to improve a translation? Help us out and
+  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
+  provide a translation&lt;/a&gt; so that your friends can use brewtarget!
+&lt;/qt&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Date</source>
-        <translation type="vanished">Kuupäev</translation>
+        <translation>Kuupäev</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -3894,15 +5920,1017 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>pitchDialog</name>
+    <message>
+        <source>Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wort Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch Rate (M cells)/(mL*P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Production Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Viability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>O2 At Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stir Plate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MM/dd/yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate Viability From Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Billions of Yeast Cells Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>primingDialog</name>
+    <message>
+        <source>Priming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of beer to prime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beer Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp of the beer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Glucose Monohydrate (corn sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anhydrous Glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sucrose (table sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Malt Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prime with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>recipeExtrasWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asst. Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date First Brewed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dd MMM yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carbonation Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>refractoDialog</name>
+    <message>
+        <source>Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20 C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refractive Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Real Extract (Plato)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>strikeWaterDialog</name>
+    <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Style</source>
-        <translation type="vanished">Õlletüüp</translation>
+        <translation>Õlletüüp</translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type of beverage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBUs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color (SRM)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carb (vols)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV (pct)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ingredients</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerListDialog</name>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterEditor</name>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>yeastEditor</name>
+    <message>
+        <source>Yeast Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Champagne</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Liquid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Culture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check it if the amount given is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flocculation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attenuation (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apparent attenuation as percentage of OG points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times Recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times this yeast has been recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked means add this yeast to secondary instead of primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_eu.ts
+++ b/translations/bt_eu.ts
@@ -359,6 +359,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2075,15 +2170,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2345,80 +2440,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2581,6 +2602,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3358,6 +3453,41 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>TimerDialog</name>
+    <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TimerListDialog</name>
     <message>
         <source>Addition Timers</source>
@@ -3366,6 +3496,58 @@ The final volume in the primary is %1.</source>
 </context>
 <context>
     <name>TimerMainDialog</name>
+    <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>No Timers</source>
         <translation type="unfinished"></translation>
@@ -3766,6 +3948,76 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>brewDayScrollWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generate Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The number where the new step should be placed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert the new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove currently selected step</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayWidget</name>
     <message>
         <source>Instructions</source>
@@ -3773,14 +4025,734 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
-    <name>hopEditor</name>
+    <name>brewNoteWidget</name>
+    <message>
+        <source>Preboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preboil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort collected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of mash before mash out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Post boil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort in BK after boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort transferred to fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume into fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> Pitch Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of wort when yeast is pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postferment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of beer into serving keg/bottles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewhouse efficiency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>equipmentEditor</name>
+    <message>
+        <source>Lauter deadspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Denbora</translation>
+        <translation type="unfinished">Denbora</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>fermentableEditor</name>
+    <message>
+        <source>Fermentable Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sugar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjunct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield as compared to glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lovibond rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add After Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This ingredient is added post boil.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse/Fine Diff (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield difference between coarse and fine grind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max In Batch (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum recommended percentage of total grist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend this be mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is Mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if it is present in mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU*gal/lb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness of pre-hopped extracts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>hopEditor</name>
+    <message>
+        <source>Hop Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aroma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>Denbora</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bittering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pellet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop Stability/Storage index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>instructionWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mark this step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step completed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
+    <message>
+        <source>Recipes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target boil size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The extraction efficiency you expect</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Style</source>
         <translation type="vanished">Estiloa</translation>
@@ -3789,41 +4761,1095 @@ The final volume in the primary is %1.</source>
         <source>Boil Time</source>
         <translation type="vanished">Irekite-denbora</translation>
     </message>
+    <message>
+        <source>Target batch size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU/GU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calories/12oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Des</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invoke the mash wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash wiz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save this mash profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;BrewTarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Brewtarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Equipments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Scale Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe to Clipboard as &amp;Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;OG Correction Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Convert Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backup Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Copy Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pr&amp;iming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select another database to merge into the current one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save all recipes, ingredients, etc. to a backup folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore recipes, ingredients, etc. from a previous backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;New Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1.0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
+        <source>Mash Designer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Denbora</translation>
+        <translation>Denbora</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion/Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Collected Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>vol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun Fullness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunVol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashEditor</name>
+    <message>
+        <source>Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Get following parameters from the recipe&apos;s equipment.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
+        <source>Mash Step Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water to infuse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of infusion water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of mash to decoct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Denbora</translation>
+        <translation>Denbora</translation>
+    </message>
+    <message>
+        <source>Time to conduct the step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp. lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashWizard</name>
+    <message>
+        <source>Mash Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash thickness (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
+        <source>Misc Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Herb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flavor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Denbora</translation>
+        <translation>Denbora</translation>
+    </message>
+    <message>
+        <source>Check it if the amount listed is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>namedMashEditor</name>
+    <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ogAdjuster</name>
+    <message>
+        <source>Adjust Volume to Hit OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured gravity pre-boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp to which the hydrometer is calibrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-or-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato (percent by mass of equivalent sucrose)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG w/o Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG if you boil as planned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated batch size after correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Formulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
+    </message>
+    <message>
+        <source>IBU Adjustments</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;qt&gt;
+   &lt;b&gt;Know another language?&lt;/b&gt;
+   &lt;br&gt;&lt;br&gt;
+   Or, would you like to improve a translation? Help us out and
+  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
+  provide a translation&lt;/a&gt; so that your friends can use brewtarget!
+&lt;/qt&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Date</source>
-        <translation type="vanished">Data</translation>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -3906,15 +5932,1017 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>pitchDialog</name>
+    <message>
+        <source>Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wort Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch Rate (M cells)/(mL*P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Production Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Viability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>O2 At Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stir Plate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MM/dd/yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate Viability From Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Billions of Yeast Cells Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>primingDialog</name>
+    <message>
+        <source>Priming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of beer to prime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beer Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp of the beer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Glucose Monohydrate (corn sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anhydrous Glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sucrose (table sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Malt Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prime with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>recipeExtrasWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asst. Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date First Brewed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dd MMM yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carbonation Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>refractoDialog</name>
+    <message>
+        <source>Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20 C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refractive Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Real Extract (Plato)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>strikeWaterDialog</name>
+    <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Style</source>
-        <translation type="vanished">Estiloa</translation>
+        <translation>Estiloa</translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type of beverage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBUs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color (SRM)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carb (vols)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV (pct)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ingredients</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerListDialog</name>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterEditor</name>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>yeastEditor</name>
+    <message>
+        <source>Yeast Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Champagne</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Liquid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Culture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check it if the amount given is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flocculation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attenuation (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apparent attenuation as percentage of OG points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times Recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times this yeast has been recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked means add this yeast to secondary instead of primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_fr.ts
+++ b/translations/bt_fr.ts
@@ -530,6 +530,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Recette</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Inventaire</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Fermentescibles</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Houblons</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Sortie</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2005,13 +2100,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2453,15 +2541,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2767,80 +2855,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Inconnu</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">Standard</translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Inventaire</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Nom</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alpha %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -3003,6 +3017,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Inconnu</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Standard</translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Inventaire</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nom</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3785,8 +3873,36 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Annuler</translation>
+        <translation type="unfinished">Annuler</translation>
     </message>
 </context>
 <context>
@@ -3799,12 +3915,56 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Démarrer</translation>
+        <translation type="unfinished">Démarrer</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Arrêter</translation>
+        <translation type="unfinished">Arrêter</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4250,54 +4410,73 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Boîte de dialogue</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Générer les Instructions</translation>
+        <translation>Générer les Instructions</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Insérer une étape</translation>
+        <translation>Insérer une étape</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Nom de la nouvelle étape</translation>
+        <translation>Nom de la nouvelle étape</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Étape #</translation>
+        <translation>Étape #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">La position à laquelle insérer la nouvelle étape</translation>
+        <translation>La position à laquelle insérer la nouvelle étape</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Insérer la nouvelle étape</translation>
+        <translation>Insérer la nouvelle étape</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Déplacer les étapes</translation>
+        <translation>Déplacer les étapes</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Déplacer l&apos;étape choisie vers le haut</translation>
+        <translation>Déplacer l&apos;étape choisie vers le haut</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Déplacer l&apos;étape choisie vers le bas</translation>
+        <translation>Déplacer l&apos;étape choisie vers le bas</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Supprimer l&apos;étape sélectionnée</translation>
+        <translation>Supprimer l&apos;étape sélectionnée</translation>
     </message>
 </context>
 <context>
@@ -4367,27 +4546,27 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Pré-ébullition</translation>
+        <translation>Pré-ébullition</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Densité Spécifique</translation>
+        <translation>Densité Spécifique</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Densité pré-ébullition</translation>
+        <translation>Densité pré-ébullition</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volume</translation>
+        <translation>Volume</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Volume de moût collecté</translation>
+        <translation>Volume de moût collecté</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Température d&apos;empâtage</translation>
+        <translation>Température d&apos;empâtage</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4395,61 +4574,61 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Température finale</translation>
+        <translation>Température finale</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Température avant mash out</translation>
+        <translation>Température avant mash out</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Post-ébullition</translation>
+        <translation>Post-ébullition</translation>
     </message>
     <message>
         <source>OG</source>
         <translatorcomment>Densité initiale
 </translatorcomment>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Densité post-ébullition</translation>
+        <translation>Densité post-ébullition</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Volume post-ébullition</translation>
+        <translation>Volume post-ébullition</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Volume de moût dans la cuve après ébullition</translation>
+        <translation>Volume de moût dans la cuve après ébullition</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Volume de moût transféré dans le fermenteur</translation>
+        <translation>Volume de moût transféré dans le fermenteur</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volume dans le fermenteur</translation>
+        <translation>Volume dans le fermenteur</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Température d&apos;ensemencement</translation>
+        <translation> Température d&apos;ensemencement</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Température du moût lors de l&apos;ensemencement</translation>
+        <translation>Température du moût lors de l&apos;ensemencement</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Après fermentation</translation>
+        <translation>Après fermentation</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Densité finale</translation>
+        <translation>Densité finale</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Volume de bière en fûts/bouteilles</translation>
+        <translation>Volume de bière en fûts/bouteilles</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4465,11 +4644,11 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">DF prévue</translation>
+        <translation>DF prévue</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Efficacité de l&apos;installation</translation>
+        <translation>Efficacité de l&apos;installation</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4481,7 +4660,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">ABV visé</translation>
+        <translation>ABV visé</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4489,19 +4668,59 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <source>brewNote</source>
-        <translation type="vanished">Notes de Brassage</translation>
+        <translation>Notes de Brassage</translation>
     </message>
     <message>
         <source>yyyy-dd-MM</source>
-        <translation type="vanished">yyyy-dd-MM</translation>
+        <translation>yyyy-dd-MM</translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4520,18 +4739,182 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Espace mort dans la cuve-filtre</translation>
+        <translation>Espace mort dans la cuve-filtre</translation>
     </message>
     <message>
         <source>equipmentEditor</source>
-        <translation type="vanished">equipmentEditor</translation>
+        <translation>equipmentEditor</translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Éditeur d&apos;équipement</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Équipement</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Par défaut</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Volume du brassin</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nom</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Volume pré-ébullition calculé</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Durée d&apos;ébullition</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Taux d&apos;évaporation (par h)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Ajout d&apos;eau dans le fermenteur</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Ajout d&apos;eau avant l&apos;ébullition</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Absorption par défaut</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Point d&apos;ébullition de l&apos;eau</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Volume de la cuve matière</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Nouvel équipement</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Éditeur de fermentescible</translation>
+        <translation>Éditeur de fermentescible</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4539,31 +4922,31 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Grain</translation>
+        <translation>Grain</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Sucre</translation>
+        <translation>Sucre</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Extrait</translation>
+        <translation>Extrait</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Extrait sec</translation>
+        <translation>Extrait sec</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Adjuvant</translation>
+        <translation>Adjuvant</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4575,43 +4958,43 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Rendement d&apos;extraction comparé au glucose</translation>
+        <translation>Rendement d&apos;extraction comparé au glucose</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Échelle de notation Lovibond</translation>
+        <translation>Échelle de notation Lovibond</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Ajouter après l&apos;ébullition</translation>
+        <translation>Ajouter après l&apos;ébullition</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Cet ingrédient est ajouté après l&apos;ébullition.</translation>
+        <translation>Cet ingrédient est ajouté après l&apos;ébullition.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origine</translation>
+        <translation>Origine</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Fournisseur</translation>
+        <translation>Fournisseur</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Diff. Grossier/Fin (%)</translation>
+        <translation>Diff. Grossier/Fin (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Différence de rendement entre un concassage grossier et un concassage fin</translation>
+        <translation>Différence de rendement entre un concassage grossier et un concassage fin</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Humidité (%)</translation>
+        <translation>Humidité (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Pourcentage d&apos;humidité en masse</translation>
+        <translation>Pourcentage d&apos;humidité en masse</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4623,43 +5006,43 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Protéine (%)</translation>
+        <translation>Protéine (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Pourcentage de protéine en masse</translation>
+        <translation>Pourcentage de protéine en masse</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Max dans le brassin (%)</translation>
+        <translation>Max dans le brassin (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Pourcentage maximal recommandé du poids total de grain</translation>
+        <translation>Pourcentage maximal recommandé du poids total de grain</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Empâtage recommandé</translation>
+        <translation>Empâtage recommandé</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Cocher pour recommander d&apos;empâter cet ingrédient</translation>
+        <translation>Cocher pour recommander d&apos;empâter cet ingrédient</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Empâté</translation>
+        <translation>Empâté</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">À cocher si cet ingrédient est empâté</translation>
+        <translation>À cocher si cet ingrédient est empâté</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Amertume (IBU*gal/lb)</translation>
+        <translation>Amertume (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Amertume des extraits pré-houblonnés</translation>
+        <translation>Amertume des extraits pré-houblonnés</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4671,22 +5054,70 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantité dans l&apos;inventaire</translation>
+        <translation>Quantité dans l&apos;inventaire</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantité dans l&apos;inventaire</translation>
+        <translation>Quantité dans l&apos;inventaire</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Couleur</translation>
+        <translation>Couleur</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Rendement %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Éditeur de houblon</translation>
+        <translation>Éditeur de houblon</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4694,7 +5125,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4702,7 +5133,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Pourcentage d&apos;acides alpha en masse</translation>
+        <translation>Pourcentage d&apos;acides alpha en masse</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4710,59 +5141,59 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Utilisation</translation>
+        <translation>Utilisation</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Empâtage</translation>
+        <translation>Empâtage</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Pré-ébullition</translation>
+        <translation>Pré-ébullition</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Ébullition</translation>
+        <translation>Ébullition</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Arômatique</translation>
+        <translation>Arômatique</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Houblonnage à cru</translation>
+        <translation>Houblonnage à cru</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Durée</translation>
+        <translation>Durée</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Amérisant</translation>
+        <translation>Amérisant</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Les deux</translation>
+        <translation>Les deux</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Cône</translation>
+        <translation>Cône</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellet</translation>
+        <translation>Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Plug</translation>
+        <translation>Plug</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4770,19 +5201,19 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Pourcentage d&apos;acides bêta en masse</translation>
+        <translation>Pourcentage d&apos;acides bêta en masse</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Indice de stabilité/durée de conservation du houblon</translation>
+        <translation>Indice de stabilité/durée de conservation du houblon</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origine</translation>
+        <translation>Origine</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4790,7 +5221,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulène</translation>
+        <translation>Humulène</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4806,7 +5237,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulène</translation>
+        <translation>Cohumulène</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4814,7 +5245,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcène</translation>
+        <translation>Myrcène</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4830,65 +5261,121 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantité dans l&apos;inventaire</translation>
+        <translation>Quantité dans l&apos;inventaire</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantité dans l&apos;inventaire</translation>
+        <translation>Quantité dans l&apos;inventaire</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Afficher une minuterie</translation>
+        <translation>Afficher une minuterie</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Afficher la minuterie</translation>
+        <translation>Afficher la minuterie</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Marquer cette étape comme achevée</translation>
+        <translation>Marquer cette étape comme achevée</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Étape achevée</translation>
+        <translation>Étape achevée</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Recettes</translation>
+        <translation>Recettes</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Styles</translation>
+        <translation>Styles</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Fermentescibles</translation>
+        <translation>Fermentescibles</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Houblons</translation>
+        <translation>Houblons</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Divers</translation>
+        <translation>Divers</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Levures</translation>
+        <translation>Levures</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Recette</translation>
+        <translation>Recette</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4896,11 +5383,11 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Nom de la recette</translation>
+        <translation>Nom de la recette</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Volume d&apos;ébullition visé</translation>
+        <translation>Volume d&apos;ébullition visé</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4916,7 +5403,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Le rendement d&apos;extraction prévu</translation>
+        <translation>Le rendement d&apos;extraction prévu</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4928,7 +5415,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Volume du brassin visé</translation>
+        <translation>Volume du brassin visé</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4936,7 +5423,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Équipement</translation>
+        <translation>Équipement</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4944,163 +5431,163 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Densité pré-ébullition</translation>
+        <translation>Densité pré-ébullition</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">DF</translation>
+        <translation>DF</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Amertume (IBU)</translation>
+        <translation>Amertume (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Couleur</translation>
+        <translation>Couleur</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Calories/33cl</translation>
+        <translation>Calories/33cl</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extras</translation>
+        <translation>Extras</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Journée de brassage</translation>
+        <translation>Journée de brassage</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Ajouter un fermentescible</translation>
+        <translation>Ajouter un fermentescible</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Supprimer le fermentescible sélectionné</translation>
+        <translation>Supprimer le fermentescible sélectionné</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Modifier le fermentescible sélectionné</translation>
+        <translation>Modifier le fermentescible sélectionné</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Ajouter un houblon</translation>
+        <translation>Ajouter un houblon</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Supprimer le houblon sélectionné</translation>
+        <translation>Supprimer le houblon sélectionné</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Modifier le houblon sélectionné</translation>
+        <translation>Modifier le houblon sélectionné</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Divers</translation>
+        <translation>Divers</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Ajouter divers</translation>
+        <translation>Ajouter divers</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Supprimer l&apos;ingrédient divers  sélectionné</translation>
+        <translation>Supprimer l&apos;ingrédient divers  sélectionné</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Modifier l&apos;ingrédient divers sélectionné</translation>
+        <translation>Modifier l&apos;ingrédient divers sélectionné</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Levures</translation>
+        <translation>Levures</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Ajouter une levure</translation>
+        <translation>Ajouter une levure</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Supprimer la levure sélectionnée</translation>
+        <translation>Supprimer la levure sélectionnée</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Modifier la levure sélectionnée</translation>
+        <translation>Modifier la levure sélectionnée</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Empâtage</translation>
+        <translation>Empâtage</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Ajouter un palier d&apos;empâtage</translation>
+        <translation>Ajouter un palier d&apos;empâtage</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Supprimer le palier d&apos;empâtage sélectionné</translation>
+        <translation>Supprimer le palier d&apos;empâtage sélectionné</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Modifier le palier d&apos;empâtage sélectionné</translation>
+        <translation>Modifier le palier d&apos;empâtage sélectionné</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Modifier les paramètres d&apos;empâtage</translation>
+        <translation>Modifier les paramètres d&apos;empâtage</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Modifier l&apos;empâtage</translation>
+        <translation>Modifier l&apos;empâtage</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Créateur d&apos;empâtage</translation>
+        <translation>Créateur d&apos;empâtage</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Faites appel à l&apos;assistant d&apos;empâtage</translation>
+        <translation>Faites appel à l&apos;assistant d&apos;empâtage</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Assistant d&apos;empâtage</translation>
+        <translation>Assistant d&apos;empâtage</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Empâtage</translation>
+        <translation>Empâtage</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Monter le palier</translation>
+        <translation>Monter le palier</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Descendre le palier</translation>
+        <translation>Descendre le palier</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Sauvegarder ce profil d&apos;empâtage</translation>
+        <translation>Sauvegarder ce profil d&apos;empâtage</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Sauvegarder le profil</translation>
+        <translation>Sauvegarder le profil</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;À propos</translation>
+        <translation>&amp;À propos</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Fichier</translation>
+        <translation>&amp;Fichier</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5112,27 +5599,27 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">Base de &amp;données</translation>
+        <translation>Base de &amp;données</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">Afficha&amp;ge</translation>
+        <translation>Afficha&amp;ge</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">Ou&amp;tils</translation>
+        <translation>Ou&amp;tils</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Barre d&apos;outils</translation>
+        <translation>Barre d&apos;outils</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">À propos de &amp;Brewtarget</translation>
+        <translation>À propos de &amp;Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">À propos de Brewtarget</translation>
+        <translation>À propos de Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5140,19 +5627,19 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Fermentescibles</translation>
+        <translation>&amp;Fermentescibles</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Houblons</translation>
+        <translation>&amp;Houblons</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5160,31 +5647,31 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Levures</translation>
+        <translation>&amp;Levures</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Équipements</translation>
+        <translation>&amp;Équipements</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Styles</translation>
+        <translation>&amp;Styles</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5192,7 +5679,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5204,55 +5691,55 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Manuel</translation>
+        <translation>&amp;Manuel</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Adapter la recette</translation>
+        <translation>&amp;Adapter la recette</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Copier la recette dans le presse papier en &amp;texte</translation>
+        <translation>Copier la recette dans le presse papier en &amp;texte</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">Aide à la correction de &amp;DI</translation>
+        <translation>Aide à la correction de &amp;DI</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Convertisseur d&apos;unités</translation>
+        <translation>&amp;Convertisseur d&apos;unités</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Sauvegarder la base de donnés</translation>
+        <translation>Sauvegarder la base de donnés</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Restaurer la base de données</translation>
+        <translation>Restaurer la base de données</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Copier la recette</translation>
+        <translation>&amp;Copier la recette</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Calculateur de &amp;sucrage</translation>
+        <translation>Calculateur de &amp;sucrage</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">Outil pour &amp;réfractomètre</translation>
+        <translation>Outil pour &amp;réfractomètre</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">Calculateur d&apos;&amp;ensemencement</translation>
+        <translation>Calculateur d&apos;&amp;ensemencement</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Fusionner les bases de données</translation>
+        <translation>Fusionner les bases de données</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Sélectionner une base de données à fusionner avec la base actuelle.</translation>
+        <translation>Sélectionner une base de données à fusionner avec la base actuelle.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5272,19 +5759,19 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Sauvegarder</translation>
+        <translation>&amp;Sauvegarder</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Sauvegarder toutes les recettes, ingrédients, etc. dans un dossier</translation>
+        <translation>Sauvegarder toutes les recettes, ingrédients, etc. dans un dossier</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Restaurer</translation>
+        <translation>&amp;Restaurer</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Restaure les recettes, ingrédients, etc. depuis une sauvegarde</translation>
+        <translation>Restaure les recettes, ingrédients, etc. depuis une sauvegarde</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5296,7 +5783,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Nouvelle recette</translation>
+        <translation>&amp;Nouvelle recette</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5304,31 +5791,31 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Afficher les minuteries</translation>
+        <translation>Afficher les minuteries</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Sauvegarder</translation>
+        <translation>Sauvegarder</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Supprimer l&apos;élément sélectionné</translation>
+        <translation>Supprimer l&apos;élément sélectionné</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Supprimer la recette</translation>
+        <translation>Supprimer la recette</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">Profils d&apos;e&amp;mpâtage</translation>
+        <translation>Profils d&apos;e&amp;mpâtage</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Profils d&apos;empâtage</translation>
+        <translation>Profils d&apos;empâtage</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
@@ -5336,18 +5823,130 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>tab_recipe</source>
-        <translation type="vanished">tab_recipe</translation>
+        <translation>tab_recipe</translation>
     </message>
     <message>
         <source>Export to &amp;BBCode</source>
-        <translation type="vanished">Exporter vers &amp;BBCode</translation>
+        <translation>Exporter vers &amp;BBCode</translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Volume du brassin</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Volume pré-ébullition</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Brassons !</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Créateur de profil d&apos;empâtage</translation>
+        <translation>Créateur de profil d&apos;empâtage</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5363,7 +5962,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Durée</translation>
+        <translation>Durée</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5371,275 +5970,311 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Suivant</translation>
+        <translation>Suivant</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Terminer</translation>
+        <translation>Terminer</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Volume d&apos;infusion/de décoction</translation>
+        <translation>Volume d&apos;infusion/de décoction</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Température d&apos;infusion</translation>
+        <translation>Température d&apos;infusion</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Volume total de moût</translation>
+        <translation>Volume total de moût</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">vol</translation>
+        <translation>vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Remplissage de la cuve</translation>
+        <translation>Remplissage de la cuve</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">volCuve</translation>
+        <translation>volCuve</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">Épaisseur</translation>
+        <translation>Épaisseur</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Éditeur de profil d&apos;empâtage</translation>
+        <translation>Éditeur de profil d&apos;empâtage</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temp. initiale du grain</translation>
+        <translation>Temp. initiale du grain</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Température de rinçage</translation>
+        <translation>Température de rinçage</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Température de rinçage ciblée</translation>
+        <translation>Température de rinçage ciblée</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH eau de rinçage</translation>
+        <translation>pH eau de rinçage</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Cuve matière</translation>
+        <translation>Cuve matière</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Température initiale</translation>
+        <translation>Température initiale</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Utiliser les données de l&apos;équipement défini dans la recette pour les paramètres suivants.</translation>
+        <translation>Utiliser les données de l&apos;équipement défini dans la recette pour les paramètres suivants.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Utiliser les valeurs de l&apos;équipement</translation>
+        <translation>Utiliser les valeurs de l&apos;équipement</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Poids</translation>
+        <translation>Poids</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Chaleur spécifique</translation>
+        <translation>Chaleur spécifique</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Chaleur spécifique de la cuve matière (cal/(g*K))</translation>
+        <translation>Chaleur spécifique de la cuve matière (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Éditeur de paliers d&apos;empâtage</translation>
+        <translation>Éditeur de paliers d&apos;empâtage</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infusion</translation>
+        <translation>Infusion</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Chauffe</translation>
+        <translation>Chauffe</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Décoction</translation>
+        <translation>Décoction</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Température cible.</translation>
+        <translation>Température cible.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Température cible de ce palier</translation>
+        <translation>Température cible de ce palier</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Volume d&apos;infusion</translation>
+        <translation>Volume d&apos;infusion</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Volume d&apos;eau à utiliser pour l&apos;infusion</translation>
+        <translation>Volume d&apos;eau à utiliser pour l&apos;infusion</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Température d&apos;infusion</translation>
+        <translation>Température d&apos;infusion</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Température de l&apos;eau d&apos;infusion</translation>
+        <translation>Température de l&apos;eau d&apos;infusion</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Volume de décoction</translation>
+        <translation>Volume de décoction</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Volume de moût à prélever pour la décoction</translation>
+        <translation>Volume de moût à prélever pour la décoction</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Durée</translation>
+        <translation>Durée</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Durée de maintien de ce palier</translation>
+        <translation>Durée de maintien de ce palier</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Temps de latence de la chauffe</translation>
+        <translation>Temps de latence de la chauffe</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Temps de latence</translation>
+        <translation>Temps de latence</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Température finale.</translation>
+        <translation>Température finale.</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Température finale de ce palier</translation>
+        <translation>Température finale de ce palier</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Rinçage par lots</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Assistant d&apos;empâtage</translation>
+        <translation>Assistant d&apos;empâtage</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Densité d&apos;empâtage (L/kg)</translation>
+        <translation>Densité d&apos;empâtage (L/kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Densité d&apos;empâtage (ne pas entrer d&apos;unités)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Éditeur d&apos;ingrédients divers</translation>
+        <translation>Éditeur d&apos;ingrédients divers</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Épices</translation>
+        <translation>Épices</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Clarifiant</translation>
+        <translation>Clarifiant</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Agent d&apos;eau</translation>
+        <translation>Agent d&apos;eau</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Herbes</translation>
+        <translation>Herbes</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Saveur</translation>
+        <translation>Saveur</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Autres</translation>
+        <translation>Autres</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Utilisation</translation>
+        <translation>Utilisation</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Ébullition</translation>
+        <translation>Ébullition</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Empâtage</translation>
+        <translation>Empâtage</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Primaire</translation>
+        <translation>Primaire</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Secondaire</translation>
+        <translation>Secondaire</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Embouteillage</translation>
+        <translation>Embouteillage</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Durée</translation>
+        <translation>Durée</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5647,15 +6282,15 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Vérifier que la quantité est exprimée en kg et non en L.</translation>
+        <translation>Vérifier que la quantité est exprimée en kg et non en L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Exprimée en poids</translation>
+        <translation>Exprimée en poids</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">À cocher si la quantité est exprimée en poids et non en volume</translation>
+        <translation>À cocher si la quantité est exprimée en poids et non en volume</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5671,192 +6306,220 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantité dans l&apos;inventaire</translation>
+        <translation>Quantité dans l&apos;inventaire</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantité dans l&apos;inventaire</translation>
+        <translation>Quantité dans l&apos;inventaire</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Éditeur de profil d&apos;empâtage</translation>
+        <translation>Éditeur de profil d&apos;empâtage</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Empâtage</translation>
+        <translation>Empâtage</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Supprimer le style sélectionné</translation>
+        <translation>Supprimer le style sélectionné</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Température initiale du grain</translation>
+        <translation>Température initiale du grain</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Température de rinçage</translation>
+        <translation>Température de rinçage</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Température de rinçage ciblée</translation>
+        <translation>Température de rinçage ciblée</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH eau de rinçage</translation>
+        <translation>pH eau de rinçage</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Cuve matière</translation>
+        <translation>Cuve matière</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Température initiale</translation>
+        <translation>Température initiale</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Valeurs de l&apos;équipement</translation>
+        <translation>Valeurs de l&apos;équipement</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Poids</translation>
+        <translation>Poids</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Chaleur spécifique</translation>
+        <translation>Chaleur spécifique</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Chaleur spécifique de la cuve matière (cal/(g*K))</translation>
+        <translation>Chaleur spécifique de la cuve matière (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Ajouter un palier d&apos;empâtage</translation>
+        <translation>Ajouter un palier d&apos;empâtage</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Supprimer le palier d&apos;empâtage sélectionné</translation>
+        <translation>Supprimer le palier d&apos;empâtage sélectionné</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Monter le palier</translation>
+        <translation>Monter le palier</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Descendre le palier</translation>
+        <translation>Descendre le palier</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Ajuster le volume pour atteindre la DI</translation>
+        <translation>Ajuster le volume pour atteindre la DI</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrée</translation>
+        <translation>Entrée</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">DS</translation>
+        <translation>DS</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Densité Spécifique mesurée pré-ébullition</translation>
+        <translation>Densité Spécifique mesurée pré-ébullition</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Température</translation>
+        <translation>Température</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Température du moût lors de la mesure de la DS</translation>
+        <translation>Température du moût lors de la mesure de la DS</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Température de calibration</translation>
+        <translation>Température de calibration</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Température à laquelle le densimètre est calibré</translation>
+        <translation>Température à laquelle le densimètre est calibré</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-ou-</translation>
+        <translation>-ou-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (pourcentage de la masse de sucrose équivalent)</translation>
+        <translation>Plato (pourcentage de la masse de sucrose équivalent)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Volume pré-ébullition</translation>
+        <translation>Volume pré-ébullition</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Volume pré-ébullition mesuré</translation>
+        <translation>Volume pré-ébullition mesuré</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Sortie</translation>
+        <translation>Sortie</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">DI sans correction</translation>
+        <translation>DI sans correction</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">DI après l&apos;ébullition prévue</translation>
+        <translation>DI après l&apos;ébullition prévue</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Ajouter à l&apos;ébullition</translation>
+        <translation>Ajouter à l&apos;ébullition</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Quantité d&apos;eau à ajouter afin d&apos;atteindre la DI prévue (ou taux d&apos;évaporation si négatif)</translation>
+        <translation>Quantité d&apos;eau à ajouter afin d&apos;atteindre la DI prévue (ou taux d&apos;évaporation si négatif)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Volume final du brassin</translation>
+        <translation>Volume final du brassin</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Volume du brassin estimé après correction</translation>
+        <translation>Volume du brassin estimé après correction</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calculer</translation>
+        <translation>Calculer</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Options</translation>
+        <translation>Options</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Unités</translation>
+        <translation>Unités</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Poids</translation>
+        <translation>Poids</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5872,7 +6535,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Température</translation>
+        <translation>Température</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5884,11 +6547,11 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volume</translation>
+        <translation>Volume</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Densité</translation>
+        <translation>Densité</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5900,7 +6563,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Couleur</translation>
+        <translation>Couleur</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5912,7 +6575,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Formules</translation>
+        <translation>Formules</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5928,7 +6591,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5940,7 +6603,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Ajustements de l&apos;IBU</translation>
+        <translation>Ajustements de l&apos;IBU</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5976,7 +6639,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Langue</translation>
+        <translation>Langue</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5986,7 +6649,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Connaissez vous une autre langue ?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Ou, souhaitez-vous  améliorer une traduction ? Aidez-nous en
@@ -5996,7 +6659,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Date</translation>
+        <translation>Date</translation>
     </message>
     <message>
         <source>mm-dd-YYYY</source>
@@ -6013,6 +6676,42 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     <message>
         <source>Noonan&apos;s approximation</source>
         <translation type="vanished">Approximation de Noonan</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6095,6 +6794,54 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6103,418 +6850,418 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Calculateur d&apos;ensemencement</translation>
+        <translation>Calculateur d&apos;ensemencement</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrée</translation>
+        <translation>Entrée</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Volume de moût</translation>
+        <translation>Volume de moût</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Pour les ales : 0.75-1. Pour les lagers : 1.5-2.</translation>
+        <translation>Pour les ales : 0.75-1. Pour les lagers : 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Taux d&apos;ensemencement (M cellules)/(mL*P)</translation>
+        <translation>Taux d&apos;ensemencement (M cellules)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Méthode d&apos;aération</translation>
+        <translation>Méthode d&apos;aération</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Date de production de la levure</translation>
+        <translation>Date de production de la levure</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Viabilité de la levure</translation>
+        <translation>Viabilité de la levure</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Aucun</translation>
+        <translation>Aucun</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">Oxygénation au début</translation>
+        <translation>Oxygénation au début</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Agitateur magnétique</translation>
+        <translation>Agitateur magnétique</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">dd/MM/yyyy</translation>
+        <translation>dd/MM/yyyy</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">TextLabel</translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Calculer la viabilité en fonction de la date</translation>
+        <translation>Calculer la viabilité en fonction de la date</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># Fioles/Smack Packs utilisés</translation>
+        <translation># Fioles/Smack Packs utilisés</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Sortie</translation>
+        <translation>Sortie</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Milliards de cellules requises</translation>
+        <translation>Milliards de cellules requises</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Fioles/Smack Packs sans Starter</translation>
+        <translation># Fioles/Smack Packs sans Starter</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Levure sèche</translation>
+        <translation>Levure sèche</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Volume de starter</translation>
+        <translation>Volume de starter</translation>
     </message>
     <message>
         <source>Volume of wort</source>
-        <translation type="vanished">Volume de moût</translation>
+        <translation>Volume de moût</translation>
     </message>
     <message>
         <source>Starting gravity of the wort</source>
-        <translation type="vanished">Densité Initial du moût</translation>
+        <translation>Densité Initial du moût</translation>
     </message>
     <message>
         <source>Aeration method</source>
-        <translation type="vanished">Méthode d&apos;aération</translation>
+        <translation>Méthode d&apos;aération</translation>
     </message>
     <message>
         <source>Production date (Best By date less three months)</source>
-        <translation type="vanished">Date de production (de préférence de moins de trois mois)</translation>
+        <translation>Date de production (de préférence de moins de trois mois)</translation>
     </message>
     <message>
         <source>Estimated viability of the yeast</source>
-        <translation type="vanished">Viabilité estimée de la levure</translation>
+        <translation>Viabilité estimée de la levure</translation>
     </message>
     <message>
         <source>Desired pitch rate</source>
-        <translation type="vanished">Taux d&apos;ensemencement souhaité</translation>
+        <translation>Taux d&apos;ensemencement souhaité</translation>
     </message>
     <message>
         <source>Number of vials/smack packs added to starter</source>
-        <translation type="vanished">Nombre de fioles/Smack Packs ajoutés au starter</translation>
+        <translation>Nombre de fioles/Smack Packs ajoutés au starter</translation>
     </message>
     <message>
         <source>How much yeast you will need</source>
-        <translation type="vanished">De combien de levure vous aurez besoin</translation>
+        <translation>De combien de levure vous aurez besoin</translation>
     </message>
     <message>
         <source>How many smack packs or vials required to reach pitch rate</source>
-        <translation type="vanished">Combien de fioles ou de Smack Packs sont nécessaires pour atteindre le taux d&apos;ensemencement</translation>
+        <translation>Combien de fioles ou de Smack Packs sont nécessaires pour atteindre le taux d&apos;ensemencement</translation>
     </message>
     <message>
         <source>Amount of dry yeast needed to reach pitch rate</source>
-        <translation type="vanished">Quantité de levure sèche nécessaire pour atteindre le taux d&apos;ensemencement</translation>
+        <translation>Quantité de levure sèche nécessaire pour atteindre le taux d&apos;ensemencement</translation>
     </message>
     <message>
         <source>Starter size to reach pitch rate</source>
-        <translation type="vanished">Volume du starter nécessaire pour atteindre le taux d&apos;ensemencement</translation>
+        <translation>Volume du starter nécessaire pour atteindre le taux d&apos;ensemencement</translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Calculateur de sucrage</translation>
+        <translation>Calculateur de sucrage</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrée</translation>
+        <translation>Entrée</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Volume de bière</translation>
+        <translation>Volume de bière</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Volume de bière à sucrer</translation>
+        <translation>Volume de bière à sucrer</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Température de la bière</translation>
+        <translation>Température de la bière</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Température de la bière</translation>
+        <translation>Température de la bière</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Volume de CO2 souhaité</translation>
+        <translation>Volume de CO2 souhaité</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Quel volume de C02 souhaitez-vous ? (1 L CO2 @ STP par L bière)</translation>
+        <translation>Quel volume de C02 souhaitez-vous ? (1 L CO2 @ STP par L bière)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glucose monohydrate (sucre de maïs)</translation>
+        <translation>Glucose monohydrate (sucre de maïs)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Glucose anhydre</translation>
+        <translation>Glucose anhydre</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sucrose (sucre blanc de table)</translation>
+        <translation>Sucrose (sucre blanc de table)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Extrait de malt en poudre</translation>
+        <translation>Extrait de malt en poudre</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Sortie</translation>
+        <translation>Sortie</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Sucrer avec</translation>
+        <translation>Sucrer avec</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Quantité d&apos;ingrédient sucrant à utiliser</translation>
+        <translation>Quantité d&apos;ingrédient sucrant à utiliser</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calculer</translation>
+        <translation>Calculer</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Brasseur</translation>
+        <translation>Brasseur</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Asst. brasseur</translation>
+        <translation>Asst. brasseur</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Note de dégustation</translation>
+        <translation>Note de dégustation</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Garde primaire (jours)</translation>
+        <translation>Garde primaire (jours)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Température primaire</translation>
+        <translation>Température primaire</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Garde secondaire (jours)</translation>
+        <translation>Garde secondaire (jours)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Température secondaire</translation>
+        <translation>Température secondaire</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Garde tertiaire (jours)</translation>
+        <translation>Garde tertiaire (jours)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Température tertiaire</translation>
+        <translation>Température tertiaire</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Garde en bouteilles/fûts (jours)</translation>
+        <translation>Garde en bouteilles/fûts (jours)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Température en bouteilles/fûts</translation>
+        <translation>Température en bouteilles/fûts</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Date à laquelle la recette a été brassée la première fois</translation>
+        <translation>Date à laquelle la recette a été brassée la première fois</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Volumes de carbonatation</translation>
+        <translation>Volumes de carbonatation</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Notes de dégustation</translation>
+        <translation>Notes de dégustation</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Outil pour réfractomètre</translation>
+        <translation>Outil pour réfractomètre</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Entées</translation>
+        <translation>Entées</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">DI (°P)</translation>
+        <translation>DI (°P)</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">DI (20°C)</translation>
+        <translation>DI (20°C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Densité actuelle (°P)</translation>
+        <translation>Densité actuelle (°P)</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calculer</translation>
+        <translation>Calculer</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Résultats</translation>
+        <translation>Résultats</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">Densité Spécifique (20°C)</translation>
+        <translation>Densité Spécifique (20°C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">ABW</translation>
+        <translation>ABW</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Indice de réfraction</translation>
+        <translation>Indice de réfraction</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Extrait réel (°P)</translation>
+        <translation>Extrait réel (°P)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">DI (20°C)</translation>
+        <translation>DI (20°C)</translation>
     </message>
     <message>
         <source>Measured original plato</source>
-        <translation type="vanished">Densité Initiale mesurée en degrés Plato</translation>
+        <translation>Densité Initiale mesurée en degrés Plato</translation>
     </message>
     <message>
         <source>Measured original gravity</source>
-        <translation type="vanished">Densité Initiale mesurée en densité spécifique à 20°C</translation>
+        <translation>Densité Initiale mesurée en densité spécifique à 20°C</translation>
     </message>
     <message>
         <source>Current measured plato</source>
-        <translation type="vanished">Densité actuelle mesurée en degrés Plato</translation>
+        <translation>Densité actuelle mesurée en degrés Plato</translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Calculateur d&apos;eau d&apos;empâtage</translation>
+        <translation>Calculateur d&apos;eau d&apos;empâtage</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Infusion initiale</translation>
+        <translation>Infusion initiale</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Température initiale du grain</translation>
+        <translation>Température initiale du grain</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Température d&apos;empâtage désirée</translation>
+        <translation>Température d&apos;empâtage désirée</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Poids du grain</translation>
+        <translation>Poids du grain</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Volume d&apos;eau</translation>
+        <translation>Volume d&apos;eau</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">Infusion de la maische</translation>
+        <translation>Infusion de la maische</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Volume d&apos;eau total</translation>
+        <translation>Volume d&apos;eau total</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Poids du grain</translation>
+        <translation>Poids du grain</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Température d&apos;empâtage réelle</translation>
+        <translation>Température d&apos;empâtage réelle</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Température de l&apos;eau d&apos;infusion</translation>
+        <translation>Température de l&apos;eau d&apos;infusion</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calculer</translation>
+        <translation>Calculer</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Température d&apos;eau d&apos;empâtage</translation>
+        <translation>Température d&apos;eau d&apos;empâtage</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Volume à ajouter</translation>
+        <translation>Volume à ajouter</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Note : Ce calculateur suppose que la cuve matière est préchauffée.</translation>
+        <translation>Note : Ce calculateur suppose que la cuve matière est préchauffée.</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Éditeur de style</translation>
+        <translation>Éditeur de style</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Style</translation>
+        <translation>Style</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Supprimer le style sélectionné</translation>
+        <translation>Supprimer le style sélectionné</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6522,55 +7269,55 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Catégorie</translation>
+        <translation>Catégorie</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Numéro de catégorie</translation>
+        <translation>Numéro de catégorie</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Lettre du style</translation>
+        <translation>Lettre du style</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Guide du style</translation>
+        <translation>Guide du style</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Type de breuvage</translation>
+        <translation>Type de breuvage</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Hydromel</translation>
+        <translation>Hydromel</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Blanche</translation>
+        <translation>Blanche</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Mixte</translation>
+        <translation>Mixte</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Cidre</translation>
+        <translation>Cidre</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6578,51 +7325,51 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Max</translation>
+        <translation>Max</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Min</translation>
+        <translation>Min</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">DI</translation>
+        <translation>DI</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">DF</translation>
+        <translation>DF</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBUs</translation>
+        <translation>IBUs</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Couleur (SRM)</translation>
+        <translation>Couleur (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Carb (vols)</translation>
+        <translation>Carb (vols)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV (%)</translation>
+        <translation>ABV (%)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Profile</translation>
+        <translation>Profile</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingrédients</translation>
+        <translation>Ingrédients</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Exemples</translation>
+        <translation>Exemples</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <source>New</source>
@@ -6636,6 +7383,50 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Annuler</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
@@ -6643,12 +7434,207 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
         <source>Timers</source>
         <translation type="vanished">Minuteries</translation>
     </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">Format</translation>
+        <translation type="unfinished">Format</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Arrêter</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6659,18 +7645,22 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notes</translation>
+        <translation>Notes</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Éditeur de levure</translation>
+        <translation>Éditeur de levure</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6678,51 +7668,51 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nom</translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Blanche</translation>
+        <translation>Blanche</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Vin</translation>
+        <translation>Vin</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Champagne</translation>
+        <translation>Champagne</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Liquide</translation>
+        <translation>Liquide</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Sèche</translation>
+        <translation>Sèche</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Gélose inclinée</translation>
+        <translation>Gélose inclinée</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Culture</translation>
+        <translation>Culture</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6730,91 +7720,91 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">À cocher si la quantité est exprimée en kg et non en L.</translation>
+        <translation>À cocher si la quantité est exprimée en kg et non en L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Exprimée en poids</translation>
+        <translation>Exprimée en poids</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">À cocher si la quantité est exprimée en poids et non en volume</translation>
+        <translation>À cocher si la quantité est exprimée en poids et non en volume</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Labo</translation>
+        <translation>Labo</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">ID du produit</translation>
+        <translation>ID du produit</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Temp. min</translation>
+        <translation>Temp. min</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Temp. min</translation>
+        <translation>Temp. min</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Temp. max</translation>
+        <translation>Temp. max</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Temp. max</translation>
+        <translation>Temp. max</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Floculation</translation>
+        <translation>Floculation</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Faible</translation>
+        <translation>Faible</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Moyen</translation>
+        <translation>Moyen</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Élevé</translation>
+        <translation>Élevé</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Très élevé</translation>
+        <translation>Très élevé</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Atténuation (%)</translation>
+        <translation>Atténuation (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Atténuation apparente en pourcentage de la densité initiale</translation>
+        <translation>Atténuation apparente en pourcentage de la densité initiale</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Nombre de cultures</translation>
+        <translation>Nombre de cultures</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Nombre de fois que cette levure a été cultivée</translation>
+        <translation>Nombre de fois que cette levure a été cultivée</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Nombre de cultures max</translation>
+        <translation>Nombre de cultures max</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Nombre de cultures max</translation>
+        <translation>Nombre de cultures max</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Ajouter en secondaire</translation>
+        <translation>Ajouter en secondaire</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">À cocher si vous souhaitez ajouter cette levure en secondaire et non primaire</translation>
+        <translation>À cocher si vous souhaitez ajouter cette levure en secondaire et non primaire</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6830,11 +7820,39 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Quantité dans l&apos;inventaire</translation>
+        <translation>Quantité dans l&apos;inventaire</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Quantité dans l&apos;inventaire</translation>
+        <translation>Quantité dans l&apos;inventaire</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notes</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_gl.ts
+++ b/translations/bt_gl.ts
@@ -466,6 +466,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Receita</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Fermento</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2190,15 +2285,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2460,80 +2555,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Descoñecido</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Nome</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2696,6 +2717,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Descoñecido</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3473,6 +3568,41 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>TimerDialog</name>
+    <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TimerListDialog</name>
     <message>
         <source>Addition Timers</source>
@@ -3481,6 +3611,58 @@ The final volume in the primary is %1.</source>
 </context>
 <context>
     <name>TimerMainDialog</name>
+    <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>No Timers</source>
         <translation type="unfinished"></translation>
@@ -3881,14 +4063,73 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulario</translation>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <source>Generate Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert step</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <source>Name of new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The number where the new step should be placed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert the new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove currently selected step</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3905,72 +4146,735 @@ The final volume in the primary is %1.</source>
 <context>
     <name>brewNoteWidget</name>
     <message>
+        <source>Preboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preboil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort collected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of mash before mash out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Post boil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort in BK after boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort transferred to fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volume no fermentador</translation>
+        <translation>Volume no fermentador</translation>
+    </message>
+    <message>
+        <source> Pitch Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of wort when yeast is pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postferment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of beer into serving keg/bottles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewhouse efficiency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected ABV</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">APV</translation>
+        <translation>APV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anotacións</translation>
+        <translation>Anotacións</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>equipmentEditor</name>
+    <message>
+        <source>Lauter deadspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Equipo</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Tempo</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anotacións</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
+        <source>Fermentable Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sugar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjunct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield as compared to glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lovibond rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add After Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This ingredient is added post boil.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse/Fine Diff (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield difference between coarse and fine grind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max In Batch (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum recommended percentage of total grist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend this be mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is Mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if it is present in mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU*gal/lb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness of pre-hopped extracts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Cor</translation>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anotacións</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
+        <source>Hop Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <source>Alpha acids as percent by mass</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Usar</translation>
+        <translation>Usar</translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aroma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Hop</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>Bittering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulario</translation>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <source>Leaf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pellet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop Stability/Storage index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anotacións</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulario</translation>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <source>Show a timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mark this step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step completed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
+        <source>Recipes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recipe</source>
-        <translation type="vanished">Receita</translation>
+        <translation>Receita</translation>
     </message>
     <message>
         <source>Name</source>
         <translation type="vanished">Nome</translation>
+    </message>
+    <message>
+        <source>Name of recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target boil size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The extraction efficiency you expect</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Style</source>
@@ -3981,25 +4885,473 @@ The final volume in the primary is %1.</source>
         <translation type="vanished">Tempo de fervura</translation>
     </message>
     <message>
+        <source>Target batch size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Equipment</source>
-        <translation type="vanished">Equipo</translation>
+        <translation>Equipo</translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">APV</translation>
+        <translation>APV</translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Cor</translation>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>IBU/GU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calories/12oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected misc</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Fermento</translation>
+        <translation>Fermento</translation>
+    </message>
+    <message>
+        <source>Add yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Des</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invoke the mash wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash wiz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save this mash profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;BrewTarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Brewtarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Equipments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Scale Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe to Clipboard as &amp;Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;OG Correction Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Convert Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backup Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Copy Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pr&amp;iming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select another database to merge into the current one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save all recipes, ingredients, etc. to a backup folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore recipes, ingredients, etc. from a previous backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;New Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1.0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Faino!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
+        <source>Mash Designer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
         <translation type="vanished">Nome</translation>
     </message>
@@ -4009,74 +5361,545 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion/Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Collected Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>vol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun Fullness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunVol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
+        <source>Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anotacións</translation>
+        <translation>Anotacións</translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Get following parameters from the recipe&apos;s equipment.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
+        <source>Mash Step Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water to infuse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of infusion water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of mash to decoct</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
+    </message>
+    <message>
+        <source>Time to conduct the step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp. lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashWizard</name>
+    <message>
+        <source>Mash Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash thickness (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
+        <source>Misc Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>Spice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Herb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flavor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Usar</translation>
+        <translation>Usar</translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottling</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
+    </message>
+    <message>
+        <source>Check it if the amount listed is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anotacións</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anotacións</translation>
+        <translation>Anotacións</translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
+        <source>Adjust Volume to Hit OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured gravity pre-boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp to which the hydrometer is calibrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-or-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Plato</source>
-        <translation type="vanished">Grados Plato</translation>
+        <translation>Grados Plato</translation>
+    </message>
+    <message>
+        <source>Plato (percent by mass of equivalent sucrose)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG w/o Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG if you boil as planned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated batch size after correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Celsius</source>
         <translation type="vanished">Centígrados</translation>
@@ -4086,8 +5909,28 @@ The final volume in the primary is %1.</source>
         <translation type="vanished">Fahrenheit</translation>
     </message>
     <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Color</source>
-        <translation type="vanished">Cor</translation>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Formulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU Adjustments</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Browse</source>
@@ -4098,8 +5941,58 @@ The final volume in the primary is %1.</source>
         <translation type="vanished">Predeterminado</translation>
     </message>
     <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;qt&gt;
+   &lt;b&gt;Know another language?&lt;/b&gt;
+   &lt;br&gt;&lt;br&gt;
+   Or, would you like to improve a translation? Help us out and
+  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
+  provide a translation&lt;/a&gt; so that your friends can use brewtarget!
+&lt;/qt&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Date</source>
-        <translation type="vanished">Data</translation>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -4182,7 +6075,257 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>pitchDialog</name>
+    <message>
+        <source>Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wort Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch Rate (M cells)/(mL*P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Production Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Viability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>O2 At Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stir Plate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MM/dd/yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate Viability From Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Billions of Yeast Cells Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>primingDialog</name>
+    <message>
+        <source>Priming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of beer to prime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beer Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp of the beer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Glucose Monohydrate (corn sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anhydrous Glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sucrose (table sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Malt Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prime with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4190,78 +6333,763 @@ The final volume in the primary is %1.</source>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulario</translation>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <source>Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asst. Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date First Brewed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dd MMM yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carbonation Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Notes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anotacións</translation>
+        <translation>Anotacións</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
+        <source>Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20 C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ABV</source>
-        <translation type="vanished">APV</translation>
+        <translation>APV</translation>
+    </message>
+    <message>
+        <source>ABW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refractive Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Real Extract (Plato)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>strikeWaterDialog</name>
+    <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Style</source>
-        <translation type="vanished">Estilo</translation>
+        <translation>Estilo</translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Categoría</translation>
+        <translation>Categoría</translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>Type of beverage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBUs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color (SRM)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carb (vols)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV (pct)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ingredients</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anotacións</translation>
+        <translation>Anotacións</translation>
     </message>
     <message>
         <source>New</source>
         <translation type="vanished">Novo</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerListDialog</name>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">Formulario</translation>
+        <translation type="unfinished">Formulario</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>waterEditor</name>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anotacións</translation>
+        <translation>Anotacións</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
+        <source>Yeast Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Champagne</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulario</translation>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <source>Liquid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Culture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check it if the amount given is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flocculation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attenuation (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apparent attenuation as percentage of OG points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times Recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times this yeast has been recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked means add this yeast to secondary instead of primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anotacións</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_hu.ts
+++ b/translations/bt_hu.ts
@@ -522,6 +522,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Recept</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Készlet</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Erjesztető anyagok</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Komló</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Kimenet</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Mégsem</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1993,13 +2088,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">minimum</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2441,15 +2529,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2755,80 +2843,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">ismeretlen</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">Normál</translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Készlet</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Név</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Mennyiség</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alfasav %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2991,6 +3005,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">ismeretlen</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Normál</translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Készlet</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Név</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Mennyiség</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfasav %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3773,8 +3861,36 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Mégsem</translation>
+        <translation type="unfinished">Mégsem</translation>
     </message>
 </context>
 <context>
@@ -3787,12 +3903,56 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Kezdés</translation>
+        <translation type="unfinished">Kezdés</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Leállítás</translation>
+        <translation type="unfinished">Leállítás</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4214,54 +4374,73 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Útmutató készítése</translation>
+        <translation>Útmutató készítése</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Lépés beszúrása</translation>
+        <translation>Lépés beszúrása</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Új lépés neve</translation>
+        <translation>Új lépés neve</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">lépés #.</translation>
+        <translation>lépés #.</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">A hely/szám, ahová az új lépés beillesztésre kerül</translation>
+        <translation>A hely/szám, ahová az új lépés beillesztésre kerül</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Új lépés beillesztése</translation>
+        <translation>Új lépés beillesztése</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Lépés áthelyezése</translation>
+        <translation>Lépés áthelyezése</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">A kijelölt lépés felfelé mozgatása</translation>
+        <translation>A kijelölt lépés felfelé mozgatása</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">A kijelölt lépés lefelé mozgatása</translation>
+        <translation>A kijelölt lépés lefelé mozgatása</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">A kijelölt lépés törlése</translation>
+        <translation>A kijelölt lépés törlése</translation>
     </message>
 </context>
 <context>
@@ -4331,27 +4510,27 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Forralást megelőző</translation>
+        <translation>Forralást megelőző</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">fajsúly (SG)</translation>
+        <translation>fajsúly (SG)</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">forralás előtti fajsúly</translation>
+        <translation>forralás előtti fajsúly</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Mennyiség</translation>
+        <translation>Mennyiség</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Színlé mennyisége</translation>
+        <translation>Színlé mennyisége</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Felöntővíz hőmérséklet</translation>
+        <translation>Felöntővíz hőmérséklet</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4359,59 +4538,59 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Végleges hőmérséklet</translation>
+        <translation>Végleges hőmérséklet</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">A kicefrézés megkezdése előtti cefre hőfoka</translation>
+        <translation>A kicefrézés megkezdése előtti cefre hőfoka</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Forralást követő</translation>
+        <translation>Forralást követő</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">kezdeti fajsúly (OG)</translation>
+        <translation>kezdeti fajsúly (OG)</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Forralás utáni fajsúly</translation>
+        <translation>Forralás utáni fajsúly</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Forralás utáni mennyiség</translation>
+        <translation>Forralás utáni mennyiség</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Sörlé mennyisége forralás után</translation>
+        <translation>Sörlé mennyisége forralás után</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Erjesztőbe átfejtett sörlé mennyisége</translation>
+        <translation>Erjesztőbe átfejtett sörlé mennyisége</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Mennyiség (erjesztőbe fejtéskor)</translation>
+        <translation>Mennyiség (erjesztőbe fejtéskor)</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Élesztővel beoltás hőfoka</translation>
+        <translation> Élesztővel beoltás hőfoka</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Sörlé hőfoka beoltáskor</translation>
+        <translation>Sörlé hőfoka beoltáskor</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Erjedést követő</translation>
+        <translation>Erjedést követő</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Végleges fajsúly</translation>
+        <translation>Végleges fajsúly</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Kiszerelési mennyiség</translation>
+        <translation>Kiszerelési mennyiség</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4427,11 +4606,11 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Várható kezdeti fajsúly</translation>
+        <translation>Várható kezdeti fajsúly</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Kihozatal</translation>
+        <translation>Kihozatal</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4443,7 +4622,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Tervezett alkoholfok (v/v%)</translation>
+        <translation>Tervezett alkoholfok (v/v%)</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4451,11 +4630,59 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">alkoholfok (v/v%)</translation>
+        <translation>alkoholfok (v/v%)</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Megjegyzések</translation>
+        <translation>Megjegyzések</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4474,14 +4701,182 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Holttér a szűrőkádban (az alfenék és az edény alja között)</translation>
+        <translation>Holttér a szűrőkádban (az alfenék és az edény alja között)</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Felszerelés szerkesztő</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Felszerelés</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Beállítás alapértelmezésként</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Főzet méret</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Név</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Idõ</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Forralás előtti mennyiség kiszámolása</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Forralási idő</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Párolgási arány (óránként)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">A főzés utolsó fázisban hozzáadott víz mennyisége</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Vízpótlás mennyisége forraláskor</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Víz forráspontja</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Cefréző edény térfogata</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Megjegyzések</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Új berendezés</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Erjeszthető összetevő szerkeszése</translation>
+        <translation>Erjeszthető összetevő szerkeszése</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4489,31 +4884,31 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Fajta</translation>
+        <translation>Fajta</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Maláta/gabona</translation>
+        <translation>Maláta/gabona</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Cukor</translation>
+        <translation>Cukor</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Folyékony malátasűrítmény (LME)</translation>
+        <translation>Folyékony malátasűrítmény (LME)</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Szárított malátasűrítmény (DME)</translation>
+        <translation>Szárított malátasűrítmény (DME)</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Adalék</translation>
+        <translation>Adalék</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4525,43 +4920,43 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Glukózhoz mért kihozatali arány</translation>
+        <translation>Glukózhoz mért kihozatali arány</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Lovibond besorolás</translation>
+        <translation>Lovibond besorolás</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Forrás után hozzáad</translation>
+        <translation>Forrás után hozzáad</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Ez az összetevő forrás után kerül hozzáadásra</translation>
+        <translation>Ez az összetevő forrás után kerül hozzáadásra</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Eredet</translation>
+        <translation>Eredet</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Szállító</translation>
+        <translation>Szállító</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Durva/finom őrlet különbsége (%)</translation>
+        <translation>Durva/finom őrlet különbsége (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Durva és finom őrlet közötti kihozatali arány különbség (%)</translation>
+        <translation>Durva és finom őrlet közötti kihozatali arány különbség (%)</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Nedvességtartalom (%)</translation>
+        <translation>Nedvességtartalom (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Nedvesség tömegszázalékban kifejezett tartalma</translation>
+        <translation>Nedvesség tömegszázalékban kifejezett tartalma</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4573,31 +4968,43 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Fehérjetartalom (%)</translation>
+        <translation>Fehérjetartalom (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Fehérjetartalom tömegszázalékban kifejezve</translation>
+        <translation>Fehérjetartalom tömegszázalékban kifejezve</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Maximum a főzetben (%)</translation>
+        <translation>Maximum a főzetben (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">A dara teljes mennyiségében maximálisan felhasználható mennyiség (%)</translation>
+        <translation>A dara teljes mennyiségében maximálisan felhasználható mennyiség (%)</translation>
+    </message>
+    <message>
+        <source>Recommend Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend this be mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is Mashed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Ellenőrizni, hogy a bekerült-e a cefrébe.</translation>
+        <translation>Ellenőrizni, hogy a bekerült-e a cefrébe.</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Keserűség (IBU * gallon/font)</translation>
+        <translation>Keserűség (IBU * gallon/font)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Előre komlózott malátakivonat keserűsége</translation>
+        <translation>Előre komlózott malátakivonat keserűsége</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4609,22 +5016,70 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Készleten lévő mennyiség</translation>
+        <translation>Készleten lévő mennyiség</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Készleten lévő mennyiség</translation>
+        <translation>Készleten lévő mennyiség</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Szín</translation>
+        <translation>Szín</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Süllyedés %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extrák</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Megjegyzések</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Komló szerkesztő</translation>
+        <translation>Komló szerkesztő</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4632,7 +5087,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4640,7 +5095,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Alfasav tartalom tömegszázalékban</translation>
+        <translation>Alfasav tartalom tömegszázalékban</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4648,59 +5103,59 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Felhasználás</translation>
+        <translation>Felhasználás</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Cefre</translation>
+        <translation>Cefre</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Színlé komlózása (forralás előtt)</translation>
+        <translation>Színlé komlózása (forralás előtt)</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Forralás</translation>
+        <translation>Forralás</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Hidegkomló</translation>
+        <translation>Hidegkomló</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Idõ</translation>
+        <translation>Idõ</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Fajta</translation>
+        <translation>Fajta</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Keserűkomló</translation>
+        <translation>Keserűkomló</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Mindkettő</translation>
+        <translation>Mindkettő</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">leveles</translation>
+        <translation>leveles</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellet</translation>
+        <translation>Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Nagy pellet (komlódugó)</translation>
+        <translation>Nagy pellet (komlódugó)</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4708,19 +5163,19 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Bétasav tartalom tömegszázalékban</translation>
+        <translation>Bétasav tartalom tömegszázalékban</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">Komló tárolási index</translation>
+        <translation>Komló tárolási index</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Komló tárolási/stabilitási mutató</translation>
+        <translation>Komló tárolási/stabilitási mutató</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Eredet</translation>
+        <translation>Eredet</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4728,7 +5183,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulene</translation>
+        <translation>Humulene</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4744,7 +5199,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulone</translation>
+        <translation>Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4752,7 +5207,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcene</translation>
+        <translation>Myrcene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4768,65 +5223,121 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Készleten lévő mennyiség</translation>
+        <translation>Készleten lévő mennyiség</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Készleten lévő mennyiség</translation>
+        <translation>Készleten lévő mennyiség</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfasav %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extrák</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Megjegyzések</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Időzítő megjelenítése</translation>
+        <translation>Időzítő megjelenítése</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Időzítő megjelenítése</translation>
+        <translation>Időzítő megjelenítése</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Befejezett lépés</translation>
+        <translation>Befejezett lépés</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Befejezett lépés</translation>
+        <translation>Befejezett lépés</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Receptek</translation>
+        <translation>Receptek</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Stílusok</translation>
+        <translation>Stílusok</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Erjesztető anyagok</translation>
+        <translation>Erjesztető anyagok</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Komló</translation>
+        <translation>Komló</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Egyebek</translation>
+        <translation>Egyebek</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Élesztők</translation>
+        <translation>Élesztők</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Recept</translation>
+        <translation>Recept</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4834,11 +5345,11 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Recept neve</translation>
+        <translation>Recept neve</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Főzet várt mennyisége</translation>
+        <translation>Főzet várt mennyisége</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4854,7 +5365,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Várható kihozatali hatékonyság</translation>
+        <translation>Várható kihozatali hatékonyság</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4866,7 +5377,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Főzet várt mennyisége</translation>
+        <translation>Főzet várt mennyisége</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4874,7 +5385,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Felszerelés</translation>
+        <translation>Felszerelés</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4882,159 +5393,163 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">kezdeti fajsúly (OG)</translation>
+        <translation>kezdeti fajsúly (OG)</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Fajsúly forraláskor</translation>
+        <translation>Fajsúly forraláskor</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">végleges fajsúly (FG)</translation>
+        <translation>végleges fajsúly (FG)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">alkoholfok (v/v%)</translation>
+        <translation>alkoholfok (v/v%)</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Keserűség (IBU)</translation>
+        <translation>Keserűség (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Szín</translation>
+        <translation>Szín</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">Keserűség/fajsúly arányszám</translation>
+        <translation>Keserűség/fajsúly arányszám</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Energiatartalom (Kcal/354ml)</translation>
+        <translation>Energiatartalom (Kcal/354ml)</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extrák</translation>
+        <translation>Extrák</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Főzés napja</translation>
+        <translation>Főzés napja</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Erjeszthető hozzávaló hozzáadása</translation>
+        <translation>Erjeszthető hozzávaló hozzáadása</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Erjeszthető hozzávaló eltávolítása</translation>
+        <translation>Erjeszthető hozzávaló eltávolítása</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Erjeszthető hozzávaló szerkesztése</translation>
+        <translation>Erjeszthető hozzávaló szerkesztése</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Komló hozzáadása</translation>
+        <translation>Komló hozzáadása</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Komló eltávolítása</translation>
+        <translation>Komló eltávolítása</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Kiválasztott komló szerkesztése</translation>
+        <translation>Kiválasztott komló szerkesztése</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Egyebek</translation>
+        <translation>Egyebek</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Egyéb hozzávaló hozzáadása</translation>
+        <translation>Egyéb hozzávaló hozzáadása</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Kiválasztott egyéb hozzávaló eltávolítása</translation>
+        <translation>Kiválasztott egyéb hozzávaló eltávolítása</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Kiválasztott egyéb hozzávaló szerkeszése</translation>
+        <translation>Kiválasztott egyéb hozzávaló szerkeszése</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Élesztő</translation>
+        <translation>Élesztő</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Élesztő hozzáadása</translation>
+        <translation>Élesztő hozzáadása</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Kiválasztott élesztő eltávolítása</translation>
+        <translation>Kiválasztott élesztő eltávolítása</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Kiválasztott élesztő szerkesztése</translation>
+        <translation>Kiválasztott élesztő szerkesztése</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Cefre</translation>
+        <translation>Cefre</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Cefrézési lépés hozzáadása</translation>
+        <translation>Cefrézési lépés hozzáadása</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Kiválasztott cefrézési lépcső eltávolítása</translation>
+        <translation>Kiválasztott cefrézési lépcső eltávolítása</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Kiválasztott cefrézési lépcső eltávolítása</translation>
+        <translation>Kiválasztott cefrézési lépcső eltávolítása</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Cefrézési tulajdonságok szerkesztése</translation>
+        <translation>Cefrézési tulajdonságok szerkesztése</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Cefrézés szerkesztése</translation>
+        <translation>Cefrézés szerkesztése</translation>
+    </message>
+    <message>
+        <source>Mash Des</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Cefrézés varázsló</translation>
+        <translation>Cefrézés varázsló</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Cefrézés varázsló</translation>
+        <translation>Cefrézés varázsló</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Cefrék</translation>
+        <translation>Cefrék</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Cefrézési lépés fel</translation>
+        <translation>Cefrézési lépés fel</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Cefrézési lépés le</translation>
+        <translation>Cefrézési lépés le</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Cefrézési profil mentése</translation>
+        <translation>Cefrézési profil mentése</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Mentés (cefrézés)</translation>
+        <translation>Mentés (cefrézés)</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Névjegy</translation>
+        <translation>&amp;Névjegy</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Fájl</translation>
+        <translation>&amp;Fájl</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5046,27 +5561,27 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Adatbázis</translation>
+        <translation>&amp;Adatbázis</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Nézet</translation>
+        <translation>&amp;Nézet</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Eszközök</translation>
+        <translation>&amp;Eszközök</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">eszközTár</translation>
+        <translation>eszközTár</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">A Brewtargetről</translation>
+        <translation>A Brewtargetről</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">a Brewtargetről</translation>
+        <translation>a Brewtargetről</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5074,19 +5589,19 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Erjesztető hozzávalók</translation>
+        <translation>&amp;Erjesztető hozzávalók</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Komlók</translation>
+        <translation>&amp;Komlók</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5094,31 +5609,31 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Élesztők</translation>
+        <translation>&amp;Élesztők</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Felszerelések</translation>
+        <translation>&amp;Felszerelések</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Stílusok</translation>
+        <translation>&amp;Stílusok</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5126,7 +5641,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5138,55 +5653,55 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Kézikönyv</translation>
+        <translation>&amp;Kézikönyv</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Recept arányítás</translation>
+        <translation>&amp;Recept arányítás</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Recept másolása a vágópadra &amp;Szővegként</translation>
+        <translation>Recept másolása a vágópadra &amp;Szővegként</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">&amp;Eredeti fajsúly korrekció segítség</translation>
+        <translation>&amp;Eredeti fajsúly korrekció segítség</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Mértékegység átváltás</translation>
+        <translation>&amp;Mértékegység átváltás</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Adatbázis mentése</translation>
+        <translation>Adatbázis mentése</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Adatbázis visszaállítás</translation>
+        <translation>Adatbázis visszaállítás</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Recept másolás</translation>
+        <translation>&amp;Recept másolás</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Számológép palackos érleléshez</translation>
+        <translation>Számológép palackos érleléshez</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">Refraktométereszközök</translation>
+        <translation>Refraktométereszközök</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">&amp;Számológép élesztővel beoltáshoz</translation>
+        <translation>&amp;Számológép élesztővel beoltáshoz</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Adatbázisok összefésülése</translation>
+        <translation>Adatbázisok összefésülése</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Másik adatbázis választása a jelenlegivel való összefésüléshez</translation>
+        <translation>Másik adatbázis választása a jelenlegivel való összefésüléshez</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5206,19 +5721,19 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Másolat készítése</translation>
+        <translation>&amp;Másolat készítése</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Minden recept, hozzávaló, stb. mentése másolatba</translation>
+        <translation>Minden recept, hozzávaló, stb. mentése másolatba</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Visszaállítás</translation>
+        <translation>&amp;Visszaállítás</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Receptek, hozzávalók, stb. visszaállítása másolatból</translation>
+        <translation>Receptek, hozzávalók, stb. visszaállítása másolatból</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5230,7 +5745,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Új recept</translation>
+        <translation>&amp;Új recept</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5238,42 +5753,162 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">dőzítők</translation>
+        <translation>dőzítők</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Mentés</translation>
+        <translation>Mentés</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Kijelölt törlése</translation>
+        <translation>Kijelölt törlése</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Recept törlése</translation>
+        <translation>Recept törlése</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Cefrék</translation>
+        <translation>&amp;Cefrék</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Cefrék</translation>
+        <translation>Cefrék</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
         <translation type="vanished">Felöntő víz kiszámítás</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Főzet méret</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Forralási mennyiség</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Kezdődjön a főzés!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Cefrézés szerkesztő</translation>
+        <translation>Cefrézés szerkesztő</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5289,7 +5924,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Idõ</translation>
+        <translation>Idõ</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5297,212 +5932,323 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Következõ</translation>
+        <translation>Következõ</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Befejezés</translation>
+        <translation>Befejezés</translation>
+    </message>
+    <message>
+        <source>Infusion/Decoction Amount</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">minimum</translation>
+        <translation>minimum</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">maximum</translation>
+        <translation>maximum</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Cefrézési hőmérséklet</translation>
+        <translation>Cefrézési hőmérséklet</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Összes színlé</translation>
+        <translation>Összes színlé</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">űrtartalom</translation>
+        <translation>űrtartalom</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Edény telítettség</translation>
+        <translation>Edény telítettség</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">Edény űrtartalom</translation>
+        <translation>Edény űrtartalom</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">sűrűség</translation>
+        <translation>sűrűség</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Cefrézés szerkesztő</translation>
+        <translation>Cefrézés szerkesztő</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Dara kezdeti hőmérséklet</translation>
+        <translation>Dara kezdeti hőmérséklet</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Máslás hőmérséklete</translation>
+        <translation>Máslás hőmérséklete</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Máslás megcélzott hőmérséklete</translation>
+        <translation>Máslás megcélzott hőmérséklete</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Máslási pH</translation>
+        <translation>Máslási pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Megjegyzések</translation>
+        <translation>Megjegyzések</translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Felvenni a következő paramétereket, mint a recepthez társított felszerelés alapértékeat</translation>
+        <translation>Felvenni a következő paramétereket, mint a recepthez társított felszerelés alapértékeat</translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Cefrézési lépés szerkesztése</translation>
+        <translation>Cefrézési lépés szerkesztése</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Fajta</translation>
+        <translation>Fajta</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infúziós cefrézés</translation>
+        <translation>Infúziós cefrézés</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Hőmérséklet</translation>
+        <translation>Hőmérséklet</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Dekokció</translation>
+        <translation>Dekokció</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Hőmérséklet célérték</translation>
+        <translation>Hőmérséklet célérték</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Cefrézési lépés megcélzott hőmérséklete</translation>
+        <translation>Cefrézési lépés megcélzott hőmérséklete</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Teljes becefrézett anyag mennyisége</translation>
+        <translation>Teljes becefrézett anyag mennyisége</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Becefrézett anyagból a víz mennyisége</translation>
+        <translation>Becefrézett anyagból a víz mennyisége</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Infúziós cefrézés hőmérséklete</translation>
+        <translation>Infúziós cefrézés hőmérséklete</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">cefrézővíz hőmérséklete</translation>
+        <translation>cefrézővíz hőmérséklete</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Dekokció mennyisége</translation>
+        <translation>Dekokció mennyisége</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Dekokcióhoz felhasznált cefre mennyisége</translation>
+        <translation>Dekokcióhoz felhasznált cefre mennyisége</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Idõ</translation>
+        <translation>Idõ</translation>
+    </message>
+    <message>
+        <source>Time to conduct the step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp. lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Felöntéses máslás</translation>
+    </message>
+</context>
+<context>
+    <name>mashWizard</name>
+    <message>
+        <source>Mash Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash thickness (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
+        <source>Misc Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Fajta</translation>
+        <translation>Fajta</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Fűszer</translation>
+        <translation>Fűszer</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Derítőszer</translation>
+        <translation>Derítőszer</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Vízkezelő anyag</translation>
+        <translation>Vízkezelő anyag</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Gyógynövény</translation>
+        <translation>Gyógynövény</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Ízanyag</translation>
+        <translation>Ízanyag</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Egyéb anyag</translation>
+        <translation>Egyéb anyag</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Felhasználás</translation>
+        <translation>Felhasználás</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Forralás</translation>
+        <translation>Forralás</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Cefre</translation>
+        <translation>Cefre</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Elsődleges</translation>
+        <translation>Elsődleges</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Másodlagos</translation>
+        <translation>Másodlagos</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Palackozás</translation>
+        <translation>Palackozás</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Idõ</translation>
+        <translation>Idõ</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="vanished">Mennyiség</translation>
+    </message>
+    <message>
+        <source>Check it if the amount listed is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -5514,92 +6260,224 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Készleten lévő mennyiség</translation>
+        <translation>Készleten lévő mennyiség</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Készleten lévő mennyiség</translation>
+        <translation>Készleten lévő mennyiség</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Megjegyzések</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mash</source>
-        <translation type="vanished">Cefre</translation>
+        <translation>Cefre</translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Dara kezdeti hőmérséklet</translation>
+        <translation>Dara kezdeti hőmérséklet</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Máslás hőmérséklete</translation>
+        <translation>Máslás hőmérséklete</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Máslás megcélzott hőmérséklete</translation>
+        <translation>Máslás megcélzott hőmérséklete</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Máslási pH</translation>
+        <translation>Máslási pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Megjegyzések</translation>
+        <translation>Megjegyzések</translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Cefrézési lépés hozzáadása</translation>
+        <translation>Cefrézési lépés hozzáadása</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Kiválasztott cefrézési lépcső eltávolítása</translation>
+        <translation>Kiválasztott cefrézési lépcső eltávolítása</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Cefrézési lépés fel</translation>
+        <translation>Cefrézési lépés fel</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Cefrézési lépés le</translation>
+        <translation>Cefrézési lépés le</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
+        <source>Adjust Volume to Hit OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input</source>
-        <translation type="vanished">Bevitel</translation>
+        <translation>Bevitel</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">fajsúly (SG)</translation>
+        <translation>fajsúly (SG)</translation>
+    </message>
+    <message>
+        <source>Measured gravity pre-boil</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Hőmérséklet</translation>
+        <translation>Hőmérséklet</translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp to which the hydrometer is calibrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-or-</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">°B</translation>
+        <translation>°B</translation>
+    </message>
+    <message>
+        <source>Plato (percent by mass of equivalent sucrose)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured pre-boil volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Kimenet</translation>
+        <translation>Kimenet</translation>
+    </message>
+    <message>
+        <source>OG w/o Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG if you boil as planned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated batch size after correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Weight</source>
-        <translation type="vanished">Súly</translation>
+        <translation>Súly</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Hőmérséklet</translation>
+        <translation>Hőmérséklet</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5611,15 +6489,27 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Mennyiség</translation>
+        <translation>Mennyiség</translation>
+    </message>
+    <message>
+        <source>Gravity</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Szín</translation>
+        <translation>Szín</translation>
+    </message>
+    <message>
+        <source>Formulas</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">Keserűség (IBU)</translation>
+        <translation>Keserűség (IBU)</translation>
+    </message>
+    <message>
+        <source>IBU Adjustments</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>First Wort</source>
@@ -5634,8 +6524,58 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
         <translation type="vanished">Alapértelmezett</translation>
     </message>
     <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;qt&gt;
+   &lt;b&gt;Know another language?&lt;/b&gt;
+   &lt;br&gt;&lt;br&gt;
+   Or, would you like to improve a translation? Help us out and
+  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
+  provide a translation&lt;/a&gt; so that your friends can use brewtarget!
+&lt;/qt&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Date</source>
-        <translation type="vanished">Időpont</translation>
+        <translation>Időpont</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -5718,6 +6658,54 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5725,103 +6713,519 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
 <context>
     <name>pitchDialog</name>
     <message>
+        <source>Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input</source>
-        <translation type="vanished">Bevitel</translation>
+        <translation>Bevitel</translation>
+    </message>
+    <message>
+        <source>Wort Volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">kezdeti fajsúly (OG)</translation>
+        <translation>kezdeti fajsúly (OG)</translation>
+    </message>
+    <message>
+        <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch Rate (M cells)/(mL*P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Production Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Viability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>O2 At Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stir Plate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MM/dd/yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate Viability From Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Kimenet</translation>
+        <translation>Kimenet</translation>
+    </message>
+    <message>
+        <source>Billions of Yeast Cells Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
+        <source>Priming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input</source>
-        <translation type="vanished">Bevitel</translation>
+        <translation>Bevitel</translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of beer to prime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beer Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp of the beer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Glucose Monohydrate (corn sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anhydrous Glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sucrose (table sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Malt Extract</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Kimenet</translation>
+        <translation>Kimenet</translation>
+    </message>
+    <message>
+        <source>Prime with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Sörfőző</translation>
+        <translation>Sörfőző</translation>
+    </message>
+    <message>
+        <source>Asst. Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date First Brewed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dd MMM yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carbonation Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Notes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Megjegyzések</translation>
+        <translation>Megjegyzések</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
+        <source>Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20 C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ABV</source>
-        <translation type="vanished">alkoholfok (v/v%)</translation>
+        <translation>alkoholfok (v/v%)</translation>
+    </message>
+    <message>
+        <source>ABW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refractive Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Real Extract (Plato)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Felöntő víz kiszámítás</translation>
+        <translation>Felöntő víz kiszámítás</translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Style</source>
-        <translation type="vanished">Stílus</translation>
+        <translation>Stílus</translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Kategória</translation>
+        <translation>Kategória</translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Fajta</translation>
+        <translation>Fajta</translation>
+    </message>
+    <message>
+        <source>Type of beverage</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
+    </message>
+    <message>
+        <source>Mead</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Búza</translation>
+        <translation>Búza</translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">kezdeti fajsúly (OG)</translation>
+        <translation>kezdeti fajsúly (OG)</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">végleges fajsúly (FG)</translation>
+        <translation>végleges fajsúly (FG)</translation>
+    </message>
+    <message>
+        <source>IBUs</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Szín (SRM)</translation>
+        <translation>Szín (SRM)</translation>
+    </message>
+    <message>
+        <source>Carb (vols)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV (pct)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ingredients</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Megjegyzések</translation>
+        <translation>Megjegyzések</translation>
     </message>
     <message>
         <source>New</source>
@@ -5835,6 +7239,50 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
         <source>Cancel</source>
         <translation type="vanished">Mégsem</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
@@ -5842,110 +7290,373 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
         <source>Timers</source>
         <translation type="vanished">Időzítők</translation>
     </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">Forma</translation>
+        <translation type="unfinished">Forma</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Leállítás</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Mégsem</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>waterEditor</name>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Megjegyzések</translation>
+        <translation>Megjegyzések</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
+    <message>
+        <source>Yeast Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Required Fields</source>
         <translation type="vanished">Szükséges mezők</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Név</translation>
+        <translation>Név</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Fajta</translation>
+        <translation>Fajta</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Búza</translation>
+        <translation>Búza</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Bor</translation>
+        <translation>Bor</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Pezsgőélesztő</translation>
+        <translation>Pezsgőélesztő</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Folyékony élesztő</translation>
+        <translation>Folyékony élesztő</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Szárított élesztő</translation>
+        <translation>Szárított élesztő</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Slant</translation>
+        <translation>Slant</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">élesztőkultúra</translation>
+        <translation>élesztőkultúra</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="vanished">Mennyiség</translation>
     </message>
     <message>
+        <source>Check it if the amount given is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Lab</source>
-        <translation type="vanished">Labor</translation>
+        <translation>Labor</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">Termékazonosító</translation>
+        <translation>Termékazonosító</translation>
+    </message>
+    <message>
+        <source>Min Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max temp</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">ülepedés</translation>
+        <translation>ülepedés</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Alacsony</translation>
+        <translation>Alacsony</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Közepes</translation>
+        <translation>Közepes</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Magas</translation>
+        <translation>Magas</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Nagyon magas</translation>
+        <translation>Nagyon magas</translation>
+    </message>
+    <message>
+        <source>Attenuation (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apparent attenuation as percentage of OG points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times Recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times this yeast has been recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked means add this yeast to secondary instead of primary</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -5954,6 +7665,42 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     <message>
         <source>Default Amount</source>
         <translation type="vanished">Mennyiségi alapérték</translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extrák</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Megjegyzések</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_it.ts
+++ b/translations/bt_it.ts
@@ -542,6 +542,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Ricetta</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Magazzino</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Fermentabili</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Luppoli</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Lievito</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2017,13 +2112,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2465,15 +2553,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2779,80 +2867,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Sconosciuto</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">Normale</translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Magazzino</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Nome</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Ammontare</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alpha %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -3015,6 +3029,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Normale</translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Magazzino</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Ammontare</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3795,6 +3883,41 @@ Il Volume finale del primo è %1.</translation>
     </message>
 </context>
 <context>
+    <name>TimerDialog</name>
+    <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TimerListDialog</name>
     <message>
         <source>Addition Timers</source>
@@ -3804,12 +3927,56 @@ Il Volume finale del primo è %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Partenza</translation>
+        <translation type="unfinished">Partenza</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Stop</translation>
+        <translation type="unfinished">Stop</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4255,54 +4422,73 @@ Il Volume finale del primo è %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialogo</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Istuzioni generali</translation>
+        <translation>Istuzioni generali</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Inserisci passaggio</translation>
+        <translation>Inserisci passaggio</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Nome del nuovo Steep</translation>
+        <translation>Nome del nuovo Steep</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Passo #</translation>
+        <translation>Passo #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Il numero in cui il nuovo passo deve essere collocato</translation>
+        <translation>Il numero in cui il nuovo passo deve essere collocato</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Inserisci nuovo step</translation>
+        <translation>Inserisci nuovo step</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Sposta steps</translation>
+        <translation>Sposta steps</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Spostare passo attualmente selezionato in alto</translation>
+        <translation>Spostare passo attualmente selezionato in alto</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Spostare passo attualmente selezionato verso il basso</translation>
+        <translation>Spostare passo attualmente selezionato verso il basso</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Rimuovere passo attualmente selezionato</translation>
+        <translation>Rimuovere passo attualmente selezionato</translation>
     </message>
 </context>
 <context>
@@ -4372,27 +4558,27 @@ Il Volume finale del primo è %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Prima della bollitura</translation>
+        <translation>Prima della bollitura</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Densità Iniziale</translation>
+        <translation>Densità Iniziale</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Densità Iniziale</translation>
+        <translation>Densità Iniziale</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volume</translation>
+        <translation>Volume</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Volume di mosto raccolto</translation>
+        <translation>Volume di mosto raccolto</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Sospensione Temperatura</translation>
+        <translation>Sospensione Temperatura</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4400,59 +4586,59 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Temperatura Finale</translation>
+        <translation>Temperatura Finale</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Temperatura mosto dopo mash out</translation>
+        <translation>Temperatura mosto dopo mash out</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Dopo Bollitura</translation>
+        <translation>Dopo Bollitura</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Densità dopo Bollitura</translation>
+        <translation>Densità dopo Bollitura</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Volume dopo Bollitura</translation>
+        <translation>Volume dopo Bollitura</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Volume del mosto in ebollizione dopo BK</translation>
+        <translation>Volume del mosto in ebollizione dopo BK</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Volume di mosto trasferito nel fermentatore</translation>
+        <translation>Volume di mosto trasferito nel fermentatore</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volume dentro al fermentatore</translation>
+        <translation>Volume dentro al fermentatore</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Temperatura intenso</translation>
+        <translation> Temperatura intenso</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Temperatura del mosto quando il lievito viene attivato</translation>
+        <translation>Temperatura del mosto quando il lievito viene attivato</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Post Fermentazione</translation>
+        <translation>Post Fermentazione</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Densità Finale</translation>
+        <translation>Densità Finale</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Volume di birra da servire nel fusto/bottiglie</translation>
+        <translation>Volume di birra da servire nel fusto/bottiglie</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4468,11 +4654,11 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">OG Stimato</translation>
+        <translation>OG Stimato</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Efficenza Birrificio</translation>
+        <translation>Efficenza Birrificio</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4484,7 +4670,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">ABV Stimato</translation>
+        <translation>ABV Stimato</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4492,19 +4678,59 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Appunti</translation>
+        <translation>Appunti</translation>
     </message>
     <message>
         <source>brewNote</source>
-        <translation type="vanished">Appunti di birrificazione</translation>
+        <translation>Appunti di birrificazione</translation>
     </message>
     <message>
         <source>yyyy-dd-MM</source>
-        <translation type="vanished">anno-giorno-mese</translation>
+        <translation>anno-giorno-mese</translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4523,18 +4749,182 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Spazio morto pentola</translation>
+        <translation>Spazio morto pentola</translation>
     </message>
     <message>
         <source>equipmentEditor</source>
-        <translation type="vanished">Editor attrezzatura</translation>
+        <translation>Editor attrezzatura</translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Editor attrezzature</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Attrezzatura</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Imposta come predefinito</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Misura Partita</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Tempo</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Calcolare il volume di pre-ebollizione</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Tempo di bollitura</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Tasso di Evaporazione (per ora)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Finale rabbocco acqua</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Rabbocco Acqua bollitore</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Assorbimento predefinito</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Punto di ebollizione dell&apos;acqua</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Volume di mash tun</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Nuova attrezzatura</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Editor Fermentabile</translation>
+        <translation>Editor Fermentabile</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4542,31 +4932,31 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipologia</translation>
+        <translation>Tipologia</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Grano</translation>
+        <translation>Grano</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Zucchero</translation>
+        <translation>Zucchero</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Estratto</translation>
+        <translation>Estratto</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Estratto secco</translation>
+        <translation>Estratto secco</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Aggiunta</translation>
+        <translation>Aggiunta</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4578,43 +4968,43 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Resa rispetto al glucosio</translation>
+        <translation>Resa rispetto al glucosio</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Valutazione Lovibond</translation>
+        <translation>Valutazione Lovibond</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Aggiungi dopo la bollitura</translation>
+        <translation>Aggiungi dopo la bollitura</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Questo ingrediente è stato aggiunto dopo la bollitura.</translation>
+        <translation>Questo ingrediente è stato aggiunto dopo la bollitura.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origine</translation>
+        <translation>Origine</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Fornitore</translation>
+        <translation>Fornitore</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Grossa/Fine Differenza(%)</translation>
+        <translation>Grossa/Fine Differenza(%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Resa differenza tra macro e micro macinatura</translation>
+        <translation>Resa differenza tra macro e micro macinatura</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Umidità (%)</translation>
+        <translation>Umidità (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Percentuale di Umidità per massa</translation>
+        <translation>Percentuale di Umidità per massa</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4626,43 +5016,43 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Proteine (%)</translation>
+        <translation>Proteine (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Perecntuale Proteine per massa</translation>
+        <translation>Perecntuale Proteine per massa</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Max nella cotta (%)</translation>
+        <translation>Max nella cotta (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Percentuale massima raccomandata di Grist totale</translation>
+        <translation>Percentuale massima raccomandata di Grist totale</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Mash raccomandato</translation>
+        <translation>Mash raccomandato</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Raccomandato in ammostamento</translation>
+        <translation>Raccomandato in ammostamento</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Ammostato</translation>
+        <translation>Ammostato</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Controllato se presente nell&apos;ammostamento</translation>
+        <translation>Controllato se presente nell&apos;ammostamento</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Amarezza (IBU*gal/lb)</translation>
+        <translation>Amarezza (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Amarezza di estratti pre luppolatura</translation>
+        <translation>Amarezza di estratti pre luppolatura</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4674,22 +5064,70 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantità in Magazzino</translation>
+        <translation>Quantità in Magazzino</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantità in Magazzino</translation>
+        <translation>Quantità in Magazzino</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Colore</translation>
+        <translation>Colore</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Prodotto</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extra</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Editor Luppolo</translation>
+        <translation>Editor Luppolo</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4697,7 +5135,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4705,7 +5143,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Alfa Acidi come percentuale in massa</translation>
+        <translation>Alfa Acidi come percentuale in massa</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4713,59 +5151,59 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Usa</translation>
+        <translation>Usa</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Ammostamento</translation>
+        <translation>Ammostamento</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Primo mosto</translation>
+        <translation>Primo mosto</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Bollitura</translation>
+        <translation>Bollitura</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Dry Hop</translation>
+        <translation>Dry Hop</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipologia</translation>
+        <translation>Tipologia</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Amarezza</translation>
+        <translation>Amarezza</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">entrambi</translation>
+        <translation>entrambi</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">foglia</translation>
+        <translation>foglia</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellet</translation>
+        <translation>Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Plug</translation>
+        <translation>Plug</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4773,19 +5211,19 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Beta Acidi come percentuale in massa</translation>
+        <translation>Beta Acidi come percentuale in massa</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Satabilità Luppolo/Indce di Stoccaggio</translation>
+        <translation>Satabilità Luppolo/Indce di Stoccaggio</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origine</translation>
+        <translation>Origine</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4793,7 +5231,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulene</translation>
+        <translation>Humulene</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4809,7 +5247,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Coumulone</translation>
+        <translation>Coumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4817,7 +5255,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Mircene</translation>
+        <translation>Mircene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4833,65 +5271,121 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantità in Magazzino</translation>
+        <translation>Quantità in Magazzino</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantità in Magazzino</translation>
+        <translation>Quantità in Magazzino</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extra</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Mostro il tempo</translation>
+        <translation>Mostro il tempo</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Mostra Timer</translation>
+        <translation>Mostra Timer</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Segna questo step completato</translation>
+        <translation>Segna questo step completato</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Step completato</translation>
+        <translation>Step completato</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Ricette</translation>
+        <translation>Ricette</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Stili</translation>
+        <translation>Stili</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Fermentabili</translation>
+        <translation>Fermentabili</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Luppoli</translation>
+        <translation>Luppoli</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Varie</translation>
+        <translation>Varie</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Lieviti</translation>
+        <translation>Lieviti</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Ricetta</translation>
+        <translation>Ricetta</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4899,11 +5393,11 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Nome della Ricetta</translation>
+        <translation>Nome della Ricetta</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Obiettivo misura bollitura</translation>
+        <translation>Obiettivo misura bollitura</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4919,7 +5413,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">L&apos;efficienza di estrazione che ci si aspetta</translation>
+        <translation>L&apos;efficienza di estrazione che ci si aspetta</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4931,7 +5425,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Obiettivo dimensione cotta</translation>
+        <translation>Obiettivo dimensione cotta</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4939,7 +5433,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Attrezzatura</translation>
+        <translation>Attrezzatura</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4947,163 +5441,163 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Bollitura SG</translation>
+        <translation>Bollitura SG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Amarezza (IBU)</translation>
+        <translation>Amarezza (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Colore</translation>
+        <translation>Colore</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Calorie/340gr</translation>
+        <translation>Calorie/340gr</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extra</translation>
+        <translation>Extra</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Giornata di Birrificazione</translation>
+        <translation>Giornata di Birrificazione</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Aggiungi a Fermentabile</translation>
+        <translation>Aggiungi a Fermentabile</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Rimuovi il fermentabile selezionato</translation>
+        <translation>Rimuovi il fermentabile selezionato</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Edit il fermentabile selezionato</translation>
+        <translation>Edit il fermentabile selezionato</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Aggiunta Luppolo</translation>
+        <translation>Aggiunta Luppolo</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Rimuovi luppolo selezionato</translation>
+        <translation>Rimuovi luppolo selezionato</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Edit luppolo selezionato</translation>
+        <translation>Edit luppolo selezionato</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Varie</translation>
+        <translation>Varie</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Aggiungi varie</translation>
+        <translation>Aggiungi varie</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Rimuovi misc selezionato</translation>
+        <translation>Rimuovi misc selezionato</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Edit misc selezionato</translation>
+        <translation>Edit misc selezionato</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Lievito</translation>
+        <translation>Lievito</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Aggiungi lievito</translation>
+        <translation>Aggiungi lievito</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Rimuovi lievito selezionato</translation>
+        <translation>Rimuovi lievito selezionato</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Edit lievito selezionato</translation>
+        <translation>Edit lievito selezionato</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Ammostamento</translation>
+        <translation>Ammostamento</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Aggiungi step di ammostamento</translation>
+        <translation>Aggiungi step di ammostamento</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Rimuovi step selezionato di ammostamento</translation>
+        <translation>Rimuovi step selezionato di ammostamento</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Rimuovi step di ammostamento selezionato</translation>
+        <translation>Rimuovi step di ammostamento selezionato</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Modifica proprietà di ammostamento</translation>
+        <translation>Modifica proprietà di ammostamento</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Modifica ammostamento</translation>
+        <translation>Modifica ammostamento</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Mash Des</translation>
+        <translation>Mash Des</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Richiamare la procedura guidata del mosto</translation>
+        <translation>Richiamare la procedura guidata del mosto</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Mask wiz</translation>
+        <translation>Mask wiz</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Ammostamenti</translation>
+        <translation>Ammostamenti</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Prosegui ammostamento</translation>
+        <translation>Prosegui ammostamento</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Regredisci ammostamento</translation>
+        <translation>Regredisci ammostamento</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Salva questo profilo di Mash</translation>
+        <translation>Salva questo profilo di Mash</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Salva Mash</translation>
+        <translation>Salva Mash</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;About</translation>
+        <translation>&amp;About</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;File</translation>
+        <translation>&amp;File</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5115,27 +5609,27 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Database</translation>
+        <translation>&amp;Database</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;View</translation>
+        <translation>&amp;View</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Strumenti</translation>
+        <translation>&amp;Strumenti</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Barra degli strumenti</translation>
+        <translation>Barra degli strumenti</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">About &amp;BrewTarget</translation>
+        <translation>About &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Chi è Brewtaget</translation>
+        <translation>Chi è Brewtaget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5143,19 +5637,19 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Fermentables</translation>
+        <translation>&amp;Fermentables</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Luppoli</translation>
+        <translation>&amp;Luppoli</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5163,31 +5657,31 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">L&amp;ieviti</translation>
+        <translation>L&amp;ieviti</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">Strum&amp;enti</translation>
+        <translation>Strum&amp;enti</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Stili</translation>
+        <translation>&amp;Stili</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5195,7 +5689,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5207,55 +5701,55 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Manuale</translation>
+        <translation>&amp;Manuale</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Scala Ricetta</translation>
+        <translation>&amp;Scala Ricetta</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Ricetta negli Appunti come &amp;Testo</translation>
+        <translation>Ricetta negli Appunti come &amp;Testo</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">Aiuto Correzione Gravità &amp;Originale</translation>
+        <translation>Aiuto Correzione Gravità &amp;Originale</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Converti Unità</translation>
+        <translation>&amp;Converti Unità</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Backup del Database</translation>
+        <translation>Backup del Database</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Ripristina Database</translation>
+        <translation>Ripristina Database</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Copia Ricetta</translation>
+        <translation>&amp;Copia Ricetta</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Calcolatore per Pr&amp;iming</translation>
+        <translation>Calcolatore per Pr&amp;iming</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">Strumenti &amp;Refrattometro</translation>
+        <translation>Strumenti &amp;Refrattometro</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">Calcolatore pitch</translation>
+        <translation>Calcolatore pitch</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Unire i database</translation>
+        <translation>Unire i database</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Selezionare un altro database da fondere in quello attuale.</translation>
+        <translation>Selezionare un altro database da fondere in quello attuale.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5275,19 +5769,19 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Backup</translation>
+        <translation>&amp;Backup</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Salva tutte le ricette, ingredienti, ecc per una cartella di backup</translation>
+        <translation>Salva tutte le ricette, ingredienti, ecc per una cartella di backup</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Ripristina</translation>
+        <translation>&amp;Ripristina</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Ripristinare ricette, ingredienti, ecc da un backup precedente</translation>
+        <translation>Ripristinare ricette, ingredienti, ecc da un backup precedente</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5299,7 +5793,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Nuova Ricetta</translation>
+        <translation>&amp;Nuova Ricetta</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5307,31 +5801,31 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Mostra Timers</translation>
+        <translation>Mostra Timers</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Salva</translation>
+        <translation>Salva</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Cancella selezionati</translation>
+        <translation>Cancella selezionati</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Cancella ricetta</translation>
+        <translation>Cancella ricetta</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">A&amp;mmosta</translation>
+        <translation>A&amp;mmosta</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Ammostamenti</translation>
+        <translation>Ammostamenti</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
@@ -5339,18 +5833,130 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>tab_recipe</source>
-        <translation type="vanished">tab_recetta</translation>
+        <translation>tab_recetta</translation>
     </message>
     <message>
         <source>Export to &amp;BBCode</source>
-        <translation type="vanished">Esporta in &amp;BBCode</translation>
+        <translation>Esporta in &amp;BBCode</translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Misura Partita</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Misura bollitura</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Birrifica!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Progettazione Ammostamenti</translation>
+        <translation>Progettazione Ammostamenti</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5366,7 +5972,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5374,275 +5980,311 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Prossimo</translation>
+        <translation>Prossimo</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Fine</translation>
+        <translation>Fine</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Importo di Infusione/Decotto</translation>
+        <translation>Importo di Infusione/Decotto</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Temperatura di infusione</translation>
+        <translation>Temperatura di infusione</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Totale Mosto Raccolto</translation>
+        <translation>Totale Mosto Raccolto</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">Vol</translation>
+        <translation>Vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Pienezza del tino</translation>
+        <translation>Pienezza del tino</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">Vol tino</translation>
+        <translation>Vol tino</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">Spessore</translation>
+        <translation>Spessore</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Editor Ammostamenti</translation>
+        <translation>Editor Ammostamenti</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temperatura iniziale del Grano</translation>
+        <translation>Temperatura iniziale del Grano</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temperatura di Sparge</translation>
+        <translation>Temperatura di Sparge</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Obiettivo Temepratuta di Saprge</translation>
+        <translation>Obiettivo Temepratuta di Saprge</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">PH Sparge</translation>
+        <translation>PH Sparge</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Note</translation>
+        <translation>Note</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Tino</translation>
+        <translation>Tino</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temp iniziale botte</translation>
+        <translation>Temp iniziale botte</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Prendi i seguenti parametri dalle attrzzature della ricetta.</translation>
+        <translation>Prendi i seguenti parametri dalle attrzzature della ricetta.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Da attrezzatura</translation>
+        <translation>Da attrezzatura</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Massa Tino</translation>
+        <translation>Massa Tino</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Tino sp.Calore</translation>
+        <translation>Tino sp.Calore</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Calore specifico del tino(Cal/(g*K))</translation>
+        <translation>Calore specifico del tino(Cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Editor Step Mash</translation>
+        <translation>Editor Step Mash</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipologia</translation>
+        <translation>Tipologia</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infusione</translation>
+        <translation>Infusione</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Decozione</translation>
+        <translation>Decozione</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Temperatura Obiettivo.</translation>
+        <translation>Temperatura Obiettivo.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Obiettivo temperatura di questo step</translation>
+        <translation>Obiettivo temperatura di questo step</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Quantità di Infusione</translation>
+        <translation>Quantità di Infusione</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Quantità d&apos;acqua in infusione</translation>
+        <translation>Quantità d&apos;acqua in infusione</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Temperatura di infusione.</translation>
+        <translation>Temperatura di infusione.</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Temperatura infusione dell&apos;acqua</translation>
+        <translation>Temperatura infusione dell&apos;acqua</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Quantità decotta</translation>
+        <translation>Quantità decotta</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Quantità di ammostamento da decotto</translation>
+        <translation>Quantità di ammostamento da decotto</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Tempo di condurre il passo</translation>
+        <translation>Tempo di condurre il passo</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Temperatura di fine lagerizzazione</translation>
+        <translation>Temperatura di fine lagerizzazione</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Tempo lagerizzazione</translation>
+        <translation>Tempo lagerizzazione</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Fine Temp.</translation>
+        <translation>Fine Temp.</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Temperatura finale di questo step</translation>
+        <translation>Temperatura finale di questo step</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Partita di Saprge</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Mash Wizard</translation>
+        <translation>Mash Wizard</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Spessore Mash (L/kg)</translation>
+        <translation>Spessore Mash (L/kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Mash spessore (non inserire alcuna unità)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Editor Misc</translation>
+        <translation>Editor Misc</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipologia</translation>
+        <translation>Tipologia</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Spezie</translation>
+        <translation>Spezie</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">affinamento</translation>
+        <translation>affinamento</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Agente dell&apos;acqua</translation>
+        <translation>Agente dell&apos;acqua</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Erba</translation>
+        <translation>Erba</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Sapore</translation>
+        <translation>Sapore</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Altro</translation>
+        <translation>Altro</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Usa</translation>
+        <translation>Usa</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Bollire</translation>
+        <translation>Bollire</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mash</translation>
+        <translation>Mash</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Primario</translation>
+        <translation>Primario</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Secondario</translation>
+        <translation>Secondario</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Imbottigliamento</translation>
+        <translation>Imbottigliamento</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5650,15 +6292,15 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Controllare se l&apos;importo indicato è in kg invece di L.</translation>
+        <translation>Controllare se l&apos;importo indicato è in kg invece di L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Ammonta al peso?</translation>
+        <translation>Ammonta al peso?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Controlla se la data quantità è peso invece di volume</translation>
+        <translation>Controlla se la data quantità è peso invece di volume</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5674,188 +6316,220 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantità in Magazzino</translation>
+        <translation>Quantità in Magazzino</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantità in Magazzino</translation>
+        <translation>Quantità in Magazzino</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mash</source>
-        <translation type="vanished">Ammostatura</translation>
+        <translation>Ammostatura</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Elimina stile selezionato</translation>
+        <translation>Elimina stile selezionato</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temp iniziale chicchi</translation>
+        <translation>Temp iniziale chicchi</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temperatura di Sparge</translation>
+        <translation>Temperatura di Sparge</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Obiettivo Temepratuta di Saprge</translation>
+        <translation>Obiettivo Temepratuta di Saprge</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH di Sparge</translation>
+        <translation>pH di Sparge</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Note</translation>
+        <translation>Note</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Tino</translation>
+        <translation>Tino</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temp iniziale botte</translation>
+        <translation>Temp iniziale botte</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Dall&apos;attrezzatura</translation>
+        <translation>Dall&apos;attrezzatura</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Massa Botte</translation>
+        <translation>Massa Botte</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Tun sp.Calore</translation>
+        <translation>Tun sp.Calore</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Calore specifico botte (cal/g*K))</translation>
+        <translation>Calore specifico botte (cal/g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Aggiungi step mash</translation>
+        <translation>Aggiungi step mash</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Rimuovi mash step selezionato</translation>
+        <translation>Rimuovi mash step selezionato</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Procedi con l&apos;ammostamento</translation>
+        <translation>Procedi con l&apos;ammostamento</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Regredisci Ammostamento</translation>
+        <translation>Regredisci Ammostamento</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Regolazione del volume a Hit OG</translation>
+        <translation>Regolazione del volume a Hit OG</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Input</translation>
+        <translation>Input</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Misurata Densità pre ebollizione</translation>
+        <translation>Misurata Densità pre ebollizione</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Temperatura dell&apos;SG letta</translation>
+        <translation>Temperatura dell&apos;SG letta</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Calibrazione temperatura</translation>
+        <translation>Calibrazione temperatura</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temperatura a cui è tarato il densimetro</translation>
+        <translation>Temperatura a cui è tarato il densimetro</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-o-</translation>
+        <translation>-o-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (percentuale in massa di saccarosio equivalente)</translation>
+        <translation>Plato (percentuale in massa di saccarosio equivalente)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Volume pre bollitura</translation>
+        <translation>Volume pre bollitura</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Misurato Volume pre ebollizione</translation>
+        <translation>Misurato Volume pre ebollizione</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Produzione</translation>
+        <translation>Produzione</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">Correzione OG w/o</translation>
+        <translation>Correzione OG w/o</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">OG se bolle come previsto</translation>
+        <translation>OG se bolle come previsto</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Aggiungere alla bollitura</translation>
+        <translation>Aggiungere alla bollitura</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Quantità di acqua necessaria da aggiungere per determinare OG previsto (o ferma la bollitura se negativo)</translation>
+        <translation>Quantità di acqua necessaria da aggiungere per determinare OG previsto (o ferma la bollitura se negativo)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Misura lotto finale</translation>
+        <translation>Misura lotto finale</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Misura lotto stimata dopo correzione</translation>
+        <translation>Misura lotto stimata dopo correzione</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcola</translation>
+        <translation>Calcola</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Opzioni</translation>
+        <translation>Opzioni</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Moduli</translation>
+        <translation>Moduli</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">peso</translation>
+        <translation>peso</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5871,7 +6545,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5883,11 +6557,11 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volume</translation>
+        <translation>Volume</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Densità</translation>
+        <translation>Densità</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5899,7 +6573,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Colore</translation>
+        <translation>Colore</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5911,7 +6585,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Formula</translation>
+        <translation>Formula</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5927,7 +6601,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5939,7 +6613,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Correzione IBU</translation>
+        <translation>Correzione IBU</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5975,7 +6649,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Lingua</translation>
+        <translation>Lingua</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5985,7 +6659,7 @@ Il Volume finale del primo è %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Know another language?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Or, would you like to improve a translation? Help us out and
@@ -5995,7 +6669,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Data</translation>
+        <translation>Data</translation>
     </message>
     <message>
         <source>mm-dd-YYYY</source>
@@ -6012,6 +6686,42 @@ Il Volume finale del primo è %1.</translation>
     <message>
         <source>Noonan&apos;s approximation</source>
         <translation type="vanished">Approssimazione di Noonan</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6094,6 +6804,54 @@ Il Volume finale del primo è %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6102,420 +6860,420 @@ Il Volume finale del primo è %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Passo tasso Calcolatrice</translation>
+        <translation>Passo tasso Calcolatrice</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Input</translation>
+        <translation>Input</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Volume Mosto</translation>
+        <translation>Volume Mosto</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Per ale, 0.75-1. Per lager, 1.5-2.</translation>
+        <translation>Per ale, 0.75-1. Per lager, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Lievito tasso (M)/(mL*P)</translation>
+        <translation>Lievito tasso (M)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Metodo di aerezione</translation>
+        <translation>Metodo di aerezione</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Data produzione Lievito</translation>
+        <translation>Data produzione Lievito</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Vitalità lievito</translation>
+        <translation>Vitalità lievito</translation>
     </message>
     <message>
         <source>None</source>
         <translatorcomment>Nessuno
 </translatorcomment>
-        <translation type="vanished">Niente</translation>
+        <translation>Niente</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">Partenza con o2</translation>
+        <translation>Partenza con o2</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Piastra mescolatrice</translation>
+        <translation>Piastra mescolatrice</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">MM/GG/AAAA</translation>
+        <translation>MM/GG/AAAA</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">Etichetta</translation>
+        <translation>Etichetta</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Calcola Vitalità dalla data</translation>
+        <translation>Calcola Vitalità dalla data</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># Fiale/Confezioni Inclinate</translation>
+        <translation># Fiale/Confezioni Inclinate</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Risultato</translation>
+        <translation>Risultato</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Miliardi di cellule di lievito richieste</translation>
+        <translation>Miliardi di cellule di lievito richieste</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Fiale/Confezioni con o senza starter</translation>
+        <translation># Fiale/Confezioni con o senza starter</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Lievito secco</translation>
+        <translation>Lievito secco</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Volume di partenza</translation>
+        <translation>Volume di partenza</translation>
     </message>
     <message>
         <source>Volume of wort</source>
-        <translation type="vanished">Volume del mosto</translation>
+        <translation>Volume del mosto</translation>
     </message>
     <message>
         <source>Starting gravity of the wort</source>
-        <translation type="vanished">Gravità iniziale del mosto</translation>
+        <translation>Gravità iniziale del mosto</translation>
     </message>
     <message>
         <source>Aeration method</source>
-        <translation type="vanished">Metodo di ossigenazione</translation>
+        <translation>Metodo di ossigenazione</translation>
     </message>
     <message>
         <source>Production date (Best By date less three months)</source>
-        <translation type="vanished">Data di produzione</translation>
+        <translation>Data di produzione</translation>
     </message>
     <message>
         <source>Estimated viability of the yeast</source>
-        <translation type="vanished">Vitalità del lievito stimata</translation>
+        <translation>Vitalità del lievito stimata</translation>
     </message>
     <message>
         <source>Desired pitch rate</source>
-        <translation type="vanished">Pitch desiderato</translation>
+        <translation>Pitch desiderato</translation>
     </message>
     <message>
         <source>Number of vials/smack packs added to starter</source>
-        <translation type="vanished">Numero di fiale/confezioni aggiute allo starter</translation>
+        <translation>Numero di fiale/confezioni aggiute allo starter</translation>
     </message>
     <message>
         <source>How much yeast you will need</source>
-        <translation type="vanished">Quanto lievito hai bisogno</translation>
+        <translation>Quanto lievito hai bisogno</translation>
     </message>
     <message>
         <source>How many smack packs or vials required to reach pitch rate</source>
-        <translation type="vanished">quanti smack packs o virali sono richiesti per raggiungere il picth rate</translation>
+        <translation>quanti smack packs o virali sono richiesti per raggiungere il picth rate</translation>
     </message>
     <message>
         <source>Amount of dry yeast needed to reach pitch rate</source>
-        <translation type="vanished">Quantità di lievito secco necessario per raggiungere il valore desiderato</translation>
+        <translation>Quantità di lievito secco necessario per raggiungere il valore desiderato</translation>
     </message>
     <message>
         <source>Starter size to reach pitch rate</source>
-        <translation type="vanished">Dimensione dello starter per raggiungere il valore desiderato</translation>
+        <translation>Dimensione dello starter per raggiungere il valore desiderato</translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Calcolatore di priming</translation>
+        <translation>Calcolatore di priming</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Input</translation>
+        <translation>Input</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Volume di bitrra raccolto</translation>
+        <translation>Volume di bitrra raccolto</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Importo di birra a serata</translation>
+        <translation>Importo di birra a serata</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Temperatura birra</translation>
+        <translation>Temperatura birra</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Temp della birra</translation>
+        <translation>Temp della birra</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Volumi desiderati</translation>
+        <translation>Volumi desiderati</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Quanti volumi di co2 vuoi (1 L CO2 @ STP per L Birra)</translation>
+        <translation>Quanti volumi di co2 vuoi (1 L CO2 @ STP per L Birra)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glucosio monoidrato (zucchero del mais)</translation>
+        <translation>Glucosio monoidrato (zucchero del mais)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">glucosio anidro</translation>
+        <translation>glucosio anidro</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Saccarosio (zucchero da tavola)</translation>
+        <translation>Saccarosio (zucchero da tavola)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Estratto di malto secco</translation>
+        <translation>Estratto di malto secco</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Produzione</translation>
+        <translation>Produzione</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Prime con</translation>
+        <translation>Prime con</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Quanto ingerdiente per il primg usare</translation>
+        <translation>Quanto ingerdiente per il primg usare</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcola</translation>
+        <translation>Calcola</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Birraio</translation>
+        <translation>Birraio</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Assistente Birraio</translation>
+        <translation>Assistente Birraio</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Valutazione assaggio</translation>
+        <translation>Valutazione assaggio</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Età primaria (giorni)</translation>
+        <translation>Età primaria (giorni)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Temperatura primaria</translation>
+        <translation>Temperatura primaria</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Età secondaria (giorni)</translation>
+        <translation>Età secondaria (giorni)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Temperatura secondaria</translation>
+        <translation>Temperatura secondaria</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Età terziaria (giorni)</translation>
+        <translation>Età terziaria (giorni)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Temperatura terziaria</translation>
+        <translation>Temperatura terziaria</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Bottiglia/Fusto età (giorni)</translation>
+        <translation>Bottiglia/Fusto età (giorni)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Bottiglia/fusto Temperatura</translation>
+        <translation>Bottiglia/fusto Temperatura</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Data di prima birrificazione</translation>
+        <translation>Data di prima birrificazione</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM YYYY</translation>
+        <translation>dd MMM YYYY</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Volume carbonazione</translation>
+        <translation>Volume carbonazione</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Note di asssaggi</translation>
+        <translation>Note di asssaggi</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Note</translation>
+        <translation>Note</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Tool Rifrattometri</translation>
+        <translation>Tool Rifrattometri</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Ingressi</translation>
+        <translation>Ingressi</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Plato origianale</translation>
+        <translation>Plato origianale</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">OG (20 C)</translation>
+        <translation>OG (20 C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Plato corrente</translation>
+        <translation>Plato corrente</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcola</translation>
+        <translation>Calcola</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Produzione</translation>
+        <translation>Produzione</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">SG (20C)</translation>
+        <translation>SG (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">ABW</translation>
+        <translation>ABW</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Indice di rifrattometro</translation>
+        <translation>Indice di rifrattometro</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Estratto reale (Plato)</translation>
+        <translation>Estratto reale (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">OG (20 C)</translation>
+        <translation>OG (20 C)</translation>
     </message>
     <message>
         <source>Measured original plato</source>
-        <translation type="vanished">Valore iniziale Plato misurato</translation>
+        <translation>Valore iniziale Plato misurato</translation>
     </message>
     <message>
         <source>Measured original gravity</source>
-        <translation type="vanished">Gravità iniziale misurata</translation>
+        <translation>Gravità iniziale misurata</translation>
     </message>
     <message>
         <source>Current measured plato</source>
-        <translation type="vanished">Valore Plato attuale misurato</translation>
+        <translation>Valore Plato attuale misurato</translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Calcolatore per acqua di Mash</translation>
+        <translation>Calcolatore per acqua di Mash</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Infusione iniziale</translation>
+        <translation>Infusione iniziale</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Temperatura iniziale dei grani</translation>
+        <translation>Temperatura iniziale dei grani</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Temperatura di ammostamento programmata</translation>
+        <translation>Temperatura di ammostamento programmata</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Peso dei grani</translation>
+        <translation>Peso dei grani</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Volume di acqua</translation>
+        <translation>Volume di acqua</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">ammostamento in infusione</translation>
+        <translation>ammostamento in infusione</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Volume totale di acqua</translation>
+        <translation>Volume totale di acqua</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Peso dei grani</translation>
+        <translation>Peso dei grani</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Temperatura reale di ammostamento</translation>
+        <translation>Temperatura reale di ammostamento</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Temperatura dell&apos;acqua di infusione</translation>
+        <translation>Temperatura dell&apos;acqua di infusione</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcola</translation>
+        <translation>Calcola</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Temperatura dell&apos;acqua preferita</translation>
+        <translation>Temperatura dell&apos;acqua preferita</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Volume da aggiungere</translation>
+        <translation>Volume da aggiungere</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Nota: Questo cacolatore assume una entola preriscaldata</translation>
+        <translation>Nota: Questo cacolatore assume una entola preriscaldata</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Editor stile</translation>
+        <translation>Editor stile</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Stile</translation>
+        <translation>Stile</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Cancella stile selezionato</translation>
+        <translation>Cancella stile selezionato</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6523,55 +7281,55 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Categoria</translation>
+        <translation>Categoria</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Numero di categoria</translation>
+        <translation>Numero di categoria</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Stile di lettera</translation>
+        <translation>Stile di lettera</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">guida allo stile</translation>
+        <translation>guida allo stile</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipologia</translation>
+        <translation>Tipologia</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Tipo di bevanda</translation>
+        <translation>Tipo di bevanda</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Mead</translation>
+        <translation>Mead</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Wheat</translation>
+        <translation>Wheat</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Mix</translation>
+        <translation>Mix</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Sidro</translation>
+        <translation>Sidro</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6579,51 +7337,51 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Max</translation>
+        <translation>Max</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Min</translation>
+        <translation>Min</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Colore (SRM)</translation>
+        <translation>Colore (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Carb (vols)</translation>
+        <translation>Carb (vols)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV (pct)</translation>
+        <translation>ABV (pct)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Profilo</translation>
+        <translation>Profilo</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingredienti</translation>
+        <translation>Ingredienti</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Esempi</translation>
+        <translation>Esempi</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Note</translation>
+        <translation>Note</translation>
     </message>
     <message>
         <source>New</source>
@@ -6637,6 +7395,50 @@ Il Volume finale del primo è %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Cancella</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
@@ -6644,12 +7446,207 @@ Il Volume finale del primo è %1.</translation>
         <source>Timers</source>
         <translation type="vanished">Timers</translation>
     </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">Forma</translation>
+        <translation type="unfinished">Forma</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Stop</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6660,18 +7657,22 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Note</translation>
+        <translation>Note</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Editor Lievito</translation>
+        <translation>Editor Lievito</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6679,51 +7680,51 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipologia</translation>
+        <translation>Tipologia</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Wheat</translation>
+        <translation>Wheat</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Vino</translation>
+        <translation>Vino</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Champagne</translation>
+        <translation>Champagne</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Liquido</translation>
+        <translation>Liquido</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Secco</translation>
+        <translation>Secco</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Inclinazione</translation>
+        <translation>Inclinazione</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Cultura</translation>
+        <translation>Cultura</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6731,91 +7732,91 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Controllare se l&apos;importo indicato è in kg invece di L.</translation>
+        <translation>Controllare se l&apos;importo indicato è in kg invece di L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Importo è il peso?</translation>
+        <translation>Importo è il peso?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Controlla se la data quantità è peso invece di volume</translation>
+        <translation>Controlla se la data quantità è peso invece di volume</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Laboratorio</translation>
+        <translation>Laboratorio</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">ID Prodotto</translation>
+        <translation>ID Prodotto</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Temperatura Minima</translation>
+        <translation>Temperatura Minima</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Temperatura Minima</translation>
+        <translation>Temperatura Minima</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Temperatura Massima</translation>
+        <translation>Temperatura Massima</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Temperatura Massima</translation>
+        <translation>Temperatura Massima</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Flocculazione</translation>
+        <translation>Flocculazione</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Basso</translation>
+        <translation>Basso</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Medio</translation>
+        <translation>Medio</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Alto</translation>
+        <translation>Alto</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Molto alto</translation>
+        <translation>Molto alto</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Attenuazione (%)</translation>
+        <translation>Attenuazione (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Attenuazione apparente come percentuale di punti OG</translation>
+        <translation>Attenuazione apparente come percentuale di punti OG</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Riattivato</translation>
+        <translation>Riattivato</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Il lievito è stato riattivato</translation>
+        <translation>Il lievito è stato riattivato</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Massima riattivazione</translation>
+        <translation>Massima riattivazione</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Massima riattivazione</translation>
+        <translation>Massima riattivazione</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Aggiungi al secondario</translation>
+        <translation>Aggiungi al secondario</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Controlla di aggiungere questo lievito secondario invece di primario</translation>
+        <translation>Controlla di aggiungere questo lievito secondario invece di primario</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6831,11 +7832,39 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Quantità in magazzino</translation>
+        <translation>Quantità in magazzino</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Quantità in magazzino</translation>
+        <translation>Quantità in magazzino</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extra</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_lv.ts
+++ b/translations/bt_lv.ts
@@ -406,6 +406,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Recepte</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2130,15 +2225,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2400,80 +2495,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Nezināms</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Nosaukums</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2636,6 +2657,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Nezināms</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nosaukums</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3413,6 +3508,41 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>TimerDialog</name>
+    <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TimerListDialog</name>
     <message>
         <source>Addition Timers</source>
@@ -3421,6 +3551,58 @@ The final volume in the primary is %1.</source>
 </context>
 <context>
     <name>TimerMainDialog</name>
+    <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>No Timers</source>
         <translation type="unfinished"></translation>
@@ -3821,10 +4003,73 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generate Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
+    </message>
+    <message>
+        <source>Name of new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The number where the new step should be placed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert the new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove currently selected step</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3841,19 +4086,442 @@ The final volume in the primary is %1.</source>
 <context>
     <name>brewNoteWidget</name>
     <message>
+        <source>Preboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preboil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort collected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of mash before mash out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Post boil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort in BK after boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort transferred to fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume into fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> Pitch Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of wort when yeast is pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postferment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of beer into serving keg/bottles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewhouse efficiency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Notes</source>
-        <translation type="vanished">Piezīmes</translation>
+        <translation>Piezīmes</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>equipmentEditor</name>
+    <message>
+        <source>Lauter deadspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Iekārtas</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nosaukums</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Laiks</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Piezīmes</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
+        <source>Fermentable Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Veids</translation>
+        <translation>Veids</translation>
+    </message>
+    <message>
+        <source>Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sugar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjunct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield as compared to glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lovibond rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add After Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This ingredient is added post boil.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse/Fine Diff (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield difference between coarse and fine grind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max In Batch (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum recommended percentage of total grist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend this be mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is Mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if it is present in mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU*gal/lb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness of pre-hopped extracts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -3864,55 +4532,770 @@ The final volume in the primary is %1.</source>
         <translation type="vanished">Noklusējuma daudzums</translation>
     </message>
     <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Color</source>
-        <translation type="vanished">Krāsa</translation>
+        <translation>Krāsa</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Piezīmes</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
+        <source>Hop Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
+    </message>
+    <message>
+        <source>Alpha acids as percent by mass</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Lietot</translation>
+        <translation>Lietot</translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aroma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Hop</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Laiks</translation>
+        <translation>Laiks</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Veids</translation>
+        <translation>Veids</translation>
+    </message>
+    <message>
+        <source>Bittering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pellet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop Stability/Storage index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes:</source>
         <translation type="vanished">Piezīmes:</translation>
     </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Piezīmes</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>instructionWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mark this step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
+        <source>Recipes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recipe</source>
-        <translation type="vanished">Recepte</translation>
+        <translation>Recepte</translation>
     </message>
     <message>
         <source>Name</source>
         <translation type="vanished">Nosaukums</translation>
     </message>
     <message>
+        <source>Name of recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target boil size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The extraction efficiency you expect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target batch size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Equipment</source>
-        <translation type="vanished">Iekārtas</translation>
+        <translation>Iekārtas</translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Krāsa</translation>
+        <translation>Krāsa</translation>
+    </message>
+    <message>
+        <source>IBU/GU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calories/12oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Des</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invoke the mash wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash wiz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save this mash profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;BrewTarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Brewtarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Equipments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Scale Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe to Clipboard as &amp;Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;OG Correction Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Convert Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backup Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Copy Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pr&amp;iming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select another database to merge into the current one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save all recipes, ingredients, etc. to a backup folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore recipes, ingredients, etc. from a previous backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;New Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1.0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Brūvē!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
+        <source>Mash Designer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
         <translation type="vanished">Nosaukums</translation>
     </message>
@@ -3922,52 +5305,323 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Laiks</translation>
+        <translation>Laiks</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion/Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Collected Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>vol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun Fullness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunVol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
+        <source>Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Piezīmes</translation>
+        <translation>Piezīmes</translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Get following parameters from the recipe&apos;s equipment.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
+        <source>Mash Step Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Veids</translation>
+        <translation>Veids</translation>
+    </message>
+    <message>
+        <source>Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water to infuse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of infusion water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of mash to decoct</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Laiks</translation>
+        <translation>Laiks</translation>
+    </message>
+    <message>
+        <source>Time to conduct the step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp. lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashWizard</name>
+    <message>
+        <source>Mash Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash thickness (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
+        <source>Misc Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Veids</translation>
+        <translation>Veids</translation>
+    </message>
+    <message>
+        <source>Spice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Herb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flavor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Lietot</translation>
+        <translation>Lietot</translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottling</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Laiks</translation>
+        <translation>Laiks</translation>
+    </message>
+    <message>
+        <source>Check it if the amount listed is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -3977,20 +5631,227 @@ The final volume in the primary is %1.</source>
         <source>Default Amount</source>
         <translation type="vanished">Noklusējuma daudzums</translation>
     </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Piezīmes</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Piezīmes</translation>
+        <translation>Piezīmes</translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ogAdjuster</name>
+    <message>
+        <source>Adjust Volume to Hit OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured gravity pre-boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp to which the hydrometer is calibrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-or-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato (percent by mass of equivalent sucrose)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG w/o Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG if you boil as planned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated batch size after correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Celsius</source>
         <translation type="vanished">Celsija</translation>
@@ -4000,8 +5861,28 @@ The final volume in the primary is %1.</source>
         <translation type="vanished">Fārenheita</translation>
     </message>
     <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Color</source>
-        <translation type="vanished">Krāsa</translation>
+        <translation>Krāsa</translation>
+    </message>
+    <message>
+        <source>Formulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU Adjustments</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Browse</source>
@@ -4012,8 +5893,58 @@ The final volume in the primary is %1.</source>
         <translation type="vanished">Noklusējuma</translation>
     </message>
     <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;qt&gt;
+   &lt;b&gt;Know another language?&lt;/b&gt;
+   &lt;br&gt;&lt;br&gt;
+   Or, would you like to improve a translation? Help us out and
+  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
+  provide a translation&lt;/a&gt; so that your friends can use brewtarget!
+&lt;/qt&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Date</source>
-        <translation type="vanished">Datums</translation>
+        <translation>Datums</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -4096,60 +6027,985 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>pitchDialog</name>
+    <message>
+        <source>Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wort Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch Rate (M cells)/(mL*P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Production Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Viability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>O2 At Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stir Plate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MM/dd/yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate Viability From Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Billions of Yeast Cells Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>primingDialog</name>
+    <message>
+        <source>Priming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of beer to prime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beer Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp of the beer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Glucose Monohydrate (corn sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anhydrous Glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sucrose (table sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Malt Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prime with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asst. Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date First Brewed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dd MMM yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carbonation Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Notes</source>
-        <translation type="vanished">Piezīmes</translation>
+        <translation>Piezīmes</translation>
+    </message>
+</context>
+<context>
+    <name>refractoDialog</name>
+    <message>
+        <source>Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20 C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refractive Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Real Extract (Plato)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>strikeWaterDialog</name>
+    <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Kategorija</translation>
+        <translation>Kategorija</translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Veids</translation>
+        <translation>Veids</translation>
+    </message>
+    <message>
+        <source>Type of beverage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBUs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color (SRM)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carb (vols)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV (pct)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ingredients</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Piezīmes</translation>
+        <translation>Piezīmes</translation>
     </message>
     <message>
         <source>New</source>
         <translation type="vanished">Jauns</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerListDialog</name>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>waterEditor</name>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Piezīmes</translation>
+        <translation>Piezīmes</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
+        <source>Yeast Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Nosaukums</translation>
+        <translation>Nosaukums</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Veids</translation>
+        <translation>Veids</translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Champagne</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Liquid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Culture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check it if the amount given is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flocculation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attenuation (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apparent attenuation as percentage of OG points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times Recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times this yeast has been recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked means add this yeast to secondary instead of primary</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4158,6 +7014,42 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Default Amount</source>
         <translation type="vanished">Noklusējuma daudzums</translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Piezīmes</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_nb.ts
+++ b/translations/bt_nb.ts
@@ -490,6 +490,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Oppskrift</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Lagerbeholdning</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Humle</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Gjær</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Utdata</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Avbryt</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1965,13 +2060,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2413,15 +2501,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2727,80 +2815,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Ukjent</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Lagerbeholdning</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Navn</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Mengde</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alfa %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2963,6 +2977,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Ukjent</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Lagerbeholdning</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Navn</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Mengde</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3745,8 +3833,36 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Avbryt</translation>
+        <translation type="unfinished">Avbryt</translation>
     </message>
 </context>
 <context>
@@ -3759,12 +3875,56 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Start</translation>
+        <translation type="unfinished">Start</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Stopp</translation>
+        <translation type="unfinished">Stopp</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4210,54 +4370,73 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialog</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Skjema</translation>
+        <translation>Skjema</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Generer instruksjoner</translation>
+        <translation>Generer instruksjoner</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Legg til fase</translation>
+        <translation>Legg til fase</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Navn på ny fase</translation>
+        <translation>Navn på ny fase</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Fase #</translation>
+        <translation>Fase #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Nummeret hvor den nye fasen skal bli plassert</translation>
+        <translation>Nummeret hvor den nye fasen skal bli plassert</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Legg til den nye fasen</translation>
+        <translation>Legg til den nye fasen</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Flytt fase</translation>
+        <translation>Flytt fase</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Flytt valgte fase opp</translation>
+        <translation>Flytt valgte fase opp</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Flytt valgte fase ned</translation>
+        <translation>Flytt valgte fase ned</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Fjern valgte fase</translation>
+        <translation>Fjern valgte fase</translation>
     </message>
 </context>
 <context>
@@ -4327,27 +4506,27 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Før koking</translation>
+        <translation>Før koking</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">SG før koking</translation>
+        <translation>SG før koking</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volum</translation>
+        <translation>Volum</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Volum på samlet vørter</translation>
+        <translation>Volum på samlet vørter</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Forhåndstemperatur</translation>
+        <translation>Forhåndstemperatur</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4355,59 +4534,59 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Endelig temperatur</translation>
+        <translation>Endelig temperatur</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Temperatur på mesk før utmesking</translation>
+        <translation>Temperatur på mesk før utmesking</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Etter koking</translation>
+        <translation>Etter koking</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">SG etter koking</translation>
+        <translation>SG etter koking</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Volum etter koking</translation>
+        <translation>Volum etter koking</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Volum på vørter i BK etter koking</translation>
+        <translation>Volum på vørter i BK etter koking</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Volum på vørter overført til gjæring</translation>
+        <translation>Volum på vørter overført til gjæring</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volum til gjæring</translation>
+        <translation>Volum til gjæring</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Temperatur på gjærstarter</translation>
+        <translation> Temperatur på gjærstarter</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Temperatur på vørter når gjær tilsettes</translation>
+        <translation>Temperatur på vørter når gjær tilsettes</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Etter gjæring</translation>
+        <translation>Etter gjæring</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Volum øl til flasking/fat</translation>
+        <translation>Volum øl til flasking/fat</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4423,11 +4602,11 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Projisert OG</translation>
+        <translation>Projisert OG</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Bryggerhusefektivitet</translation>
+        <translation>Bryggerhusefektivitet</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4439,7 +4618,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Projisert ABV</translation>
+        <translation>Projisert ABV</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4447,11 +4626,59 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notater</translation>
+        <translation>Notater</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4470,14 +4697,182 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Dødrom i separasjonstank</translation>
+        <translation>Dødrom i separasjonstank</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Utstyrsredigering</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Utstyr</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Sett som forvalgt</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Bryggevolum</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Navn</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Kalkuler volum før koking</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Koketid</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Frodampningsrate (pr time)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Endelig etterfyllingsvann</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Etterfyllingsvann kjele</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Normalverdi absorpsjon</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Kokepunkt for vann</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Volum på meskekar</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notater</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Nytt utstyr</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Redigering av gjærbart</translation>
+        <translation>Redigering av gjærbart</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4485,31 +4880,31 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Korn</translation>
+        <translation>Korn</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Sukker</translation>
+        <translation>Sukker</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Ekstrakt</translation>
+        <translation>Ekstrakt</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Tørr ekstrakt</translation>
+        <translation>Tørr ekstrakt</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Adjunkt</translation>
+        <translation>Adjunkt</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4521,43 +4916,43 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Utbytte sammenlignet med glykose</translation>
+        <translation>Utbytte sammenlignet med glykose</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Lovibond rate</translation>
+        <translation>Lovibond rate</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Legg til etter koking</translation>
+        <translation>Legg til etter koking</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Denne ingrediensen legges til før koking</translation>
+        <translation>Denne ingrediensen legges til før koking</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Opphav</translation>
+        <translation>Opphav</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Leverandør</translation>
+        <translation>Leverandør</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Grov/Fin Diff (%)</translation>
+        <translation>Grov/Fin Diff (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Utbyttefoskjell mellom grov og fin oppmaling</translation>
+        <translation>Utbyttefoskjell mellom grov og fin oppmaling</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Fuktighet (%)</translation>
+        <translation>Fuktighet (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Massens fuktighetsprosent</translation>
+        <translation>Massens fuktighetsprosent</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4569,43 +4964,43 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Protein (%)</translation>
+        <translation>Protein (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Massens proteinprosent</translation>
+        <translation>Massens proteinprosent</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Maks i batch (%)</translation>
+        <translation>Maks i batch (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Maksimal anbefalt andel av total malt</translation>
+        <translation>Maksimal anbefalt andel av total malt</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Anbefalt mesket</translation>
+        <translation>Anbefalt mesket</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Anbefal dette til å bli mesket</translation>
+        <translation>Anbefal dette til å bli mesket</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Blir mesket</translation>
+        <translation>Blir mesket</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Sjekk om det er tilstede i mesk</translation>
+        <translation>Sjekk om det er tilstede i mesk</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Bitterhet (IBU*gal/lb)</translation>
+        <translation>Bitterhet (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Bitterhet på prehumlede ekstrakter</translation>
+        <translation>Bitterhet på prehumlede ekstrakter</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4617,22 +5012,70 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Mengde i varebeholdning</translation>
+        <translation>Mengde i varebeholdning</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Mengde i varebeholdning</translation>
+        <translation>Mengde i varebeholdning</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Farge</translation>
+        <translation>Farge</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Utbytte %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Ekstra</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notater</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Rediger humle</translation>
+        <translation>Rediger humle</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4640,7 +5083,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4648,7 +5091,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Massens alfasyrer som prosent</translation>
+        <translation>Massens alfasyrer som prosent</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4656,59 +5099,59 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Bruk</translation>
+        <translation>Bruk</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mesk</translation>
+        <translation>Mesk</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Skylling</translation>
+        <translation>Skylling</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Kok</translation>
+        <translation>Kok</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Tørrhumle</translation>
+        <translation>Tørrhumle</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tid</translation>
+        <translation>Tid</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Forbitrende</translation>
+        <translation>Forbitrende</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Begge</translation>
+        <translation>Begge</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Skjema</translation>
+        <translation>Skjema</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Blad</translation>
+        <translation>Blad</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellet</translation>
+        <translation>Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Plugg</translation>
+        <translation>Plugg</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4716,19 +5159,19 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Massens betasyrer i prosent</translation>
+        <translation>Massens betasyrer i prosent</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Humlestabilitet/Lagringsindex</translation>
+        <translation>Humlestabilitet/Lagringsindex</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Opphav</translation>
+        <translation>Opphav</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4736,7 +5179,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulene</translation>
+        <translation>Humulene</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4752,7 +5195,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulone</translation>
+        <translation>Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4760,7 +5203,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcene</translation>
+        <translation>Myrcene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4776,65 +5219,121 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Mengde i varebeholdning</translation>
+        <translation>Mengde i varebeholdning</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Mengde i varebeholdning</translation>
+        <translation>Mengde i varebeholdning</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Ekstra</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notater</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Skjema</translation>
+        <translation>Skjema</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Vis et tidsur</translation>
+        <translation>Vis et tidsur</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Vis tidsur</translation>
+        <translation>Vis tidsur</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Merk fase som ferdig</translation>
+        <translation>Merk fase som ferdig</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Fase ferdig</translation>
+        <translation>Fase ferdig</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Oppskrifter</translation>
+        <translation>Oppskrifter</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Stiler</translation>
+        <translation>Stiler</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Gjærbart</translation>
+        <translation>Gjærbart</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Humle</translation>
+        <translation>Humle</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Diverse</translation>
+        <translation>Diverse</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Gjær</translation>
+        <translation>Gjær</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Oppskrift</translation>
+        <translation>Oppskrift</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4842,11 +5341,11 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Navn på oppskrift</translation>
+        <translation>Navn på oppskrift</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Kokevolum mål</translation>
+        <translation>Kokevolum mål</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4862,7 +5361,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Ekstraksjonseffektiviteten du forventer</translation>
+        <translation>Ekstraksjonseffektiviteten du forventer</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4874,7 +5373,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Batchvolum mål</translation>
+        <translation>Batchvolum mål</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4882,7 +5381,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Utstyr</translation>
+        <translation>Utstyr</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4890,163 +5389,163 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">SG koking</translation>
+        <translation>SG koking</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Bitterhet (IBU)</translation>
+        <translation>Bitterhet (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Farge</translation>
+        <translation>Farge</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Kalorier/12oz</translation>
+        <translation>Kalorier/12oz</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Ekstra</translation>
+        <translation>Ekstra</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Bryggedag</translation>
+        <translation>Bryggedag</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Legg til gjærbart</translation>
+        <translation>Legg til gjærbart</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Fjern valgt gjærbar</translation>
+        <translation>Fjern valgt gjærbar</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Rediger valgt gjærbar</translation>
+        <translation>Rediger valgt gjærbar</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Legg til humle</translation>
+        <translation>Legg til humle</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Fjern valgt humle</translation>
+        <translation>Fjern valgt humle</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Rediger valgt humle</translation>
+        <translation>Rediger valgt humle</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Diverse</translation>
+        <translation>Diverse</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Legg til diverse</translation>
+        <translation>Legg til diverse</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Fjern valgt diverse</translation>
+        <translation>Fjern valgt diverse</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Rediger valgt diverse</translation>
+        <translation>Rediger valgt diverse</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Gjær</translation>
+        <translation>Gjær</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Legg til gjær</translation>
+        <translation>Legg til gjær</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Fjern valgt gjær</translation>
+        <translation>Fjern valgt gjær</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Rediger valgt gjær</translation>
+        <translation>Rediger valgt gjær</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mesk</translation>
+        <translation>Mesk</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Legg til meskefase</translation>
+        <translation>Legg til meskefase</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Fjern valgt meskefase</translation>
+        <translation>Fjern valgt meskefase</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Rediger valgt meskefase</translation>
+        <translation>Rediger valgt meskefase</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Rediger meskeegenskaper</translation>
+        <translation>Rediger meskeegenskaper</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Rediger mesk</translation>
+        <translation>Rediger mesk</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Mesk Des</translation>
+        <translation>Mesk Des</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Start meskeveilleder</translation>
+        <translation>Start meskeveilleder</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Meskeveil.</translation>
+        <translation>Meskeveil.</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Mesker</translation>
+        <translation>Mesker</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Meskeopptrinn</translation>
+        <translation>Meskeopptrinn</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Meskenedtrinn</translation>
+        <translation>Meskenedtrinn</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Lagre denne meskeprofilen</translation>
+        <translation>Lagre denne meskeprofilen</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Lagre mesk</translation>
+        <translation>Lagre mesk</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Om</translation>
+        <translation>&amp;Om</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Fil</translation>
+        <translation>&amp;Fil</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5058,27 +5557,27 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Database</translation>
+        <translation>&amp;Database</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Vis</translation>
+        <translation>&amp;Vis</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Verktøy</translation>
+        <translation>&amp;Verktøy</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Verktøylinje</translation>
+        <translation>Verktøylinje</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">Om &amp;BrewTarget</translation>
+        <translation>Om &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Om Brewtarget</translation>
+        <translation>Om Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5086,19 +5585,19 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Gjærbare</translation>
+        <translation>&amp;Gjærbare</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Humler</translation>
+        <translation>&amp;Humler</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5106,31 +5605,31 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Gjær</translation>
+        <translation>&amp;Gjær</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Utstyr</translation>
+        <translation>&amp;Utstyr</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Øltyper</translation>
+        <translation>&amp;Øltyper</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5138,7 +5637,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5150,55 +5649,55 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Manual</translation>
+        <translation>&amp;Manual</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Skaler oppskift</translation>
+        <translation>&amp;Skaler oppskift</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Oppskrift til utklippstavle som &amp;Tekst</translation>
+        <translation>Oppskrift til utklippstavle som &amp;Tekst</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">&amp;OG korreksjon hjelp</translation>
+        <translation>&amp;OG korreksjon hjelp</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Konverter enheter</translation>
+        <translation>&amp;Konverter enheter</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Sikkerhetskopier database</translation>
+        <translation>Sikkerhetskopier database</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Gjenopprett database</translation>
+        <translation>Gjenopprett database</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Kopier oppskrift</translation>
+        <translation>&amp;Kopier oppskrift</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Ka&amp;rboneringskalkulator</translation>
+        <translation>Ka&amp;rboneringskalkulator</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">&amp;Refraktometerverktøy</translation>
+        <translation>&amp;Refraktometerverktøy</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">&amp;Gærstartkalkulator</translation>
+        <translation>&amp;Gærstartkalkulator</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Legg sammen databaser</translation>
+        <translation>Legg sammen databaser</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Velg database du vil slå sammen med gjeldende</translation>
+        <translation>Velg database du vil slå sammen med gjeldende</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5218,19 +5717,19 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Sikkerhetskopi</translation>
+        <translation>&amp;Sikkerhetskopi</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Lagre alle oppskrifter, ingredienser, etc til en sikkerhetskopimappe</translation>
+        <translation>Lagre alle oppskrifter, ingredienser, etc til en sikkerhetskopimappe</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Gjenopprett</translation>
+        <translation>&amp;Gjenopprett</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Gjenopprett oppskrifter, ingredenser, etc. fra en tidligere backup</translation>
+        <translation>Gjenopprett oppskrifter, ingredenser, etc. fra en tidligere backup</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5242,7 +5741,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Ny oppskrift</translation>
+        <translation>&amp;Ny oppskrift</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5250,42 +5749,162 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Vis tidtakere</translation>
+        <translation>Vis tidtakere</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Lagre</translation>
+        <translation>Lagre</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Slett merkede</translation>
+        <translation>Slett merkede</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Slett oppskrift</translation>
+        <translation>Slett oppskrift</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Mesk</translation>
+        <translation>&amp;Mesk</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Mesker</translation>
+        <translation>Mesker</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
         <translation type="vanished">Meskevannkalkulator</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Bryggevolum</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Kokevolum</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Start brygg!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Meskedesigner</translation>
+        <translation>Meskedesigner</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5301,7 +5920,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tid</translation>
+        <translation>Tid</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5309,275 +5928,311 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Neste</translation>
+        <translation>Neste</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Avslutt</translation>
+        <translation>Avslutt</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Mengde infusjon/avkok</translation>
+        <translation>Mengde infusjon/avkok</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">maks</translation>
+        <translation>maks</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Infusjonstemperatur</translation>
+        <translation>Infusjonstemperatur</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Totalt samlet vørter</translation>
+        <translation>Totalt samlet vørter</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">vol</translation>
+        <translation>vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Karfullhet</translation>
+        <translation>Karfullhet</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">Karvolum</translation>
+        <translation>Karvolum</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">tykkelse</translation>
+        <translation>tykkelse</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Meskeredigerer</translation>
+        <translation>Meskeredigerer</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temperatur malt</translation>
+        <translation>Temperatur malt</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temepratur meskevann</translation>
+        <translation>Temepratur meskevann</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Måltemperatur meskevann</translation>
+        <translation>Måltemperatur meskevann</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Meskevannets pH</translation>
+        <translation>Meskevannets pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notater</translation>
+        <translation>Notater</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Kar</translation>
+        <translation>Kar</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temperatur kar</translation>
+        <translation>Temperatur kar</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Hent følgende parametere fra oppskriftens utstyr</translation>
+        <translation>Hent følgende parametere fra oppskriftens utstyr</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Fra utstyr</translation>
+        <translation>Fra utstyr</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Karets masse</translation>
+        <translation>Karets masse</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Karets spesifikk varme</translation>
+        <translation>Karets spesifikk varme</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Karets spesifikk varme (cal/(g*K))</translation>
+        <translation>Karets spesifikk varme (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Stegmeskredigerer</translation>
+        <translation>Stegmeskredigerer</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infusjon</translation>
+        <translation>Infusjon</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatur</translation>
+        <translation>Temperatur</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Innkoking</translation>
+        <translation>Innkoking</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Måltemp.</translation>
+        <translation>Måltemp.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Måltemp. denne fase</translation>
+        <translation>Måltemp. denne fase</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Infusjonsmengde</translation>
+        <translation>Infusjonsmengde</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Mengde vann til infusjon</translation>
+        <translation>Mengde vann til infusjon</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Infusjonstemp.</translation>
+        <translation>Infusjonstemp.</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Innfusjonsvannets temperatur</translation>
+        <translation>Innfusjonsvannets temperatur</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Innkokingsmengde</translation>
+        <translation>Innkokingsmengde</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Mengde mesk til å innkoke</translation>
+        <translation>Mengde mesk til å innkoke</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tid</translation>
+        <translation>Tid</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Tid til å gjennomføre trinnet</translation>
+        <translation>Tid til å gjennomføre trinnet</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Temp. forsinkelsestid</translation>
+        <translation>Temp. forsinkelsestid</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Forsinkelsestid</translation>
+        <translation>Forsinkelsestid</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Slutttemp.</translation>
+        <translation>Slutttemp.</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Endelig temp. for denne fasen</translation>
+        <translation>Endelig temp. for denne fasen</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Skylling</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Meskeveilleder</translation>
+        <translation>Meskeveilleder</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Mesketetthet (L/kg)</translation>
+        <translation>Mesketetthet (L/kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Mesketetthet (ikke skriv inn enhet)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Diverseredigerer</translation>
+        <translation>Diverseredigerer</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Krydder</translation>
+        <translation>Krydder</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Klaringsmiddel</translation>
+        <translation>Klaringsmiddel</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Vannjustering</translation>
+        <translation>Vannjustering</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Urt</translation>
+        <translation>Urt</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Smak</translation>
+        <translation>Smak</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Annet</translation>
+        <translation>Annet</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Bruk</translation>
+        <translation>Bruk</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Kok</translation>
+        <translation>Kok</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mesk</translation>
+        <translation>Mesk</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Primær</translation>
+        <translation>Primær</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Sekundær</translation>
+        <translation>Sekundær</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Flasking</translation>
+        <translation>Flasking</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tid</translation>
+        <translation>Tid</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5585,15 +6240,15 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Sjekk etter om mengde listet opp er i kg i stedet for L.</translation>
+        <translation>Sjekk etter om mengde listet opp er i kg i stedet for L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Mengde er i vekt?</translation>
+        <translation>Mengde er i vekt?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Sjekk etter om mengde listet opp er i vekt i stedet for volum.</translation>
+        <translation>Sjekk etter om mengde listet opp er i vekt i stedet for volum.</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5609,192 +6264,220 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Mengde i varebeholdning</translation>
+        <translation>Mengde i varebeholdning</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Mengde i varebeholdning</translation>
+        <translation>Mengde i varebeholdning</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notater</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Navngitt meskeredigerer</translation>
+        <translation>Navngitt meskeredigerer</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mesk</translation>
+        <translation>Mesk</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Slett valgt stil</translation>
+        <translation>Slett valgt stil</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temperatur malt</translation>
+        <translation>Temperatur malt</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temepratur meskevann</translation>
+        <translation>Temepratur meskevann</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Måltemperatur meskevann</translation>
+        <translation>Måltemperatur meskevann</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Meskevannets pH</translation>
+        <translation>Meskevannets pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notater</translation>
+        <translation>Notater</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Kar</translation>
+        <translation>Kar</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temperatur kar</translation>
+        <translation>Temperatur kar</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Fra utstyr</translation>
+        <translation>Fra utstyr</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Karets masse</translation>
+        <translation>Karets masse</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Karets spesifikk varme</translation>
+        <translation>Karets spesifikk varme</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Karets spesifikk varme (cal/(g*K))</translation>
+        <translation>Karets spesifikk varme (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Legg til meskefase</translation>
+        <translation>Legg til meskefase</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Fjern valgt meskefase</translation>
+        <translation>Fjern valgt meskefase</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Meskeopptrinn</translation>
+        <translation>Meskeopptrinn</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Meskenedtrinn</translation>
+        <translation>Meskenedtrinn</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Juster volum for å treffe OG</translation>
+        <translation>Juster volum for å treffe OG</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Inndata</translation>
+        <translation>Inndata</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Målt SG før koking</translation>
+        <translation>Målt SG før koking</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temp</translation>
+        <translation>Temp</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Temperatur ved måling av SG</translation>
+        <translation>Temperatur ved måling av SG</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Kalibreringstemperatur</translation>
+        <translation>Kalibreringstemperatur</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temperatur når gavitasjonsmeteret er kalibrert</translation>
+        <translation>Temperatur når gavitasjonsmeteret er kalibrert</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-eller-</translation>
+        <translation>-eller-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (prosent ekvivalent sukrose i massen)</translation>
+        <translation>Plato (prosent ekvivalent sukrose i massen)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Volum før koking</translation>
+        <translation>Volum før koking</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Målt volum før koking</translation>
+        <translation>Målt volum før koking</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Utdata</translation>
+        <translation>Utdata</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">OG uten korrigering</translation>
+        <translation>OG uten korrigering</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">OG hvis du koker som planlagt</translation>
+        <translation>OG hvis du koker som planlagt</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Legg til i kok</translation>
+        <translation>Legg til i kok</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Mengde vann du må tilsette for å treffe planlagt OG (eller koke ut hvis negativt tall)</translation>
+        <translation>Mengde vann du må tilsette for å treffe planlagt OG (eller koke ut hvis negativt tall)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Endelig batchstørrelse</translation>
+        <translation>Endelig batchstørrelse</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Estimert batchstørrelse etter korrigering</translation>
+        <translation>Estimert batchstørrelse etter korrigering</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Beregn</translation>
+        <translation>Beregn</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Alternativer</translation>
+        <translation>Alternativer</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Enheter</translation>
+        <translation>Enheter</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Vekt</translation>
+        <translation>Vekt</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5810,7 +6493,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatur</translation>
+        <translation>Temperatur</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5822,11 +6505,11 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volum</translation>
+        <translation>Volum</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Gravitasjon</translation>
+        <translation>Gravitasjon</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5838,7 +6521,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Farge</translation>
+        <translation>Farge</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5850,7 +6533,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Formularer</translation>
+        <translation>Formularer</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5866,7 +6549,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5878,7 +6561,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">IBU-justeringer</translation>
+        <translation>IBU-justeringer</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5914,7 +6597,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Språk</translation>
+        <translation>Språk</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5924,7 +6607,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Kan du et annet språk?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Eller, vil du forbedre en oversettelse? Hjelp oss å  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
@@ -5933,7 +6616,43 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Dato</translation>
+        <translation>Dato</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6016,6 +6735,54 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6024,362 +6791,418 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Gjæringsratekalkulator</translation>
+        <translation>Gjæringsratekalkulator</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Inndata</translation>
+        <translation>Inndata</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Volum vørter</translation>
+        <translation>Volum vørter</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">For ale, 0.75-1. For lager, 1.5-2.</translation>
+        <translation>For ale, 0.75-1. For lager, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Gjæringsrate (M cells)/(mL*P)</translation>
+        <translation>Gjæringsrate (M cells)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Innluftingsmetode</translation>
+        <translation>Innluftingsmetode</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Gjærens produksjonsdato</translation>
+        <translation>Gjærens produksjonsdato</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Gjærens levedyktighet</translation>
+        <translation>Gjærens levedyktighet</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Ingen</translation>
+        <translation>Ingen</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 ved start</translation>
+        <translation>O2 ved start</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Magnet rører</translation>
+        <translation>Magnet rører</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">MM/dd/yyyy</translation>
+        <translation>MM/dd/yyyy</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">Tekstetikett</translation>
+        <translation>Tekstetikett</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Kalkuler levedyktighet ut i fra dato</translation>
+        <translation>Kalkuler levedyktighet ut i fra dato</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># Prøverør/pakker tilsatt</translation>
+        <translation># Prøverør/pakker tilsatt</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Utdata</translation>
+        <translation>Utdata</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Milliarder gjærseller som kreves</translation>
+        <translation>Milliarder gjærseller som kreves</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Prøverør/pakker foruten starter</translation>
+        <translation># Prøverør/pakker foruten starter</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Tørrgjær</translation>
+        <translation>Tørrgjær</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Startervolum</translation>
+        <translation>Startervolum</translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Karboneringskalkulator</translation>
+        <translation>Karboneringskalkulator</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Inndata</translation>
+        <translation>Inndata</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Samlet volum øl</translation>
+        <translation>Samlet volum øl</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Mengde øl til karbonering</translation>
+        <translation>Mengde øl til karbonering</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Øltemperatur</translation>
+        <translation>Øltemperatur</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Øllets temperatur</translation>
+        <translation>Øllets temperatur</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Ønsket mengde</translation>
+        <translation>Ønsket mengde</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Hvor mye CO2 du vil ha (1 L CO2 @ 1 atm per L øl)</translation>
+        <translation>Hvor mye CO2 du vil ha (1 L CO2 @ 1 atm per L øl)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glucose monohydrate (Druesukker)</translation>
+        <translation>Glucose monohydrate (Druesukker)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Anhydrous Glucose</translation>
+        <translation>Anhydrous Glucose</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sucrose (Vanlig sukker)</translation>
+        <translation>Sucrose (Vanlig sukker)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Tørr maltekstrakt</translation>
+        <translation>Tørr maltekstrakt</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Utdata</translation>
+        <translation>Utdata</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Karboner med</translation>
+        <translation>Karboner med</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Hvor mye karboneringsingrediens å bruke</translation>
+        <translation>Hvor mye karboneringsingrediens å bruke</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Beregn</translation>
+        <translation>Beregn</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Skjema</translation>
+        <translation>Skjema</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Brygger</translation>
+        <translation>Brygger</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Ass. brygger</translation>
+        <translation>Ass. brygger</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Smaksrate</translation>
+        <translation>Smaksrate</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Primærtid (dager)</translation>
+        <translation>Primærtid (dager)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Primærtemperatur</translation>
+        <translation>Primærtemperatur</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Sekundærtid (dager)</translation>
+        <translation>Sekundærtid (dager)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Sekundærtemperatur</translation>
+        <translation>Sekundærtemperatur</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Tertiærtid (dager)</translation>
+        <translation>Tertiærtid (dager)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Tertiærtemperatur</translation>
+        <translation>Tertiærtemperatur</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Flaske/Fat-tid (dager)</translation>
+        <translation>Flaske/Fat-tid (dager)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Flaske/Fat-temperatur</translation>
+        <translation>Flaske/Fat-temperatur</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Dato først brygget</translation>
+        <translation>Dato først brygget</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Karboneringsmengde</translation>
+        <translation>Karboneringsmengde</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Smaksnotater</translation>
+        <translation>Smaksnotater</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notater</translation>
+        <translation>Notater</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Refraktometerverktøy</translation>
+        <translation>Refraktometerverktøy</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Inndata</translation>
+        <translation>Inndata</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Original Plato</translation>
+        <translation>Original Plato</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">OG (20 C)</translation>
+        <translation>OG (20 C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Gjeldende Plato</translation>
+        <translation>Gjeldende Plato</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Beregn</translation>
+        <translation>Beregn</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Utdata</translation>
+        <translation>Utdata</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">SG (20C)</translation>
+        <translation>SG (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">ABW</translation>
+        <translation>ABW</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Refraktiv index</translation>
+        <translation>Refraktiv index</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Virkelig ekstrakt (Plato)</translation>
+        <translation>Virkelig ekstrakt (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">OG (20C)</translation>
+        <translation>OG (20C)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Meskevannkalkulator</translation>
+        <translation>Meskevannkalkulator</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Initiell infusjon</translation>
+        <translation>Initiell infusjon</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Orginal malttemperatur</translation>
+        <translation>Orginal malttemperatur</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Måltemperatur mesk</translation>
+        <translation>Måltemperatur mesk</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Maltvekt</translation>
+        <translation>Maltvekt</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Vannvolum</translation>
+        <translation>Vannvolum</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">Meskinfusjon</translation>
+        <translation>Meskinfusjon</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Totalvolum vann</translation>
+        <translation>Totalvolum vann</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Maltvekt</translation>
+        <translation>Maltvekt</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Faktisk mesketemperatur</translation>
+        <translation>Faktisk mesketemperatur</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Innfusjonsvanntemperatur</translation>
+        <translation>Innfusjonsvanntemperatur</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Beregn</translation>
+        <translation>Beregn</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Meskevanntemperatur</translation>
+        <translation>Meskevanntemperatur</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Volum å tilsette</translation>
+        <translation>Volum å tilsette</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">NB: Denne kalkulatoren antar et forhåndsvarmet meskekar</translation>
+        <translation>NB: Denne kalkulatoren antar et forhåndsvarmet meskekar</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Øltyperedigerer</translation>
+        <translation>Øltyperedigerer</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Øltype</translation>
+        <translation>Øltype</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Slett valgt øltype</translation>
+        <translation>Slett valgt øltype</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6387,55 +7210,55 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Ølkategori</translation>
+        <translation>Ølkategori</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Ølkategorinummer</translation>
+        <translation>Ølkategorinummer</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Øltypebokstav</translation>
+        <translation>Øltypebokstav</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Hvilke rettningslinjer</translation>
+        <translation>Hvilke rettningslinjer</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Type drikke</translation>
+        <translation>Type drikke</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Mjød</translation>
+        <translation>Mjød</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Hvete</translation>
+        <translation>Hvete</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Blandet</translation>
+        <translation>Blandet</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Sider</translation>
+        <translation>Sider</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6443,51 +7266,51 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Maks</translation>
+        <translation>Maks</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Min</translation>
+        <translation>Min</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBU&apos;er</translation>
+        <translation>IBU&apos;er</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Farge (SRM)</translation>
+        <translation>Farge (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Karb (Vols)</translation>
+        <translation>Karb (Vols)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV (pst)</translation>
+        <translation>ABV (pst)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Profil</translation>
+        <translation>Profil</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingredienser</translation>
+        <translation>Ingredienser</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Eksempler</translation>
+        <translation>Eksempler</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notater</translation>
+        <translation>Notater</translation>
     </message>
     <message>
         <source>New</source>
@@ -6501,12 +7324,258 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Avbryt</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
     <message>
         <source>Timers</source>
         <translation type="vanished">Tidtakere</translation>
+    </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Stopp</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Avbryt</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6517,18 +7586,22 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notater</translation>
+        <translation>Notater</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Gjærredigerer</translation>
+        <translation>Gjærredigerer</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6536,51 +7609,51 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Navn</translation>
+        <translation>Navn</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Hvete</translation>
+        <translation>Hvete</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Vin</translation>
+        <translation>Vin</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Champagne</translation>
+        <translation>Champagne</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Skjema</translation>
+        <translation>Skjema</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Flytende</translation>
+        <translation>Flytende</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Tørr</translation>
+        <translation>Tørr</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Prøverør</translation>
+        <translation>Prøverør</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Kultur</translation>
+        <translation>Kultur</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6588,91 +7661,91 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Sjekk etter om mengden er gitt i kg instedet for L.</translation>
+        <translation>Sjekk etter om mengden er gitt i kg instedet for L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Mengde er i vekt?</translation>
+        <translation>Mengde er i vekt?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Sjekk etter om mengden er gitt i vekt instedet for volum.</translation>
+        <translation>Sjekk etter om mengden er gitt i vekt instedet for volum.</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Lab</translation>
+        <translation>Lab</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">Produkt-ID</translation>
+        <translation>Produkt-ID</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Min Temp</translation>
+        <translation>Min Temp</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Min Temp</translation>
+        <translation>Min Temp</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Maks Temp</translation>
+        <translation>Maks Temp</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Maks Temp</translation>
+        <translation>Maks Temp</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Flokkulering</translation>
+        <translation>Flokkulering</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Lav</translation>
+        <translation>Lav</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Medium</translation>
+        <translation>Medium</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Høy</translation>
+        <translation>Høy</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Veldig høy</translation>
+        <translation>Veldig høy</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Attenuation (%)</translation>
+        <translation>Attenuation (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Tilsynelatende demping i prosent av OG-poeng</translation>
+        <translation>Tilsynelatende demping i prosent av OG-poeng</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Ganger rekulturert</translation>
+        <translation>Ganger rekulturert</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Antall ganger denne gjæren er rekulturert</translation>
+        <translation>Antall ganger denne gjæren er rekulturert</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Maks rekultureringer</translation>
+        <translation>Maks rekultureringer</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Maks antall ganger rekulturering</translation>
+        <translation>Maks antall ganger rekulturering</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Legg til i sekundær</translation>
+        <translation>Legg til i sekundær</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Avkrysset betyr: Legg til denne gjær i sekundær i stedet for primær</translation>
+        <translation>Avkrysset betyr: Legg til denne gjær i sekundær i stedet for primær</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6688,11 +7761,39 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Mengde i varebeholdning</translation>
+        <translation>Mengde i varebeholdning</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Mengde i varebeholdning</translation>
+        <translation>Mengde i varebeholdning</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Ekstra</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notater</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_nl.ts
+++ b/translations/bt_nl.ts
@@ -534,6 +534,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Recept</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Inventaris</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Vergistbaren</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Hop</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Gist</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Uitvoer</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1997,17 +2092,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min</translation>
-    </message>
-    <message>
-        <source>WK</source>
-        <translation type="obsolete">°WK</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2465,15 +2549,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2782,64 +2866,6 @@ Foutmelding:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">Normaal</translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alpha %</translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -3002,6 +3028,64 @@ Foutmelding:
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Onbekend</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Normaal</translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3805,35 +3889,35 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     <name>TimerDialog</name>
     <message>
         <source>Addition Timer</source>
-        <translation type="vanished">Toevoeg Timer</translation>
+        <translation>Toevoeg Timer</translation>
     </message>
     <message>
         <source>Set Addition Time(min):</source>
-        <translation type="vanished">Stel toevoeg tijd in (min):</translation>
+        <translation>Stel toevoeg tijd in (min):</translation>
     </message>
     <message>
         <source>Time Remaining:</source>
-        <translation type="vanished">Resterende Tijd:</translation>
+        <translation>Resterende Tijd:</translation>
     </message>
     <message>
         <source>Notes: </source>
-        <translation type="vanished">Aantekeningen: </translation>
+        <translation>Aantekeningen: </translation>
     </message>
     <message>
         <source>Notes...</source>
-        <translation type="vanished">Aantekeningen...</translation>
+        <translation>Aantekeningen...</translation>
     </message>
     <message>
         <source>Set Alarm sound</source>
-        <translation type="vanished">Stel alarm geluid in</translation>
+        <translation>Stel alarm geluid in</translation>
     </message>
     <message>
         <source>Stop Alarm</source>
-        <translation type="vanished">Stop Alarm</translation>
+        <translation>Stop Alarm</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="vanished">Annuleren</translation>
+        <translation>Annuleren</translation>
     </message>
 </context>
 <context>
@@ -3847,55 +3931,55 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     <name>TimerMainDialog</name>
     <message>
         <source>Main Boil Timer</source>
-        <translation type="vanished">Hoofd Kook Timer</translation>
+        <translation>Hoofd Kook Timer</translation>
     </message>
     <message>
         <source>Add Timer</source>
-        <translation type="vanished">Toevoeg Timer</translation>
+        <translation>Toevoeg Timer</translation>
     </message>
     <message>
         <source>Start</source>
-        <translation type="vanished">Start</translation>
+        <translation>Start</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="vanished">Stop</translation>
+        <translation>Stop</translation>
     </message>
     <message>
         <source>Reset</source>
-        <translation type="vanished">Reset</translation>
+        <translation>Reset</translation>
     </message>
     <message>
         <source>Hide Timers</source>
-        <translation type="vanished">Verberg Timers</translation>
+        <translation>Verberg Timers</translation>
     </message>
     <message>
         <source>Show Timers</source>
-        <translation type="vanished">Timers naar voorgrond</translation>
+        <translation>Timers naar voorgrond</translation>
     </message>
     <message>
         <source>Cancel Timers</source>
-        <translation type="vanished">Annuleer Timers</translation>
+        <translation>Annuleer Timers</translation>
     </message>
     <message>
         <source>Load Current Recipe</source>
-        <translation type="vanished">Laad Huidige Recept</translation>
+        <translation>Laad Huidige Recept</translation>
     </message>
     <message>
         <source>Set Boil Timer (mins):</source>
-        <translation type="vanished">Stel kook timer in (min):</translation>
+        <translation>Stel kook timer in (min):</translation>
     </message>
     <message>
         <source>Set Boil Time Here</source>
-        <translation type="vanished">Kook tijd</translation>
+        <translation>Kook tijd</translation>
     </message>
     <message>
         <source>Limit Alarm Ring Time </source>
-        <translation type="vanished">Limiteer Alarm Tijd </translation>
+        <translation>Limiteer Alarm Tijd </translation>
     </message>
     <message>
         <source>Alarm Ring Time (secs):</source>
-        <translation type="vanished">Alarm Tijd (s):</translation>
+        <translation>Alarm Tijd (s):</translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4309,54 +4393,73 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialoog</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Vorm</translation>
+        <translation>Vorm</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Genereer Instructies</translation>
+        <translation>Genereer Instructies</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Voeg stap toe</translation>
+        <translation>Voeg stap toe</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Naam van de nieuwe stap</translation>
+        <translation>Naam van de nieuwe stap</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Stap #</translation>
+        <translation>Stap #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Het nummer waar de nieuwe staop geplaatst moet worden</translation>
+        <translation>Het nummer waar de nieuwe staop geplaatst moet worden</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Voer de nieuwe stap in</translation>
+        <translation>Voer de nieuwe stap in</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Verplaats stappen</translation>
+        <translation>Verplaats stappen</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Verplaats de geselecteerde stap omhoog</translation>
+        <translation>Verplaats de geselecteerde stap omhoog</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Verplaats de geselecteerde stap omlaag</translation>
+        <translation>Verplaats de geselecteerde stap omlaag</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Verwijder geselecteerde stap</translation>
+        <translation>Verwijder geselecteerde stap</translation>
     </message>
 </context>
 <context>
@@ -4426,27 +4529,27 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Voor het koken</translation>
+        <translation>Voor het koken</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">SG voor het koken</translation>
+        <translation>SG voor het koken</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volume</translation>
+        <translation>Volume</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Verzamelde wort volume</translation>
+        <translation>Verzamelde wort volume</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Maisch water start temperatuur</translation>
+        <translation>Maisch water start temperatuur</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4454,59 +4557,59 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Eind Temp</translation>
+        <translation>Eind Temp</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Maisch temperatuur voor het uitmaischen</translation>
+        <translation>Maisch temperatuur voor het uitmaischen</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Na het koken</translation>
+        <translation>Na het koken</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Oorspronkelijk SG</translation>
+        <translation>Oorspronkelijk SG</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">SG na het koken</translation>
+        <translation>SG na het koken</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Volume na het koken</translation>
+        <translation>Volume na het koken</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Wortvolume in kook ketel na het koken</translation>
+        <translation>Wortvolume in kook ketel na het koken</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Hoeveelheid wort overgeheveld naar de vergister</translation>
+        <translation>Hoeveelheid wort overgeheveld naar de vergister</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volume in het vergistingsvat</translation>
+        <translation>Volume in het vergistingsvat</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Gistgift temp</translation>
+        <translation> Gistgift temp</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Wort temperatuur tijdens de gistgift</translation>
+        <translation>Wort temperatuur tijdens de gistgift</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Na het vergisten</translation>
+        <translation>Na het vergisten</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Eind SG</translation>
+        <translation>Eind SG</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Biervolume naar vat/flessen</translation>
+        <translation>Biervolume naar vat/flessen</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4522,11 +4625,11 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Geschatte OG</translation>
+        <translation>Geschatte OG</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Brouwerij rendement</translation>
+        <translation>Brouwerij rendement</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4538,7 +4641,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Geschatte ABV</translation>
+        <translation>Geschatte ABV</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4546,19 +4649,59 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV (%)</translation>
+        <translation>ABV (%)</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Aantekeningen</translation>
+        <translation>Aantekeningen</translation>
     </message>
     <message>
         <source>brewNote</source>
-        <translation type="vanished">brewNote</translation>
+        <translation>brewNote</translation>
     </message>
     <message>
         <source>yyyy-dd-MM</source>
-        <translation type="vanished">jjjj-dd-MM</translation>
+        <translation>jjjj-dd-MM</translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4577,18 +4720,182 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Dode ruimte Klaring</translation>
+        <translation>Dode ruimte Klaring</translation>
     </message>
     <message>
         <source>equipmentEditor</source>
-        <translation type="vanished">apparatuurEditor</translation>
+        <translation>apparatuurEditor</translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Apparatuur Editor</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Apparatuur</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Als standaard instellen</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Batch Grootte</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Naam</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Tijd</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Bereken volume voor het koken</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Kook tijd</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Verdampingssnelheid (per uur)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Uiteindelijk top-up water</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Ketel top-up water</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Standaard Absorbtie</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Water Kookpunt</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Volume van het maisch vat</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Nieuwe apparatuur</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Vergistbaren Editor</translation>
+        <translation>Vergistbaren Editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4596,31 +4903,31 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Graan</translation>
+        <translation>Graan</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Suiker</translation>
+        <translation>Suiker</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Extract</translation>
+        <translation>Extract</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Droog Extract</translation>
+        <translation>Droog Extract</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Aanvulling</translation>
+        <translation>Aanvulling</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4632,83 +4939,83 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Rendement in vergelijking met glucose</translation>
+        <translation>Rendement in vergelijking met glucose</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Lovibond waarde</translation>
+        <translation>Lovibond waarde</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Toevoegen na het koken</translation>
+        <translation>Toevoegen na het koken</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Dit ingrediënt is na het koken toegevoegd.</translation>
+        <translation>Dit ingrediënt is na het koken toegevoegd.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origine</translation>
+        <translation>Origine</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Leverancier</translation>
+        <translation>Leverancier</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Grof/Fijn Verschil (%)</translation>
+        <translation>Grof/Fijn Verschil (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Rendement verschil tussen grof en fijn geschrootte mout</translation>
+        <translation>Rendement verschil tussen grof en fijn geschrootte mout</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Vloeistof (%)</translation>
+        <translation>Vloeistof (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Vocht percentage bij massa</translation>
+        <translation>Vocht percentage bij massa</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Proteïne (%)</translation>
+        <translation>Proteïne (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Eiwit percentage bij massa</translation>
+        <translation>Eiwit percentage bij massa</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Max In Batch (%)</translation>
+        <translation>Max In Batch (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Maximum aanbevolen percentage van totale schrootsel</translation>
+        <translation>Maximum aanbevolen percentage van totale schrootsel</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Aanbevolen maisch</translation>
+        <translation>Aanbevolen maisch</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Aanbevolen om te maischen</translation>
+        <translation>Aanbevolen om te maischen</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">is gemaischt</translation>
+        <translation>is gemaischt</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Gecontroleerd op aanwezigheid in maisch</translation>
+        <translation>Gecontroleerd op aanwezigheid in maisch</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Bitterheid (IBU*gal/lb)</translation>
+        <translation>Bitterheid (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Bitterheid van voorgehopte extracten</translation>
+        <translation>Bitterheid van voorgehopte extracten</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4720,26 +5027,70 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Hoeveelheid in de Inventaris</translation>
+        <translation>Hoeveelheid in de Inventaris</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Hoeveelheid in de inventaris</translation>
+        <translation>Hoeveelheid in de inventaris</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Kleur</translation>
+        <translation>Kleur</translation>
     </message>
     <message>
         <source>Diastatic power</source>
-        <translation type="vanished">Diastatische kracht</translation>
+        <translation>Diastatische kracht</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Rendement %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Hop Editor</translation>
+        <translation>Hop Editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4747,7 +5098,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4755,7 +5106,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Alpha ziir als percentage van de massa</translation>
+        <translation>Alpha ziir als percentage van de massa</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4763,59 +5114,59 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Gebruik</translation>
+        <translation>Gebruik</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maisch</translation>
+        <translation>Maisch</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Eerste Wort</translation>
+        <translation>Eerste Wort</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Koken</translation>
+        <translation>Koken</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Dry Hop</translation>
+        <translation>Dry Hop</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tijd</translation>
+        <translation>Tijd</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Bitterhop</translation>
+        <translation>Bitterhop</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Beide</translation>
+        <translation>Beide</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Vorm</translation>
+        <translation>Vorm</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Blad</translation>
+        <translation>Blad</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellet</translation>
+        <translation>Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Geperste hop</translation>
+        <translation>Geperste hop</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4823,19 +5174,19 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Beta zuur als percentage van de massa</translation>
+        <translation>Beta zuur als percentage van de massa</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Hop Stabiliteit/Opslag index</translation>
+        <translation>Hop Stabiliteit/Opslag index</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origine</translation>
+        <translation>Origine</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4843,7 +5194,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humuleen</translation>
+        <translation>Humuleen</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4859,7 +5210,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumuloon</translation>
+        <translation>Cohumuloon</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4867,7 +5218,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrceen</translation>
+        <translation>Myrceen</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4883,73 +5234,129 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Hoeveelheid in de Inventaris</translation>
+        <translation>Hoeveelheid in de Inventaris</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Hoeveelheid in de inventaris</translation>
+        <translation>Hoeveelheid in de inventaris</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alpha %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Vorm</translation>
+        <translation>Vorm</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Toon een timer</translation>
+        <translation>Toon een timer</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Toon timer</translation>
+        <translation>Toon timer</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Markeer deze stap als compleet</translation>
+        <translation>Markeer deze stap als compleet</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Stap compleet</translation>
+        <translation>Stap compleet</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Recepten</translation>
+        <translation>Recepten</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Stijlen</translation>
+        <translation>Stijlen</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Vergistbaren</translation>
+        <translation>Vergistbaren</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Hop</translation>
+        <translation>Hop</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Diversen</translation>
+        <translation>Diversen</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Gist</translation>
+        <translation>Gist</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Recept</translation>
+        <translation>Recept</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Naam van het recept</translation>
+        <translation>Naam van het recept</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Streef Kook grootte</translation>
+        <translation>Streef Kook grootte</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4961,7 +5368,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Verwachtte brouwzaal rendement</translation>
+        <translation>Verwachtte brouwzaal rendement</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4973,167 +5380,167 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Streef Batch grootte</translation>
+        <translation>Streef Batch grootte</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Oorspronkelijke SG</translation>
+        <translation>Oorspronkelijke SG</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Kook SG</translation>
+        <translation>Kook SG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">Eind SG</translation>
+        <translation>Eind SG</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV (%)</translation>
+        <translation>ABV (%)</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Bitterheid (IBU)</translation>
+        <translation>Bitterheid (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Kleur</translation>
+        <translation>Kleur</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Calorieën/35.5cl (=12oz)</translation>
+        <translation>Calorieën/35.5cl (=12oz)</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extras</translation>
+        <translation>Extras</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Brouwdag</translation>
+        <translation>Brouwdag</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Voeg een vergistbare toe</translation>
+        <translation>Voeg een vergistbare toe</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Verwijder geselecteerde vergistbare</translation>
+        <translation>Verwijder geselecteerde vergistbare</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Edit geselecteerde vergistbare</translation>
+        <translation>Edit geselecteerde vergistbare</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Voeg Hop toe</translation>
+        <translation>Voeg Hop toe</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Verwijder geselecteerde hop</translation>
+        <translation>Verwijder geselecteerde hop</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Edit geselecteerde hop</translation>
+        <translation>Edit geselecteerde hop</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Diversen</translation>
+        <translation>Diversen</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Voeg diversen toe</translation>
+        <translation>Voeg diversen toe</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Verwijder geselecteerde diversen</translation>
+        <translation>Verwijder geselecteerde diversen</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Edit geselecteerde Diversen</translation>
+        <translation>Edit geselecteerde Diversen</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Gist</translation>
+        <translation>Gist</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Voeg Gist toe</translation>
+        <translation>Voeg Gist toe</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Verwijder geselecteerde gist</translation>
+        <translation>Verwijder geselecteerde gist</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Edit geselecteerde gist</translation>
+        <translation>Edit geselecteerde gist</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maisch</translation>
+        <translation>Maisch</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Voeg maisch stap toe</translation>
+        <translation>Voeg maisch stap toe</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Verwijder geselecteerde maisch stap</translation>
+        <translation>Verwijder geselecteerde maisch stap</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Edit geselecteerde maisch stap</translation>
+        <translation>Edit geselecteerde maisch stap</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Edit maisch eigenschappen</translation>
+        <translation>Edit maisch eigenschappen</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Edit maisch</translation>
+        <translation>Edit maisch</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Maisch bestemming</translation>
+        <translation>Maisch bestemming</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Draai de maisch wizard</translation>
+        <translation>Draai de maisch wizard</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Maisch wizard</translation>
+        <translation>Maisch wizard</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Maisch</translation>
+        <translation>Maisch</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Maisch stap omhoog</translation>
+        <translation>Maisch stap omhoog</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Maisch stap omlaag</translation>
+        <translation>Maisch stap omlaag</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Sla dit maisch profiel op</translation>
+        <translation>Sla dit maisch profiel op</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Opslaan Maisch</translation>
+        <translation>Opslaan Maisch</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Over</translation>
+        <translation>&amp;Over</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Bestand</translation>
+        <translation>&amp;Bestand</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5145,27 +5552,27 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Database</translation>
+        <translation>&amp;Database</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Bekijk</translation>
+        <translation>&amp;Bekijk</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Gereedschap</translation>
+        <translation>&amp;Gereedschap</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">gereedschapsBalk</translation>
+        <translation>gereedschapsBalk</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">Over &amp;BrewTarget</translation>
+        <translation>Over &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Over Brewtarget</translation>
+        <translation>Over Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5173,51 +5580,51 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Vergistbaren</translation>
+        <translation>&amp;Vergistbaren</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Hop</translation>
+        <translation>&amp;Hop</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Gist</translation>
+        <translation>&amp;Gist</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Apparatuur</translation>
+        <translation>&amp;Apparatuur</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Stijlen</translation>
+        <translation>&amp;Stijlen</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5225,55 +5632,55 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Handleiding</translation>
+        <translation>&amp;Handleiding</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Schaal Recept</translation>
+        <translation>&amp;Schaal Recept</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Recept naar Klembord als &amp;Tekst</translation>
+        <translation>Recept naar Klembord als &amp;Tekst</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">Hulp bij correctie &amp;oorspronkelijk SG</translation>
+        <translation>Hulp bij correctie &amp;oorspronkelijk SG</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Conversie Eenheden</translation>
+        <translation>&amp;Conversie Eenheden</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Backup Database</translation>
+        <translation>Backup Database</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Restore Database</translation>
+        <translation>Restore Database</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Kopieer Recept</translation>
+        <translation>&amp;Kopieer Recept</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Rekenhulp &amp;suiker toevoeging</translation>
+        <translation>Rekenhulp &amp;suiker toevoeging</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">&amp;Refractometer Gereedschap</translation>
+        <translation>&amp;Refractometer Gereedschap</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">&amp;Gistgift rekenhulp</translation>
+        <translation>&amp;Gistgift rekenhulp</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Database Samenvoegen</translation>
+        <translation>Database Samenvoegen</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Selecteer een andere database om samen te voegen met de huidige.</translation>
+        <translation>Selecteer een andere database om samen te voegen met de huidige.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5293,19 +5700,19 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Backup</translation>
+        <translation>&amp;Backup</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Alle recepten, ingrediënten, etc. opslaan in een backup map</translation>
+        <translation>Alle recepten, ingrediënten, etc. opslaan in een backup map</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">He&amp;rstellen</translation>
+        <translation>He&amp;rstellen</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Herstel recepten, ingrediënten, etc. van een vorige backup</translation>
+        <translation>Herstel recepten, ingrediënten, etc. van een vorige backup</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5317,51 +5724,51 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Nieuw recept</translation>
+        <translation>&amp;Nieuw recept</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Toon timer</translation>
+        <translation>Toon timer</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Opslaan</translation>
+        <translation>Opslaan</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Verwijder selectie</translation>
+        <translation>Verwijder selectie</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Verwijder recept</translation>
+        <translation>Verwijder recept</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Maisch</translation>
+        <translation>&amp;Maisch</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Maisch</translation>
+        <translation>Maisch</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>tab_recipe</source>
-        <translation type="vanished">tab_recipe</translation>
+        <translation>tab_recipe</translation>
     </message>
     <message>
         <source>Export to &amp;BBCode</source>
-        <translation type="vanished">Exporteer als &amp;BBCode</translation>
+        <translation>Exporteer als &amp;BBCode</translation>
     </message>
     <message>
         <source>&amp;Name</source>
-        <translation type="vanished">&amp;Naam</translation>
+        <translation>&amp;Naam</translation>
     </message>
     <message>
         <source>Tar&amp;get Boil Size</source>
-        <translation type="vanished">Streef Kook &amp;Grootte</translation>
+        <translation>Streef Kook &amp;Grootte</translation>
     </message>
     <message>
         <source>Calc&amp;ulated Boil Size</source>
@@ -5369,11 +5776,11 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>E&amp;quipment</source>
-        <translation type="vanished">&amp;Apparatuur</translation>
+        <translation>&amp;Apparatuur</translation>
     </message>
     <message>
         <source>Target Batch Si&amp;ze</source>
-        <translation type="vanished">&amp;Streef Batch grootte</translation>
+        <translation>&amp;Streef Batch grootte</translation>
     </message>
     <message>
         <source>In&amp;ventory</source>
@@ -5381,334 +5788,418 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>M&amp;iscs</source>
-        <translation type="vanished">&amp;Diversen</translation>
+        <translation>&amp;Diversen</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation type="vanished">&amp;Afsluiten</translation>
+        <translation>&amp;Afsluiten</translation>
     </message>
     <message>
         <source>Optio&amp;ns</source>
-        <translation type="vanished">&amp;Opties</translation>
+        <translation>&amp;Opties</translation>
     </message>
     <message>
         <source>Ti&amp;mers</source>
-        <translation type="vanished">&amp;Timers</translation>
+        <translation>&amp;Timers</translation>
     </message>
     <message>
         <source>Strike &amp;Water Calculator</source>
-        <translation type="vanished">&amp;Maischwater Rekenhulp</translation>
+        <translation>&amp;Maischwater Rekenhulp</translation>
     </message>
     <message>
         <source>&amp;Hydrometer Temp Adjustment</source>
-        <translation type="vanished">&amp;Hydrometer Temp Correctie</translation>
+        <translation>&amp;Hydrometer Temp Correctie</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Apparatuur</translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Batch Grootte</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Kook Volume</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Brouw het!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Maisch Ontwerper</translation>
+        <translation>Maisch Ontwerper</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tijd</translation>
+        <translation>Tijd</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Volgende</translation>
+        <translation>Volgende</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Beëindigen</translation>
+        <translation>Beëindigen</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Infusie/Decoctie Hoeveelheid</translation>
+        <translation>Infusie/Decoctie Hoeveelheid</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Infusie Temp</translation>
+        <translation>Infusie Temp</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Totaal Verzamelde Wort</translation>
+        <translation>Totaal Verzamelde Wort</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">vol</translation>
+        <translation>vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Volheid van het vat</translation>
+        <translation>Volheid van het vat</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">Vat Volume</translation>
+        <translation>Vat Volume</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">Dikte</translation>
+        <translation>Dikte</translation>
     </message>
     <message>
         <source>&amp;Name</source>
-        <translation type="vanished">&amp;Naam</translation>
+        <translation>&amp;Naam</translation>
     </message>
     <message>
         <source>&amp;Type</source>
-        <translation type="vanished">&amp;Type</translation>
+        <translation>&amp;Type</translation>
     </message>
     <message>
         <source>Tar&amp;get temp.</source>
-        <translation type="vanished">&amp;Doel temperatuur.</translation>
+        <translation>&amp;Doel temperatuur.</translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Maisch Editor</translation>
+        <translation>Maisch Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Initiële graan temp</translation>
+        <translation>Initiële graan temp</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Spoel temp</translation>
+        <translation>Spoel temp</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Beoogde Spoel temp</translation>
+        <translation>Beoogde Spoel temp</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Spoel pH</translation>
+        <translation>Spoel pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Aantekeningen</translation>
+        <translation>Aantekeningen</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Vat</translation>
+        <translation>Vat</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Initiële vat temp</translation>
+        <translation>Initiële vat temp</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Verkrijg de volgende parameters van de apparatuur van het recept.</translation>
+        <translation>Verkrijg de volgende parameters van de apparatuur van het recept.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Van Apparatuur</translation>
+        <translation>Van Apparatuur</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Vat massa</translation>
+        <translation>Vat massa</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Vat spec. hitte</translation>
+        <translation>Vat spec. hitte</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Vat specifieke hitte (cal/g*K)</translation>
+        <translation>Vat specifieke hitte (cal/g*K)</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Maisch Stap Editor</translation>
+        <translation>Maisch Stap Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infusie</translation>
+        <translation>Infusie</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temeratuur</translation>
+        <translation>Temeratuur</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Decoctie</translation>
+        <translation>Decoctie</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Beoogde temp.</translation>
+        <translation>Beoogde temp.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Beoogde temp van deze stap</translation>
+        <translation>Beoogde temp van deze stap</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Infusie Hoeveelheid</translation>
+        <translation>Infusie Hoeveelheid</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Hoeveelheid water voor infusie</translation>
+        <translation>Hoeveelheid water voor infusie</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Infusie temp.</translation>
+        <translation>Infusie temp.</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Temperatuur van infusie water</translation>
+        <translation>Temperatuur van infusie water</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Decoctie Hoeveelheid</translation>
+        <translation>Decoctie Hoeveelheid</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Hoeveelheid maisch voor decoctie</translation>
+        <translation>Hoeveelheid maisch voor decoctie</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tijd</translation>
+        <translation>Tijd</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Tijd om stap uit te voeren</translation>
+        <translation>Tijd om stap uit te voeren</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Temp. lagfase</translation>
+        <translation>Temp. lagfase</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">lagfase</translation>
+        <translation>lagfase</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Eind temp.</translation>
+        <translation>Eind temp.</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Eind temp. van deze stap</translation>
+        <translation>Eind temp. van deze stap</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Batch Spoelen</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Maisch wizard</translation>
+        <translation>Maisch wizard</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Maisch dikte (L/kg)</translation>
+        <translation>Maisch dikte (L/kg)</translation>
     </message>
     <message>
         <source>No Spar&amp;ge</source>
-        <translation type="vanished">&amp;Niet Spoelen</translation>
+        <translation>&amp;Niet Spoelen</translation>
     </message>
     <message>
         <source>Fl&amp;y Sparge</source>
-        <translation type="vanished">&amp;Fly Spoelen</translation>
+        <translation>&amp;Fly Spoelen</translation>
     </message>
     <message>
         <source>Ba&amp;tch Sparge</source>
-        <translation type="vanished">&amp;Batch Spoelen</translation>
+        <translation>&amp;Batch Spoelen</translation>
     </message>
     <message>
         <source>Batches</source>
-        <translation type="vanished">Batches</translation>
+        <translation>Batches</translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Diversen Editor</translation>
+        <translation>Diversen Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Specerij</translation>
+        <translation>Specerij</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Fining</translation>
+        <translation>Fining</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Waterbehandeling</translation>
+        <translation>Waterbehandeling</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Kruid</translation>
+        <translation>Kruid</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Smaak</translation>
+        <translation>Smaak</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Overig</translation>
+        <translation>Overig</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Gebruik</translation>
+        <translation>Gebruik</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Koken</translation>
+        <translation>Koken</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maisch</translation>
+        <translation>Maisch</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Hoofdvergististing</translation>
+        <translation>Hoofdvergististing</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Secundair</translation>
+        <translation>Secundair</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Bottelen</translation>
+        <translation>Bottelen</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tijd</translation>
+        <translation>Tijd</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5716,15 +6207,15 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Controleer of de hoeveelheid vermeld staat in kg i.p.v. L.</translation>
+        <translation>Controleer of de hoeveelheid vermeld staat in kg i.p.v. L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Hoeveelheid is gewicht?</translation>
+        <translation>Hoeveelheid is gewicht?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Controleer of de opgegeven hoeveelheid gewicht is i.p.v. volume</translation>
+        <translation>Controleer of de opgegeven hoeveelheid gewicht is i.p.v. volume</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5740,224 +6231,248 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Hoeveelheid in de Inventaris</translation>
+        <translation>Hoeveelheid in de Inventaris</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Hoeveelheid in de Inventaris</translation>
+        <translation>Hoeveelheid in de Inventaris</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Opgeslagen Maisch Bewerker</translation>
+        <translation>Opgeslagen Maisch Bewerker</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Maisch</translation>
+        <translation>Maisch</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Verwijder geselecteerde stijl</translation>
+        <translation>Verwijder geselecteerde stijl</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Initiële graan temp</translation>
+        <translation>Initiële graan temp</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Spoel temp</translation>
+        <translation>Spoel temp</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Beoogde Spoel temp</translation>
+        <translation>Beoogde Spoel temp</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Spoel pH</translation>
+        <translation>Spoel pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Aantekeningen</translation>
+        <translation>Aantekeningen</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Vat</translation>
+        <translation>Vat</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Initiële vat temp</translation>
+        <translation>Initiële vat temp</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Van Apparatuur</translation>
+        <translation>Van Apparatuur</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Vat massa</translation>
+        <translation>Vat massa</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Vat spec. hitte</translation>
+        <translation>Vat spec. hitte</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Vat specifieke hitte (cal/g*K)</translation>
+        <translation>Vat specifieke hitte (cal/g*K)</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Voeg maisch stap toe</translation>
+        <translation>Voeg maisch stap toe</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Verwijder geselecteerde maisch stap</translation>
+        <translation>Verwijder geselecteerde maisch stap</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Maisch stap omhoog</translation>
+        <translation>Maisch stap omhoog</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Maisch stap omlaag</translation>
+        <translation>Maisch stap omlaag</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Corrigeer volume om met OG samen te komen</translation>
+        <translation>Corrigeer volume om met OG samen te komen</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Invoer</translation>
+        <translation>Invoer</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Gemeten SG voor het koken</translation>
+        <translation>Gemeten SG voor het koken</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temp</translation>
+        <translation>Temp</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Temperatuur van het afgelezen SG</translation>
+        <translation>Temperatuur van het afgelezen SG</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Calibratie Temp</translation>
+        <translation>Calibratie Temp</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temp waar op de hydrometer is gecaibreerd</translation>
+        <translation>Temp waar op de hydrometer is gecaibreerd</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-of-</translation>
+        <translation>-of-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (massa percentage van sucrose equivalent)</translation>
+        <translation>Plato (massa percentage van sucrose equivalent)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Volume voor het koken</translation>
+        <translation>Volume voor het koken</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Gemeten volume voor het koken</translation>
+        <translation>Gemeten volume voor het koken</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Uitvoer</translation>
+        <translation>Uitvoer</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">Oorspronkelijk SG zonder correctie</translation>
+        <translation>Oorspronkelijk SG zonder correctie</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">Oorspronkelijk SG bij koken volgens planning</translation>
+        <translation>Oorspronkelijk SG bij koken volgens planning</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Toevoegen bij het koken</translation>
+        <translation>Toevoegen bij het koken</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Benodigde hoeveelheid water om toe te voegen om eht geplande oorspronkelijk SG te halen (of verdampen indien negatief)</translation>
+        <translation>Benodigde hoeveelheid water om toe te voegen om eht geplande oorspronkelijk SG te halen (of verdampen indien negatief)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Uiteindelijke Batch Grootte</translation>
+        <translation>Uiteindelijke Batch Grootte</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Geschatte batch grootte na correctie</translation>
+        <translation>Geschatte batch grootte na correctie</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Bereken</translation>
+        <translation>Bereken</translation>
     </message>
     <message>
         <source>ogAdjuster</source>
-        <translation type="vanished">ogAdjuster</translation>
+        <translation>ogAdjuster</translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Opties</translation>
+        <translation>Opties</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Eenheden</translation>
+        <translation>Eenheden</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Gewicht</translation>
+        <translation>Gewicht</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatuur</translation>
+        <translation>Temperatuur</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volume</translation>
+        <translation>Volume</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Kleur</translation>
+        <translation>Kleur</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Formules</translation>
+        <translation>Formules</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">IBU Correcties</translation>
+        <translation>IBU Correcties</translation>
     </message>
     <message>
         <source>Browse</source>
@@ -5965,7 +6480,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Taal</translation>
+        <translation>Taal</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5975,7 +6490,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
 	   &lt;b&gt;Beheerst u een andere taal?&lt;/b&gt;
           &lt;br&gt;&lt;br&gt;
          Of, zou u een vertaling willen verbeteren? Help ons en
@@ -5985,43 +6500,43 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Datum</translation>
+        <translation>Datum</translation>
     </message>
     <message>
         <source>Forumulas</source>
-        <translation type="vanished">Formules</translation>
+        <translation>Formules</translation>
     </message>
     <message>
         <source>Mash Hop (%)</source>
-        <translation type="vanished">Maish Hop (%)</translation>
+        <translation>Maish Hop (%)</translation>
     </message>
     <message>
         <source>First Wort (%)</source>
-        <translation type="vanished">Eerste Wort (%)</translation>
+        <translation>Eerste Wort (%)</translation>
     </message>
     <message>
         <source>Databases</source>
-        <translation type="vanished">Databases</translation>
+        <translation>Databases</translation>
     </message>
     <message>
         <source>Engines</source>
-        <translation type="vanished">Engines</translation>
+        <translation>Engines</translation>
     </message>
     <message>
         <source>RDBMS Engine</source>
-        <translation type="vanished">RDBMS Engine</translation>
+        <translation>RDBMS Engine</translation>
     </message>
     <message>
         <source>Test Connection</source>
-        <translation type="vanished">Test Connectie</translation>
+        <translation>Test Connectie</translation>
     </message>
     <message>
         <source>Configuration</source>
-        <translation type="vanished">Configuratie</translation>
+        <translation>Configuratie</translation>
     </message>
     <message>
         <source>Restore defaults</source>
-        <translation type="vanished">Herstel standaard instellingen</translation>
+        <translation>Herstel standaard instellingen</translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6109,7 +6624,51 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Diastatic power</source>
-        <translation type="vanished">Diastatische kracht</translation>
+        <translation>Diastatische kracht</translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
@@ -6120,418 +6679,418 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Rekenhulp Gistgift</translation>
+        <translation>Rekenhulp Gistgift</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Invoer</translation>
+        <translation>Invoer</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Wort Volume</translation>
+        <translation>Wort Volume</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Oorspronkelijk SG</translation>
+        <translation>Oorspronkelijk SG</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">0.75-1 voor ales. 1.5-2 voor pils.</translation>
+        <translation>0.75-1 voor ales. 1.5-2 voor pils.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Gistgift (M cellen)/(mL*P)</translation>
+        <translation>Gistgift (M cellen)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Beluchtings Methode</translation>
+        <translation>Beluchtings Methode</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Gist Productie Datum</translation>
+        <translation>Gist Productie Datum</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Gist Viabiliteit</translation>
+        <translation>Gist Viabiliteit</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">None</translation>
+        <translation>None</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 aan het begin</translation>
+        <translation>O2 aan het begin</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Roer Plaat</translation>
+        <translation>Roer Plaat</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">MM/dd/jjjj</translation>
+        <translation>MM/dd/jjjj</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">TekstLabel</translation>
+        <translation>TekstLabel</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Bereken Viabiliteit van Datum</translation>
+        <translation>Bereken Viabiliteit van Datum</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># Buisjes/Smack Packs toegevoegd</translation>
+        <translation># Buisjes/Smack Packs toegevoegd</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Uitvoer</translation>
+        <translation>Uitvoer</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Miljoenen Benodigde Gist Cellen</translation>
+        <translation>Miljoenen Benodigde Gist Cellen</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Buisjes/Smack Packs zonder Starter</translation>
+        <translation># Buisjes/Smack Packs zonder Starter</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Gedroogde Gist</translation>
+        <translation>Gedroogde Gist</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Starter Volume</translation>
+        <translation>Starter Volume</translation>
     </message>
     <message>
         <source>Volume of wort</source>
-        <translation type="vanished">Wort volume</translation>
+        <translation>Wort volume</translation>
     </message>
     <message>
         <source>Starting gravity of the wort</source>
-        <translation type="vanished">Begin SG van de wort</translation>
+        <translation>Begin SG van de wort</translation>
     </message>
     <message>
         <source>Aeration method</source>
-        <translation type="vanished">Beluchtings Methode</translation>
+        <translation>Beluchtings Methode</translation>
     </message>
     <message>
         <source>Production date (Best By date less three months)</source>
-        <translation type="vanished">Productie datum (THT min 3 maanden)</translation>
+        <translation>Productie datum (THT min 3 maanden)</translation>
     </message>
     <message>
         <source>Estimated viability of the yeast</source>
-        <translation type="vanished">Geschatte viabiliteit van de gist</translation>
+        <translation>Geschatte viabiliteit van de gist</translation>
     </message>
     <message>
         <source>Desired pitch rate</source>
-        <translation type="vanished">Gewenste gistgift hoeveelheid</translation>
+        <translation>Gewenste gistgift hoeveelheid</translation>
     </message>
     <message>
         <source>Number of vials/smack packs added to starter</source>
-        <translation type="vanished">Aantal buisjes/smack packs toegevoegd aan de starter</translation>
+        <translation>Aantal buisjes/smack packs toegevoegd aan de starter</translation>
     </message>
     <message>
         <source>How much yeast you will need</source>
-        <translation type="vanished">Hoeveel gist u nodig heeft</translation>
+        <translation>Hoeveel gist u nodig heeft</translation>
     </message>
     <message>
         <source>How many smack packs or vials required to reach pitch rate</source>
-        <translation type="vanished">Hoeveel buisjes of smack packs nodig zijn om de benodigde gistgift hoeveelheid te behalen</translation>
+        <translation>Hoeveel buisjes of smack packs nodig zijn om de benodigde gistgift hoeveelheid te behalen</translation>
     </message>
     <message>
         <source>Amount of dry yeast needed to reach pitch rate</source>
-        <translation type="vanished">Hoeveel droge gist nodig is om de gistgift hoeveelheid te behalen</translation>
+        <translation>Hoeveel droge gist nodig is om de gistgift hoeveelheid te behalen</translation>
     </message>
     <message>
         <source>Starter size to reach pitch rate</source>
-        <translation type="vanished">Starter grootte om de gistgift hoeveelheid te behalen</translation>
+        <translation>Starter grootte om de gistgift hoeveelheid te behalen</translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Gistgift Rekenhulp</translation>
+        <translation>Gistgift Rekenhulp</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Invoer</translation>
+        <translation>Invoer</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Verzamelde Bier Volume</translation>
+        <translation>Verzamelde Bier Volume</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Hoeveelheid bier om gist toe te voegen</translation>
+        <translation>Hoeveelheid bier om gist toe te voegen</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Bier Temperatuur</translation>
+        <translation>Bier Temperatuur</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Temp van het bier</translation>
+        <translation>Temp van het bier</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Gewenste Volumes</translation>
+        <translation>Gewenste Volumes</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Hoeveel volumes CO2 u wilt ((1 liter CO2 @ STP per liter bier)</translation>
+        <translation>Hoeveel volumes CO2 u wilt ((1 liter CO2 @ STP per liter bier)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glucose Monohydrate (mais suiker)</translation>
+        <translation>Glucose Monohydrate (mais suiker)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Watervrije Glucose</translation>
+        <translation>Watervrije Glucose</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sucrose (kristalsuiker)</translation>
+        <translation>Sucrose (kristalsuiker)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Gedroogd Mout Extract</translation>
+        <translation>Gedroogd Mout Extract</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Uitvoer</translation>
+        <translation>Uitvoer</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Gistgift met</translation>
+        <translation>Gistgift met</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Hoeveel gist ingrediënt te gebruiken</translation>
+        <translation>Hoeveel gist ingrediënt te gebruiken</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Bereken</translation>
+        <translation>Bereken</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Vorm</translation>
+        <translation>Vorm</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Brouwer</translation>
+        <translation>Brouwer</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Assistent Brouwer</translation>
+        <translation>Assistent Brouwer</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Smaak waardering</translation>
+        <translation>Smaak waardering</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Hoofdvergisting duur (dagen)</translation>
+        <translation>Hoofdvergisting duur (dagen)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Temp hoofdvergisting</translation>
+        <translation>Temp hoofdvergisting</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Duur navergisting (dagen)</translation>
+        <translation>Duur navergisting (dagen)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Temp navergisting</translation>
+        <translation>Temp navergisting</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Duur hergisting (dagen)</translation>
+        <translation>Duur hergisting (dagen)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Temp hergisting</translation>
+        <translation>Temp hergisting</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Duur Fles/Vat (dagen)</translation>
+        <translation>Duur Fles/Vat (dagen)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Temp Fles/Vat (dagen)</translation>
+        <translation>Temp Fles/Vat (dagen)</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Datum Eerste Brouwsel</translation>
+        <translation>Datum Eerste Brouwsel</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Koolzuur Volumes</translation>
+        <translation>Koolzuur Volumes</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Proef Aantekeningen</translation>
+        <translation>Proef Aantekeningen</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Aantekeningen</translation>
+        <translation>Aantekeningen</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Refractometer Gereedschap</translation>
+        <translation>Refractometer Gereedschap</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Invoer</translation>
+        <translation>Invoer</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Oorspronkelijke Plato</translation>
+        <translation>Oorspronkelijke Plato</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">Oorspronkelijk SG (20 °C)</translation>
+        <translation>Oorspronkelijk SG (20 °C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Huidige Plato</translation>
+        <translation>Huidige Plato</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Bereken</translation>
+        <translation>Bereken</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Uitvoer</translation>
+        <translation>Uitvoer</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">SG (20°C)</translation>
+        <translation>SG (20°C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV (%)</translation>
+        <translation>ABV (%)</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">Alc (gew%)</translation>
+        <translation>Alc (gew%)</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Refractieve index</translation>
+        <translation>Refractieve index</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Werkelijk Extract (Plato)</translation>
+        <translation>Werkelijk Extract (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">Oorspronkelijk SG (20 °C)</translation>
+        <translation>Oorspronkelijk SG (20 °C)</translation>
     </message>
     <message>
         <source>Measured original plato</source>
-        <translation type="vanished">Gemeten oorspronkelijke Plato</translation>
+        <translation>Gemeten oorspronkelijke Plato</translation>
     </message>
     <message>
         <source>Measured original gravity</source>
-        <translation type="vanished">Gemeten oorspronkelijk SG</translation>
+        <translation>Gemeten oorspronkelijk SG</translation>
     </message>
     <message>
         <source>Current measured plato</source>
-        <translation type="vanished">Huidige gemeten plato</translation>
+        <translation>Huidige gemeten plato</translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Maischwater Rekenhulp</translation>
+        <translation>Maischwater Rekenhulp</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Initiële Infusie</translation>
+        <translation>Initiële Infusie</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Oorspronkelijke Graan Temperatuur</translation>
+        <translation>Oorspronkelijke Graan Temperatuur</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Richt Maisch Temperatuur</translation>
+        <translation>Richt Maisch Temperatuur</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Graangewicht</translation>
+        <translation>Graangewicht</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Watervolume</translation>
+        <translation>Watervolume</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">Maisch Infusie</translation>
+        <translation>Maisch Infusie</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Totaal Watervolume</translation>
+        <translation>Totaal Watervolume</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Graangewicht</translation>
+        <translation>Graangewicht</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Eigenlijke Maisch Temperatuur</translation>
+        <translation>Eigenlijke Maisch Temperatuur</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Infusie Water Temperatuur</translation>
+        <translation>Infusie Water Temperatuur</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Bereken</translation>
+        <translation>Bereken</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Maischwater Temperatuur</translation>
+        <translation>Maischwater Temperatuur</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Volume om toe te voegen</translation>
+        <translation>Volume om toe te voegen</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">NB: Deze rekenhulp gaat uit van een voorverwarmde maisch ketel.</translation>
+        <translation>NB: Deze rekenhulp gaat uit van een voorverwarmde maisch ketel.</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Stijl Editor</translation>
+        <translation>Stijl Editor</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Stijl</translation>
+        <translation>Stijl</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Verwijder geselecteerde stijl</translation>
+        <translation>Verwijder geselecteerde stijl</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6539,55 +7098,55 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Categorie</translation>
+        <translation>Categorie</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Categorie nummer</translation>
+        <translation>Categorie nummer</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Stijl letter</translation>
+        <translation>Stijl letter</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Stijl gids</translation>
+        <translation>Stijl gids</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Type drank</translation>
+        <translation>Type drank</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Pils</translation>
+        <translation>Pils</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Mede</translation>
+        <translation>Mede</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Tarwe</translation>
+        <translation>Tarwe</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Gemengd</translation>
+        <translation>Gemengd</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Cider</translation>
+        <translation>Cider</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6595,51 +7154,51 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Max</translation>
+        <translation>Max</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Min</translation>
+        <translation>Min</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Oorspronkelijk SG</translation>
+        <translation>Oorspronkelijk SG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">Eind SG</translation>
+        <translation>Eind SG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBU&apos;s</translation>
+        <translation>IBU&apos;s</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Kleur (SRM)</translation>
+        <translation>Kleur (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Koolzuur (vol)</translation>
+        <translation>Koolzuur (vol)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV(%)</translation>
+        <translation>ABV(%)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Profiel</translation>
+        <translation>Profiel</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingrediënten</translation>
+        <translation>Ingrediënten</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Voorbeelden</translation>
+        <translation>Voorbeelden</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Aantekeningen</translation>
+        <translation>Aantekeningen</translation>
     </message>
     <message>
         <source>New</source>
@@ -6653,35 +7212,254 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Annuleren</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
     <message>
         <source>Addition Timers</source>
-        <translation type="vanished">Toevoeg Timers</translation>
+        <translation>Toevoeg Timers</translation>
     </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Vorm</translation>
+        <translation>Vorm</translation>
     </message>
     <message>
         <source>Add:</source>
-        <translation type="vanished">Voeg toe:</translation>
+        <translation>Voeg toe:</translation>
     </message>
     <message>
         <source>Notes...</source>
-        <translation type="vanished">Notities...</translation>
+        <translation>Notities...</translation>
     </message>
     <message>
         <source>At:</source>
-        <translation type="vanished">Op:</translation>
+        <translation>Op:</translation>
     </message>
     <message>
         <source>mins</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Stop</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6692,18 +7470,22 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Aantekeningen</translation>
+        <translation>Aantekeningen</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Gist Editor</translation>
+        <translation>Gist Editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6711,51 +7493,51 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Naam</translation>
+        <translation>Naam</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Pils</translation>
+        <translation>Pils</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Tarwe</translation>
+        <translation>Tarwe</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Wijn</translation>
+        <translation>Wijn</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Champagne</translation>
+        <translation>Champagne</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Vorm</translation>
+        <translation>Vorm</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Vloeistof</translation>
+        <translation>Vloeistof</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Gedroogd</translation>
+        <translation>Gedroogd</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Opgekweekt</translation>
+        <translation>Opgekweekt</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Cultuur</translation>
+        <translation>Cultuur</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6763,91 +7545,91 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Controleer of de opgegeven hoeveelheid in kg is i.p.v.in L.</translation>
+        <translation>Controleer of de opgegeven hoeveelheid in kg is i.p.v.in L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Hoeveelheid is gewicht?</translation>
+        <translation>Hoeveelheid is gewicht?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Controleer of de opgegeven hoeveelheid een gewicht is i.p.v. een volume</translation>
+        <translation>Controleer of de opgegeven hoeveelheid een gewicht is i.p.v. een volume</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Lab</translation>
+        <translation>Lab</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">Product ID</translation>
+        <translation>Product ID</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Min Temp</translation>
+        <translation>Min Temp</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Min temp</translation>
+        <translation>Min temp</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Max Temp</translation>
+        <translation>Max Temp</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Max temp</translation>
+        <translation>Max temp</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Flocculatie</translation>
+        <translation>Flocculatie</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Laag</translation>
+        <translation>Laag</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Gemiddeld</translation>
+        <translation>Gemiddeld</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Hoog</translation>
+        <translation>Hoog</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Erg Hoog</translation>
+        <translation>Erg Hoog</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Vergisting (%)</translation>
+        <translation>Vergisting (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Schijnbare Vergisting als percentage van het oorspronkelijke SG</translation>
+        <translation>Schijnbare Vergisting als percentage van het oorspronkelijke SG</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Aantal keren opgekweekt</translation>
+        <translation>Aantal keren opgekweekt</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Aantal keren dat deze gist is opgekweekt</translation>
+        <translation>Aantal keren dat deze gist is opgekweekt</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Max keren opkweken</translation>
+        <translation>Max keren opkweken</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Max keren opkweken</translation>
+        <translation>Max keren opkweken</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Voeg toe aan navergisting</translation>
+        <translation>Voeg toe aan navergisting</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Aangevinkt betekent: voeg gist toe aan navergisting i.p.v. hoofdvergisting</translation>
+        <translation>Aangevinkt betekent: voeg gist toe aan navergisting i.p.v. hoofdvergisting</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6863,11 +7645,39 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Hoeveelheid in de Inventaris</translation>
+        <translation>Hoeveelheid in de Inventaris</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Hoeveelheid in de inventaris</translation>
+        <translation>Hoeveelheid in de inventaris</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_pl.ts
+++ b/translations/bt_pl.ts
@@ -490,6 +490,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Magazyn</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Składniki fermentacji</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Chmiele</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Drożdże</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Wynik</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1965,13 +2060,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min.</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2413,15 +2501,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2727,80 +2815,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Nieznane</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Magazyn</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Ilość</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alfa %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2963,6 +2977,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Nieznane</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Magazyn</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Ilość</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3745,8 +3833,36 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Anuluj</translation>
+        <translation type="unfinished">Anuluj</translation>
     </message>
 </context>
 <context>
@@ -3759,12 +3875,56 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Start</translation>
+        <translation type="unfinished">Start</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Stop</translation>
+        <translation type="unfinished">Stop</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4210,54 +4370,73 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialog</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Postać</translation>
+        <translation>Postać</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Wygeneruj instrukcje</translation>
+        <translation>Wygeneruj instrukcje</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Dodaj krok</translation>
+        <translation>Dodaj krok</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Nazwa nowego kroku</translation>
+        <translation>Nazwa nowego kroku</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Krok #</translation>
+        <translation>Krok #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Numer gdzie powinien znaleść się nowy krok zacierania</translation>
+        <translation>Numer gdzie powinien znaleść się nowy krok zacierania</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Dodaj nowy krok</translation>
+        <translation>Dodaj nowy krok</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Przesuń kroki</translation>
+        <translation>Przesuń kroki</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Przesuń wybrany krok wyżej</translation>
+        <translation>Przesuń wybrany krok wyżej</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Przesuń wybrany krok niżej</translation>
+        <translation>Przesuń wybrany krok niżej</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Usuń wybrany krok</translation>
+        <translation>Usuń wybrany krok</translation>
     </message>
 </context>
 <context>
@@ -4327,27 +4506,27 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Przed gotowaniem</translation>
+        <translation>Przed gotowaniem</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Gęstość (SG)</translation>
+        <translation>Gęstość (SG)</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Gęstość przed gotowaniem</translation>
+        <translation>Gęstość przed gotowaniem</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Objętość</translation>
+        <translation>Objętość</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Temperatura brzeczki</translation>
+        <translation>Temperatura brzeczki</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4355,59 +4534,59 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Docelowa temp.</translation>
+        <translation>Docelowa temp.</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Temperatura zacieru przed wygrzewaniem</translation>
+        <translation>Temperatura zacieru przed wygrzewaniem</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Po gotowaniu</translation>
+        <translation>Po gotowaniu</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Gęstość (OG)</translation>
+        <translation>Gęstość (OG)</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Gęstość po gotowaniu</translation>
+        <translation>Gęstość po gotowaniu</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Objętość po gotowaniu</translation>
+        <translation>Objętość po gotowaniu</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Objętość brzeczki w kadzi</translation>
+        <translation>Objętość brzeczki w kadzi</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Objętość brzeczki po przelaniu do fermentora</translation>
+        <translation>Objętość brzeczki po przelaniu do fermentora</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Obj.w fermentorze</translation>
+        <translation>Obj.w fermentorze</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Temp. zadania drożdży</translation>
+        <translation> Temp. zadania drożdży</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Temperatura brzeczki podczas zadania drożdży</translation>
+        <translation>Temperatura brzeczki podczas zadania drożdży</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Po fermentacji</translation>
+        <translation>Po fermentacji</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Końcowa gęstość (FG)</translation>
+        <translation>Końcowa gęstość (FG)</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Objętość piwa w KEGach/butelkach</translation>
+        <translation>Objętość piwa w KEGach/butelkach</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4423,11 +4602,11 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Oczekiwana gęstość (OG)</translation>
+        <translation>Oczekiwana gęstość (OG)</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Wydajność browaru</translation>
+        <translation>Wydajność browaru</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4439,7 +4618,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Projektowana zaw. alk.</translation>
+        <translation>Projektowana zaw. alk.</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4447,11 +4626,59 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Faktyczna zaw. alk.</translation>
+        <translation>Faktyczna zaw. alk.</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notatki</translation>
+        <translation>Notatki</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4470,14 +4697,182 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Martwa strefa filtratora</translation>
+        <translation>Martwa strefa filtratora</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Edytor sprzętu</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Domyślne</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Wielkość warki</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Czas</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Wylicz objętość przed gotowaniem</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Czas gotowania</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Szybkość parowania (na godz.)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Początkowa ilość wody w fermentorze</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Początkowa ilość wody w kotle</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Standardowa absorbcja</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Temperatura wrzenia wody</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Pojemność kadzi zaciernej</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notatki</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Nowy sprzęt</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Edytor składnika fermentacji</translation>
+        <translation>Edytor składnika fermentacji</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4485,31 +4880,31 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Słód</translation>
+        <translation>Słód</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Cukier</translation>
+        <translation>Cukier</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Ekstrakt</translation>
+        <translation>Ekstrakt</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Suchy ekstrakt</translation>
+        <translation>Suchy ekstrakt</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Dodatek</translation>
+        <translation>Dodatek</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4521,43 +4916,43 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Ekstraktywność w porównaniu do glukozy</translation>
+        <translation>Ekstraktywność w porównaniu do glukozy</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Wartosć Lovibond</translation>
+        <translation>Wartosć Lovibond</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Dodawany po gotowaniu</translation>
+        <translation>Dodawany po gotowaniu</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Ten składnik dodawany jest po gotowaniu.</translation>
+        <translation>Ten składnik dodawany jest po gotowaniu.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Kraj pochodzenia</translation>
+        <translation>Kraj pochodzenia</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Dostawca</translation>
+        <translation>Dostawca</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Różnica frakcji grube/drobnej (%)</translation>
+        <translation>Różnica frakcji grube/drobnej (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Różnica wydajności pomiędzy frakcją grubą i drobną</translation>
+        <translation>Różnica wydajności pomiędzy frakcją grubą i drobną</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Wilgoć (%)</translation>
+        <translation>Wilgoć (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Procent wilgoci w masie</translation>
+        <translation>Procent wilgoci w masie</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4569,43 +4964,43 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Białka (%)</translation>
+        <translation>Białka (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Procent białek w masie</translation>
+        <translation>Procent białek w masie</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Maks. w warce (%)</translation>
+        <translation>Maks. w warce (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Maksymalna zalecana procentowa zawartość w całym zasypie</translation>
+        <translation>Maksymalna zalecana procentowa zawartość w całym zasypie</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Zalecane zacieranie</translation>
+        <translation>Zalecane zacieranie</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Zalecane jest aby składnik był poddany zacieraniu</translation>
+        <translation>Zalecane jest aby składnik był poddany zacieraniu</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Będzie zacierany</translation>
+        <translation>Będzie zacierany</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Zazanacz jeśli będzie obecny w zacierze</translation>
+        <translation>Zazanacz jeśli będzie obecny w zacierze</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Goryczka</translation>
+        <translation>Goryczka</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Goryczka dodatków niechmielowych</translation>
+        <translation>Goryczka dodatków niechmielowych</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4617,22 +5012,70 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Ilość w magazynie</translation>
+        <translation>Ilość w magazynie</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Ilość w magazynie</translation>
+        <translation>Ilość w magazynie</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Kolor</translation>
+        <translation>Kolor</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Ekstraktywność %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Szczegóły</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notatki</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Edytor chmielu</translation>
+        <translation>Edytor chmielu</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4640,7 +5083,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4648,7 +5091,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Procent alfa-kwasów w masie</translation>
+        <translation>Procent alfa-kwasów w masie</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4656,59 +5099,59 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Użycie</translation>
+        <translation>Użycie</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Zacieranie</translation>
+        <translation>Zacieranie</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Chmielenie przedniej brzeczki</translation>
+        <translation>Chmielenie przedniej brzeczki</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Gotowanie</translation>
+        <translation>Gotowanie</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Chmielenie na aromat</translation>
+        <translation>Chmielenie na aromat</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Chmielenie na zimno</translation>
+        <translation>Chmielenie na zimno</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Czas</translation>
+        <translation>Czas</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Goryczkowy</translation>
+        <translation>Goryczkowy</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Uniwersalny</translation>
+        <translation>Uniwersalny</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Postać</translation>
+        <translation>Postać</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Szyszka</translation>
+        <translation>Szyszka</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Granulat</translation>
+        <translation>Granulat</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Tabletka</translation>
+        <translation>Tabletka</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4716,19 +5159,19 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Procent beta-kwasów w masie</translation>
+        <translation>Procent beta-kwasów w masie</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Indeks stabilności i przechowywania chmielu</translation>
+        <translation>Indeks stabilności i przechowywania chmielu</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Pochodzenie</translation>
+        <translation>Pochodzenie</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4736,7 +5179,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humulony</translation>
+        <translation>Humulony</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4752,7 +5195,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulone</translation>
+        <translation>Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4760,7 +5203,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcene</translation>
+        <translation>Myrcene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4776,65 +5219,121 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Ilość w magazynie</translation>
+        <translation>Ilość w magazynie</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Ilość w magazynie</translation>
+        <translation>Ilość w magazynie</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Szczegóły</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notatki</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Pokaż minutnik</translation>
+        <translation>Pokaż minutnik</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Pokaż minutnik</translation>
+        <translation>Pokaż minutnik</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Oznacz krok jako zakończony</translation>
+        <translation>Oznacz krok jako zakończony</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Krok zakończony</translation>
+        <translation>Krok zakończony</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Receptury</translation>
+        <translation>Receptury</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Style</translation>
+        <translation>Style</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Składniki fermentacji</translation>
+        <translation>Składniki fermentacji</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Chmiele</translation>
+        <translation>Chmiele</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Dodatki</translation>
+        <translation>Dodatki</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Drożdze</translation>
+        <translation>Drożdze</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Receptura</translation>
+        <translation>Receptura</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4842,11 +5341,11 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Nazwa receptury</translation>
+        <translation>Nazwa receptury</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Docelowa objętość brzeczki przed gotowaniem</translation>
+        <translation>Docelowa objętość brzeczki przed gotowaniem</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4862,7 +5361,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Wydajność której oczekujesz</translation>
+        <translation>Wydajność której oczekujesz</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4874,7 +5373,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Docelowa wielkość warki</translation>
+        <translation>Docelowa wielkość warki</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4882,7 +5381,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Sprzęt</translation>
+        <translation>Sprzęt</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4890,163 +5389,163 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Gęstość początkowa</translation>
+        <translation>Gęstość początkowa</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Gęstość przed gotowaniem</translation>
+        <translation>Gęstość przed gotowaniem</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">Gęstość końcowa</translation>
+        <translation>Gęstość końcowa</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Alkohol (ABV)</translation>
+        <translation>Alkohol (ABV)</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Goryczka (IBU)</translation>
+        <translation>Goryczka (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Barwa</translation>
+        <translation>Barwa</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">Wskaźnik goryczki</translation>
+        <translation>Wskaźnik goryczki</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Kalorie w małym piwie</translation>
+        <translation>Kalorie w małym piwie</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Szczegóły</translation>
+        <translation>Szczegóły</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Dzień warzenia</translation>
+        <translation>Dzień warzenia</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Dodaj składnik fermentacji</translation>
+        <translation>Dodaj składnik fermentacji</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Usuń składnik fermentacji</translation>
+        <translation>Usuń składnik fermentacji</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Edutj wybrany składnik fermentacji</translation>
+        <translation>Edutj wybrany składnik fermentacji</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Dodaj chmiel</translation>
+        <translation>Dodaj chmiel</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Usuń wybrany chmiel</translation>
+        <translation>Usuń wybrany chmiel</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Edytuj wybrany chmiel</translation>
+        <translation>Edytuj wybrany chmiel</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Dodatki</translation>
+        <translation>Dodatki</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Dodaj dodatek</translation>
+        <translation>Dodaj dodatek</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Usuń wybrany dodatek</translation>
+        <translation>Usuń wybrany dodatek</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Edytuj wybrany dodatek</translation>
+        <translation>Edytuj wybrany dodatek</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Drożdże</translation>
+        <translation>Drożdże</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Dodaj drożdże</translation>
+        <translation>Dodaj drożdże</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Usuń wybrane drożdże</translation>
+        <translation>Usuń wybrane drożdże</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Edytuj wybrane drożdże</translation>
+        <translation>Edytuj wybrane drożdże</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Zacieranie</translation>
+        <translation>Zacieranie</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Dodaj krok zacierania</translation>
+        <translation>Dodaj krok zacierania</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Usuń wybrany krok zacierania</translation>
+        <translation>Usuń wybrany krok zacierania</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Etytuj wybrany krok zacierania</translation>
+        <translation>Etytuj wybrany krok zacierania</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Edytuj właściwości zacierania</translation>
+        <translation>Edytuj właściwości zacierania</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Właściwości zacierania</translation>
+        <translation>Właściwości zacierania</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Kreator zacierania</translation>
+        <translation>Kreator zacierania</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Wywołaj pomocnika zacierania</translation>
+        <translation>Wywołaj pomocnika zacierania</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Pomocnik zacierania</translation>
+        <translation>Pomocnik zacierania</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Schematy zacierania</translation>
+        <translation>Schematy zacierania</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Nastepna przerwa</translation>
+        <translation>Nastepna przerwa</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Poprzednia przerwa</translation>
+        <translation>Poprzednia przerwa</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Zapisz schemat zacierania</translation>
+        <translation>Zapisz schemat zacierania</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Zapisz schemat zacierania</translation>
+        <translation>Zapisz schemat zacierania</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">Pomo&amp;c</translation>
+        <translation>Pomo&amp;c</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Plik</translation>
+        <translation>&amp;Plik</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5058,27 +5557,27 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Baza danych</translation>
+        <translation>&amp;Baza danych</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Widok</translation>
+        <translation>&amp;Widok</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Narzędzia</translation>
+        <translation>&amp;Narzędzia</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Pasek narzędzi</translation>
+        <translation>Pasek narzędzi</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">O &amp;BrewTarget</translation>
+        <translation>O &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">O Brewtarget</translation>
+        <translation>O Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5086,19 +5585,19 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Składniki fermentacji</translation>
+        <translation>&amp;Składniki fermentacji</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">C&amp;hmiele</translation>
+        <translation>C&amp;hmiele</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5106,31 +5605,31 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+D</translation>
+        <translation>Ctrl+D</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Drożdze</translation>
+        <translation>&amp;Drożdze</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+D</translation>
+        <translation>Ctrl+D</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Sprzęt</translation>
+        <translation>&amp;Sprzęt</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+S</translation>
+        <translation>Ctrl+S</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">Sty&amp;le</translation>
+        <translation>Sty&amp;le</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+L</translation>
+        <translation>Ctrl+L</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5138,7 +5637,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+W</translation>
+        <translation>Ctrl+W</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5150,55 +5649,55 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Podręcznik</translation>
+        <translation>&amp;Podręcznik</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Skaluj recepturę</translation>
+        <translation>&amp;Skaluj recepturę</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Kopiuj recepturę do schowka jako &amp;tekst</translation>
+        <translation>Kopiuj recepturę do schowka jako &amp;tekst</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">&amp;Korekcja gęstości</translation>
+        <translation>&amp;Korekcja gęstości</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Konwerter jednostek</translation>
+        <translation>&amp;Konwerter jednostek</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Stwórz kopię zapasową bazy danych</translation>
+        <translation>Stwórz kopię zapasową bazy danych</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Przywróć bazę danych</translation>
+        <translation>Przywróć bazę danych</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">Skopiuj re&amp;cepturę</translation>
+        <translation>Skopiuj re&amp;cepturę</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Kalkulator surowca do refermantacj&amp;i</translation>
+        <translation>Kalkulator surowca do refermantacj&amp;i</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">Narzędzia &amp;refraktometru</translation>
+        <translation>Narzędzia &amp;refraktometru</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">Kalkula&amp;tor ilości drożdży</translation>
+        <translation>Kalkula&amp;tor ilości drożdży</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Połączenie baz danych</translation>
+        <translation>Połączenie baz danych</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Wybierz bazę danych do połączenia z obecną bazą.</translation>
+        <translation>Wybierz bazę danych do połączenia z obecną bazą.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5218,19 +5717,19 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Utwórz kopię zapasową</translation>
+        <translation>&amp;Utwórz kopię zapasową</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Zapisz wszystkie receptury, składniki itd do folderu kopii zapasowej</translation>
+        <translation>Zapisz wszystkie receptury, składniki itd do folderu kopii zapasowej</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Przywróć z kopii zapasowej</translation>
+        <translation>&amp;Przywróć z kopii zapasowej</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Przywróć wszystkie receptury, składniki itd z folderu kopii zapasowej</translation>
+        <translation>Przywróć wszystkie receptury, składniki itd z folderu kopii zapasowej</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5242,7 +5741,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Nowa receptura</translation>
+        <translation>&amp;Nowa receptura</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5250,42 +5749,162 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Pokaż minutniki</translation>
+        <translation>Pokaż minutniki</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Zapisz</translation>
+        <translation>Zapisz</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Usuń zaznaczenie</translation>
+        <translation>Usuń zaznaczenie</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Usuń recepturę</translation>
+        <translation>Usuń recepturę</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">Schematy &amp;zacierania</translation>
+        <translation>Schematy &amp;zacierania</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Zacierania</translation>
+        <translation>Zacierania</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
         <translation type="vanished">Kalkulator wody do infuzji</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Wielkość warki</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Objętość do gotowania</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Uwarz!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Kreator zacierania</translation>
+        <translation>Kreator zacierania</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5301,7 +5920,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Czas</translation>
+        <translation>Czas</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5309,275 +5928,311 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Dalej</translation>
+        <translation>Dalej</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Koniec</translation>
+        <translation>Koniec</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Miara infuzji/dekokcji</translation>
+        <translation>Miara infuzji/dekokcji</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min.</translation>
+        <translation>min.</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">maks.</translation>
+        <translation>maks.</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Temperatura infuzji</translation>
+        <translation>Temperatura infuzji</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Całkowila objętość uzyskanej brzeczki</translation>
+        <translation>Całkowila objętość uzyskanej brzeczki</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">obj.</translation>
+        <translation>obj.</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Napełnienie kadzi zaciernej</translation>
+        <translation>Napełnienie kadzi zaciernej</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">obj. kadzi</translation>
+        <translation>obj. kadzi</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">grubość</translation>
+        <translation>grubość</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Parametry zacierania</translation>
+        <translation>Parametry zacierania</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Pocz. temertatura słodu</translation>
+        <translation>Pocz. temertatura słodu</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temperatura wysładzania</translation>
+        <translation>Temperatura wysładzania</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Temperatura wysładzania</translation>
+        <translation>Temperatura wysładzania</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH wysładzania</translation>
+        <translation>pH wysładzania</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notatki</translation>
+        <translation>Notatki</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Kadź zacierna</translation>
+        <translation>Kadź zacierna</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Pocz. temperatura</translation>
+        <translation>Pocz. temperatura</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Pobierz poniższe parametry ze sprzętu.</translation>
+        <translation>Pobierz poniższe parametry ze sprzętu.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Pobierz z ustawień sprzętu</translation>
+        <translation>Pobierz z ustawień sprzętu</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Masa kadzi</translation>
+        <translation>Masa kadzi</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Ciepło wł. kadzi</translation>
+        <translation>Ciepło wł. kadzi</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Ciepło właściwe kadzi (cal/(g*K))</translation>
+        <translation>Ciepło właściwe kadzi (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Edytor kroków zacierania</translation>
+        <translation>Edytor kroków zacierania</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa kroku</translation>
+        <translation>Nazwa kroku</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infuzja</translation>
+        <translation>Infuzja</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Programowanie temperaturowe</translation>
+        <translation>Programowanie temperaturowe</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Dekokcja</translation>
+        <translation>Dekokcja</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Docelowa temp.</translation>
+        <translation>Docelowa temp.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Docelowa temeratura tego kroku</translation>
+        <translation>Docelowa temeratura tego kroku</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Wielkość infuzji</translation>
+        <translation>Wielkość infuzji</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Ilość dodanej wody</translation>
+        <translation>Ilość dodanej wody</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Temp. infuzji</translation>
+        <translation>Temp. infuzji</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Temperatura dodanej wody</translation>
+        <translation>Temperatura dodanej wody</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Wielkość dekokcji</translation>
+        <translation>Wielkość dekokcji</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Ilość dekoktu</translation>
+        <translation>Ilość dekoktu</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Czas</translation>
+        <translation>Czas</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Czas przeprowadzenia kroku</translation>
+        <translation>Czas przeprowadzenia kroku</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Temp. czasu zwłoki</translation>
+        <translation>Temp. czasu zwłoki</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Czas zwłoki</translation>
+        <translation>Czas zwłoki</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Temp. końcowa</translation>
+        <translation>Temp. końcowa</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Końcowa temperatura kroku</translation>
+        <translation>Końcowa temperatura kroku</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Wysładzanie</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Pomocnik zacierania</translation>
+        <translation>Pomocnik zacierania</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Gęstość zacieru</translation>
+        <translation>Gęstość zacieru</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Gęstość zacieru (nie podawaj jednostek)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Edytor dodatków</translation>
+        <translation>Edytor dodatków</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Przyprawa</translation>
+        <translation>Przyprawa</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Substancja klarująca</translation>
+        <translation>Substancja klarująca</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Uzdatnianie wody</translation>
+        <translation>Uzdatnianie wody</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Zioło</translation>
+        <translation>Zioło</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Aromat</translation>
+        <translation>Aromat</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Inny</translation>
+        <translation>Inny</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Użycie</translation>
+        <translation>Użycie</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Gotowanie</translation>
+        <translation>Gotowanie</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Zacieranie</translation>
+        <translation>Zacieranie</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Fermentacja Burzliwa</translation>
+        <translation>Fermentacja Burzliwa</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Fermentacja Cicha</translation>
+        <translation>Fermentacja Cicha</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Butlekowanie</translation>
+        <translation>Butlekowanie</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Czas</translation>
+        <translation>Czas</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5585,15 +6240,15 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Zaznacz jeśli ilość podana jest w kg a nie w L.</translation>
+        <translation>Zaznacz jeśli ilość podana jest w kg a nie w L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Czy ilość jest wagą?</translation>
+        <translation>Czy ilość jest wagą?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Zaznacz jeśli podana ilość jest wagą a nie objętością</translation>
+        <translation>Zaznacz jeśli podana ilość jest wagą a nie objętością</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5609,192 +6264,220 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Ilość w magazynie</translation>
+        <translation>Ilość w magazynie</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Ilość w magazynie</translation>
+        <translation>Ilość w magazynie</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notatki</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Edytor schematów zacierania</translation>
+        <translation>Edytor schematów zacierania</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Zacieranie</translation>
+        <translation>Zacieranie</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Usuń wybrany styl</translation>
+        <translation>Usuń wybrany styl</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Początkowa temperatura słodu</translation>
+        <translation>Początkowa temperatura słodu</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temperatura wysładzania</translation>
+        <translation>Temperatura wysładzania</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Docelowa temperatura wysładzania</translation>
+        <translation>Docelowa temperatura wysładzania</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH wysładzania</translation>
+        <translation>pH wysładzania</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notatki</translation>
+        <translation>Notatki</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Kadź zacierna</translation>
+        <translation>Kadź zacierna</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Początkowa temperatura kadzi</translation>
+        <translation>Początkowa temperatura kadzi</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Pobierz z ustawień sprzętu</translation>
+        <translation>Pobierz z ustawień sprzętu</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Masa kadzi</translation>
+        <translation>Masa kadzi</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Ciepło właściwe kadzi</translation>
+        <translation>Ciepło właściwe kadzi</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Ciepło właściwe kadzi (cal/(g*K))</translation>
+        <translation>Ciepło właściwe kadzi (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Dodaj krok zacierania</translation>
+        <translation>Dodaj krok zacierania</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Usuń wybrany krok zacierania</translation>
+        <translation>Usuń wybrany krok zacierania</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Nastepna przerwa</translation>
+        <translation>Nastepna przerwa</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Poprzednia przerwa</translation>
+        <translation>Poprzednia przerwa</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Dopasuj objętość by uzyskać gęstość początkową</translation>
+        <translation>Dopasuj objętość by uzyskać gęstość początkową</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Dane</translation>
+        <translation>Dane</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Gęstość przed gotowaniem (SG)</translation>
+        <translation>Gęstość przed gotowaniem (SG)</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Gęstość zmierzona przed gotowaniem (SG)</translation>
+        <translation>Gęstość zmierzona przed gotowaniem (SG)</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temp.</translation>
+        <translation>Temp.</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Temperatura odczytu gęstości</translation>
+        <translation>Temperatura odczytu gęstości</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Temp. kalibracji</translation>
+        <translation>Temp. kalibracji</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temperatura w której kallibrowany jest gęstościomierz</translation>
+        <translation>Temperatura w której kallibrowany jest gęstościomierz</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-lub-</translation>
+        <translation>-lub-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (procent masy ekwiwalent sacharozy)</translation>
+        <translation>Plato (procent masy ekwiwalent sacharozy)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Objętość przed gotowaniem</translation>
+        <translation>Objętość przed gotowaniem</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Zmierzona objętość przed gotowaniem</translation>
+        <translation>Zmierzona objętość przed gotowaniem</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Wynik</translation>
+        <translation>Wynik</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">Gęstość bez korekcji</translation>
+        <translation>Gęstość bez korekcji</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">Gęstość przy gotowaniu zgodnie z planem</translation>
+        <translation>Gęstość przy gotowaniu zgodnie z planem</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Dodaj do gotowania</translation>
+        <translation>Dodaj do gotowania</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Ilość wody którą musisz dodać aby uzyskać planowaną gęstość (lub odparować jeśli ujemne)</translation>
+        <translation>Ilość wody którą musisz dodać aby uzyskać planowaną gęstość (lub odparować jeśli ujemne)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Końcowa wielkość warki</translation>
+        <translation>Końcowa wielkość warki</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Przybliżona wielkość warki po korekcie</translation>
+        <translation>Przybliżona wielkość warki po korekcie</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Wylicz</translation>
+        <translation>Wylicz</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Opcje</translation>
+        <translation>Opcje</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Jednostki</translation>
+        <translation>Jednostki</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Waga</translation>
+        <translation>Waga</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5810,7 +6493,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5822,11 +6505,11 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Objętość</translation>
+        <translation>Objętość</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Gęstość</translation>
+        <translation>Gęstość</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5838,7 +6521,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Barwa</translation>
+        <translation>Barwa</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5850,7 +6533,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Formuły wyliczeń</translation>
+        <translation>Formuły wyliczeń</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5866,7 +6549,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5878,7 +6561,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Dostosowanie IBU</translation>
+        <translation>Dostosowanie IBU</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5914,7 +6597,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Język</translation>
+        <translation>Język</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5924,7 +6607,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Używasz innego języka?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Chciałbyś udoskonalić tłumaczenie? Pomóż nam i 
@@ -5934,7 +6617,43 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Data</translation>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6017,6 +6736,54 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6025,362 +6792,418 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Kalkilator ilości drożdży</translation>
+        <translation>Kalkilator ilości drożdży</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Dane</translation>
+        <translation>Dane</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Objętość brzeczki</translation>
+        <translation>Objętość brzeczki</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Gęstość początkowa (OG)</translation>
+        <translation>Gęstość początkowa (OG)</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Dla ale: 0,75-1. Dla legerów: 1,5-2.</translation>
+        <translation>Dla ale: 0,75-1. Dla legerów: 1,5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Ilość zadania (M komórki)/(mL*P)</translation>
+        <translation>Ilość zadania (M komórki)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Metoda natleniania</translation>
+        <translation>Metoda natleniania</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Data produkcji drożdży</translation>
+        <translation>Data produkcji drożdży</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Żywotność drożdży</translation>
+        <translation>Żywotność drożdży</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Brak</translation>
+        <translation>Brak</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 na początku</translation>
+        <translation>O2 na początku</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Mieszadło magnetyczne</translation>
+        <translation>Mieszadło magnetyczne</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">mm/dd/rrrr</translation>
+        <translation>mm/dd/rrrr</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">Etykieta</translation>
+        <translation>Etykieta</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Wylicz żywotność z daty</translation>
+        <translation>Wylicz żywotność z daty</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># Szaszetki/Fiolki</translation>
+        <translation># Szaszetki/Fiolki</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Wynik</translation>
+        <translation>Wynik</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Miliardy komórek drożdżowych</translation>
+        <translation>Miliardy komórek drożdżowych</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Szaszetki/Fiolki bez startera</translation>
+        <translation># Szaszetki/Fiolki bez startera</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Drożdże suche</translation>
+        <translation>Drożdże suche</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Objętość startera</translation>
+        <translation>Objętość startera</translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Kalkulator surowca do refermantacji</translation>
+        <translation>Kalkulator surowca do refermantacji</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Źródło</translation>
+        <translation>Źródło</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Ilość piwa</translation>
+        <translation>Ilość piwa</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Ilość piwa do refermentacji</translation>
+        <translation>Ilość piwa do refermentacji</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Temperatura piwa</translation>
+        <translation>Temperatura piwa</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Temperatura piwa</translation>
+        <translation>Temperatura piwa</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Docelowa zawartość CO2</translation>
+        <translation>Docelowa zawartość CO2</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Jaka jest pożądana zawartość CO2 (1 L CO2 @ STP w L piwa)</translation>
+        <translation>Jaka jest pożądana zawartość CO2 (1 L CO2 @ STP w L piwa)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glukoza krystaliczna (glukoza, dekstroza, cukier kukurydziany)</translation>
+        <translation>Glukoza krystaliczna (glukoza, dekstroza, cukier kukurydziany)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Glukoza bezwodna</translation>
+        <translation>Glukoza bezwodna</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sacharoza (cukier stołowy)</translation>
+        <translation>Sacharoza (cukier stołowy)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Suchy ekstrakt słodowy</translation>
+        <translation>Suchy ekstrakt słodowy</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Wynik</translation>
+        <translation>Wynik</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Ilość surowca do refermentacji</translation>
+        <translation>Ilość surowca do refermentacji</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Ile użyć surowca do refermantacji</translation>
+        <translation>Ile użyć surowca do refermantacji</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Wylicz</translation>
+        <translation>Wylicz</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Postać</translation>
+        <translation>Postać</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Piwowar</translation>
+        <translation>Piwowar</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Asystent piwowara</translation>
+        <translation>Asystent piwowara</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Ocena smaku</translation>
+        <translation>Ocena smaku</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Fermentacja burzliwa (dni)</translation>
+        <translation>Fermentacja burzliwa (dni)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Temp. fermentacji burzliwej</translation>
+        <translation>Temp. fermentacji burzliwej</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Fermentacja cicha (dni)</translation>
+        <translation>Fermentacja cicha (dni)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Temp. fermentacji cichej</translation>
+        <translation>Temp. fermentacji cichej</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Trzecia fermentacja (dni)</translation>
+        <translation>Trzecia fermentacja (dni)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Temp. trzeciej fermentacji</translation>
+        <translation>Temp. trzeciej fermentacji</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Długość leżakowania (dni)</translation>
+        <translation>Długość leżakowania (dni)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Temperatura leżakowania</translation>
+        <translation>Temperatura leżakowania</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Data pierwszego warzenia</translation>
+        <translation>Data pierwszego warzenia</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Zawartość CO2</translation>
+        <translation>Zawartość CO2</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Notatki z degustacji</translation>
+        <translation>Notatki z degustacji</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notatki</translation>
+        <translation>Notatki</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Narzędzia refraktometru</translation>
+        <translation>Narzędzia refraktometru</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Dane</translation>
+        <translation>Dane</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Oryginalne Plato</translation>
+        <translation>Oryginalne Plato</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">Gęstość (20 C)</translation>
+        <translation>Gęstość (20 C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Aktualne Plato</translation>
+        <translation>Aktualne Plato</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Wylicz</translation>
+        <translation>Wylicz</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Wyniki</translation>
+        <translation>Wyniki</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">Gęstość SG (20 C)</translation>
+        <translation>Gęstość SG (20 C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Alkohol (ABV)</translation>
+        <translation>Alkohol (ABV)</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">Alkohol wagowo (ABW)</translation>
+        <translation>Alkohol wagowo (ABW)</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Indeks refrakcyjny</translation>
+        <translation>Indeks refrakcyjny</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Prawdziwy ekstrakt (Plato)</translation>
+        <translation>Prawdziwy ekstrakt (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">Gęstość OG (20 C)</translation>
+        <translation>Gęstość OG (20 C)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Kalkulator wody do infuzji</translation>
+        <translation>Kalkulator wody do infuzji</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Pierwsza infuzja</translation>
+        <translation>Pierwsza infuzja</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Pierwotna temperatura słodów</translation>
+        <translation>Pierwotna temperatura słodów</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Docelowa temperatura zacieru</translation>
+        <translation>Docelowa temperatura zacieru</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Waga ziarna</translation>
+        <translation>Waga ziarna</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Objętość wody</translation>
+        <translation>Objętość wody</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">Zacieranie infuzyjne</translation>
+        <translation>Zacieranie infuzyjne</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Całkowita objętość wody</translation>
+        <translation>Całkowita objętość wody</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Waga ziarna</translation>
+        <translation>Waga ziarna</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Obecna temperatura zacieru</translation>
+        <translation>Obecna temperatura zacieru</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Temperatura wody do infuzji</translation>
+        <translation>Temperatura wody do infuzji</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Oblicz</translation>
+        <translation>Oblicz</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Temperatura wody do pierwszej infuzji</translation>
+        <translation>Temperatura wody do pierwszej infuzji</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Objętość  do dodania</translation>
+        <translation>Objętość  do dodania</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Uwaga: kalkulator zakłada podgrzaną kadź zacierną</translation>
+        <translation>Uwaga: kalkulator zakłada podgrzaną kadź zacierną</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Edytor stylu</translation>
+        <translation>Edytor stylu</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Styl</translation>
+        <translation>Styl</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Usuń wybrany styl</translation>
+        <translation>Usuń wybrany styl</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6388,55 +7211,55 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Kategoria</translation>
+        <translation>Kategoria</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Numer kategorii</translation>
+        <translation>Numer kategorii</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Litera stylu</translation>
+        <translation>Litera stylu</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Przewodnik stylu</translation>
+        <translation>Przewodnik stylu</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Gatunek piwa</translation>
+        <translation>Gatunek piwa</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Miodowe</translation>
+        <translation>Miodowe</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Pszeniczne</translation>
+        <translation>Pszeniczne</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Mieszane</translation>
+        <translation>Mieszane</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Cydr</translation>
+        <translation>Cydr</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6444,51 +7267,51 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Maks.</translation>
+        <translation>Maks.</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Min.</translation>
+        <translation>Min.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Barwa (SRM)</translation>
+        <translation>Barwa (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Nagazowanie (vol)</translation>
+        <translation>Nagazowanie (vol)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">Alkohol (procent)</translation>
+        <translation>Alkohol (procent)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Profil</translation>
+        <translation>Profil</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Składniki</translation>
+        <translation>Składniki</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Przykłady</translation>
+        <translation>Przykłady</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notatki</translation>
+        <translation>Notatki</translation>
     </message>
     <message>
         <source>New</source>
@@ -6502,12 +7325,258 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Anuluj</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
     <message>
         <source>Timers</source>
         <translation type="vanished">Minutniki</translation>
+    </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Stop</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6518,18 +7587,22 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notatki</translation>
+        <translation>Notatki</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Edytor drożdży</translation>
+        <translation>Edytor drożdży</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6537,51 +7610,51 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nazwa</translation>
+        <translation>Nazwa</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Pszenica</translation>
+        <translation>Pszenica</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Wino</translation>
+        <translation>Wino</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Szampan</translation>
+        <translation>Szampan</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Postać</translation>
+        <translation>Postać</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Płynne</translation>
+        <translation>Płynne</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Suche</translation>
+        <translation>Suche</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Skos</translation>
+        <translation>Skos</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Gęstwa</translation>
+        <translation>Gęstwa</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6589,91 +7662,91 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Zaznacz jeśli ilość podana jest w kg a nie w L.</translation>
+        <translation>Zaznacz jeśli ilość podana jest w kg a nie w L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Czy ilość jest wagą?</translation>
+        <translation>Czy ilość jest wagą?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Zaznacz jeśli podana ilość jest wagą a nie objętością</translation>
+        <translation>Zaznacz jeśli podana ilość jest wagą a nie objętością</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Laboratorium</translation>
+        <translation>Laboratorium</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">ID produktu</translation>
+        <translation>ID produktu</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Min. Temp.</translation>
+        <translation>Min. Temp.</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Min. temp.</translation>
+        <translation>Min. temp.</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Maks. Temp.</translation>
+        <translation>Maks. Temp.</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Maks. temp.</translation>
+        <translation>Maks. temp.</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Flokulacja</translation>
+        <translation>Flokulacja</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Niska</translation>
+        <translation>Niska</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Średnia</translation>
+        <translation>Średnia</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Wysoka</translation>
+        <translation>Wysoka</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Bardzo wysoka</translation>
+        <translation>Bardzo wysoka</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Żywotność (%)</translation>
+        <translation>Żywotność (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Żywotność jako procent punktów OG</translation>
+        <translation>Żywotność jako procent punktów OG</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Ilość pokoleń</translation>
+        <translation>Ilość pokoleń</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Które pokolenie drożdży</translation>
+        <translation>Które pokolenie drożdży</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Maks. pokoleń</translation>
+        <translation>Maks. pokoleń</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Maksymalna ilość pokoleń</translation>
+        <translation>Maksymalna ilość pokoleń</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Dodawane do fermentacji cichej</translation>
+        <translation>Dodawane do fermentacji cichej</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Oznacza, że te drożdże dodawane są do fermentacji cichej</translation>
+        <translation>Oznacza, że te drożdże dodawane są do fermentacji cichej</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6689,11 +7762,39 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Ilość w magazynie</translation>
+        <translation>Ilość w magazynie</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Ilość w magazynie</translation>
+        <translation>Ilość w magazynie</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Szczegóły</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Notatki</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_pt.ts
+++ b/translations/bt_pt.ts
@@ -522,6 +522,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Receita</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Inventário</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Fermentáveis</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Levedura</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Saída</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1997,13 +2092,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">mín</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2445,15 +2533,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2759,80 +2847,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Desconhecido</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Inventário</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Nome</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Quantidade</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alfa %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2995,6 +3009,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Desconhecido</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Inventário</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Quantidade</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3777,8 +3865,36 @@ O volume final do fermentador primário é %1.</translation>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation type="unfinished">Cancelar</translation>
     </message>
 </context>
 <context>
@@ -3791,12 +3907,56 @@ O volume final do fermentador primário é %1.</translation>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Iniciar</translation>
+        <translation type="unfinished">Iniciar</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Parar</translation>
+        <translation type="unfinished">Parar</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4242,54 +4402,73 @@ O volume final do fermentador primário é %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Diálogo</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulário</translation>
+        <translation>Formulário</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Gerar Instruções</translation>
+        <translation>Gerar Instruções</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Inserir etapas</translation>
+        <translation>Inserir etapas</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Nome de novo passo</translation>
+        <translation>Nome de novo passo</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Passo #</translation>
+        <translation>Passo #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Número onde o novo passo deve ser colocado</translation>
+        <translation>Número onde o novo passo deve ser colocado</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Inserir novo passo</translation>
+        <translation>Inserir novo passo</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Mover passos</translation>
+        <translation>Mover passos</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Mover para cima passo selecionado</translation>
+        <translation>Mover para cima passo selecionado</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Mover para baixo passo selecionado</translation>
+        <translation>Mover para baixo passo selecionado</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Remover passo selecionado</translation>
+        <translation>Remover passo selecionado</translation>
     </message>
 </context>
 <context>
@@ -4359,27 +4538,27 @@ O volume final do fermentador primário é %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Pré-fervura</translation>
+        <translation>Pré-fervura</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Gravidade antes da fervura</translation>
+        <translation>Gravidade antes da fervura</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volume</translation>
+        <translation>Volume</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Volume de erva coletado</translation>
+        <translation>Volume de erva coletado</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Temperatura a atingir</translation>
+        <translation>Temperatura a atingir</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4387,59 +4566,59 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Temperatura Final</translation>
+        <translation>Temperatura Final</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Temperatura  do mosto antes do mash out</translation>
+        <translation>Temperatura  do mosto antes do mash out</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Pós-fervura</translation>
+        <translation>Pós-fervura</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Densidade pós-fervura</translation>
+        <translation>Densidade pós-fervura</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Volume pós-fervura</translation>
+        <translation>Volume pós-fervura</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Volume de mosto na panela após a fervura</translation>
+        <translation>Volume de mosto na panela após a fervura</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Volume de mosto transferido para o fermentador</translation>
+        <translation>Volume de mosto transferido para o fermentador</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volume no Fermentador</translation>
+        <translation>Volume no Fermentador</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Temperatura de adição</translation>
+        <translation> Temperatura de adição</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Temperatura do mosto quando é adicionado fermento</translation>
+        <translation>Temperatura do mosto quando é adicionado fermento</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Pós-fermentação</translation>
+        <translation>Pós-fermentação</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Gravidade final</translation>
+        <translation>Gravidade final</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Volume de cerveja pronto em barril/garrafas</translation>
+        <translation>Volume de cerveja pronto em barril/garrafas</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4455,11 +4634,11 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">OG Projetada</translation>
+        <translation>OG Projetada</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Eficiência do conjunto</translation>
+        <translation>Eficiência do conjunto</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4471,7 +4650,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">ABV esperado</translation>
+        <translation>ABV esperado</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4479,15 +4658,59 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>yyyy-dd-MM</source>
-        <translation type="vanished">AAAA-MM-DD</translation>
+        <translation>AAAA-MM-DD</translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4506,14 +4729,182 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Volume morto do tanque de filtração</translation>
+        <translation>Volume morto do tanque de filtração</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Editor de Equipamentos</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Equipamento</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Configurar como Padrão</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Volume da batelada</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Tempo</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Calcular volume pré-fervura</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Tempo de Fervura</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Taxa de evaporação por hora</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Água para encher até o fim</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Água adicionada à panela</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Absorção padrão</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Ponto de Ebolição da Água</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Volume da panela de mosturação</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Novo Equipamento</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Editor de Fermentável</translation>
+        <translation>Editor de Fermentável</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4521,31 +4912,31 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Grão</translation>
+        <translation>Grão</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Açúcar</translation>
+        <translation>Açúcar</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Extrato</translation>
+        <translation>Extrato</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Extrato Seco</translation>
+        <translation>Extrato Seco</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Adjunto</translation>
+        <translation>Adjunto</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4557,43 +4948,43 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Rendimento quando comparado a glicose</translation>
+        <translation>Rendimento quando comparado a glicose</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Taxa de Lovibond</translation>
+        <translation>Taxa de Lovibond</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Adicione Após a Fervura</translation>
+        <translation>Adicione Após a Fervura</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Esse ingrediente é adicionado na pós-fevura.</translation>
+        <translation>Esse ingrediente é adicionado na pós-fevura.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origem</translation>
+        <translation>Origem</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Fornecedor</translation>
+        <translation>Fornecedor</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Groso/Fino Diff (%)</translation>
+        <translation>Groso/Fino Diff (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Diferença de rendimento entre moagem grossa e fina</translation>
+        <translation>Diferença de rendimento entre moagem grossa e fina</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Umidade (%)</translation>
+        <translation>Umidade (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Percentual de umidade pela massa</translation>
+        <translation>Percentual de umidade pela massa</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4605,43 +4996,43 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Proteínas (%)</translation>
+        <translation>Proteínas (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Porcentagem de Proteína por Massa</translation>
+        <translation>Porcentagem de Proteína por Massa</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Máx. no Lote (%)</translation>
+        <translation>Máx. no Lote (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Percentagem máxima recomendada da carga total</translation>
+        <translation>Percentagem máxima recomendada da carga total</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Mosturação Recomendada</translation>
+        <translation>Mosturação Recomendada</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Recomendado para ser moído</translation>
+        <translation>Recomendado para ser moído</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">É Moído</translation>
+        <translation>É Moído</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Verifique se isto esta presente na mosturação</translation>
+        <translation>Verifique se isto esta presente na mosturação</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Amargor (IBU*gal/lb)</translation>
+        <translation>Amargor (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Amargor de extratos de malte pré-lupulados</translation>
+        <translation>Amargor de extratos de malte pré-lupulados</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4653,22 +5044,70 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantidade no inventário</translation>
+        <translation>Quantidade no inventário</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantidade no inventário</translation>
+        <translation>Quantidade no inventário</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Cor</translation>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Rendimento %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Editor de Lúpulos</translation>
+        <translation>Editor de Lúpulos</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4676,7 +5115,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4684,7 +5123,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Ácidos alfa em porcentagem de massa</translation>
+        <translation>Ácidos alfa em porcentagem de massa</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4692,59 +5131,59 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Uso</translation>
+        <translation>Uso</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mosto</translation>
+        <translation>Mosto</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Primeiro mosto</translation>
+        <translation>Primeiro mosto</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Ferver</translation>
+        <translation>Ferver</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Aroma</translation>
+        <translation>Aroma</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Dry Hop</translation>
+        <translation>Dry Hop</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Amargor</translation>
+        <translation>Amargor</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Ambos</translation>
+        <translation>Ambos</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulário</translation>
+        <translation>Formulário</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Folha</translation>
+        <translation>Folha</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellet</translation>
+        <translation>Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Plug</translation>
+        <translation>Plug</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4752,19 +5191,19 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Ácidos Beta em percentual da massa</translation>
+        <translation>Ácidos Beta em percentual da massa</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Índice de Estabilidade/Estocagem do Lúpulo</translation>
+        <translation>Índice de Estabilidade/Estocagem do Lúpulo</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Origem</translation>
+        <translation>Origem</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4772,7 +5211,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Humuleno</translation>
+        <translation>Humuleno</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4788,7 +5227,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumuleno</translation>
+        <translation>Cohumuleno</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4796,7 +5235,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Mirceno</translation>
+        <translation>Mirceno</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4812,65 +5251,121 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantidade no inventário</translation>
+        <translation>Quantidade no inventário</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantidade no inventário</translation>
+        <translation>Quantidade no inventário</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulário</translation>
+        <translation>Formulário</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Mostrar um cronômetro</translation>
+        <translation>Mostrar um cronômetro</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Mostrar o cronômetro</translation>
+        <translation>Mostrar o cronômetro</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Marcar esse passo como concluído</translation>
+        <translation>Marcar esse passo como concluído</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Passo concluído</translation>
+        <translation>Passo concluído</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Receitas</translation>
+        <translation>Receitas</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Estilos</translation>
+        <translation>Estilos</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Fermentáveis</translation>
+        <translation>Fermentáveis</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Lúlupos</translation>
+        <translation>Lúlupos</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Adjunto</translation>
+        <translation>Adjunto</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Leveduras</translation>
+        <translation>Leveduras</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Receita</translation>
+        <translation>Receita</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4878,11 +5373,11 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Nome de receita</translation>
+        <translation>Nome de receita</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Tamanho Alvo de Fervura</translation>
+        <translation>Tamanho Alvo de Fervura</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4898,7 +5393,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Eficiência de extração esperada</translation>
+        <translation>Eficiência de extração esperada</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4910,7 +5405,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Tamanho Alvo de Fornada</translation>
+        <translation>Tamanho Alvo de Fornada</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4918,7 +5413,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Equipamento</translation>
+        <translation>Equipamento</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4926,163 +5421,163 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">SG de Fervura</translation>
+        <translation>SG de Fervura</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Amargor (IBU)</translation>
+        <translation>Amargor (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Calorias/12oz</translation>
+        <translation>Calorias/12oz</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extras</translation>
+        <translation>Extras</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Dia de Confecção de Cerveja</translation>
+        <translation>Dia de Confecção de Cerveja</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Adicionar um Fermentável</translation>
+        <translation>Adicionar um Fermentável</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Remover o Fermentável Selecionado</translation>
+        <translation>Remover o Fermentável Selecionado</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Editar o Fermentável Selecionado</translation>
+        <translation>Editar o Fermentável Selecionado</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Adicionar Lúpulo</translation>
+        <translation>Adicionar Lúpulo</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Remover Lúpulo Selecionado</translation>
+        <translation>Remover Lúpulo Selecionado</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Editar Lúpulo Selecionado</translation>
+        <translation>Editar Lúpulo Selecionado</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Adjuntos</translation>
+        <translation>Adjuntos</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Adicionar Adjunto</translation>
+        <translation>Adicionar Adjunto</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Remover adjunto selecionado</translation>
+        <translation>Remover adjunto selecionado</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Editar adjunto selecionado</translation>
+        <translation>Editar adjunto selecionado</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Levedura</translation>
+        <translation>Levedura</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Adicionar Levedura</translation>
+        <translation>Adicionar Levedura</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Remover Levedura Selecionada</translation>
+        <translation>Remover Levedura Selecionada</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Editar levedura selecionada</translation>
+        <translation>Editar levedura selecionada</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mosto</translation>
+        <translation>Mosto</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Adicionar Passo de Mosturação</translation>
+        <translation>Adicionar Passo de Mosturação</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Remover Passo de Mosturação Selecionado</translation>
+        <translation>Remover Passo de Mosturação Selecionado</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Editar Passo de Mosturação Selecionado</translation>
+        <translation>Editar Passo de Mosturação Selecionado</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Editar Propriedades de Mosturação</translation>
+        <translation>Editar Propriedades de Mosturação</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Editar Mosto</translation>
+        <translation>Editar Mosto</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Descrição de Mosturação</translation>
+        <translation>Descrição de Mosturação</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Utilizar o Assistente de Mosturação</translation>
+        <translation>Utilizar o Assistente de Mosturação</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Assistente de Mosturação</translation>
+        <translation>Assistente de Mosturação</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Mostos</translation>
+        <translation>Mostos</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Acelerar Brassagem</translation>
+        <translation>Acelerar Brassagem</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Atrasar brassagem</translation>
+        <translation>Atrasar brassagem</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Salvar o Perfil da Mosturação</translation>
+        <translation>Salvar o Perfil da Mosturação</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Salvar Mosto</translation>
+        <translation>Salvar Mosto</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Sobre</translation>
+        <translation>&amp;Sobre</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Arquivo</translation>
+        <translation>&amp;Arquivo</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5094,27 +5589,27 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Base de dados</translation>
+        <translation>&amp;Base de dados</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Visualizar</translation>
+        <translation>&amp;Visualizar</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Ferramentas</translation>
+        <translation>&amp;Ferramentas</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Barra de Ferramentas</translation>
+        <translation>Barra de Ferramentas</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">Sobre &amp;BrewTarget</translation>
+        <translation>Sobre &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Sobre BrewTarget</translation>
+        <translation>Sobre BrewTarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5122,19 +5617,19 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Fermentáveis</translation>
+        <translation>&amp;Fermentáveis</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Lúpulos</translation>
+        <translation>&amp;Lúpulos</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5142,31 +5637,31 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Leveduras</translation>
+        <translation>&amp;Leveduras</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Equipamentos</translation>
+        <translation>&amp;Equipamentos</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">Estilo&amp;s</translation>
+        <translation>Estilo&amp;s</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5174,7 +5669,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5186,55 +5681,55 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Manual</translation>
+        <translation>&amp;Manual</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Escalonamento da Receita</translation>
+        <translation>&amp;Escalonamento da Receita</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Receita para Área de Transferência como &amp;Texto</translation>
+        <translation>Receita para Área de Transferência como &amp;Texto</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">&amp;Ajuda na Correção da OG</translation>
+        <translation>&amp;Ajuda na Correção da OG</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Converter Unidades</translation>
+        <translation>&amp;Converter Unidades</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Cópia de Segurança de Banco de Dados</translation>
+        <translation>Cópia de Segurança de Banco de Dados</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Restaura Banco de Dados</translation>
+        <translation>Restaura Banco de Dados</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Copiar Receita</translation>
+        <translation>&amp;Copiar Receita</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">&amp;Calculadora de Gaseficação</translation>
+        <translation>&amp;Calculadora de Gaseficação</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">&amp;Ferramentas do Refratômetro</translation>
+        <translation>&amp;Ferramentas do Refratômetro</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">&amp;Calculadora de Inoculação</translation>
+        <translation>&amp;Calculadora de Inoculação</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Fundir Bases de Dados</translation>
+        <translation>Fundir Bases de Dados</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Selecionar outra base de dados para fundir com a corrente.</translation>
+        <translation>Selecionar outra base de dados para fundir com a corrente.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5254,19 +5749,19 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Cópia de Segurança</translation>
+        <translation>&amp;Cópia de Segurança</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Salvar todas as receitas, os ingredientes, etc. para o diretório de cópia de segurança</translation>
+        <translation>Salvar todas as receitas, os ingredientes, etc. para o diretório de cópia de segurança</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Restaurar</translation>
+        <translation>&amp;Restaurar</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Restaurar receitas, ingredientes, etc. a partir de cópia de segurança anterior</translation>
+        <translation>Restaurar receitas, ingredientes, etc. a partir de cópia de segurança anterior</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5278,7 +5773,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Nova Receita</translation>
+        <translation>&amp;Nova Receita</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5286,42 +5781,162 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Exibir Temporizadores</translation>
+        <translation>Exibir Temporizadores</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Salvar</translation>
+        <translation>Salvar</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Excluir selecionado</translation>
+        <translation>Excluir selecionado</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Excluir receita</translation>
+        <translation>Excluir receita</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Mosturas</translation>
+        <translation>&amp;Mosturas</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Mosturas</translation>
+        <translation>Mosturas</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
         <translation type="vanished">Calculador de água inicial</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Volume da batelada</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Tamanho da Fervura</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Inicie Produção de Cerveja!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Designer da Mosturação</translation>
+        <translation>Designer da Mosturação</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5337,7 +5952,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5345,275 +5960,311 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Próximo</translation>
+        <translation>Próximo</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Finalizar</translation>
+        <translation>Finalizar</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Quantidade de Infusão/Decocção</translation>
+        <translation>Quantidade de Infusão/Decocção</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">mín</translation>
+        <translation>mín</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">máx</translation>
+        <translation>máx</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Temperatura de Infusão</translation>
+        <translation>Temperatura de Infusão</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Total de Mosto Coletado</translation>
+        <translation>Total de Mosto Coletado</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">vol</translation>
+        <translation>vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Capacidade de enchimento panela</translation>
+        <translation>Capacidade de enchimento panela</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">Volume da tina</translation>
+        <translation>Volume da tina</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">espessura</translation>
+        <translation>espessura</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Editor de Mostura</translation>
+        <translation>Editor de Mostura</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temperatura inicial dos grãos</translation>
+        <translation>Temperatura inicial dos grãos</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temperatura de aspersão</translation>
+        <translation>Temperatura de aspersão</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">meta da temperatura de aspersão</translation>
+        <translation>meta da temperatura de aspersão</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH de aspersão</translation>
+        <translation>pH de aspersão</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Tina</translation>
+        <translation>Tina</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temperatura inicial da tina</translation>
+        <translation>Temperatura inicial da tina</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Obter os seguintes parâmetros dos equipamentos da receita.</translation>
+        <translation>Obter os seguintes parâmetros dos equipamentos da receita.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Do equipamento</translation>
+        <translation>Do equipamento</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Massa da tina</translation>
+        <translation>Massa da tina</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Calor específico da tina</translation>
+        <translation>Calor específico da tina</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Calor específico da tina (cal/(g*K))</translation>
+        <translation>Calor específico da tina (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Editor de etapa de mostura</translation>
+        <translation>Editor de etapa de mostura</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Infusão</translation>
+        <translation>Infusão</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Cozimento</translation>
+        <translation>Cozimento</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Temperatura Alvo</translation>
+        <translation>Temperatura Alvo</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Temperatura Alvo desse passo</translation>
+        <translation>Temperatura Alvo desse passo</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Quantidade de Infusão</translation>
+        <translation>Quantidade de Infusão</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Quantidade de água para infundir</translation>
+        <translation>Quantidade de água para infundir</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Temperatura de Infusão</translation>
+        <translation>Temperatura de Infusão</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Temperatura da água de infusão</translation>
+        <translation>Temperatura da água de infusão</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Quantidade de decocção</translation>
+        <translation>Quantidade de decocção</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Quantidade do mosto para decocção</translation>
+        <translation>Quantidade do mosto para decocção</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">tempo para realizar a etapa</translation>
+        <translation>tempo para realizar a etapa</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">tempo de atraso</translation>
+        <translation>tempo de atraso</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Atraso</translation>
+        <translation>Atraso</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Temperatura Final</translation>
+        <translation>Temperatura Final</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Temperatura Final desse passo</translation>
+        <translation>Temperatura Final desse passo</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Aspersão do Lote</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Assistente de mostura</translation>
+        <translation>Assistente de mostura</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Densidade da mostura (L/Kg)</translation>
+        <translation>Densidade da mostura (L/Kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Densidade da mostura (não entre com nenhuma unidade)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Editor de Adjunto</translation>
+        <translation>Editor de Adjunto</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Tempero</translation>
+        <translation>Tempero</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Ajustes</translation>
+        <translation>Ajustes</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Corretor de água</translation>
+        <translation>Corretor de água</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Erva</translation>
+        <translation>Erva</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Sabor</translation>
+        <translation>Sabor</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Outro</translation>
+        <translation>Outro</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Uso</translation>
+        <translation>Uso</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Ferver</translation>
+        <translation>Ferver</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mosto</translation>
+        <translation>Mosto</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Primário</translation>
+        <translation>Primário</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Secundário</translation>
+        <translation>Secundário</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Engarrafamento</translation>
+        <translation>Engarrafamento</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5621,15 +6272,15 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Checar se a quantidade está em Kg em vez de L.</translation>
+        <translation>Checar se a quantidade está em Kg em vez de L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Quantidade é o peso?</translation>
+        <translation>Quantidade é o peso?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Verifique se a quantidade informada é um peso ao invés de um volume</translation>
+        <translation>Verifique se a quantidade informada é um peso ao invés de um volume</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5645,192 +6296,220 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Quantidade no inventário</translation>
+        <translation>Quantidade no inventário</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Quantidade no inventário</translation>
+        <translation>Quantidade no inventário</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Editor de Brassagem Nomeado</translation>
+        <translation>Editor de Brassagem Nomeado</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mosto</translation>
+        <translation>Mosto</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Excluir estilo selecionado</translation>
+        <translation>Excluir estilo selecionado</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Temperatura inicial dos grãos</translation>
+        <translation>Temperatura inicial dos grãos</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Temperatura de aspersão</translation>
+        <translation>Temperatura de aspersão</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">meta da temperatura de aspersão</translation>
+        <translation>meta da temperatura de aspersão</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH de aspersão</translation>
+        <translation>pH de aspersão</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anotações</translation>
+        <translation>Anotações</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Tina</translation>
+        <translation>Tina</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Temperatura inicial de tina</translation>
+        <translation>Temperatura inicial de tina</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Do Equipamento</translation>
+        <translation>Do Equipamento</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Massa da tina</translation>
+        <translation>Massa da tina</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Calor específico da tina</translation>
+        <translation>Calor específico da tina</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Calor específico da tina (cal/(g*K))</translation>
+        <translation>Calor específico da tina (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Adicionar passo de Mosturação</translation>
+        <translation>Adicionar passo de Mosturação</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Remover passo de Mosturação Selecionado</translation>
+        <translation>Remover passo de Mosturação Selecionado</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Acelerar Mosturação</translation>
+        <translation>Acelerar Mosturação</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Atrasar Mosturação</translation>
+        <translation>Atrasar Mosturação</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Ajuste o volume para atingir a OG</translation>
+        <translation>Ajuste o volume para atingir a OG</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrada</translation>
+        <translation>Entrada</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG (gravidade inicial)</translation>
+        <translation>SG (gravidade inicial)</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Gravidade medida antes da fervura</translation>
+        <translation>Gravidade medida antes da fervura</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Temperatura da SG medida</translation>
+        <translation>Temperatura da SG medida</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Calibração de Temperatura</translation>
+        <translation>Calibração de Temperatura</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temperatura de calibragem do hidrômetro</translation>
+        <translation>Temperatura de calibragem do hidrômetro</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-ou-</translation>
+        <translation>-ou-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (percentagem, em massa, equivalente de sacarose</translation>
+        <translation>Plato (percentagem, em massa, equivalente de sacarose</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Volume de Pré-fervura</translation>
+        <translation>Volume de Pré-fervura</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Volume de pré-fervura medido</translation>
+        <translation>Volume de pré-fervura medido</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Saída</translation>
+        <translation>Saída</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">OG com a correção</translation>
+        <translation>OG com a correção</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">OG se você ferver como o planejado</translation>
+        <translation>OG se você ferver como o planejado</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Adicionar à Fervura</translation>
+        <translation>Adicionar à Fervura</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Quantidade de água que você necessita adicionar para atingir a OG planejada (ferva se for negativo)</translation>
+        <translation>Quantidade de água que você necessita adicionar para atingir a OG planejada (ferva se for negativo)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Tamanho final da brassagem</translation>
+        <translation>Tamanho final da brassagem</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Tamanho estimado da brassagem após correção</translation>
+        <translation>Tamanho estimado da brassagem após correção</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Opções</translation>
+        <translation>Opções</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Unidades</translation>
+        <translation>Unidades</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Peso</translation>
+        <translation>Peso</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5846,7 +6525,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatura</translation>
+        <translation>Temperatura</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5858,11 +6537,11 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volume</translation>
+        <translation>Volume</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Gravidade</translation>
+        <translation>Gravidade</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5874,7 +6553,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5886,7 +6565,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Fórmulas</translation>
+        <translation>Fórmulas</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5902,7 +6581,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5914,7 +6593,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Ajustes de IBU</translation>
+        <translation>Ajustes de IBU</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5950,7 +6629,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Línguas</translation>
+        <translation>Línguas</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5960,7 +6639,7 @@ O volume final do fermentador primário é %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Conhece outra língua?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Ou deseja melhorar uma tradução? Nos ajude e
@@ -5970,7 +6649,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Data</translation>
+        <translation>Data</translation>
     </message>
     <message>
         <source>mm-dd-YYYY</source>
@@ -5983,6 +6662,42 @@ O volume final do fermentador primário é %1.</translation>
     <message>
         <source>YYYY-dd-mm</source>
         <translation type="vanished">AAAA-DD-MM</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6065,6 +6780,54 @@ O volume final do fermentador primário é %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6073,382 +6836,418 @@ O volume final do fermentador primário é %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Calculadora de taxa de inoculação</translation>
+        <translation>Calculadora de taxa de inoculação</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrada</translation>
+        <translation>Entrada</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Volume de mosto</translation>
+        <translation>Volume de mosto</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Para ales, 0.75-1. para lagers, 1.5-2.</translation>
+        <translation>Para ales, 0.75-1. para lagers, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Taxa de inóculo (M cells)/(mL*P)</translation>
+        <translation>Taxa de inóculo (M cells)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Método de Aeração</translation>
+        <translation>Método de Aeração</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Data de Produção da levedura</translation>
+        <translation>Data de Produção da levedura</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Viabilidade da Levedura</translation>
+        <translation>Viabilidade da Levedura</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Nenhum</translation>
+        <translation>Nenhum</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 no início</translation>
+        <translation>O2 no início</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Stir Plate</translation>
+        <translation>Stir Plate</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">MM/dd/aaaa</translation>
+        <translation>MM/dd/aaaa</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">Texto da Etiqueta</translation>
+        <translation>Texto da Etiqueta</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Calcular viabilidade a partir da data</translation>
+        <translation>Calcular viabilidade a partir da data</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># Frascos/SmackPacks lançados</translation>
+        <translation># Frascos/SmackPacks lançados</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Saída</translation>
+        <translation>Saída</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Bilhões de células requeridas</translation>
+        <translation>Bilhões de células requeridas</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Frascos/SmackPacks w/o Starter</translation>
+        <translation># Frascos/SmackPacks w/o Starter</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Levedura Seca</translation>
+        <translation>Levedura Seca</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Volume de Starter</translation>
+        <translation>Volume de Starter</translation>
     </message>
     <message>
         <source>Volume of wort</source>
-        <translation type="vanished">Volume do mosto</translation>
+        <translation>Volume do mosto</translation>
     </message>
     <message>
         <source>Starting gravity of the wort</source>
-        <translation type="vanished">Gravidade inicial do mosto</translation>
+        <translation>Gravidade inicial do mosto</translation>
     </message>
     <message>
         <source>Aeration method</source>
-        <translation type="vanished">Método de aeração</translation>
+        <translation>Método de aeração</translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>How much yeast you will need</source>
-        <translation type="vanished">Quanto de fermento (levedura) precisará</translation>
+        <translation>Quanto de fermento (levedura) precisará</translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Calculadora de Priming</translation>
+        <translation>Calculadora de Priming</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Entrada</translation>
+        <translation>Entrada</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Volume de cerveja coletada</translation>
+        <translation>Volume de cerveja coletada</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Quantidade de cerveja para preparar</translation>
+        <translation>Quantidade de cerveja para preparar</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Temperatura da Cerveja</translation>
+        <translation>Temperatura da Cerveja</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Temperatura da cerveja</translation>
+        <translation>Temperatura da cerveja</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Volume desejado</translation>
+        <translation>Volume desejado</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Quantos volumes de CO2 você quer (1 L CO2 @ STP  por L cerveja)</translation>
+        <translation>Quantos volumes de CO2 você quer (1 L CO2 @ STP  por L cerveja)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glicose Monohidratada (açúcar de milho)</translation>
+        <translation>Glicose Monohidratada (açúcar de milho)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Glicose Anídrica</translation>
+        <translation>Glicose Anídrica</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Sacarose</translation>
+        <translation>Sacarose</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Extrair Malte Seco</translation>
+        <translation>Extrair Malte Seco</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Saída</translation>
+        <translation>Saída</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Escorvar com</translation>
+        <translation>Escorvar com</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Quanto ingrediente escorvado para usar</translation>
+        <translation>Quanto ingrediente escorvado para usar</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulário</translation>
+        <translation>Formulário</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Cervejeiro</translation>
+        <translation>Cervejeiro</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Assistente Cervejeiro</translation>
+        <translation>Assistente Cervejeiro</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Avaliação de Sabor</translation>
+        <translation>Avaliação de Sabor</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Tempo no Primário (dias)</translation>
+        <translation>Tempo no Primário (dias)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Temperatura do Fermentador Primário</translation>
+        <translation>Temperatura do Fermentador Primário</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Idade do Secundário (dias)</translation>
+        <translation>Idade do Secundário (dias)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Temperatura do Secundário</translation>
+        <translation>Temperatura do Secundário</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Idade do Terciário (dias)</translation>
+        <translation>Idade do Terciário (dias)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Temperatura do Terciário</translation>
+        <translation>Temperatura do Terciário</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Idade de Garrafa/Barril (dias)</translation>
+        <translation>Idade de Garrafa/Barril (dias)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Temperatura de Garrafa/Barril</translation>
+        <translation>Temperatura de Garrafa/Barril</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Primeira Data de Cerveja Produzida</translation>
+        <translation>Primeira Data de Cerveja Produzida</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Volume de Carbonação</translation>
+        <translation>Volume de Carbonação</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Provar Notas</translation>
+        <translation>Provar Notas</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Ferramentas de Refratômetro</translation>
+        <translation>Ferramentas de Refratômetro</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Entradas</translation>
+        <translation>Entradas</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Platô inicial</translation>
+        <translation>Platô inicial</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">OG (20 C)</translation>
+        <translation>OG (20 C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Platô atual</translation>
+        <translation>Platô atual</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Saídas</translation>
+        <translation>Saídas</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">SG (20C)</translation>
+        <translation>SG (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">ABW</translation>
+        <translation>ABW</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Índice Refrativo</translation>
+        <translation>Índice Refrativo</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Extrato real (Platô)</translation>
+        <translation>Extrato real (Platô)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">OG (20C)</translation>
+        <translation>OG (20C)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Measured original gravity</source>
-        <translation type="vanished">Gravidade original medida</translation>
+        <translation>Gravidade original medida</translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Calculador de água inicial</translation>
+        <translation>Calculador de água inicial</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Infusão Inicial</translation>
+        <translation>Infusão Inicial</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Temperatura Original dos Grãos</translation>
+        <translation>Temperatura Original dos Grãos</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Temperatura Alvo do Mosto</translation>
+        <translation>Temperatura Alvo do Mosto</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Peso dos Grãos</translation>
+        <translation>Peso dos Grãos</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Volume de Água</translation>
+        <translation>Volume de Água</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">Infusão do Mosto</translation>
+        <translation>Infusão do Mosto</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Volume Total de Água</translation>
+        <translation>Volume Total de Água</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Peso dos Grãos</translation>
+        <translation>Peso dos Grãos</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Temperatura Atual do Mosto</translation>
+        <translation>Temperatura Atual do Mosto</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Temperatura de Infusão da Água</translation>
+        <translation>Temperatura de Infusão da Água</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Calcular</translation>
+        <translation>Calcular</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Temperatura da água inicial</translation>
+        <translation>Temperatura da água inicial</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Volume a ser adicionado</translation>
+        <translation>Volume a ser adicionado</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Nota: esse cálculo assume um tonel de mosto pré-aquecido</translation>
+        <translation>Nota: esse cálculo assume um tonel de mosto pré-aquecido</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Editor de Estilo</translation>
+        <translation>Editor de Estilo</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Estilo</translation>
+        <translation>Estilo</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Excluir estilo selecionado</translation>
+        <translation>Excluir estilo selecionado</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6456,55 +7255,55 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Categoria</translation>
+        <translation>Categoria</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Número da Categoria</translation>
+        <translation>Número da Categoria</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Estilo de Letra</translation>
+        <translation>Estilo de Letra</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Guia de Estilos</translation>
+        <translation>Guia de Estilos</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Tipo de Bebida</translation>
+        <translation>Tipo de Bebida</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Hidromel</translation>
+        <translation>Hidromel</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Trigo</translation>
+        <translation>Trigo</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Mista</translation>
+        <translation>Mista</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Cidra</translation>
+        <translation>Cidra</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6512,51 +7311,51 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Máx</translation>
+        <translation>Máx</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Mín</translation>
+        <translation>Mín</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBUs</translation>
+        <translation>IBUs</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Cor (SRM)</translation>
+        <translation>Cor (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Carb (vols)</translation>
+        <translation>Carb (vols)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV (pct)</translation>
+        <translation>ABV (pct)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Perfil</translation>
+        <translation>Perfil</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingredientes</translation>
+        <translation>Ingredientes</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Exemplos</translation>
+        <translation>Exemplos</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
     </message>
     <message>
         <source>New</source>
@@ -6570,12 +7369,258 @@ O volume final do fermentador primário é %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Cancelar</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
     <message>
         <source>Timers</source>
         <translation type="vanished">Temporizadores</translation>
+    </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Parar</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6586,18 +7631,22 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Notas</translation>
+        <translation>Notas</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Edição de Levedura</translation>
+        <translation>Edição de Levedura</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6605,51 +7654,51 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Trigo</translation>
+        <translation>Trigo</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Vinho</translation>
+        <translation>Vinho</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Champanhe</translation>
+        <translation>Champanhe</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Forma</translation>
+        <translation>Forma</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Líquido</translation>
+        <translation>Líquido</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Seco</translation>
+        <translation>Seco</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Tubo inclinado contendo cultura pura de levedura</translation>
+        <translation>Tubo inclinado contendo cultura pura de levedura</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Cultura</translation>
+        <translation>Cultura</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6657,91 +7706,91 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Verifique se a quantidade informada é em quilograma ao inves de litros.</translation>
+        <translation>Verifique se a quantidade informada é em quilograma ao inves de litros.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Quantidade é peso?</translation>
+        <translation>Quantidade é peso?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Verifique se a quantidade informada é um peso ao invés de um volume</translation>
+        <translation>Verifique se a quantidade informada é um peso ao invés de um volume</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Laboratório</translation>
+        <translation>Laboratório</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">ID de Produto</translation>
+        <translation>ID de Produto</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Temperatura Mínima</translation>
+        <translation>Temperatura Mínima</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Temperatura Mínima</translation>
+        <translation>Temperatura Mínima</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Temperatura Máxima</translation>
+        <translation>Temperatura Máxima</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Temperatura Máxima</translation>
+        <translation>Temperatura Máxima</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Floculação</translation>
+        <translation>Floculação</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Baixo</translation>
+        <translation>Baixo</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Médio</translation>
+        <translation>Médio</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Alto</translation>
+        <translation>Alto</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Muito Alto</translation>
+        <translation>Muito Alto</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Atenuação (%)</translation>
+        <translation>Atenuação (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Atenuação aparente como percentagem de medida do OG</translation>
+        <translation>Atenuação aparente como percentagem de medida do OG</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Vezes recultivadas</translation>
+        <translation>Vezes recultivadas</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Vezes que esta levedura foi recultivada</translation>
+        <translation>Vezes que esta levedura foi recultivada</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Máximo de recultivos</translation>
+        <translation>Máximo de recultivos</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Máximo de recultivos</translation>
+        <translation>Máximo de recultivos</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Adicionar ao Secundário</translation>
+        <translation>Adicionar ao Secundário</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Selecionado significa adicionar o fermento no secundário, em vez de primário</translation>
+        <translation>Selecionado significa adicionar o fermento no secundário, em vez de primário</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6757,11 +7806,39 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Quantidade em estoque</translation>
+        <translation>Quantidade em estoque</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Quantidade em estoque</translation>
+        <translation>Quantidade em estoque</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extras</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_ru.ts
+++ b/translations/bt_ru.ts
@@ -526,6 +526,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Рецепт</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Инвентарь</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Хмель</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Дрожжи</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">Результат</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2009,13 +2104,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">мин.</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2461,15 +2549,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2779,80 +2867,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Инвентарь</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Количество</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Альфа %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -3015,6 +3029,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Инвентарь</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Количество</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Альфа %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3797,8 +3885,36 @@ The final volume in the primary is %1.</source>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">Отменить</translation>
+        <translation type="unfinished">Отменить</translation>
     </message>
 </context>
 <context>
@@ -3811,12 +3927,56 @@ The final volume in the primary is %1.</source>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">Пуск</translation>
+        <translation type="unfinished">Пуск</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">Стоп</translation>
+        <translation type="unfinished">Стоп</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4262,54 +4422,73 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Диалог</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Форма</translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Создать инструкции</translation>
+        <translation>Создать инструкции</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Добавить этап</translation>
+        <translation>Добавить этап</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Название нового этапа</translation>
+        <translation>Название нового этапа</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Этап №</translation>
+        <translation>Этап №</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Номер добавляемого этапа</translation>
+        <translation>Номер добавляемого этапа</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Вставить новый этап</translation>
+        <translation>Вставить новый этап</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Переместить этапы</translation>
+        <translation>Переместить этапы</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Переместить выбранный этап вверх</translation>
+        <translation>Переместить выбранный этап вверх</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Переместить выбранный этап вниз</translation>
+        <translation>Переместить выбранный этап вниз</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Удалить выбранный этап</translation>
+        <translation>Удалить выбранный этап</translation>
     </message>
 </context>
 <context>
@@ -4379,27 +4558,27 @@ The final volume in the primary is %1.</source>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Перед кипячением</translation>
+        <translation>Перед кипячением</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Плотность SG</translation>
+        <translation>Плотность SG</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Плотность до кипячения</translation>
+        <translation>Плотность до кипячения</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Объём</translation>
+        <translation>Объём</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Объем собранного сусла</translation>
+        <translation>Объем собранного сусла</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Температура закипания</translation>
+        <translation>Температура закипания</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4407,59 +4586,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Конечная температура</translation>
+        <translation>Конечная температура</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Температура затора перед окончанием затирания</translation>
+        <translation>Температура затора перед окончанием затирания</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">После кипячения</translation>
+        <translation>После кипячения</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Начальная плотность (OG)</translation>
+        <translation>Начальная плотность (OG)</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Плотность после кипячения</translation>
+        <translation>Плотность после кипячения</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Объем сусла после кипячения</translation>
+        <translation>Объем сусла после кипячения</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Объем сусла в сусловарнике после кипячения</translation>
+        <translation>Объем сусла в сусловарнике после кипячения</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Объем сусла, перелитого в бродильню</translation>
+        <translation>Объем сусла, перелитого в бродильню</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Объем сусла в бродильне</translation>
+        <translation>Объем сусла в бродильне</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Температура засева</translation>
+        <translation> Температура засева</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Температура сусла в момент добавления дрожжей</translation>
+        <translation>Температура сусла в момент добавления дрожжей</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">После брожения</translation>
+        <translation>После брожения</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Конечная плотность</translation>
+        <translation>Конечная плотность</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Объем пива, розлитого в кеги/бутылки</translation>
+        <translation>Объем пива, розлитого в кеги/бутылки</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4475,11 +4654,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Предполагаемая НП</translation>
+        <translation>Предполагаемая НП</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Эффективность затирания</translation>
+        <translation>Эффективность затирания</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4491,7 +4670,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Предполагаемый % алк.(об)</translation>
+        <translation>Предполагаемый % алк.(об)</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4499,11 +4678,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">% алкоголя (об.)</translation>
+        <translation>% алкоголя (об.)</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Примечания</translation>
+        <translation>Примечания</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4522,14 +4749,182 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Свободно в заторнике</translation>
+        <translation>Свободно в заторнике</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Редактор оборудования</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Оборудование</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">По умолчанию</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Размер затора</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Время</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Рассчитать предварочный объём</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Время кипячения</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Скорость испарения (в час)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Доливаемая в сусловарник вода</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Доливка воды в котёл</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Впитываемость по умолчанию</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Точка кипения воды</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Объём заторника</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Новое оборудование</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Редактор сбраживаемых ингридиентов</translation>
+        <translation>Редактор сбраживаемых ингридиентов</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4537,31 +4932,31 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Солод</translation>
+        <translation>Солод</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Сахар</translation>
+        <translation>Сахар</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Экстракт</translation>
+        <translation>Экстракт</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Сухой экстракт</translation>
+        <translation>Сухой экстракт</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Дополнение</translation>
+        <translation>Дополнение</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4573,43 +4968,43 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Продуктивность относительно глюкозы</translation>
+        <translation>Продуктивность относительно глюкозы</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Рейтинг Lovibond</translation>
+        <translation>Рейтинг Lovibond</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">Добавить после кипячения</translation>
+        <translation>Добавить после кипячения</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Этот ингредиент добавлен после кипячения</translation>
+        <translation>Этот ингредиент добавлен после кипячения</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Происхождение</translation>
+        <translation>Происхождение</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Поставщик</translation>
+        <translation>Поставщик</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Разность грубый/тонкий помол (%)</translation>
+        <translation>Разность грубый/тонкий помол (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Разность в продуктивности между грубым и тонким помолом</translation>
+        <translation>Разность в продуктивности между грубым и тонким помолом</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Влажность (%)</translation>
+        <translation>Влажность (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Процент влаги по массе</translation>
+        <translation>Процент влаги по массе</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4621,43 +5016,43 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Белок (%)</translation>
+        <translation>Белок (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Белок в процентах к массе</translation>
+        <translation>Белок в процентах к массе</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Макс. в засыпи (%)</translation>
+        <translation>Макс. в засыпи (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Максимально допустимый процент в засыпи</translation>
+        <translation>Максимально допустимый процент в засыпи</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Рекомендуется затереть</translation>
+        <translation>Рекомендуется затереть</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Рекомендуется подвергнуть затиранию</translation>
+        <translation>Рекомендуется подвергнуть затиранию</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Затерто</translation>
+        <translation>Затерто</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Отмечено, если это присутствует в засыпи</translation>
+        <translation>Отмечено, если это присутствует в засыпи</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Горечь (IBU*гал./фт.)</translation>
+        <translation>Горечь (IBU*гал./фт.)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Горечь охмеленных экстрактов</translation>
+        <translation>Горечь охмеленных экстрактов</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4669,22 +5064,70 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Количество в инвентаре</translation>
+        <translation>Количество в инвентаре</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Количество в инвентаре</translation>
+        <translation>Количество в инвентаре</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Цвет</translation>
+        <translation>Цвет</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Выход %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Дополнительно</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Редактор сортов хмеля</translation>
+        <translation>Редактор сортов хмеля</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4692,7 +5135,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4700,7 +5143,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Альфа-кислот как процент по массе</translation>
+        <translation>Альфа-кислот как процент по массе</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4708,59 +5151,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Использование</translation>
+        <translation>Использование</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Затор</translation>
+        <translation>Затор</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Первое сусло</translation>
+        <translation>Первое сусло</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Кипячение</translation>
+        <translation>Кипячение</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Аромат</translation>
+        <translation>Аромат</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Сухое охмеление</translation>
+        <translation>Сухое охмеление</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Время</translation>
+        <translation>Время</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Горечь</translation>
+        <translation>Горечь</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Оба</translation>
+        <translation>Оба</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Форма</translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Шишковой</translation>
+        <translation>Шишковой</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Гранулы</translation>
+        <translation>Гранулы</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Пробка</translation>
+        <translation>Пробка</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4768,19 +5211,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Бета-кислот как процент по массе</translation>
+        <translation>Бета-кислот как процент по массе</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Индекс Стабильности/Сохранности Хмеля</translation>
+        <translation>Индекс Стабильности/Сохранности Хмеля</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Происхождение</translation>
+        <translation>Происхождение</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4788,7 +5231,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Гумулон</translation>
+        <translation>Гумулон</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4804,7 +5247,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Когумулон</translation>
+        <translation>Когумулон</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4812,7 +5255,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Мирцен</translation>
+        <translation>Мирцен</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4828,65 +5271,121 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Количество в инвентаре</translation>
+        <translation>Количество в инвентаре</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Количество в инвентаре</translation>
+        <translation>Количество в инвентаре</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Альфа %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Дополнительно</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Форма</translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Показать таймер</translation>
+        <translation>Показать таймер</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Показать таймер</translation>
+        <translation>Показать таймер</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Пометить этот этап, как завершённый</translation>
+        <translation>Пометить этот этап, как завершённый</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Этап завершён</translation>
+        <translation>Этап завершён</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Рецепты</translation>
+        <translation>Рецепты</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Стили</translation>
+        <translation>Стили</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Сбраживаемое</translation>
+        <translation>Сбраживаемое</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Хмель</translation>
+        <translation>Хмель</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Прочее</translation>
+        <translation>Прочее</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Дрожжи</translation>
+        <translation>Дрожжи</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Рецепт</translation>
+        <translation>Рецепт</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4894,11 +5393,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Название рецепта</translation>
+        <translation>Название рецепта</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Планируемый объем варки</translation>
+        <translation>Планируемый объем варки</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4914,7 +5413,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Ожидаемая эффективность</translation>
+        <translation>Ожидаемая эффективность</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4926,7 +5425,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Планируемый объем готовой партии</translation>
+        <translation>Планируемый объем готовой партии</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4934,7 +5433,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Оборудование</translation>
+        <translation>Оборудование</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4942,163 +5441,163 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Начальная плотность (OG)</translation>
+        <translation>Начальная плотность (OG)</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Плотность при кипячении</translation>
+        <translation>Плотность при кипячении</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">Конечная плотность</translation>
+        <translation>Конечная плотность</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">% алкоголя (об.)</translation>
+        <translation>% алкоголя (об.)</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Горечь (IBU)</translation>
+        <translation>Горечь (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Цвет</translation>
+        <translation>Цвет</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">Горечь IBU/GU</translation>
+        <translation>Горечь IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Калории/0.33л</translation>
+        <translation>Калории/0.33л</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Дополнительно</translation>
+        <translation>Дополнительно</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">День варки</translation>
+        <translation>День варки</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Добавить компонент</translation>
+        <translation>Добавить компонент</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Удалить выбранный компонент</translation>
+        <translation>Удалить выбранный компонент</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Редактировать выбранный ингридиент</translation>
+        <translation>Редактировать выбранный ингридиент</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Добавить хмель</translation>
+        <translation>Добавить хмель</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Удалить выбранный хмель</translation>
+        <translation>Удалить выбранный хмель</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Изменить выбранный хмель</translation>
+        <translation>Изменить выбранный хмель</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Прочее</translation>
+        <translation>Прочее</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Добавить прочее</translation>
+        <translation>Добавить прочее</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Удалить выбранный элемент</translation>
+        <translation>Удалить выбранный элемент</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Редактировать выбранный элемент</translation>
+        <translation>Редактировать выбранный элемент</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Дрожжи</translation>
+        <translation>Дрожжи</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Добавить дрожжи</translation>
+        <translation>Добавить дрожжи</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Удалить выбранные дрожжи</translation>
+        <translation>Удалить выбранные дрожжи</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Редактировать выбранные дрожжи</translation>
+        <translation>Редактировать выбранные дрожжи</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Затор</translation>
+        <translation>Затор</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Добавить этап затирания</translation>
+        <translation>Добавить этап затирания</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Удалить выбранный этап затирания</translation>
+        <translation>Удалить выбранный этап затирания</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Редактировать выбранный этап затирания</translation>
+        <translation>Редактировать выбранный этап затирания</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Редактировать свойства затора</translation>
+        <translation>Редактировать свойства затора</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Редактировать затор</translation>
+        <translation>Редактировать затор</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Редактор затора</translation>
+        <translation>Редактор затора</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Вызвать мастера затора</translation>
+        <translation>Вызвать мастера затора</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Мастер затора</translation>
+        <translation>Мастер затора</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Затирания</translation>
+        <translation>Затирания</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Этап затирания выше</translation>
+        <translation>Этап затирания выше</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Этап затирания ниже</translation>
+        <translation>Этап затирания ниже</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Сохранить этот профайл затирания</translation>
+        <translation>Сохранить этот профайл затирания</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Сохранить затирание</translation>
+        <translation>Сохранить затирание</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Справка</translation>
+        <translation>&amp;Справка</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Файл</translation>
+        <translation>&amp;Файл</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5110,27 +5609,27 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;База данных</translation>
+        <translation>&amp;База данных</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Вид</translation>
+        <translation>&amp;Вид</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;Инструменты</translation>
+        <translation>&amp;Инструменты</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Панель инструментов</translation>
+        <translation>Панель инструментов</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">&amp;О BrewTarget</translation>
+        <translation>&amp;О BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">О Brewtarget</translation>
+        <translation>О Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5138,19 +5637,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Сбраживаемое</translation>
+        <translation>&amp;Сбраживаемое</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Хмель</translation>
+        <translation>&amp;Хмель</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5158,31 +5657,31 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">Д&amp;рожжи</translation>
+        <translation>Д&amp;рожжи</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Оборудование</translation>
+        <translation>&amp;Оборудование</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Сорта</translation>
+        <translation>&amp;Сорта</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5190,7 +5689,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5202,55 +5701,55 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Руководство</translation>
+        <translation>&amp;Руководство</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Масштабирование рецепта</translation>
+        <translation>&amp;Масштабирование рецепта</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">&amp;Копировать рецепт в буфер в виде текста</translation>
+        <translation>&amp;Копировать рецепт в буфер в виде текста</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">Коррекция &amp;НП</translation>
+        <translation>Коррекция &amp;НП</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">&amp;Преобразование единиц</translation>
+        <translation>&amp;Преобразование единиц</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Резервная копия базы данных</translation>
+        <translation>Резервная копия базы данных</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Восстановление Базы</translation>
+        <translation>Восстановление Базы</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Копировать рецепт</translation>
+        <translation>&amp;Копировать рецепт</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">&amp;Карбонизация</translation>
+        <translation>&amp;Карбонизация</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">&amp;Рефрактометр</translation>
+        <translation>&amp;Рефрактометр</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">&amp;Нормы засева</translation>
+        <translation>&amp;Нормы засева</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Объединить базы данных</translation>
+        <translation>Объединить базы данных</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Выберите другую базу данных для объединения с текущей базой.</translation>
+        <translation>Выберите другую базу данных для объединения с текущей базой.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5270,19 +5769,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Резервное копирование</translation>
+        <translation>&amp;Резервное копирование</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Сохранить все рецепты, ингредиенты и т.п. в папке резервной копии</translation>
+        <translation>Сохранить все рецепты, ингредиенты и т.п. в папке резервной копии</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Восстановление</translation>
+        <translation>&amp;Восстановление</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Восстановить рецепты, ингредиенты и т.п. из резервной копии</translation>
+        <translation>Восстановить рецепты, ингредиенты и т.п. из резервной копии</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5294,7 +5793,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Новый рецепт</translation>
+        <translation>&amp;Новый рецепт</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5302,30 +5801,158 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Показать таймеры</translation>
+        <translation>Показать таймеры</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Сохранить</translation>
+        <translation>Сохранить</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Удалить выбранный</translation>
+        <translation>Удалить выбранный</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Удалить рецепт</translation>
+        <translation>Удалить рецепт</translation>
+    </message>
+    <message>
+        <source>&amp;Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Размер затора</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Размер кипячения</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Сварить!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Дизайнер засыпи</translation>
+        <translation>Дизайнер засыпи</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5341,7 +5968,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Время</translation>
+        <translation>Время</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5349,275 +5976,311 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Далее</translation>
+        <translation>Далее</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Закончить</translation>
+        <translation>Закончить</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Объем доливки/отварки</translation>
+        <translation>Объем доливки/отварки</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">мин.</translation>
+        <translation>мин.</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">макс.</translation>
+        <translation>макс.</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Температура настаивания</translation>
+        <translation>Температура настаивания</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Всего собрано сусла</translation>
+        <translation>Всего собрано сусла</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">об.</translation>
+        <translation>об.</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Наполнение заторника</translation>
+        <translation>Наполнение заторника</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">затОб.</translation>
+        <translation>затОб.</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">густота</translation>
+        <translation>густота</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Редактор засыпи</translation>
+        <translation>Редактор засыпи</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Начальная температура солода</translation>
+        <translation>Начальная температура солода</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Температура промывки</translation>
+        <translation>Температура промывки</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Нужная температура промывки</translation>
+        <translation>Нужная температура промывки</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH промывки</translation>
+        <translation>pH промывки</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Примечания</translation>
+        <translation>Примечания</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Заторник</translation>
+        <translation>Заторник</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Начальная температура затора</translation>
+        <translation>Начальная температура затора</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Взять следующие параметры с оборудования из рецепта.</translation>
+        <translation>Взять следующие параметры с оборудования из рецепта.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">С Оборудования</translation>
+        <translation>С Оборудования</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Масса Заторника</translation>
+        <translation>Масса Заторника</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Теплоемк. Заторника</translation>
+        <translation>Теплоемк. Заторника</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Теплоемкость Заторника (кал/(гр*С))</translation>
+        <translation>Теплоемкость Заторника (кал/(гр*С))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Редактор Шага Затирания</translation>
+        <translation>Редактор Шага Затирания</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Настаивание</translation>
+        <translation>Настаивание</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Температура</translation>
+        <translation>Температура</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Отвар</translation>
+        <translation>Отвар</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Нужная температура</translation>
+        <translation>Нужная температура</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Нужная температура этого шага</translation>
+        <translation>Нужная температура этого шага</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">Объем доливки</translation>
+        <translation>Объем доливки</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Объем воды для доливки</translation>
+        <translation>Объем воды для доливки</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Темп.доливки</translation>
+        <translation>Темп.доливки</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Температура доливаемой воды</translation>
+        <translation>Температура доливаемой воды</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Объем отварки</translation>
+        <translation>Объем отварки</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Объем отвариваемого затора</translation>
+        <translation>Объем отвариваемого затора</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Время</translation>
+        <translation>Время</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Время выполнения шага</translation>
+        <translation>Время выполнения шага</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Температура лаг-паузы</translation>
+        <translation>Температура лаг-паузы</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Лаг-пауза</translation>
+        <translation>Лаг-пауза</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Конечная температура</translation>
+        <translation>Конечная температура</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Температура в конце этого шага</translation>
+        <translation>Температура в конце этого шага</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Промывка &apos;частями&apos;.</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Мастер затора</translation>
+        <translation>Мастер затора</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Густота затора (л/кг)</translation>
+        <translation>Густота затора (л/кг)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">Густота затора (ничего не вводите)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Редактор прочих ингредиентов</translation>
+        <translation>Редактор прочих ингредиентов</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Специя</translation>
+        <translation>Специя</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Очистка</translation>
+        <translation>Очистка</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Агент воды</translation>
+        <translation>Агент воды</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Трава</translation>
+        <translation>Трава</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Аромат</translation>
+        <translation>Аромат</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Другое</translation>
+        <translation>Другое</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Использование</translation>
+        <translation>Использование</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Кипячение</translation>
+        <translation>Кипячение</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Затор</translation>
+        <translation>Затор</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Главное брожение</translation>
+        <translation>Главное брожение</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Дображивание</translation>
+        <translation>Дображивание</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Бутылирование</translation>
+        <translation>Бутылирование</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Время</translation>
+        <translation>Время</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5625,15 +6288,15 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Включите, если количество задано в кг, а не в литрах.</translation>
+        <translation>Включите, если количество задано в кг, а не в литрах.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Количество - вес?</translation>
+        <translation>Количество - вес?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Отметьте, если указанное количество - вес, а не объем</translation>
+        <translation>Отметьте, если указанное количество - вес, а не объем</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5649,188 +6312,220 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Количество в инвентаре</translation>
+        <translation>Количество в инвентаре</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Количество в инвентаре</translation>
+        <translation>Количество в инвентаре</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mash</source>
-        <translation type="vanished">Затор</translation>
+        <translation>Затор</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Удалить выбранный сорт</translation>
+        <translation>Удалить выбранный сорт</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Начальная температура солода</translation>
+        <translation>Начальная температура солода</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Температура промывки</translation>
+        <translation>Температура промывки</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Нужная температура промывки</translation>
+        <translation>Нужная температура промывки</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">pH промывки</translation>
+        <translation>pH промывки</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Заметки</translation>
+        <translation>Заметки</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Заторник</translation>
+        <translation>Заторник</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Начальная температура в заторнике</translation>
+        <translation>Начальная температура в заторнике</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">С Оборудования</translation>
+        <translation>С Оборудования</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Масса Заторника</translation>
+        <translation>Масса Заторника</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Теплоемк. Заторника</translation>
+        <translation>Теплоемк. Заторника</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Теплоемкость Заторника (кал/(гр*С))</translation>
+        <translation>Теплоемкость Заторника (кал/(гр*С))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Добавить этап сусловарения</translation>
+        <translation>Добавить этап сусловарения</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Удалить выбранный этап сусловарения</translation>
+        <translation>Удалить выбранный этап сусловарения</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Этап затирания выше</translation>
+        <translation>Этап затирания выше</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Предыдущий этап сусловарения</translation>
+        <translation>Предыдущий этап сусловарения</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Коррекция объема для получения НП</translation>
+        <translation>Коррекция объема для получения НП</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Ввод</translation>
+        <translation>Ввод</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">Плотность SG</translation>
+        <translation>Плотность SG</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Измеренная плотность до кипячения</translation>
+        <translation>Измеренная плотность до кипячения</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Температура</translation>
+        <translation>Температура</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Температура, при которой измерялась плотность</translation>
+        <translation>Температура, при которой измерялась плотность</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Калибровка температуры</translation>
+        <translation>Калибровка температуры</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Темп., на которую откалиброван ареометр</translation>
+        <translation>Темп., на которую откалиброван ареометр</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-или-</translation>
+        <translation>-или-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Плато</translation>
+        <translation>Плато</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Плато (процент по массе эквивалента сахара)</translation>
+        <translation>Плато (процент по массе эквивалента сахара)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Объем до кипячения</translation>
+        <translation>Объем до кипячения</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Измеренный объем до кипячения</translation>
+        <translation>Измеренный объем до кипячения</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Результат</translation>
+        <translation>Результат</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">НП без коррекции</translation>
+        <translation>НП без коррекции</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">НП если варка по плану</translation>
+        <translation>НП если варка по плану</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Добавить в варочник</translation>
+        <translation>Добавить в варочник</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">количество воды, которое нужно добавить или выпарить чтобы достичь требуемую НП</translation>
+        <translation>количество воды, которое нужно добавить или выпарить чтобы достичь требуемую НП</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Окончательный объем готового сусла</translation>
+        <translation>Окончательный объем готового сусла</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Оценочный объем готового сусла после коррекции</translation>
+        <translation>Оценочный объем готового сусла после коррекции</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Расчитать</translation>
+        <translation>Расчитать</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Параметры</translation>
+        <translation>Параметры</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Единицы</translation>
+        <translation>Единицы</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Вес</translation>
+        <translation>Вес</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5846,7 +6541,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Температура</translation>
+        <translation>Температура</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5858,11 +6553,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Объём</translation>
+        <translation>Объём</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Плотность</translation>
+        <translation>Плотность</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5874,7 +6569,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Цвет</translation>
+        <translation>Цвет</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5886,7 +6581,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Формулы</translation>
+        <translation>Формулы</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5902,7 +6597,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">Горечь IBU</translation>
+        <translation>Горечь IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5914,7 +6609,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">Корректировки горечи по IBU</translation>
+        <translation>Корректировки горечи по IBU</translation>
     </message>
     <message>
         <source>First Wort</source>
@@ -5942,7 +6637,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Язык</translation>
+        <translation>Язык</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5952,21 +6647,53 @@ The final volume in the primary is %1.</source>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Знаете другой язык?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
-   Или хотите улучшить перевод? Помогите нам и 
+   Или хотите улучшить перевод? Помогите нам и
    &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
    пришлите перевод&lt;/a&gt;, чтобы ваши друзья могли пользоваться brewtarget!
 &lt;/qt&gt;</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Формат даты</translation>
+        <translation>Формат даты</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Databases</source>
-        <translation type="vanished">Базы данных</translation>
+        <translation>Базы данных</translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6049,6 +6776,54 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6057,322 +6832,418 @@ The final volume in the primary is %1.</source>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Калькулятор нормы задачи дрожжей</translation>
+        <translation>Калькулятор нормы задачи дрожжей</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Ввод</translation>
+        <translation>Ввод</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Объем сусла</translation>
+        <translation>Объем сусла</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">Начальная плотность (OG)</translation>
+        <translation>Начальная плотность (OG)</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">Для элей 0.75-1. Для лагеров 1.5-2.</translation>
+        <translation>Для элей 0.75-1. Для лагеров 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Норма засева (млн.клеток/мл*П)</translation>
+        <translation>Норма засева (млн.клеток/мл*П)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Метод аэрации</translation>
+        <translation>Метод аэрации</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Дата производства дрожжей</translation>
+        <translation>Дата производства дрожжей</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">% живых дрожжей</translation>
+        <translation>% живых дрожжей</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Ничего</translation>
+        <translation>Ничего</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">Начальное содержание кислорода</translation>
+        <translation>Начальное содержание кислорода</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Магнитная мешалка</translation>
+        <translation>Магнитная мешалка</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">мм/дд/гггг</translation>
+        <translation>мм/дд/гггг</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">Текстовая метка</translation>
+        <translation>Текстовая метка</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Рассчитать % живых дрожжей от Даты</translation>
+        <translation>Рассчитать % живых дрожжей от Даты</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># Использовано пакетиков дрожжей</translation>
+        <translation># Использовано пакетиков дрожжей</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Результат</translation>
+        <translation>Результат</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Требуется дрожжевых клеток (млрд.)</translation>
+        <translation>Требуется дрожжевых клеток (млрд.)</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Пакетиков дрожжей без стартера</translation>
+        <translation># Пакетиков дрожжей без стартера</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Сухие дрожжи</translation>
+        <translation>Сухие дрожжи</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Объем стартера</translation>
+        <translation>Объем стартера</translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Калькулятор карбонизации</translation>
+        <translation>Калькулятор карбонизации</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Ввод</translation>
+        <translation>Ввод</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Полученный объем пива</translation>
+        <translation>Полученный объем пива</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Объем карбонизируемого пива</translation>
+        <translation>Объем карбонизируемого пива</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Температура пива</translation>
+        <translation>Температура пива</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Темп. пива</translation>
+        <translation>Темп. пива</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Желаемая степень карбонизации</translation>
+        <translation>Желаемая степень карбонизации</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Сколько объемов CO2 желаете получить (1л CO2 / 1л пива)</translation>
+        <translation>Сколько объемов CO2 желаете получить (1л CO2 / 1л пива)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Глюкоза моногидрат (кукурузный сахар)</translation>
+        <translation>Глюкоза моногидрат (кукурузный сахар)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Глюкоза безводная</translation>
+        <translation>Глюкоза безводная</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Сахароза (столовый сахар)</translation>
+        <translation>Сахароза (столовый сахар)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Сухой солодовый экстракт</translation>
+        <translation>Сухой солодовый экстракт</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Результат</translation>
+        <translation>Результат</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Чем карбонизируем</translation>
+        <translation>Чем карбонизируем</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Сколько праймера требуется</translation>
+        <translation>Сколько праймера требуется</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Расчитать</translation>
+        <translation>Расчитать</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Форма</translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Пивовар</translation>
+        <translation>Пивовар</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Помощник пивовара</translation>
+        <translation>Помощник пивовара</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Оценка вкуса</translation>
+        <translation>Оценка вкуса</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Срок брожения (дней)</translation>
+        <translation>Срок брожения (дней)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Температура брожения</translation>
+        <translation>Температура брожения</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">Срок дображивания (дней)</translation>
+        <translation>Срок дображивания (дней)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Температура дображивания</translation>
+        <translation>Температура дображивания</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Срок выдержки (дней)</translation>
+        <translation>Срок выдержки (дней)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Температура выдержки</translation>
+        <translation>Температура выдержки</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Выдержка в бутылках/кеге (дней)</translation>
+        <translation>Выдержка в бутылках/кеге (дней)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Температура бутылок/кег</translation>
+        <translation>Температура бутылок/кег</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Дата первой варки</translation>
+        <translation>Дата первой варки</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">дд МММ гггг</translation>
+        <translation>дд МММ гггг</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">Степень карбонизации</translation>
+        <translation>Степень карбонизации</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Замечания по вкусу</translation>
+        <translation>Замечания по вкусу</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Примечания</translation>
+        <translation>Примечания</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Калькулятор для рефрактометра</translation>
+        <translation>Калькулятор для рефрактометра</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Ввод</translation>
+        <translation>Ввод</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Начальное Плато</translation>
+        <translation>Начальное Плато</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">Начальная плотность (OG) (20С)</translation>
+        <translation>Начальная плотность (OG) (20С)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Текущее Плато</translation>
+        <translation>Текущее Плато</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Расчитать</translation>
+        <translation>Расчитать</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Результаты</translation>
+        <translation>Результаты</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">Плотность SG (20С)</translation>
+        <translation>Плотность SG (20С)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">% алкоголя (об.)</translation>
+        <translation>% алкоголя (об.)</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">% алк.(вес)</translation>
+        <translation>% алк.(вес)</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Показатель преломления</translation>
+        <translation>Показатель преломления</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Действительный экстракт (Плато)</translation>
+        <translation>Действительный экстракт (Плато)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">Начальная плотность (OG) (20С)</translation>
+        <translation>Начальная плотность (OG) (20С)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Температура солода</translation>
+        <translation>Температура солода</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Необходимая температура затирания</translation>
+        <translation>Необходимая температура затирания</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Вес солода</translation>
+        <translation>Вес солода</translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Вес солода</translation>
+        <translation>Вес солода</translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Рассчитать</translation>
+        <translation>Рассчитать</translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Редактор сортов</translation>
+        <translation>Редактор сортов</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Сорт</translation>
+        <translation>Сорт</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Удалить выбранный сорт</translation>
+        <translation>Удалить выбранный сорт</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6380,55 +7251,55 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Категория</translation>
+        <translation>Категория</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Номер категории</translation>
+        <translation>Номер категории</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Сорт</translation>
+        <translation>Сорт</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Классификация сортов</translation>
+        <translation>Классификация сортов</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Тип напитка</translation>
+        <translation>Тип напитка</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Лагер</translation>
+        <translation>Лагер</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Эль</translation>
+        <translation>Эль</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Медовуха</translation>
+        <translation>Медовуха</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Пшеница</translation>
+        <translation>Пшеница</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Смешанный</translation>
+        <translation>Смешанный</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Сидр</translation>
+        <translation>Сидр</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6436,51 +7307,51 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Макс.</translation>
+        <translation>Макс.</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Мин.</translation>
+        <translation>Мин.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">НП</translation>
+        <translation>НП</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">КП</translation>
+        <translation>КП</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Цвет (SRM)</translation>
+        <translation>Цвет (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Карбонизация (об.)</translation>
+        <translation>Карбонизация (об.)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">%алк.(об.)</translation>
+        <translation>%алк.(об.)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Краткое описание</translation>
+        <translation>Краткое описание</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ингредиенты</translation>
+        <translation>Ингредиенты</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Примеры</translation>
+        <translation>Примеры</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Примечания</translation>
+        <translation>Примечания</translation>
     </message>
     <message>
         <source>New</source>
@@ -6494,6 +7365,50 @@ The final volume in the primary is %1.</source>
         <source>Cancel</source>
         <translation type="vanished">Отменить</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
@@ -6501,12 +7416,207 @@ The final volume in the primary is %1.</source>
         <source>Timers</source>
         <translation type="vanished">Таймеры</translation>
     </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">Форма</translation>
+        <translation type="unfinished">Форма</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Стоп</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6517,18 +7627,22 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Примечания</translation>
+        <translation>Примечания</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Информация о дрожжах</translation>
+        <translation>Информация о дрожжах</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6536,51 +7650,51 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Название</translation>
+        <translation>Название</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Элевые</translation>
+        <translation>Элевые</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Лагерные</translation>
+        <translation>Лагерные</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Пшеничные</translation>
+        <translation>Пшеничные</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Винные</translation>
+        <translation>Винные</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Шампанские</translation>
+        <translation>Шампанские</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Форма</translation>
+        <translation>Форма</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Жидкие</translation>
+        <translation>Жидкие</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Сухие</translation>
+        <translation>Сухие</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">В пробирке</translation>
+        <translation>В пробирке</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Культура</translation>
+        <translation>Культура</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6588,91 +7702,91 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Отметьте, если количество указано в кг вместо л.</translation>
+        <translation>Отметьте, если количество указано в кг вместо л.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Количество - вес?</translation>
+        <translation>Количество - вес?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Отмечено, если указанное количество - вес, а не объем</translation>
+        <translation>Отмечено, если указанное количество - вес, а не объем</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Лаборатория</translation>
+        <translation>Лаборатория</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">ID продукта</translation>
+        <translation>ID продукта</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Мин. температура</translation>
+        <translation>Мин. температура</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Минимальная температура</translation>
+        <translation>Минимальная температура</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Макс. температура</translation>
+        <translation>Макс. температура</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Максимальная температура</translation>
+        <translation>Максимальная температура</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">Флоккуляция</translation>
+        <translation>Флоккуляция</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Низкая</translation>
+        <translation>Низкая</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Средняя</translation>
+        <translation>Средняя</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Высокая</translation>
+        <translation>Высокая</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Очень высокая</translation>
+        <translation>Очень высокая</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Степень сбраживания (%)</translation>
+        <translation>Степень сбраживания (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Видимая степень сбраживания в процентах от НП</translation>
+        <translation>Видимая степень сбраживания в процентах от НП</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Сколько раз использовались повторно</translation>
+        <translation>Сколько раз использовались повторно</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Сколько раз эти дрожжи повторно использовались</translation>
+        <translation>Сколько раз эти дрожжи повторно использовались</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Максимальное число повторных использований</translation>
+        <translation>Максимальное число повторных использований</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Максимальное число повторных использований</translation>
+        <translation>Максимальное число повторных использований</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Добавлять на карбонизацию</translation>
+        <translation>Добавлять на карбонизацию</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Если отмечено, добавьте эти дрожжи на карбонизацию вместо главного брожения</translation>
+        <translation>Если отмечено, добавьте эти дрожжи на карбонизацию вместо главного брожения</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6685,6 +7799,42 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Default Amount</source>
         <translation type="vanished">Количество по-умолчанию</translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Дополнительно</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_sr.ts
+++ b/translations/bt_sr.ts
@@ -490,6 +490,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Рецепт</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Инвентар</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Слад</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Хмељ</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Квасац</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2290,15 +2385,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2588,80 +2683,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Непознато</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished">Инвентар</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Назив</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Количина</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Алфа %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2824,6 +2845,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Непознато</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished">Инвентар</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Назив</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Количина</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Алфа %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3601,6 +3696,41 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>TimerDialog</name>
+    <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TimerListDialog</name>
     <message>
         <source>Addition Timers</source>
@@ -3609,6 +3739,58 @@ The final volume in the primary is %1.</source>
 </context>
 <context>
     <name>TimerMainDialog</name>
+    <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>No Timers</source>
         <translation type="unfinished"></translation>
@@ -4017,14 +4199,73 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Облик</translation>
+        <translation>Облик</translation>
+    </message>
+    <message>
+        <source>Generate Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert step</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
+    </message>
+    <message>
+        <source>Name of new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The number where the new step should be placed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert the new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove currently selected step</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4041,66 +4282,521 @@ The final volume in the primary is %1.</source>
 <context>
     <name>brewNoteWidget</name>
     <message>
+        <source>Preboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preboil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Volume</source>
-        <translation type="vanished">Запремина</translation>
+        <translation>Запремина</translation>
+    </message>
+    <message>
+        <source>Volume of wort collected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of mash before mash out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Post boil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort in BK after boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort transferred to fermenter</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Запремина која је ушла у ферментор</translation>
+        <translation>Запремина која је ушла у ферментор</translation>
+    </message>
+    <message>
+        <source> Pitch Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of wort when yeast is pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postferment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of beer into serving keg/bottles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewhouse efficiency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected ABV</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Белешке</translation>
+        <translation>Белешке</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>equipmentEditor</name>
+    <message>
+        <source>Lauter deadspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Опрема</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Назив</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Трајање</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Белешке</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
+        <source>Fermentable Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Житарица</translation>
+        <translation>Житарица</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Шећер</translation>
+        <translation>Шећер</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Екстракт</translation>
+        <translation>Екстракт</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">Суви екстракт</translation>
+        <translation>Суви екстракт</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Прилог</translation>
+        <translation>Прилог</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="vanished">Количина</translation>
     </message>
     <message>
+        <source>Yield as compared to glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lovibond rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add After Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This ingredient is added post boil.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse/Fine Diff (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield difference between coarse and fine grind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max In Batch (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum recommended percentage of total grist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend this be mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is Mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if it is present in mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU*gal/lb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness of pre-hopped extracts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Color</source>
-        <translation type="vanished">Боја</translation>
+        <translation>Боја</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Принос %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Белешке</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
+        <source>Hop Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
+    </message>
+    <message>
+        <source>Alpha acids as percent by mass</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4108,89 +4804,221 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Користи</translation>
+        <translation>Користи</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Укомљавање</translation>
+        <translation>Укомљавање</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Прва сладовина</translation>
+        <translation>Прва сладовина</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Кључање</translation>
+        <translation>Кључање</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Арома</translation>
+        <translation>Арома</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Суво хмељње</translation>
+        <translation>Суво хмељње</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Трајање</translation>
+        <translation>Трајање</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Горчина</translation>
+        <translation>Горчина</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Обе</translation>
+        <translation>Обе</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Облик</translation>
+        <translation>Облик</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Лист</translation>
+        <translation>Лист</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Грануле</translation>
+        <translation>Грануле</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Чеп</translation>
+        <translation>Чеп</translation>
+    </message>
+    <message>
+        <source>Beta acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop Stability/Storage index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Алфа %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Белешке</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Облик</translation>
+        <translation>Облик</translation>
+    </message>
+    <message>
+        <source>Show a timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mark this step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step completed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Рецепти</translation>
+        <translation>Рецепти</translation>
+    </message>
+    <message>
+        <source>Styles</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Слад</translation>
+        <translation>Слад</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Хмељ</translation>
+        <translation>Хмељ</translation>
+    </message>
+    <message>
+        <source>Miscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeasts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Рецепт</translation>
+        <translation>Рецепт</translation>
     </message>
     <message>
         <source>Name</source>
         <translation type="vanished">Назив</translation>
+    </message>
+    <message>
+        <source>Name of recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target boil size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The extraction efficiency you expect</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Style</source>
@@ -4201,41 +5029,473 @@ The final volume in the primary is %1.</source>
         <translation type="vanished">Дужина кључања</translation>
     </message>
     <message>
+        <source>Target batch size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Equipment</source>
-        <translation type="vanished">Опрема</translation>
+        <translation>Опрема</translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Боја</translation>
+        <translation>Боја</translation>
+    </message>
+    <message>
+        <source>IBU/GU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calories/12oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected hop</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Разно</translation>
+        <translation>Разно</translation>
+    </message>
+    <message>
+        <source>Add misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected misc</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Квасац</translation>
+        <translation>Квасац</translation>
+    </message>
+    <message>
+        <source>Add yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected yeast</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Укомљавање</translation>
+        <translation>Укомљавање</translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Des</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invoke the mash wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash wiz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save this mash profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;BrewTarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Brewtarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Equipments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Scale Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe to Clipboard as &amp;Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;OG Correction Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Convert Units</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Направи сигурносну копију базе</translation>
+        <translation>Направи сигурносну копију базе</translation>
+    </message>
+    <message>
+        <source>Restore Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Copy Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pr&amp;iming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select another database to merge into the current one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save all recipes, ingredients, etc. to a backup folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore recipes, ingredients, etc. from a previous backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;New Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timers</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Сачувај</translation>
+        <translation>Сачувај</translation>
+    </message>
+    <message>
+        <source>Delete selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1.0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Скувај!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
+        <source>Mash Designer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
         <translation type="vanished">Назив</translation>
     </message>
@@ -4245,153 +5505,548 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Трајање</translation>
+        <translation>Трајање</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion/Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Температура инфузије</translation>
+        <translation>Температура инфузије</translation>
+    </message>
+    <message>
+        <source>Total Collected Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>vol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun Fullness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunVol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
+        <source>Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Белешке</translation>
+        <translation>Белешке</translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Get following parameters from the recipe&apos;s equipment.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
+        <source>Mash Step Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">Инфузија</translation>
+        <translation>Инфузија</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Температура</translation>
+        <translation>Температура</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Добијање есенције</translation>
+        <translation>Добијање есенције</translation>
+    </message>
+    <message>
+        <source>Target temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water to infuse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of infusion water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of mash to decoct</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Трајање</translation>
+        <translation>Трајање</translation>
+    </message>
+    <message>
+        <source>Time to conduct the step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp. lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashWizard</name>
+    <message>
+        <source>Mash Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash thickness (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
+        <source>Misc Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Зачин</translation>
+        <translation>Зачин</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Додатак</translation>
+        <translation>Додатак</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Третирање воде</translation>
+        <translation>Третирање воде</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Биљни зачин</translation>
+        <translation>Биљни зачин</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Укус</translation>
+        <translation>Укус</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Друго</translation>
+        <translation>Друго</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Користи</translation>
+        <translation>Користи</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Кључање</translation>
+        <translation>Кључање</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Укомљавање</translation>
+        <translation>Укомљавање</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Примарна</translation>
+        <translation>Примарна</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Секундарна</translation>
+        <translation>Секундарна</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Флаширање</translation>
+        <translation>Флаширање</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Трајање</translation>
+        <translation>Трајање</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="vanished">Количина</translation>
     </message>
+    <message>
+        <source>Check it if the amount listed is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Белешке</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mash</source>
-        <translation type="vanished">Укомљавање</translation>
+        <translation>Укомљавање</translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Белешке</translation>
+        <translation>Белешке</translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
+        <source>Adjust Volume to Hit OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured gravity pre-boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Temp</source>
-        <translation type="vanished">Температура</translation>
+        <translation>Температура</translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp to which the hydrometer is calibrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-or-</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
+    </message>
+    <message>
+        <source>Plato (percent by mass of equivalent sucrose)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG w/o Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG if you boil as planned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated batch size after correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Weight</source>
-        <translation type="vanished">Тежина</translation>
+        <translation>Тежина</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Температура</translation>
+        <translation>Температура</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -4403,15 +6058,27 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Запремина</translation>
+        <translation>Запремина</translation>
+    </message>
+    <message>
+        <source>Gravity</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Боја</translation>
+        <translation>Боја</translation>
+    </message>
+    <message>
+        <source>Formulas</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
+    </message>
+    <message>
+        <source>IBU Adjustments</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>First Wort</source>
@@ -4426,8 +6093,58 @@ The final volume in the primary is %1.</source>
         <translation type="vanished">Подразумевано</translation>
     </message>
     <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;qt&gt;
+   &lt;b&gt;Know another language?&lt;/b&gt;
+   &lt;br&gt;&lt;br&gt;
+   Or, would you like to improve a translation? Help us out and
+  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
+  provide a translation&lt;/a&gt; so that your friends can use brewtarget!
+&lt;/qt&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Date</source>
-        <translation type="vanished">Датум</translation>
+        <translation>Датум</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -4510,7 +6227,257 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>pitchDialog</name>
+    <message>
+        <source>Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wort Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch Rate (M cells)/(mL*P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Production Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Viability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>O2 At Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stir Plate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MM/dd/yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate Viability From Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Billions of Yeast Cells Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>primingDialog</name>
+    <message>
+        <source>Priming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of beer to prime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beer Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp of the beer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Glucose Monohydrate (corn sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anhydrous Glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sucrose (table sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Malt Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prime with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4518,57 +6485,316 @@ The final volume in the primary is %1.</source>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Облик</translation>
+        <translation>Облик</translation>
+    </message>
+    <message>
+        <source>Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asst. Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date First Brewed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dd MMM yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carbonation Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Notes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Белешке</translation>
+        <translation>Белешке</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
+        <source>Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20 C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
+    </message>
+    <message>
+        <source>ABW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refractive Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Real Extract (Plato)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>strikeWaterDialog</name>
+    <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Style</source>
-        <translation type="vanished">Стил</translation>
+        <translation>Стил</translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Врста</translation>
+        <translation>Врста</translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <source>Type of beverage</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Лагер</translation>
+        <translation>Лагер</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ејл</translation>
+        <translation>Ејл</translation>
+    </message>
+    <message>
+        <source>Mead</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Пшеница</translation>
+        <translation>Пшеница</translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBUs</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Боја (SRM)</translation>
+        <translation>Боја (SRM)</translation>
+    </message>
+    <message>
+        <source>Carb (vols)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV (pct)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ingredients</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Белешке</translation>
+        <translation>Белешке</translation>
     </message>
     <message>
         <source>New</source>
@@ -4578,94 +6804,452 @@ The final volume in the primary is %1.</source>
         <source>Save</source>
         <translation type="vanished">Сачувај</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerListDialog</name>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">Облик</translation>
+        <translation type="unfinished">Облик</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>waterEditor</name>
     <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Белешке</translation>
+        <translation>Белешке</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
+        <source>Yeast Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Name</source>
-        <translation type="vanished">Назив</translation>
+        <translation>Назив</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Тип</translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ејл</translation>
+        <translation>Ејл</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Лагер</translation>
+        <translation>Лагер</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Пшеница</translation>
+        <translation>Пшеница</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Вино</translation>
+        <translation>Вино</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Шампањац</translation>
+        <translation>Шампањац</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Облик</translation>
+        <translation>Облик</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Течност</translation>
+        <translation>Течност</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Суво</translation>
+        <translation>Суво</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Искошено</translation>
+        <translation>Искошено</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Култура</translation>
+        <translation>Култура</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="vanished">Количина</translation>
     </message>
     <message>
+        <source>Check it if the amount given is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flocculation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Low</source>
-        <translation type="vanished">Ниско</translation>
+        <translation>Ниско</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Средње</translation>
+        <translation>Средње</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Високо</translation>
+        <translation>Високо</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Врло високо</translation>
+        <translation>Врло високо</translation>
+    </message>
+    <message>
+        <source>Attenuation (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apparent attenuation as percentage of OG points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times Recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times this yeast has been recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked means add this yeast to secondary instead of primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Белешке</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_sv.ts
+++ b/translations/bt_sv.ts
@@ -530,6 +530,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">Recept</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">Jäsbart</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">Humle</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">Jäst</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Avbryt</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1993,13 +2088,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">min</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2457,15 +2545,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2735,80 +2823,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Okänd</translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished">Normal</translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Namn</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Mängd</translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">Alfa %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2971,6 +2985,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Okänd</translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Normal</translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Namn</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Mängd</translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3778,35 +3866,35 @@ Primärens slutgiltiga volym är %1.</translation>
     <name>TimerDialog</name>
     <message>
         <source>Addition Timer</source>
-        <translation type="vanished">Tillsats timer</translation>
+        <translation>Tillsats timer</translation>
     </message>
     <message>
         <source>Set Addition Time(min):</source>
-        <translation type="vanished">Sätt Tillsats tid(min):</translation>
+        <translation>Sätt Tillsats tid(min):</translation>
     </message>
     <message>
         <source>Time Remaining:</source>
-        <translation type="vanished">Återstående tid:</translation>
+        <translation>Återstående tid:</translation>
     </message>
     <message>
         <source>Notes: </source>
-        <translation type="vanished">Anteckningar: </translation>
+        <translation>Anteckningar: </translation>
     </message>
     <message>
         <source>Notes...</source>
-        <translation type="vanished">Anteckningar...</translation>
+        <translation>Anteckningar...</translation>
     </message>
     <message>
         <source>Set Alarm sound</source>
-        <translation type="vanished">Sätt alarmljud</translation>
+        <translation>Sätt alarmljud</translation>
     </message>
     <message>
         <source>Stop Alarm</source>
-        <translation type="vanished">Stoppa alarm</translation>
+        <translation>Stoppa alarm</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
+        <translation>Avbryt</translation>
     </message>
 </context>
 <context>
@@ -3820,55 +3908,55 @@ Primärens slutgiltiga volym är %1.</translation>
     <name>TimerMainDialog</name>
     <message>
         <source>Main Boil Timer</source>
-        <translation type="vanished">Huvudkoks timer</translation>
+        <translation>Huvudkoks timer</translation>
     </message>
     <message>
         <source>Add Timer</source>
-        <translation type="vanished">Lägg till timer</translation>
+        <translation>Lägg till timer</translation>
     </message>
     <message>
         <source>Start</source>
-        <translation type="vanished">Starta</translation>
+        <translation>Starta</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="vanished">Stopp</translation>
+        <translation>Stopp</translation>
     </message>
     <message>
         <source>Reset</source>
-        <translation type="vanished">Nollställ</translation>
+        <translation>Nollställ</translation>
     </message>
     <message>
         <source>Hide Timers</source>
-        <translation type="vanished">Göm Timers</translation>
+        <translation>Göm Timers</translation>
     </message>
     <message>
         <source>Show Timers</source>
-        <translation type="vanished">Visa Timers</translation>
+        <translation>Visa Timers</translation>
     </message>
     <message>
         <source>Cancel Timers</source>
-        <translation type="vanished">Avbryt Timers</translation>
+        <translation>Avbryt Timers</translation>
     </message>
     <message>
         <source>Load Current Recipe</source>
-        <translation type="vanished">Ladda nuvarande Recept</translation>
+        <translation>Ladda nuvarande Recept</translation>
     </message>
     <message>
         <source>Set Boil Timer (mins):</source>
-        <translation type="vanished">Sätt koktid (min):</translation>
+        <translation>Sätt koktid (min):</translation>
     </message>
     <message>
         <source>Set Boil Time Here</source>
-        <translation type="vanished">Sätt koktid här</translation>
+        <translation>Sätt koktid här</translation>
     </message>
     <message>
         <source>Limit Alarm Ring Time </source>
-        <translation type="vanished">Begränsa Alarmets ringtid </translation>
+        <translation>Begränsa Alarmets ringtid </translation>
     </message>
     <message>
         <source>Alarm Ring Time (secs):</source>
-        <translation type="vanished">Alarmets ringtid (sek):</translation>
+        <translation>Alarmets ringtid (sek):</translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4282,54 +4370,73 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialog</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulär</translation>
+        <translation>Formulär</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">Generera instruktioner</translation>
+        <translation>Generera instruktioner</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">Lägg till steg</translation>
+        <translation>Lägg till steg</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">Namn för nytt steg</translation>
+        <translation>Namn för nytt steg</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">Steg #</translation>
+        <translation>Steg #</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">Numret för det nya steget</translation>
+        <translation>Numret för det nya steget</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">Lägg till det nya steget</translation>
+        <translation>Lägg till det nya steget</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">Fler steg</translation>
+        <translation>Fler steg</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">Flytta valt steg uppåt</translation>
+        <translation>Flytta valt steg uppåt</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">Flytta valt steg nedåt</translation>
+        <translation>Flytta valt steg nedåt</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">Ta bort valt steg</translation>
+        <translation>Ta bort valt steg</translation>
     </message>
 </context>
 <context>
@@ -4399,27 +4506,27 @@ Primärens slutgiltiga volym är %1.</translation>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Före kokning</translation>
+        <translation>Före kokning</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Densitet före kok</translation>
+        <translation>Densitet före kok</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volym</translation>
+        <translation>Volym</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">Volym på vörten</translation>
+        <translation>Volym på vörten</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">Strike Temp</translation>
+        <translation>Strike Temp</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4427,59 +4534,59 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">Slutgiltig temperatur</translation>
+        <translation>Slutgiltig temperatur</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">Mäskens temperatur innan &quot;Mash out&quot;</translation>
+        <translation>Mäskens temperatur innan &quot;Mash out&quot;</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Efter kokning</translation>
+        <translation>Efter kokning</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">Densitet efter kokning</translation>
+        <translation>Densitet efter kokning</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Volym efter kokning</translation>
+        <translation>Volym efter kokning</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">Vörtvolymen i BK efter koket</translation>
+        <translation>Vörtvolymen i BK efter koket</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">Mängden vört som överförts till jäskaret</translation>
+        <translation>Mängden vört som överförts till jäskaret</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">Volym i jäskärl</translation>
+        <translation>Volym i jäskärl</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> Temperatur för pitch</translation>
+        <translation> Temperatur för pitch</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">Vörtens temperatur när jästen tillsätts</translation>
+        <translation>Vörtens temperatur när jästen tillsätts</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Efter jäsning</translation>
+        <translation>Efter jäsning</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">Slutgiltig densitet</translation>
+        <translation>Slutgiltig densitet</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">Volymen Öl till serveringskaggen/flaskor</translation>
+        <translation>Volymen Öl till serveringskaggen/flaskor</translation>
     </message>
     <message>
         <source>percent efficiency into boil kettle</source>
@@ -4495,11 +4602,11 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">Beräknad OG</translation>
+        <translation>Beräknad OG</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">Brygghusets effektivitet</translation>
+        <translation>Brygghusets effektivitet</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4511,7 +4618,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">Beräknad volymprocent alkohol</translation>
+        <translation>Beräknad volymprocent alkohol</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4519,19 +4626,59 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Alkoholhalt</translation>
+        <translation>Alkoholhalt</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anteckningar</translation>
+        <translation>Anteckningar</translation>
     </message>
     <message>
         <source>brewNote</source>
-        <translation type="vanished">Bryggnotering</translation>
+        <translation>Bryggnotering</translation>
     </message>
     <message>
         <source>yyyy-dd-MM</source>
-        <translation type="vanished">yyyy-dd-MM</translation>
+        <translation>yyyy-dd-MM</translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4550,18 +4697,182 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">Lauter dödutrymme</translation>
+        <translation>Lauter dödutrymme</translation>
     </message>
     <message>
         <source>equipmentEditor</source>
-        <translation type="vanished">Utrusnings-editor</translation>
+        <translation>Utrusnings-editor</translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">Utrustningseditor</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">Utrustning</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">Använd som standard</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Satsstorlek</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Namn</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">Tid</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">Berkäknad volym för kok</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">Koktid</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">Avdunstning (per timme)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">Avslutande uppfyllning Vatten</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">Kittel uppfyllning vatten</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">Standard Absorberingsförmåga</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">Vattnets kokpunkt</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">Mäsktunnans volym</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anteckningar</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">Ny utrustning</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">Jäsbart-editor</translation>
+        <translation>Jäsbart-editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4569,31 +4880,31 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Stil</translation>
+        <translation>Stil</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">Malt</translation>
+        <translation>Malt</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">Socker</translation>
+        <translation>Socker</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">Extrakt</translation>
+        <translation>Extrakt</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">torrextrakt</translation>
+        <translation>torrextrakt</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">Tillsats</translation>
+        <translation>Tillsats</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4605,43 +4916,43 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">Avkastning jämfört med glukos</translation>
+        <translation>Avkastning jämfört med glukos</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">Lovibond skala</translation>
+        <translation>Lovibond skala</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">addera efter kok</translation>
+        <translation>addera efter kok</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">Denna ingrediens adderas efter koket.</translation>
+        <translation>Denna ingrediens adderas efter koket.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Ursprung</translation>
+        <translation>Ursprung</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">Leverantör</translation>
+        <translation>Leverantör</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">Grov/fin diff (%)</translation>
+        <translation>Grov/fin diff (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">Avkastningsdifferens mellan grov och fin malning</translation>
+        <translation>Avkastningsdifferens mellan grov och fin malning</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">Fuktighet (%)</translation>
+        <translation>Fuktighet (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">Fuktighetsgrad per massa</translation>
+        <translation>Fuktighetsgrad per massa</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4653,43 +4964,43 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">Protein (%)</translation>
+        <translation>Protein (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">Procent av protein per massa</translation>
+        <translation>Procent av protein per massa</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">Max i Sats (%)</translation>
+        <translation>Max i Sats (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">Maximalt rekommenderad procent av total mäld</translation>
+        <translation>Maximalt rekommenderad procent av total mäld</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">Rekommenderad mäsk</translation>
+        <translation>Rekommenderad mäsk</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">Rekommenderas att detta mäskas</translation>
+        <translation>Rekommenderas att detta mäskas</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">Är mäskat</translation>
+        <translation>Är mäskat</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">Kontrollera om det finns i mäsken</translation>
+        <translation>Kontrollera om det finns i mäsken</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">Bitterhet (IBU*gal/lb)</translation>
+        <translation>Bitterhet (IBU*gal/lb)</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">Bitterhet av extrakt före Humlen</translation>
+        <translation>Bitterhet av extrakt före Humlen</translation>
     </message>
     <message>
         <source>Notes:</source>
@@ -4701,22 +5012,70 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Antal i Lager</translation>
+        <translation>Antal i Lager</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Antal i Lager</translation>
+        <translation>Antal i Lager</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Färg</translation>
+        <translation>Färg</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">Ge %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extra</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anteckningar</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">Humle-editor</translation>
+        <translation>Humle-editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4724,7 +5083,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4732,7 +5091,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">Alfasyror som Procent per massa</translation>
+        <translation>Alfasyror som Procent per massa</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4740,59 +5099,59 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Använd</translation>
+        <translation>Använd</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mäsk</translation>
+        <translation>Mäsk</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">Första Vörten</translation>
+        <translation>Första Vörten</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Kokning</translation>
+        <translation>Kokning</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">Arom</translation>
+        <translation>Arom</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">Torrhumling</translation>
+        <translation>Torrhumling</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tid</translation>
+        <translation>Tid</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Stil</translation>
+        <translation>Stil</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">Bitter</translation>
+        <translation>Bitter</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">Både</translation>
+        <translation>Både</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulär</translation>
+        <translation>Formulär</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">Löv</translation>
+        <translation>Löv</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">Pellets</translation>
+        <translation>Pellets</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">Puck</translation>
+        <translation>Puck</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4800,19 +5159,19 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">Betasyror som Procent per massa</translation>
+        <translation>Betasyror som Procent per massa</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">HSI</translation>
+        <translation>HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">Humlestabilitet/förvaringsindex</translation>
+        <translation>Humlestabilitet/förvaringsindex</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">Ursprung</translation>
+        <translation>Ursprung</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4820,7 +5179,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">Terpener</translation>
+        <translation>Terpener</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4836,7 +5195,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">Cohumulone</translation>
+        <translation>Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4844,7 +5203,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">Myrcen</translation>
+        <translation>Myrcen</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4860,65 +5219,121 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Antal i Lager</translation>
+        <translation>Antal i Lager</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Antal i Lager</translation>
+        <translation>Antal i Lager</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">Alfa %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extra</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anteckningar</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulär</translation>
+        <translation>Formulär</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">Visa en timer</translation>
+        <translation>Visa en timer</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">Visa timer</translation>
+        <translation>Visa timer</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">Markera steg som slutfört</translation>
+        <translation>Markera steg som slutfört</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">Steg slutfört</translation>
+        <translation>Steg slutfört</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Recept</translation>
+        <translation>Recept</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">Stilar</translation>
+        <translation>Stilar</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">Jäsbart</translation>
+        <translation>Jäsbart</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">Humle</translation>
+        <translation>Humle</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Diverse</translation>
+        <translation>Diverse</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">Jäst</translation>
+        <translation>Jäst</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">Recept</translation>
+        <translation>Recept</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4926,11 +5341,11 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">Namn på recept</translation>
+        <translation>Namn på recept</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">Måsättning kokstorlek</translation>
+        <translation>Måsättning kokstorlek</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4946,7 +5361,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">Utvinningseffektiviteten du förväntas</translation>
+        <translation>Utvinningseffektiviteten du förväntas</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4958,7 +5373,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">Målsättning satsstorlek</translation>
+        <translation>Målsättning satsstorlek</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4966,7 +5381,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">Utrustning</translation>
+        <translation>Utrustning</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4974,163 +5389,163 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">Kok SG</translation>
+        <translation>Kok SG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Alkoholhalt</translation>
+        <translation>Alkoholhalt</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">Bitterhet (IBU)</translation>
+        <translation>Bitterhet (IBU)</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Färg</translation>
+        <translation>Färg</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">Kalorier/12oz</translation>
+        <translation>Kalorier/12oz</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">Extra</translation>
+        <translation>Extra</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Bryggdagen</translation>
+        <translation>Bryggdagen</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">Lägg till en jäsbar produkt</translation>
+        <translation>Lägg till en jäsbar produkt</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">Ta bort Jäsbar produkt</translation>
+        <translation>Ta bort Jäsbar produkt</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">Redigera jäsbar produkt</translation>
+        <translation>Redigera jäsbar produkt</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">Lägg till Humle</translation>
+        <translation>Lägg till Humle</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">Ta bort Vald Humle</translation>
+        <translation>Ta bort Vald Humle</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">Redigera Vald Humle</translation>
+        <translation>Redigera Vald Humle</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">Övrigt</translation>
+        <translation>Övrigt</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">Lägg till Diverse</translation>
+        <translation>Lägg till Diverse</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">Ta bort vald Diverse</translation>
+        <translation>Ta bort vald Diverse</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">Redigera vald Diverse</translation>
+        <translation>Redigera vald Diverse</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">Jäst</translation>
+        <translation>Jäst</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">Lägg till Jäst</translation>
+        <translation>Lägg till Jäst</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">Ta bort vald jäst</translation>
+        <translation>Ta bort vald jäst</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">Editera vald jäst</translation>
+        <translation>Editera vald jäst</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mäsk</translation>
+        <translation>Mäsk</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Lägg till Mäsk-steg</translation>
+        <translation>Lägg till Mäsk-steg</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Ta bort valt Mäsk-steg</translation>
+        <translation>Ta bort valt Mäsk-steg</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">Redigera valt Mäsk-steg</translation>
+        <translation>Redigera valt Mäsk-steg</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">Redigera Mäsk-egenskaper</translation>
+        <translation>Redigera Mäsk-egenskaper</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">Redigera Mäsk</translation>
+        <translation>Redigera Mäsk</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">Mäsk Des</translation>
+        <translation>Mäsk Des</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">Starta mäskguiden</translation>
+        <translation>Starta mäskguiden</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">Mäskguide</translation>
+        <translation>Mäskguide</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Mäskar</translation>
+        <translation>Mäskar</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Mäskning steg upp</translation>
+        <translation>Mäskning steg upp</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Mäskning steg ner</translation>
+        <translation>Mäskning steg ner</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">Spara Mäskprofilen</translation>
+        <translation>Spara Mäskprofilen</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">Spara Mäsk</translation>
+        <translation>Spara Mäsk</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">&amp;Om</translation>
+        <translation>&amp;Om</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Arkiv</translation>
+        <translation>&amp;Arkiv</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5142,27 +5557,27 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">&amp;Databas</translation>
+        <translation>&amp;Databas</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Visa</translation>
+        <translation>&amp;Visa</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">Verk&amp;tyg</translation>
+        <translation>Verk&amp;tyg</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">Verktygsrad</translation>
+        <translation>Verktygsrad</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">Om &amp;BrewTarget</translation>
+        <translation>Om &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">Om Brewtarget</translation>
+        <translation>Om Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5170,19 +5585,19 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">&amp;Jäsbara produkter</translation>
+        <translation>&amp;Jäsbara produkter</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">Ctrl+F</translation>
+        <translation>Ctrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">&amp;Humle</translation>
+        <translation>&amp;Humle</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">Ctrl+H</translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5190,31 +5605,31 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">Ctrl+M</translation>
+        <translation>Ctrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">&amp;Jäst</translation>
+        <translation>&amp;Jäst</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">&amp;Utrustning</translation>
+        <translation>&amp;Utrustning</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">Ctrl+E</translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">&amp;Stilar</translation>
+        <translation>&amp;Stilar</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">Ctrl+T</translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5222,7 +5637,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">Ctrl+Q</translation>
+        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5234,55 +5649,55 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">&amp;Manual</translation>
+        <translation>&amp;Manual</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">&amp;Skala Recept</translation>
+        <translation>&amp;Skala Recept</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">Recept till Urklipp som &amp;Text</translation>
+        <translation>Recept till Urklipp som &amp;Text</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">&amp;OG korrigerings Hjälp</translation>
+        <translation>&amp;OG korrigerings Hjälp</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">Konvertera Enheter (&amp;C)</translation>
+        <translation>Konvertera Enheter (&amp;C)</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">Säkerhetskopiera databasen</translation>
+        <translation>Säkerhetskopiera databasen</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">Återställ databas</translation>
+        <translation>Återställ databas</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">&amp;Kopiera Recept</translation>
+        <translation>&amp;Kopiera Recept</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">Pr&amp;iming Kalkulator</translation>
+        <translation>Pr&amp;iming Kalkulator</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">&amp;Refraktometer verktyg</translation>
+        <translation>&amp;Refraktometer verktyg</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">Förkultiverings kalkulator (&amp;P)</translation>
+        <translation>Förkultiverings kalkulator (&amp;P)</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">Sammanfoga databaser</translation>
+        <translation>Sammanfoga databaser</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">Välj en annan databas för att sammanfoga till den aktuella.</translation>
+        <translation>Välj en annan databas för att sammanfoga till den aktuella.</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5302,19 +5717,19 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">&amp;Säkerhetskopiera</translation>
+        <translation>&amp;Säkerhetskopiera</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">Spara alla recept, ingredienser o.s.v. till en säkerhetskopieringsmapp</translation>
+        <translation>Spara alla recept, ingredienser o.s.v. till en säkerhetskopieringsmapp</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">&amp;Återställ</translation>
+        <translation>&amp;Återställ</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">Återställ recept, ingredienser o.s.v. från en tidigare säkerhetskopiering</translation>
+        <translation>Återställ recept, ingredienser o.s.v. från en tidigare säkerhetskopiering</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5326,7 +5741,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">&amp;Nytt recept</translation>
+        <translation>&amp;Nytt recept</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5334,31 +5749,31 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">Visa tidtagare</translation>
+        <translation>Visa tidtagare</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Spara</translation>
+        <translation>Spara</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">Ta bort valda</translation>
+        <translation>Ta bort valda</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">Ta bort recept</translation>
+        <translation>Ta bort recept</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Mäskningar</translation>
+        <translation>&amp;Mäskningar</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">Mäskningar</translation>
+        <translation>Mäskningar</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
     </message>
     <message>
         <source>Strike Water Calculator</source>
@@ -5366,322 +5781,442 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>tab_recipe</source>
-        <translation type="vanished">tab_recipe</translation>
+        <translation>tab_recipe</translation>
     </message>
     <message>
         <source>Export to &amp;BBCode</source>
-        <translation type="vanished">Exportera till &amp;BBCode</translation>
+        <translation>Exportera till &amp;BBCode</translation>
     </message>
     <message>
         <source>Hydrometer Temp Adjustment</source>
         <translation type="vanished">Justering av hydrometer temperatur</translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished">&amp;Namn</translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">Satsstorlek</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">Kokmängd</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished">Brygg den!</translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">Mäskningsdesigner</translation>
+        <translation>Mäskningsdesigner</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tid</translation>
+        <translation>Tid</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">Nästa</translation>
+        <translation>Nästa</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">Slutför</translation>
+        <translation>Slutför</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">Infusions-/Avkokningsmängd</translation>
+        <translation>Infusions-/Avkokningsmängd</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">Infusionstemperatur</translation>
+        <translation>Infusionstemperatur</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">Totalt insamlad vört</translation>
+        <translation>Totalt insamlad vört</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">vol</translation>
+        <translation>vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">Tun Fullhet</translation>
+        <translation>Tun Fullhet</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">tunVol</translation>
+        <translation>tunVol</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">tjocklek</translation>
+        <translation>tjocklek</translation>
     </message>
     <message>
         <source>&amp;Name</source>
-        <translation type="vanished">&amp;Namn</translation>
+        <translation>&amp;Namn</translation>
     </message>
     <message>
         <source>&amp;Type</source>
-        <translation type="vanished">&amp;Typ</translation>
+        <translation>&amp;Typ</translation>
     </message>
     <message>
         <source>Tar&amp;get temp.</source>
-        <translation type="vanished">&amp;Måltemp.</translation>
+        <translation>&amp;Måltemp.</translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">Mäskningsredigerare</translation>
+        <translation>Mäskningsredigerare</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Initial korntemperatur</translation>
+        <translation>Initial korntemperatur</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Sparge temp</translation>
+        <translation>Sparge temp</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Sparge Måltemperatur</translation>
+        <translation>Sparge Måltemperatur</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Sparge pH</translation>
+        <translation>Sparge pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anteckningar</translation>
+        <translation>Anteckningar</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Tun</translation>
+        <translation>Tun</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Initial tun temp</translation>
+        <translation>Initial tun temp</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">Få följande parametrar från receptets utrustning.</translation>
+        <translation>Få följande parametrar från receptets utrustning.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Från utrustning</translation>
+        <translation>Från utrustning</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Tun mass</translation>
+        <translation>Tun mass</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Tun sp. värme</translation>
+        <translation>Tun sp. värme</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Tun specifik värme (cal/(g*K))</translation>
+        <translation>Tun specifik värme (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">Mäskningsstegredigerare</translation>
+        <translation>Mäskningsstegredigerare</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Stil</translation>
+        <translation>Stil</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">avkok</translation>
+        <translation>avkok</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatur</translation>
+        <translation>Temperatur</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">Avkok</translation>
+        <translation>Avkok</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">Måltemp.</translation>
+        <translation>Måltemp.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">Måltemp. av detta steg</translation>
+        <translation>Måltemp. av detta steg</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">infusionsmängd</translation>
+        <translation>infusionsmängd</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">Mängd vatten att fylla på</translation>
+        <translation>Mängd vatten att fylla på</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">Infusionstemp.</translation>
+        <translation>Infusionstemp.</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">Temperatur på påfyllnadsvattnet</translation>
+        <translation>Temperatur på påfyllnadsvattnet</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">Avkoksmänd</translation>
+        <translation>Avkoksmänd</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">Mängd av vatten att koka bort</translation>
+        <translation>Mängd av vatten att koka bort</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tid</translation>
+        <translation>Tid</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">Tid att utföra steg</translation>
+        <translation>Tid att utföra steg</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">Temp. fördröjningstid</translation>
+        <translation>Temp. fördröjningstid</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">Fördröjningstid</translation>
+        <translation>Fördröjningstid</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">Slutlig temp.</translation>
+        <translation>Slutlig temp.</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">Slutlig temp. av det här steget</translation>
+        <translation>Slutlig temp. av det här steget</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished">Löpande vattning</translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">Batch vattning</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">Mäsk Guide</translation>
+        <translation>Mäsk Guide</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">Mäsktjocklek</translation>
+        <translation>Mäsktjocklek</translation>
     </message>
     <message>
         <source>No Spar&amp;ge</source>
-        <translation type="vanished">Ingen Spar&amp;ge</translation>
+        <translation>Ingen Spar&amp;ge</translation>
     </message>
     <message>
         <source>Fl&amp;y Sparge</source>
-        <translation type="vanished">Sparge injektion (&amp;y)</translation>
+        <translation>Sparge injektion (&amp;y)</translation>
     </message>
     <message>
         <source>Ba&amp;tch Sparge</source>
-        <translation type="vanished">Ba&amp;tch Sparge</translation>
+        <translation>Ba&amp;tch Sparge</translation>
     </message>
     <message>
         <source>Batches</source>
-        <translation type="vanished">Satser</translation>
+        <translation>Satser</translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">Misc Editor</translation>
+        <translation>Misc Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Stil</translation>
+        <translation>Stil</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">Krydda</translation>
+        <translation>Krydda</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">Klarningsmedel</translation>
+        <translation>Klarningsmedel</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">Vattenbehandling</translation>
+        <translation>Vattenbehandling</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">Örtkrydda</translation>
+        <translation>Örtkrydda</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">Smak</translation>
+        <translation>Smak</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">Övrigt</translation>
+        <translation>Övrigt</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">Använd</translation>
+        <translation>Använd</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">Kokning</translation>
+        <translation>Kokning</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mäsk</translation>
+        <translation>Mäsk</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">Primär</translation>
+        <translation>Primär</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">Sekundär</translation>
+        <translation>Sekundär</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">Flasktappning</translation>
+        <translation>Flasktappning</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Tid</translation>
+        <translation>Tid</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5689,15 +6224,15 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">Kontrollera om mängden är listad i kg istället för L.</translation>
+        <translation>Kontrollera om mängden är listad i kg istället för L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Mängden är i vikt?</translation>
+        <translation>Mängden är i vikt?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Markera denna om värdet indikerar vikt istället för volym</translation>
+        <translation>Markera denna om värdet indikerar vikt istället för volym</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5713,224 +6248,248 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Amount in Inventory</source>
-        <translation type="vanished">Antal i Lager</translation>
+        <translation>Antal i Lager</translation>
     </message>
     <message>
         <source>Amount in inventory</source>
-        <translation type="vanished">Antal i Lager</translation>
+        <translation>Antal i Lager</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anteckningar</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">Namngiben Mäsk Redigerare</translation>
+        <translation>Namngiben Mäsk Redigerare</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">Mäsk</translation>
+        <translation>Mäsk</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Ta bort vald Stil</translation>
+        <translation>Ta bort vald Stil</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">Initial korntemperatur</translation>
+        <translation>Initial korntemperatur</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">Sparge temp</translation>
+        <translation>Sparge temp</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">Sparge Måltemperatur</translation>
+        <translation>Sparge Måltemperatur</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">Sparge pH</translation>
+        <translation>Sparge pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anteckningar</translation>
+        <translation>Anteckningar</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">Tun</translation>
+        <translation>Tun</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">Initial tun temp</translation>
+        <translation>Initial tun temp</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">Från utrustning</translation>
+        <translation>Från utrustning</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">Tun mass</translation>
+        <translation>Tun mass</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">Tun sp. värme</translation>
+        <translation>Tun sp. värme</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">Tun specifik värme (cal/(g*K))</translation>
+        <translation>Tun specifik värme (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">Lägg till Mäsk-steg</translation>
+        <translation>Lägg till Mäsk-steg</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">Ta bort valt Mäsk-steg</translation>
+        <translation>Ta bort valt Mäsk-steg</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">Mäskning steg upp</translation>
+        <translation>Mäskning steg upp</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">Mäskning steg ner</translation>
+        <translation>Mäskning steg ner</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">Justera Mängd för att träffa OG</translation>
+        <translation>Justera Mängd för att träffa OG</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Inmatning</translation>
+        <translation>Inmatning</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">Mätt densitet före kok</translation>
+        <translation>Mätt densitet före kok</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">Temperatur</translation>
+        <translation>Temperatur</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">Temperatur vid SG avläsning</translation>
+        <translation>Temperatur vid SG avläsning</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">Kalibrations temperatur</translation>
+        <translation>Kalibrations temperatur</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">Temp. som hydrometer är kalibrerad till</translation>
+        <translation>Temp. som hydrometer är kalibrerad till</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">-eller-</translation>
+        <translation>-eller-</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">Plato</translation>
+        <translation>Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">Plato (viktprocent av likvärdig sackaros)</translation>
+        <translation>Plato (viktprocent av likvärdig sackaros)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">Volym före kok</translation>
+        <translation>Volym före kok</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">Uppmätt volym före kok</translation>
+        <translation>Uppmätt volym före kok</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultat</translation>
+        <translation>Resultat</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">OG utan korrigering</translation>
+        <translation>OG utan korrigering</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">OG om du kokar som planerat</translation>
+        <translation>OG om du kokar som planerat</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">Lägg till i kok</translation>
+        <translation>Lägg till i kok</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">Mängd vatten du behöver lägga till för att träffa planerad OG ( eller koka bort om negativt)</translation>
+        <translation>Mängd vatten du behöver lägga till för att träffa planerad OG ( eller koka bort om negativt)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">Slutlig Batch storlek</translation>
+        <translation>Slutlig Batch storlek</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">Uppskattad batch storlek efter korrigering</translation>
+        <translation>Uppskattad batch storlek efter korrigering</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Beräkna</translation>
+        <translation>Beräkna</translation>
     </message>
     <message>
         <source>ogAdjuster</source>
-        <translation type="vanished">ogJusterare</translation>
+        <translation>ogJusterare</translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">Inställningar</translation>
+        <translation>Inställningar</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">Enhet</translation>
+        <translation>Enhet</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">Vikt</translation>
+        <translation>Vikt</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">Temperatur</translation>
+        <translation>Temperatur</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">Volym</translation>
+        <translation>Volym</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">Gravitation</translation>
+        <translation>Gravitation</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">Färg</translation>
+        <translation>Färg</translation>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">Formler</translation>
+        <translation>Formler</translation>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">IBU justeringar</translation>
+        <translation>IBU justeringar</translation>
     </message>
     <message>
         <source>Browse</source>
@@ -5938,7 +6497,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Språk</translation>
+        <translation>Språk</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5948,7 +6507,7 @@ Primärens slutgiltiga volym är %1.</translation>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Känner du till ett annat språk?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Eller, vill du förbättra en översättning? Hjälp oss att
@@ -5958,43 +6517,43 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">Datum</translation>
+        <translation>Datum</translation>
     </message>
     <message>
         <source>Forumulas</source>
-        <translation type="vanished">Formler</translation>
+        <translation>Formler</translation>
     </message>
     <message>
         <source>Mash Hop (%)</source>
-        <translation type="vanished">Mäsk Humle (%)</translation>
+        <translation>Mäsk Humle (%)</translation>
     </message>
     <message>
         <source>First Wort (%)</source>
-        <translation type="vanished">Första vörten (%)</translation>
+        <translation>Första vörten (%)</translation>
     </message>
     <message>
         <source>Databases</source>
-        <translation type="vanished">Databaser</translation>
+        <translation>Databaser</translation>
     </message>
     <message>
         <source>Engines</source>
-        <translation type="vanished">Databasmotorer</translation>
+        <translation>Databasmotorer</translation>
     </message>
     <message>
         <source>RDBMS Engine</source>
-        <translation type="vanished">RDBMS motor</translation>
+        <translation>RDBMS motor</translation>
     </message>
     <message>
         <source>Test Connection</source>
-        <translation type="vanished">Testa kopplingen</translation>
+        <translation>Testa kopplingen</translation>
     </message>
     <message>
         <source>Configuration</source>
-        <translation type="vanished">Konfigurering</translation>
+        <translation>Konfigurering</translation>
     </message>
     <message>
         <source>Restore defaults</source>
-        <translation type="vanished">Återställ standardvärden</translation>
+        <translation>Återställ standardvärden</translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -6081,6 +6640,54 @@ Primärens slutgiltiga volym är %1.</translation>
         <translation type="vanished">Hur ofta ska säkerhetskopior tas: 1 betyder Alltid ta säkerhetskopia</translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6089,418 +6696,418 @@ Primärens slutgiltiga volym är %1.</translation>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">Förkulturs kalkylator</translation>
+        <translation>Förkulturs kalkylator</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Indata</translation>
+        <translation>Indata</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">Vörtvolym</translation>
+        <translation>Vörtvolym</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">för Ale, 0.76-1. För Lager, 1.5-2.</translation>
+        <translation>för Ale, 0.76-1. För Lager, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">Förkultur (M celler)/(mL*P)</translation>
+        <translation>Förkultur (M celler)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">Luftningsmetod</translation>
+        <translation>Luftningsmetod</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">Jästens produktionsdatum</translation>
+        <translation>Jästens produktionsdatum</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">Jästens livskraft</translation>
+        <translation>Jästens livskraft</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">Ingen</translation>
+        <translation>Ingen</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2 vid start</translation>
+        <translation>O2 vid start</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">Omrörningsplatta</translation>
+        <translation>Omrörningsplatta</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">MM/dd/yyyy</translation>
+        <translation>MM/dd/yyyy</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">Textetikett</translation>
+        <translation>Textetikett</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">Beräkna livskraft från datum</translation>
+        <translation>Beräkna livskraft från datum</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished"># flaktor/paket använda</translation>
+        <translation># flaktor/paket använda</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultat</translation>
+        <translation>Resultat</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">Miljarder av Jästceller som krävs</translation>
+        <translation>Miljarder av Jästceller som krävs</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished"># Flaskor/Paket utan startare</translation>
+        <translation># Flaskor/Paket utan startare</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">Torrjäst</translation>
+        <translation>Torrjäst</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">Startvolym</translation>
+        <translation>Startvolym</translation>
     </message>
     <message>
         <source>Volume of wort</source>
-        <translation type="vanished">Vörtvolym</translation>
+        <translation>Vörtvolym</translation>
     </message>
     <message>
         <source>Starting gravity of the wort</source>
-        <translation type="vanished">Startgravitaion av vörten</translation>
+        <translation>Startgravitaion av vörten</translation>
     </message>
     <message>
         <source>Aeration method</source>
-        <translation type="vanished">Luftningsmetod</translation>
+        <translation>Luftningsmetod</translation>
     </message>
     <message>
         <source>Production date (Best By date less three months)</source>
-        <translation type="vanished">Produktionsdatum (Bäst föredatum mindre än tre månader)</translation>
+        <translation>Produktionsdatum (Bäst föredatum mindre än tre månader)</translation>
     </message>
     <message>
         <source>Estimated viability of the yeast</source>
-        <translation type="vanished">Uppskattad livskraft på jästen</translation>
+        <translation>Uppskattad livskraft på jästen</translation>
     </message>
     <message>
         <source>Desired pitch rate</source>
-        <translation type="vanished">Önskad förkultivering</translation>
+        <translation>Önskad förkultivering</translation>
     </message>
     <message>
         <source>Number of vials/smack packs added to starter</source>
-        <translation type="vanished">Antal Flaskor/smack-packs tillagda till startern</translation>
+        <translation>Antal Flaskor/smack-packs tillagda till startern</translation>
     </message>
     <message>
         <source>How much yeast you will need</source>
-        <translation type="vanished">Hur mycket jäst du behöver</translation>
+        <translation>Hur mycket jäst du behöver</translation>
     </message>
     <message>
         <source>How many smack packs or vials required to reach pitch rate</source>
-        <translation type="vanished">Hur många Smack-packs eller flaskor som krävs till förkultiveringen</translation>
+        <translation>Hur många Smack-packs eller flaskor som krävs till förkultiveringen</translation>
     </message>
     <message>
         <source>Amount of dry yeast needed to reach pitch rate</source>
-        <translation type="vanished">Mängd Torrjäst som behövs för till förkultiveringen</translation>
+        <translation>Mängd Torrjäst som behövs för till förkultiveringen</translation>
     </message>
     <message>
         <source>Starter size to reach pitch rate</source>
-        <translation type="vanished">startstorlek till förkultiveringen</translation>
+        <translation>startstorlek till förkultiveringen</translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">Priming kalkylator</translation>
+        <translation>Priming kalkylator</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">Indata</translation>
+        <translation>Indata</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">Tappad Ölvolym</translation>
+        <translation>Tappad Ölvolym</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">Mängd öl att kultivera</translation>
+        <translation>Mängd öl att kultivera</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">Öltemperatur</translation>
+        <translation>Öltemperatur</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">Öltemp</translation>
+        <translation>Öltemp</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">Önskad Volym</translation>
+        <translation>Önskad Volym</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">Hur mycket CO2 du vill ha (1L CO2 @ STP per L öl)</translation>
+        <translation>Hur mycket CO2 du vill ha (1L CO2 @ STP per L öl)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">Glykosmonohydrat (majssocker)</translation>
+        <translation>Glykosmonohydrat (majssocker)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">Vattenfri glykos</translation>
+        <translation>Vattenfri glykos</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">Socker (Bordssocker)</translation>
+        <translation>Socker (Bordssocker)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">Torrt maltextrakt</translation>
+        <translation>Torrt maltextrakt</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">Resultat</translation>
+        <translation>Resultat</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">Prime med</translation>
+        <translation>Prime med</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">Hur mycket Primingingrediens att använda</translation>
+        <translation>Hur mycket Primingingrediens att använda</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Beräkna</translation>
+        <translation>Beräkna</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulär</translation>
+        <translation>Formulär</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">Bryggare</translation>
+        <translation>Bryggare</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">Assist. bryggare</translation>
+        <translation>Assist. bryggare</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">Smakbetyg</translation>
+        <translation>Smakbetyg</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">Primär ålder (dagar)</translation>
+        <translation>Primär ålder (dagar)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">Primärens temperatur</translation>
+        <translation>Primärens temperatur</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">secundär ålder (dagar)</translation>
+        <translation>secundär ålder (dagar)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">Secundärens temperatur</translation>
+        <translation>Secundärens temperatur</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">Tertiär ålder (dagar)</translation>
+        <translation>Tertiär ålder (dagar)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">Tertiärens temperatur</translation>
+        <translation>Tertiärens temperatur</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">Flaska/Tunna ålder (dagar)</translation>
+        <translation>Flaska/Tunna ålder (dagar)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">Flaska/Tunna temperatur</translation>
+        <translation>Flaska/Tunna temperatur</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">Första bryggdatum</translation>
+        <translation>Första bryggdatum</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">kolsydningsvolym</translation>
+        <translation>kolsydningsvolym</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">Smakprov noteringar</translation>
+        <translation>Smakprov noteringar</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anteckningar</translation>
+        <translation>Anteckningar</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">Refraktometer verktyg</translation>
+        <translation>Refraktometer verktyg</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">Indata</translation>
+        <translation>Indata</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">Original Plato</translation>
+        <translation>Original Plato</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">OG (20 C)</translation>
+        <translation>OG (20 C)</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">Nuvarande Plato</translation>
+        <translation>Nuvarande Plato</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Beräkna</translation>
+        <translation>Beräkna</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">Resultat</translation>
+        <translation>Resultat</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">SG (20C)</translation>
+        <translation>SG (20C)</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">Alkoholhalt</translation>
+        <translation>Alkoholhalt</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">Viktprocent (ABW)</translation>
+        <translation>Viktprocent (ABW)</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">Brytningsindex</translation>
+        <translation>Brytningsindex</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">Verkligt extrakt (Plato)</translation>
+        <translation>Verkligt extrakt (Plato)</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">OG (20C)</translation>
+        <translation>OG (20C)</translation>
     </message>
     <message>
         <source>Measured original plato</source>
-        <translation type="vanished">Uppmätt verkligt Plato</translation>
+        <translation>Uppmätt verkligt Plato</translation>
     </message>
     <message>
         <source>Measured original gravity</source>
-        <translation type="vanished">Uppmätt ursprungling gravitation</translation>
+        <translation>Uppmätt ursprungling gravitation</translation>
     </message>
     <message>
         <source>Current measured plato</source>
-        <translation type="vanished">Nu uppmätt Plato</translation>
+        <translation>Nu uppmätt Plato</translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
         <source>Strike Water Calculator</source>
-        <translation type="vanished">Tillsatsvatten kalkylator</translation>
+        <translation>Tillsatsvatten kalkylator</translation>
     </message>
     <message>
         <source>Initial Infusion</source>
-        <translation type="vanished">Initial insats</translation>
+        <translation>Initial insats</translation>
     </message>
     <message>
         <source>Original Grain Temperature</source>
-        <translation type="vanished">Ursprunglig Korn temperatur</translation>
+        <translation>Ursprunglig Korn temperatur</translation>
     </message>
     <message>
         <source>Target Mash Temperature</source>
-        <translation type="vanished">Måltemperatur för Mäsk</translation>
+        <translation>Måltemperatur för Mäsk</translation>
     </message>
     <message>
         <source>Weight of Grain</source>
-        <translation type="vanished">Kornvikt</translation>
+        <translation>Kornvikt</translation>
     </message>
     <message>
         <source>Volume of Water</source>
-        <translation type="vanished">Vattenvolym</translation>
+        <translation>Vattenvolym</translation>
     </message>
     <message>
         <source>Mash Infusion</source>
-        <translation type="vanished">Mäskinfusion</translation>
+        <translation>Mäskinfusion</translation>
     </message>
     <message>
         <source>Total Volume of Water</source>
-        <translation type="vanished">Totalvolym av vatten</translation>
+        <translation>Totalvolym av vatten</translation>
     </message>
     <message>
         <source>Grain Weight</source>
-        <translation type="vanished">Kornvikt</translation>
+        <translation>Kornvikt</translation>
     </message>
     <message>
         <source>Actual Mash Temperature</source>
-        <translation type="vanished">Faktisk Mäsktemperatur</translation>
+        <translation>Faktisk Mäsktemperatur</translation>
     </message>
     <message>
         <source>Infusion Water Temperature</source>
-        <translation type="vanished">Infutsionsvattentemperatur</translation>
+        <translation>Infutsionsvattentemperatur</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">Beräkna</translation>
+        <translation>Beräkna</translation>
     </message>
     <message>
         <source>Strike Water Temperature</source>
-        <translation type="vanished">Tillsatsvattentemperatur</translation>
+        <translation>Tillsatsvattentemperatur</translation>
     </message>
     <message>
         <source>Volume to add</source>
-        <translation type="vanished">Volym att lägga till</translation>
+        <translation>Volym att lägga till</translation>
     </message>
     <message>
         <source>Note: This calculator assumes a preheated mash tun.</source>
-        <translation type="vanished">Not.: Kalkylatorn utgår ifrån en förvärmd mäsk tun.</translation>
+        <translation>Not.: Kalkylatorn utgår ifrån en förvärmd mäsk tun.</translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">Stilredigerare</translation>
+        <translation>Stilredigerare</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">Stil</translation>
+        <translation>Stil</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">Ta bort vald Stil</translation>
+        <translation>Ta bort vald Stil</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6508,55 +7115,55 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">Kategori</translation>
+        <translation>Kategori</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">Kategorinummer</translation>
+        <translation>Kategorinummer</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">Stilbrev</translation>
+        <translation>Stilbrev</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">Stilguide</translation>
+        <translation>Stilguide</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Stil</translation>
+        <translation>Stil</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">Typ av dryck</translation>
+        <translation>Typ av dryck</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">Mjöd</translation>
+        <translation>Mjöd</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Vete</translation>
+        <translation>Vete</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">Blandad</translation>
+        <translation>Blandad</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">Cider</translation>
+        <translation>Cider</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6564,51 +7171,51 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">Max</translation>
+        <translation>Max</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">Min</translation>
+        <translation>Min</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBUs</translation>
+        <translation>IBUs</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">Färg (SRM)</translation>
+        <translation>Färg (SRM)</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">Kolsyrning (vols)</translation>
+        <translation>Kolsyrning (vols)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV (pct)</translation>
+        <translation>ABV (pct)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">Profil</translation>
+        <translation>Profil</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">Ingredienser</translation>
+        <translation>Ingredienser</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">Exempel</translation>
+        <translation>Exempel</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anteckningar</translation>
+        <translation>Anteckningar</translation>
     </message>
     <message>
         <source>New</source>
@@ -6622,35 +7229,254 @@ Primärens slutgiltiga volym är %1.</translation>
         <source>Cancel</source>
         <translation type="vanished">Avbryt</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
     <message>
         <source>Addition Timers</source>
-        <translation type="vanished">Tillsats Timers</translation>
+        <translation>Tillsats Timers</translation>
     </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulär</translation>
+        <translation>Formulär</translation>
     </message>
     <message>
         <source>Add:</source>
-        <translation type="vanished">Lägg till:</translation>
+        <translation>Lägg till:</translation>
     </message>
     <message>
         <source>Notes...</source>
-        <translation type="vanished">Anteckningar...</translation>
+        <translation>Anteckningar...</translation>
     </message>
     <message>
         <source>At:</source>
-        <translation type="vanished">Vid:</translation>
+        <translation>Vid:</translation>
     </message>
     <message>
         <source>mins</source>
-        <translation type="vanished">minuter</translation>
+        <translation>minuter</translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">Stopp</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Avbryt</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6661,18 +7487,22 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">Anteckningar</translation>
+        <translation>Anteckningar</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">Jästeditor</translation>
+        <translation>Jästeditor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6680,51 +7510,51 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">Ale</translation>
+        <translation>Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">Lager</translation>
+        <translation>Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">Vete</translation>
+        <translation>Vete</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">Vin</translation>
+        <translation>Vin</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">Champagne</translation>
+        <translation>Champagne</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulär</translation>
+        <translation>Formulär</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Vätska</translation>
+        <translation>Vätska</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Torrt</translation>
+        <translation>Torrt</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Lutning</translation>
+        <translation>Lutning</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Kultur</translation>
+        <translation>Kultur</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6732,91 +7562,91 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">Markera denna om mängden anges i kilo istället för liter.</translation>
+        <translation>Markera denna om mängden anges i kilo istället för liter.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">Mängden är i vikt?</translation>
+        <translation>Mängden är i vikt?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">Markera denna om värdet indikerar vikt istället för volym</translation>
+        <translation>Markera denna om värdet indikerar vikt istället för volym</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">Lab</translation>
+        <translation>Lab</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">Produkt-ID</translation>
+        <translation>Produkt-ID</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">Min temp</translation>
+        <translation>Min temp</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">Min temp</translation>
+        <translation>Min temp</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">Max temp</translation>
+        <translation>Max temp</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">Max temp</translation>
+        <translation>Max temp</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">flockulering</translation>
+        <translation>flockulering</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">Låg</translation>
+        <translation>Låg</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Mellan</translation>
+        <translation>Mellan</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">Hög</translation>
+        <translation>Hög</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Mycket hög</translation>
+        <translation>Mycket hög</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">Förtunning (%)</translation>
+        <translation>Förtunning (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">Uppenbar försvagnings som procent av OG värde</translation>
+        <translation>Uppenbar försvagnings som procent av OG värde</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">Antal omodlingar</translation>
+        <translation>Antal omodlingar</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">Antal gånger denna jäst har blivit omodlad</translation>
+        <translation>Antal gånger denna jäst har blivit omodlad</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">Max antal omodlingar</translation>
+        <translation>Max antal omodlingar</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Max antal omodlingar</translation>
+        <translation>Max antal omodlingar</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">Tillsätt i sekundären</translation>
+        <translation>Tillsätt i sekundären</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">Markering betyder att den här jästen ska tillsättas i sekundären istället för i primären</translation>
+        <translation>Markering betyder att den här jästen ska tillsättas i sekundären istället för i primären</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6832,11 +7662,39 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>Quanta in Inventory</source>
-        <translation type="vanished">Mängd i lager</translation>
+        <translation>Mängd i lager</translation>
     </message>
     <message>
         <source>Quanta in inventory</source>
-        <translation type="vanished">Mängd i lager</translation>
+        <translation>Mängd i lager</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">Extra</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">Anteckningar</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_tr.ts
+++ b/translations/bt_tr.ts
@@ -355,6 +355,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -2071,15 +2166,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2341,80 +2436,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2577,6 +2598,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3354,6 +3449,41 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>TimerDialog</name>
+    <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TimerListDialog</name>
     <message>
         <source>Addition Timers</source>
@@ -3362,6 +3492,58 @@ The final volume in the primary is %1.</source>
 </context>
 <context>
     <name>TimerMainDialog</name>
+    <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>No Timers</source>
         <translation type="unfinished"></translation>
@@ -3762,14 +3944,804 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
-    <name>hopEditor</name>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>brewDayScrollWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generate Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The number where the new step should be placed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert the new step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move currently selected step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove currently selected step</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>brewNoteWidget</name>
+    <message>
+        <source>Preboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preboil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort collected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of mash before mash out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Post boil gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postboil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort in BK after boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort transferred to fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume into fermenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> Pitch Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of wort when yeast is pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postferment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of beer into serving keg/bottles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewhouse efficiency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>equipmentEditor</name>
+    <message>
+        <source>Lauter deadspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">Süre</translation>
+        <translation type="unfinished">Süre</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>fermentableEditor</name>
+    <message>
+        <source>Fermentable Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sugar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjunct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield as compared to glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lovibond rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add After Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This ingredient is added post boil.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse/Fine Diff (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield difference between coarse and fine grind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moisture percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protein percentage by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max In Batch (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum recommended percentage of total grist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recommend this be mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Is Mashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if it is present in mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU*gal/lb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness of pre-hopped extracts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>hopEditor</name>
+    <message>
+        <source>Hop Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aroma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>Süre</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bittering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pellet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta acids as percent by mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop Stability/Storage index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>instructionWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mark this step completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Step completed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
+    <message>
+        <source>Recipes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name of recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target boil size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The extraction efficiency you expect</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Style</source>
         <translation type="vanished">Biçem</translation>
@@ -3778,37 +4750,1095 @@ The final volume in the primary is %1.</source>
         <source>Boil Time</source>
         <translation type="vanished">Kaynama Süresi</translation>
     </message>
+    <message>
+        <source>Target batch size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bitterness (IBU)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU/GU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calories/12oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Des</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invoke the mash wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash wiz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save this mash profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;BrewTarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Brewtarget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Fermentables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Yeasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Equipments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Styles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Scale Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe to Clipboard as &amp;Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;OG Correction Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Convert Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backup Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Copy Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pr&amp;iming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select another database to merge into the current one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save all recipes, ingredients, etc. to a backup folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore recipes, ingredients, etc. from a previous backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;New Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Mashs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mashes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1.0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
+        <source>Mash Designer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Süre</translation>
+        <translation>Süre</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion/Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Collected Wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>vol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun Fullness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunVol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashEditor</name>
+    <message>
+        <source>Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Get following parameters from the recipe&apos;s equipment.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
+        <source>Mash Step Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water to infuse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infuse temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of infusion water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoction Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of mash to decoct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Süre</translation>
+        <translation>Süre</translation>
+    </message>
+    <message>
+        <source>Time to conduct the step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp. lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lag time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End temp.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final temp. of this step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mashWizard</name>
+    <message>
+        <source>Mash Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash thickness (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
+        <source>Misc Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Herb</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flavor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Time</source>
-        <translation type="vanished">Süre</translation>
+        <translation>Süre</translation>
+    </message>
+    <message>
+        <source>Check it if the amount listed is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>namedMashEditor</name>
+    <message>
+        <source>Named Mash Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial grain temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge temp target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sparge pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial tun temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From Equipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun mass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun sp. heat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tun specific heat (cal/(g*K))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected mash step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash step down</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ogAdjuster</name>
+    <message>
+        <source>Adjust Volume to Hit OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured gravity pre-boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of SG reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calibration Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp to which the hydrometer is calibrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-or-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plato (percent by mass of equivalent sucrose)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured pre-boil volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG w/o Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG if you boil as planned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final Batch Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated batch size after correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Formulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBU Adjustments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;qt&gt;
+   &lt;b&gt;Know another language?&lt;/b&gt;
+   &lt;br&gt;&lt;br&gt;
+   Or, would you like to improve a translation? Help us out and
+  &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
+  provide a translation&lt;/a&gt; so that your friends can use brewtarget!
+&lt;/qt&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Date</source>
-        <translation type="vanished">Tarih</translation>
+        <translation>Tarih</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -3891,15 +5921,1017 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>pitchDialog</name>
+    <message>
+        <source>Pitch Rate Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wort Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch Rate (M cells)/(mL*P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Production Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast Viability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>O2 At Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stir Plate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MM/dd/yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate Viability From Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs Pitched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Billions of Yeast Cells Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Vials/Smack Packs w/o Starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>primingDialog</name>
+    <message>
+        <source>Priming Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected Beer Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of beer to prime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beer Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temp of the beer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Glucose Monohydrate (corn sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anhydrous Glucose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sucrose (table sugar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry Malt Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prime with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much priming ingredient to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>recipeExtrasWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asst. Brewer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Primary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secondary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tertiary Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Age (days)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bottle/Keg Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Date First Brewed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dd MMM yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carbonation Volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Taste Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>refractoDialog</name>
+    <message>
+        <source>Refractometer Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20 C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refractive Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Real Extract (Plato)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG (20C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>strikeWaterDialog</name>
+    <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
+        <source>Style Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Style</source>
-        <translation type="vanished">Biçem</translation>
+        <translation>Biçem</translation>
+    </message>
+    <message>
+        <source>Delete selected style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Category number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type of beverage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IBUs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color (SRM)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Carb (vols)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV (pct)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ingredients</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerListDialog</name>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timerWidget</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterEditor</name>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>yeastEditor</name>
+    <message>
+        <source>Yeast Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Champagne</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Liquid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Culture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check it if the amount given is in kg instead of L.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount is weight?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked if the given amount is weight instead of volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flocculation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attenuation (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apparent attenuation as percentage of OG points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times Recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Times this yeast has been recultured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max recultures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Secondary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checked means add this yeast to secondary instead of primary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_zh.ts
+++ b/translations/bt_zh.ts
@@ -486,6 +486,101 @@
     </message>
 </context>
 <context>
+    <name>BtPrintAndPreview</name>
+    <message>
+        <source>Print And Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe</source>
+        <translation type="unfinished">食谱</translation>
+    </message>
+    <message>
+        <source>Select Recipe(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select what to include</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brewday Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fermentables</source>
+        <translation type="unfinished">发酵物Fermentables</translation>
+    </message>
+    <message>
+        <source>Hops</source>
+        <translation type="unfinished">酒花Hops</translation>
+    </message>
+    <message>
+        <source>Micelleneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast</source>
+        <translation type="unfinished">酵母Yeast</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished">产量Output</translation>
+    </message>
+    <message>
+        <source>Paper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paper size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select available Printers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BtSplashScreen</name>
     <message>
         <source>Loading...</source>
@@ -1957,13 +2052,6 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
-    <name>Measurement::Units</name>
-    <message>
-        <source>min</source>
-        <translation type="obsolete">分钟min</translation>
-    </message>
-</context>
-<context>
     <name>Misc</name>
     <message>
         <source>Spice</source>
@@ -2405,15 +2493,15 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Would you like Brewtarget to transfer your data to the new database? NOTE: If you&apos;ve already loaded the data, say No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please restart Brewtarget to connect to the new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving the options without testing the connection can cause Brewken to not restart.  Your changes have been discarded, which is likely really, really crappy UX.  Please open a bug explaining exactly how you got to this message.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2719,80 +2807,6 @@ Log file may contain more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Detailed (for debugging)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warnings and Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Errors only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not create new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not write to new log file directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> reverting to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Inventory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alpha %</source>
-        <translation type="unfinished">阿尔法Alpha %</translation>
-    </message>
-    <message>
-        <source>No inventory available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open PostgreSQL DB connection to %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open SQLite DB file %1.
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Water</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>kg</source>
         <extracomment>NOTE FOR TRANSLATORS: The abbreviated name of each unit (eg &quot;kg&quot; for kilograms, &quot;g&quot; for grams, etc) must be</extracomment>
         <translation type="unfinished"></translation>
@@ -2955,6 +2969,80 @@ Log file may contain more details.</source>
     </message>
     <message>
         <source>DiastaticPower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Detailed (for debugging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warnings and Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Errors only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not create new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write to new log file directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> reverting to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">阿尔法Alpha %</translation>
+    </message>
+    <message>
+        <source>No inventory available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open PostgreSQL DB connection to %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open SQLite DB file %1.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resource directory &quot;%1&quot; is missing.  Some features will be unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3737,8 +3825,36 @@ The final volume in the primary is %1.</source>
 <context>
     <name>TimerDialog</name>
     <message>
+        <source>Addition Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Addition Time(min):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time Remaining:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Alarm sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop Alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Cancel</source>
-        <translation type="obsolete">取消</translation>
+        <translation type="unfinished">取消</translation>
     </message>
 </context>
 <context>
@@ -3751,12 +3867,56 @@ The final volume in the primary is %1.</source>
 <context>
     <name>TimerMainDialog</name>
     <message>
+        <source>Main Boil Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Start</source>
-        <translation type="obsolete">开始</translation>
+        <translation type="unfinished">开始</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="obsolete">停止</translation>
+        <translation type="unfinished">停止</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Current Recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Timer (mins):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Boil Time Here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit Alarm Ring Time </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alarm Ring Time (secs):</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No Timers</source>
@@ -4202,54 +4362,73 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>ancestorDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">对话Dialog</translation>
+    </message>
+    <message>
+        <source>is an descendant of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>brewDayScrollWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">形式Form</translation>
+        <translation>形式Form</translation>
     </message>
     <message>
         <source>Generate Instructions</source>
-        <translation type="vanished">生成指令</translation>
+        <translation>生成指令</translation>
     </message>
     <message>
         <source>Insert step</source>
-        <translation type="vanished">插入步骤</translation>
+        <translation>插入步骤</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Name of new step</source>
-        <translation type="vanished">新的一步名称</translation>
+        <translation>新的一步名称</translation>
     </message>
     <message>
         <source>Step #</source>
-        <translation type="vanished">步骤＃</translation>
+        <translation>步骤＃</translation>
     </message>
     <message>
         <source>The number where the new step should be placed</source>
-        <translation type="vanished">应放置在新的步骤的数目</translation>
+        <translation>应放置在新的步骤的数目</translation>
     </message>
     <message>
         <source>Insert the new step</source>
-        <translation type="vanished">插入新的一步Insert the new stepyi</translation>
+        <translation>插入新的一步Insert the new stepyi</translation>
     </message>
     <message>
         <source>Move steps</source>
-        <translation type="vanished">移动步骤Move steps</translation>
+        <translation>移动步骤Move steps</translation>
     </message>
     <message>
         <source>Move currently selected step up</source>
-        <translation type="vanished">移动当前选中的加强Move currently selected step up</translation>
+        <translation>移动当前选中的加强Move currently selected step up</translation>
     </message>
     <message>
         <source>Move currently selected step down</source>
-        <translation type="vanished">移动当前选中下台Move currently selected step down</translation>
+        <translation>移动当前选中下台Move currently selected step down</translation>
     </message>
     <message>
         <source>Remove currently selected step</source>
-        <translation type="vanished">删除当前选中的一步Remove currently selected step</translation>
+        <translation>删除当前选中的一步Remove currently selected step</translation>
     </message>
 </context>
 <context>
@@ -4319,27 +4498,27 @@ The final volume in the primary is %1.</source>
     <name>brewNoteWidget</name>
     <message>
         <source>Preboil</source>
-        <translation type="vanished">Preboil</translation>
+        <translation>Preboil</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Preboil gravity</source>
-        <translation type="vanished">Preboil重力Preboil gravity</translation>
+        <translation>Preboil重力Preboil gravity</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">量体积体积Volume</translation>
+        <translation>量体积体积Volume</translation>
     </message>
     <message>
         <source>Volume of wort collected</source>
-        <translation type="vanished">收集的麦芽汁的体积</translation>
+        <translation>收集的麦芽汁的体积</translation>
     </message>
     <message>
         <source>Strike Temp</source>
-        <translation type="vanished">行使温度Strike Temp</translation>
+        <translation>行使温度Strike Temp</translation>
     </message>
     <message>
         <source>Temperature of mash after dough in</source>
@@ -4347,59 +4526,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Final Temp</source>
-        <translation type="vanished">最终温度Final Temp</translation>
+        <translation>最终温度Final Temp</translation>
     </message>
     <message>
         <source>Temperature of mash before mash out</source>
-        <translation type="vanished">混搭出前醪温度</translation>
+        <translation>混搭出前醪温度</translation>
     </message>
     <message>
         <source>Postboil</source>
-        <translation type="vanished">Postboil</translation>
+        <translation>Postboil</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Post boil gravity</source>
-        <translation type="vanished">烧开后重力Post boil gravity</translation>
+        <translation>烧开后重力Post boil gravity</translation>
     </message>
     <message>
         <source>Postboil Volume</source>
-        <translation type="vanished">Postboil体积Postboil Volume</translation>
+        <translation>Postboil体积Postboil Volume</translation>
     </message>
     <message>
         <source>Volume of wort in BK after boil</source>
-        <translation type="vanished">在BK卷麦汁煮沸后Volume of wort in BK after boil</translation>
+        <translation>在BK卷麦汁煮沸后Volume of wort in BK after boil</translation>
     </message>
     <message>
         <source>Volume of wort transferred to fermenter</source>
-        <translation type="vanished">麦汁量转移到发酵Volume of wort transferred to fermenter</translation>
+        <translation>麦汁量转移到发酵Volume of wort transferred to fermenter</translation>
     </message>
     <message>
         <source>Volume into fermenter</source>
-        <translation type="vanished">进入发酵罐的体积Volume into fermenter</translation>
+        <translation>进入发酵罐的体积Volume into fermenter</translation>
     </message>
     <message>
         <source> Pitch Temp</source>
-        <translation type="vanished"> 间距温度 Pitch Temp</translation>
+        <translation> 间距温度 Pitch Temp</translation>
     </message>
     <message>
         <source>Temperature of wort when yeast is pitched</source>
-        <translation type="vanished">麦汁温度时，酵母投Temperature of wort when yeast is pitched</translation>
+        <translation>麦汁温度时，酵母投Temperature of wort when yeast is pitched</translation>
     </message>
     <message>
         <source>Postferment</source>
-        <translation type="vanished">Postferment</translation>
+        <translation>Postferment</translation>
     </message>
     <message>
         <source>Final gravity</source>
-        <translation type="vanished">最后重力</translation>
+        <translation>最后重力</translation>
     </message>
     <message>
         <source>Volume of beer into serving keg/bottles</source>
-        <translation type="vanished">服成桶/瓶啤酒量</translation>
+        <translation>服成桶/瓶啤酒量</translation>
     </message>
     <message>
         <source>Eff into BK</source>
@@ -4411,11 +4590,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Projected OG</source>
-        <translation type="vanished">预计OG</translation>
+        <translation>预计OG</translation>
     </message>
     <message>
         <source>Brewhouse efficiency</source>
-        <translation type="vanished">啤酒厂效率</translation>
+        <translation>啤酒厂效率</translation>
     </message>
     <message>
         <source>Brewhouse Eff</source>
@@ -4427,7 +4606,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Projected ABV</source>
-        <translation type="vanished">预计ABVProjected ABV</translation>
+        <translation>预计ABVProjected ABV</translation>
     </message>
     <message>
         <source>ABV based on FG</source>
@@ -4435,11 +4614,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">说明Notes</translation>
+        <translation>说明Notes</translation>
+    </message>
+    <message>
+        <source>brewNote</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yyyy-dd-MM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature of strike water before dough in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Efficiency into boil kettle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected OG, based on measured FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected ABV based on recipe OG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ABV based on user-reported FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attenuation based on yeast specified in recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Projected yeast attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yeast attentuation based on user-reported OG and FG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured yeast attenuation</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4458,14 +4685,182 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Lauter deadspace</source>
-        <translation type="vanished">纯净的死亡空间Lauter deadspace</translation>
+        <translation>纯净的死亡空间Lauter deadspace</translation>
+    </message>
+    <message>
+        <source>equipmentEditor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equipment Editor</source>
+        <translation type="unfinished">设备编辑器Equipment Editor</translation>
+    </message>
+    <message>
+        <source>Equipment</source>
+        <translation type="unfinished">设备Equipment</translation>
+    </message>
+    <message>
+        <source>Set as Default</source>
+        <translation type="unfinished">设置为默认Set as Default</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-boil Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">批次大小Batch Size</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>batchSize_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished">时间Time</translation>
+    </message>
+    <message>
+        <source>Calculate pre-boil volume</source>
+        <translation type="unfinished">计算预熬音量Calculate pre-boil volume</translation>
+    </message>
+    <message>
+        <source>Boil time</source>
+        <translation type="unfinished">煮沸时间Boil time</translation>
+    </message>
+    <message>
+        <source>Evaporation rate (per hr)</source>
+        <translation type="unfinished">蒸发率（每小时）Evaporation rate (per hr)</translation>
+    </message>
+    <message>
+        <source>evapRate_lHr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Final top-up water</source>
+        <translation type="unfinished">最终补足水Final top-up water</translation>
+    </message>
+    <message>
+        <source>topUpWater_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle top-up water</source>
+        <translation type="unfinished">水壶补足水Kettle top-up water</translation>
+    </message>
+    <message>
+        <source>topUpKettle_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Kettle to Fermenter Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>trubChillerLoss_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lauterDeadspace_l</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Physics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Absorption</source>
+        <translation type="unfinished">默认吸收</translation>
+    </message>
+    <message>
+        <source>Grain absorption (L/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hop % Utilization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>grainAbsorption_LKg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Boiling Point of Water</source>
+        <translation type="unfinished">水的沸点</translation>
+    </message>
+    <message>
+        <source>Mash tun Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash tun Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of mash tun</source>
+        <translation type="unfinished">糖化桶体积</translation>
+    </message>
+    <message>
+        <source>hopUtilization_pct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>boilingPoint_c</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunWeight_kg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specific Heat (Cal/(g*C))</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>tunSpecificHeat_calGC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">说明Notes</translation>
+    </message>
+    <message>
+        <source>New equipment</source>
+        <translation type="unfinished">新设备New equipment</translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>fermentableEditor</name>
     <message>
         <source>Fermentable Editor</source>
-        <translation type="vanished">可发酵的编辑Fermentable Editor</translation>
+        <translation>可发酵的编辑Fermentable Editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4473,31 +4868,31 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">类型Type</translation>
+        <translation>类型Type</translation>
     </message>
     <message>
         <source>Grain</source>
-        <translation type="vanished">粮食</translation>
+        <translation>粮食</translation>
     </message>
     <message>
         <source>Sugar</source>
-        <translation type="vanished">糖</translation>
+        <translation>糖</translation>
     </message>
     <message>
         <source>Extract</source>
-        <translation type="vanished">提取</translation>
+        <translation>提取</translation>
     </message>
     <message>
         <source>Dry Extract</source>
-        <translation type="vanished">干浸膏Dry Extract</translation>
+        <translation>干浸膏Dry Extract</translation>
     </message>
     <message>
         <source>Adjunct</source>
-        <translation type="vanished">附属物</translation>
+        <translation>附属物</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4509,43 +4904,43 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Yield as compared to glucose</source>
-        <translation type="vanished">良品率相比为葡萄糖Yield as compared to glucose</translation>
+        <translation>良品率相比为葡萄糖Yield as compared to glucose</translation>
     </message>
     <message>
         <source>Lovibond rating</source>
-        <translation type="vanished">罗维朋评级Lovibond rating</translation>
+        <translation>罗维朋评级Lovibond rating</translation>
     </message>
     <message>
         <source>Add After Boil</source>
-        <translation type="vanished">开锅后加入Add After Boil</translation>
+        <translation>开锅后加入Add After Boil</translation>
     </message>
     <message>
         <source>This ingredient is added post boil.</source>
-        <translation type="vanished">这种成分加入后烧开。This ingredient is added post boil.</translation>
+        <translation>这种成分加入后烧开。This ingredient is added post boil.</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">来源Origin</translation>
+        <translation>来源Origin</translation>
     </message>
     <message>
         <source>Supplier</source>
-        <translation type="vanished">提供者Supplier</translation>
+        <translation>提供者Supplier</translation>
     </message>
     <message>
         <source>Coarse/Fine Diff (%)</source>
-        <translation type="vanished">粗/细变化（％）Coarse/Fine Diff (%)</translation>
+        <translation>粗/细变化（％）Coarse/Fine Diff (%)</translation>
     </message>
     <message>
         <source>Yield difference between coarse and fine grind</source>
-        <translation type="vanished">粗，细研磨的产量之间的差异Yield difference between coarse and fine grind</translation>
+        <translation>粗，细研磨的产量之间的差异Yield difference between coarse and fine grind</translation>
     </message>
     <message>
         <source>Moisture (%)</source>
-        <translation type="vanished">水分（％）Moisture (%)</translation>
+        <translation>水分（％）Moisture (%)</translation>
     </message>
     <message>
         <source>Moisture percentage by mass</source>
-        <translation type="vanished">水分的质量百分比Moisture percentage by mass</translation>
+        <translation>水分的质量百分比Moisture percentage by mass</translation>
     </message>
     <message>
         <source>DP (Lintner)</source>
@@ -4557,58 +4952,114 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Protein (%)</source>
-        <translation type="vanished">蛋白质（％）Protein (%)</translation>
+        <translation>蛋白质（％）Protein (%)</translation>
     </message>
     <message>
         <source>Protein percentage by mass</source>
-        <translation type="vanished">蛋白质的质量百分比Protein percentage by mass</translation>
+        <translation>蛋白质的质量百分比Protein percentage by mass</translation>
     </message>
     <message>
         <source>Max In Batch (%)</source>
-        <translation type="vanished">最大批量（％）Max In Batch (%)</translation>
+        <translation>最大批量（％）Max In Batch (%)</translation>
     </message>
     <message>
         <source>Maximum recommended percentage of total grist</source>
-        <translation type="vanished">推荐的最大百分比总谷物Maximum recommended percentage of total grist</translation>
+        <translation>推荐的最大百分比总谷物Maximum recommended percentage of total grist</translation>
     </message>
     <message>
         <source>Recommend Mash</source>
-        <translation type="vanished">推荐醪Recommend Mash</translation>
+        <translation>推荐醪Recommend Mash</translation>
     </message>
     <message>
         <source>Recommend this be mashed</source>
-        <translation type="vanished">推荐这捣碎Recommend this be mashed</translation>
+        <translation>推荐这捣碎Recommend this be mashed</translation>
     </message>
     <message>
         <source>Is Mashed</source>
-        <translation type="vanished">捣碎Is Mashed</translation>
+        <translation>捣碎Is Mashed</translation>
     </message>
     <message>
         <source>Checked if it is present in mash</source>
-        <translation type="vanished">检查，如果它是存在于麦芽浆中Checked if it is present in mash</translation>
+        <translation>检查，如果它是存在于麦芽浆中Checked if it is present in mash</translation>
     </message>
     <message>
         <source>Bitterness (IBU*gal/lb)</source>
-        <translation type="vanished">苦味（IBU加仑/磅）苦（IBU *加仑/磅）</translation>
+        <translation>苦味（IBU加仑/磅）苦（IBU *加仑/磅）</translation>
     </message>
     <message>
         <source>Bitterness of pre-hopped extracts</source>
-        <translation type="vanished">预跳上提取的苦味Bitterness of pre-hopped extracts</translation>
+        <translation>预跳上提取的苦味Bitterness of pre-hopped extracts</translation>
     </message>
     <message>
         <source>Notes:</source>
         <translation type="vanished">附注：Notes:</translation>
     </message>
     <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Color</source>
-        <translation type="vanished">颜色Color</translation>
+        <translation>颜色Color</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yield %</source>
+        <translation type="unfinished">率％</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">额外Extras</translation>
+    </message>
+    <message>
+        <source>origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>supplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">说明Notes</translation>
+    </message>
+    <message>
+        <source>New fermentable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>hopEditor</name>
     <message>
         <source>Hop Editor</source>
-        <translation type="vanished">跳编辑Hop Editor</translation>
+        <translation>跳编辑Hop Editor</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -4616,7 +5067,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Alpha (%)</source>
@@ -4624,7 +5075,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Alpha acids as percent by mass</source>
-        <translation type="vanished">α-酸为质量百分比Alpha acids as percent by mass</translation>
+        <translation>α-酸为质量百分比Alpha acids as percent by mass</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -4632,59 +5083,59 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">使用Use</translation>
+        <translation>使用Use</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">糖化Mash</translation>
+        <translation>糖化Mash</translation>
     </message>
     <message>
         <source>First Wort</source>
-        <translation type="vanished">第一次麦芽汁First Wort</translation>
+        <translation>第一次麦芽汁First Wort</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">熬Boil</translation>
+        <translation>熬Boil</translation>
     </message>
     <message>
         <source>Aroma</source>
-        <translation type="vanished">香气</translation>
+        <translation>香气</translation>
     </message>
     <message>
         <source>Dry Hop</source>
-        <translation type="vanished">干合Dry Hop</translation>
+        <translation>干合Dry Hop</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">时间Time</translation>
+        <translation>时间Time</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">类型Type</translation>
+        <translation>类型Type</translation>
     </message>
     <message>
         <source>Bittering</source>
-        <translation type="vanished">苦味	 Bittering</translation>
+        <translation>苦味	 Bittering</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="vanished">两Both</translation>
+        <translation>两Both</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">形式Form</translation>
+        <translation>形式Form</translation>
     </message>
     <message>
         <source>Leaf</source>
-        <translation type="vanished">叶Leaf</translation>
+        <translation>叶Leaf</translation>
     </message>
     <message>
         <source>Pellet</source>
-        <translation type="vanished">丸Pellet</translation>
+        <translation>丸Pellet</translation>
     </message>
     <message>
         <source>Plug</source>
-        <translation type="vanished">插头Plug</translation>
+        <translation>插头Plug</translation>
     </message>
     <message>
         <source>Beta (%)</source>
@@ -4692,19 +5143,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Beta acids as percent by mass</source>
-        <translation type="vanished">β氨基酸为质量百分比Beta acids as percent by mass</translation>
+        <translation>β氨基酸为质量百分比Beta acids as percent by mass</translation>
     </message>
     <message>
         <source>HSI</source>
-        <translation type="vanished">溪HSI</translation>
+        <translation>溪HSI</translation>
     </message>
     <message>
         <source>Hop Stability/Storage index</source>
-        <translation type="vanished">啤酒花稳定/存储索引Hop Stability/Storage index</translation>
+        <translation>啤酒花稳定/存储索引Hop Stability/Storage index</translation>
     </message>
     <message>
         <source>Origin</source>
-        <translation type="vanished">来源Origin</translation>
+        <translation>来源Origin</translation>
     </message>
     <message>
         <source>Humulene (%)</source>
@@ -4712,7 +5163,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Humulene</source>
-        <translation type="vanished">蛇麻烯Humulene</translation>
+        <translation>蛇麻烯Humulene</translation>
     </message>
     <message>
         <source>Caryophyllene (%)</source>
@@ -4728,7 +5179,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Cohumulone</source>
-        <translation type="vanished">草酮Cohumulone</translation>
+        <translation>草酮Cohumulone</translation>
     </message>
     <message>
         <source>Myrcene (%)</source>
@@ -4736,7 +5187,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Myrcene</source>
-        <translation type="vanished">月桂烯Myrcene</translation>
+        <translation>月桂烯Myrcene</translation>
     </message>
     <message>
         <source>Substitutes:</source>
@@ -4746,59 +5197,123 @@ The final volume in the primary is %1.</source>
         <source>Notes:</source>
         <translation type="vanished">附注：Notes:</translation>
     </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alpha %</source>
+        <translation type="unfinished">阿尔法Alpha %</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">额外Extras</translation>
+    </message>
+    <message>
+        <source>Cohumulone %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Myrcene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beta %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humulene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Caryophyllene %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Substitutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">说明Notes</translation>
+    </message>
+    <message>
+        <source>New hop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">形式Form</translation>
+        <translation>形式Form</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation type="vanished">显示一个计时器Show a timer</translation>
+        <translation>显示一个计时器Show a timer</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation type="vanished">显示计时器Show timer</translation>
+        <translation>显示计时器Show timer</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation type="vanished">标记完成这一步Mark this step completed</translation>
+        <translation>标记完成这一步Mark this step completed</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation type="vanished">步骤完成Step completed</translation>
+        <translation>步骤完成Step completed</translation>
     </message>
 </context>
 <context>
     <name>mainWindow</name>
     <message>
         <source>Recipes</source>
-        <translation type="vanished">Recipes食谱</translation>
+        <translation>Recipes食谱</translation>
     </message>
     <message>
         <source>Styles</source>
-        <translation type="vanished">样式Styles</translation>
+        <translation>样式Styles</translation>
     </message>
     <message>
         <source>Fermentables</source>
-        <translation type="vanished">发酵物Fermentables</translation>
+        <translation>发酵物Fermentables</translation>
     </message>
     <message>
         <source>Hops</source>
-        <translation type="vanished">酒花Hops</translation>
+        <translation>酒花Hops</translation>
     </message>
     <message>
         <source>Miscs</source>
-        <translation type="vanished">Miscs</translation>
+        <translation>Miscs</translation>
     </message>
     <message>
         <source>Yeasts</source>
-        <translation type="vanished">酵母菌Yeasts</translation>
+        <translation>酵母菌Yeasts</translation>
     </message>
     <message>
         <source>Recipe</source>
-        <translation type="vanished">食谱</translation>
+        <translation>食谱</translation>
     </message>
     <message>
         <source>Name</source>
@@ -4806,11 +5321,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name of recipe</source>
-        <translation type="vanished">配方名称Name of recipe</translation>
+        <translation>配方名称Name of recipe</translation>
     </message>
     <message>
         <source>Target boil size</source>
-        <translation type="vanished">目标熬大小的Target boil size</translation>
+        <translation>目标熬大小的Target boil size</translation>
     </message>
     <message>
         <source>Efficiency (%)</source>
@@ -4826,7 +5341,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>The extraction efficiency you expect</source>
-        <translation type="vanished">你期望的萃取效率The extraction efficiency you expect</translation>
+        <translation>你期望的萃取效率The extraction efficiency you expect</translation>
     </message>
     <message>
         <source>Style</source>
@@ -4838,7 +5353,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Target batch size</source>
-        <translation type="vanished">目标批量大小</translation>
+        <translation>目标批量大小</translation>
     </message>
     <message>
         <source>Target Batch Size</source>
@@ -4846,7 +5361,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Equipment</source>
-        <translation type="vanished">设备Equipment</translation>
+        <translation>设备Equipment</translation>
     </message>
     <message>
         <source>Target Boil Size</source>
@@ -4854,163 +5369,163 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>Boil SG</source>
-        <translation type="vanished">煮SGBoil SG</translation>
+        <translation>煮SGBoil SG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>Bitterness (IBU)</source>
-        <translation type="vanished">苦味（IBU）</translation>
+        <translation>苦味（IBU）</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">颜色Color</translation>
+        <translation>颜色Color</translation>
     </message>
     <message>
         <source>IBU/GU</source>
-        <translation type="vanished">IBU/GU</translation>
+        <translation>IBU/GU</translation>
     </message>
     <message>
         <source>Calories/12oz</source>
-        <translation type="vanished">卡路里/ 12盎司Calories/12oz</translation>
+        <translation>卡路里/ 12盎司Calories/12oz</translation>
     </message>
     <message>
         <source>Extras</source>
-        <translation type="vanished">额外Extras</translation>
+        <translation>额外Extras</translation>
     </message>
     <message>
         <source>Brewday</source>
-        <translation type="vanished">Brewday</translation>
+        <translation>Brewday</translation>
     </message>
     <message>
         <source>Add a fermentable</source>
-        <translation type="vanished">添加一个可发酵Add a fermentable</translation>
+        <translation>添加一个可发酵Add a fermentable</translation>
     </message>
     <message>
         <source>Remove selected fermentable</source>
-        <translation type="vanished">删除选定的发酵Remove selected fermentable</translation>
+        <translation>删除选定的发酵Remove selected fermentable</translation>
     </message>
     <message>
         <source>Edit selected fermentable</source>
-        <translation type="vanished">编辑选定的可发酵Edit selected fermentable</translation>
+        <translation>编辑选定的可发酵Edit selected fermentable</translation>
     </message>
     <message>
         <source>Add hop</source>
-        <translation type="vanished">添加酒花Add hop</translation>
+        <translation>添加酒花Add hop</translation>
     </message>
     <message>
         <source>Remove selected hop</source>
-        <translation type="vanished">删除选定的跳Remove selected hop</translation>
+        <translation>删除选定的跳Remove selected hop</translation>
     </message>
     <message>
         <source>Edit selected hop</source>
-        <translation type="vanished">编辑选择Edit selected hop</translation>
+        <translation>编辑选择Edit selected hop</translation>
     </message>
     <message>
         <source>Miscellaneous</source>
-        <translation type="vanished">杂项Miscellaneous</translation>
+        <translation>杂项Miscellaneous</translation>
     </message>
     <message>
         <source>Add misc</source>
-        <translation type="vanished">添加杂项Add misc</translation>
+        <translation>添加杂项Add misc</translation>
     </message>
     <message>
         <source>Remove selected misc</source>
-        <translation type="vanished">移动选定杂项Remove selected misc</translation>
+        <translation>移动选定杂项Remove selected misc</translation>
     </message>
     <message>
         <source>Edit selected misc</source>
-        <translation type="vanished">编辑选定的杂项Edit selected misc</translation>
+        <translation>编辑选定的杂项Edit selected misc</translation>
     </message>
     <message>
         <source>Yeast</source>
-        <translation type="vanished">酵母Yeast</translation>
+        <translation>酵母Yeast</translation>
     </message>
     <message>
         <source>Add yeast</source>
-        <translation type="vanished">添加酵母Add yeast</translation>
+        <translation>添加酵母Add yeast</translation>
     </message>
     <message>
         <source>Remove selected yeast</source>
-        <translation type="vanished">删除选定的酵母Remove selected yeast</translation>
+        <translation>删除选定的酵母Remove selected yeast</translation>
     </message>
     <message>
         <source>Edit selected yeast</source>
-        <translation type="vanished">编辑选择的酵母Edit selected yeast</translation>
+        <translation>编辑选择的酵母Edit selected yeast</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">糖化Mash</translation>
+        <translation>糖化Mash</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">添加醪步骤“Add mash step</translation>
+        <translation>添加醪步骤“Add mash step</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">删除选定的醪步骤</translation>
+        <translation>删除选定的醪步骤</translation>
     </message>
     <message>
         <source>Edit selected mash step</source>
-        <translation type="vanished">编辑选定的醪步骤“</translation>
+        <translation>编辑选定的醪步骤“</translation>
     </message>
     <message>
         <source>Edit mash properties</source>
-        <translation type="vanished">编辑捣烂属性Edit mash properties</translation>
+        <translation>编辑捣烂属性Edit mash properties</translation>
     </message>
     <message>
         <source>Edit mash</source>
-        <translation type="vanished">编辑捣烂编辑捣烂</translation>
+        <translation>编辑捣烂编辑捣烂</translation>
     </message>
     <message>
         <source>Mash Des</source>
-        <translation type="vanished">醪DESMash Des</translation>
+        <translation>醪DESMash Des</translation>
     </message>
     <message>
         <source>Invoke the mash wizard</source>
-        <translation type="vanished">调用捣烂向导Invoke the mash wizard</translation>
+        <translation>调用捣烂向导Invoke the mash wizard</translation>
     </message>
     <message>
         <source>Mash wiz</source>
-        <translation type="vanished">醪WIZMash wiz</translation>
+        <translation>醪WIZMash wiz</translation>
     </message>
     <message>
         <source>Mashs</source>
-        <translation type="vanished">Mashs</translation>
+        <translation>Mashs</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">糖化加强Mash step up</translation>
+        <translation>糖化加强Mash step up</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">糖化下台Mash step down</translation>
+        <translation>糖化下台Mash step down</translation>
     </message>
     <message>
         <source>Save this mash profile</source>
-        <translation type="vanished">保存此捣烂文件Save this mash profile</translation>
+        <translation>保存此捣烂文件Save this mash profile</translation>
     </message>
     <message>
         <source>Save Mash</source>
-        <translation type="vanished">保存醪Save Mash</translation>
+        <translation>保存醪Save Mash</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="vanished">关于(&amp;A)</translation>
+        <translation>关于(&amp;A)</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">文件(&amp;F)</translation>
+        <translation>文件(&amp;F)</translation>
     </message>
     <message>
         <source>&amp;Brewday</source>
@@ -5022,27 +5537,27 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Database</source>
-        <translation type="vanished">和数据库&amp;Database</translation>
+        <translation>和数据库&amp;Database</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">查看(&amp;V)</translation>
+        <translation>查看(&amp;V)</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation type="vanished">&amp;工具</translation>
+        <translation>&amp;工具</translation>
     </message>
     <message>
         <source>toolBar</source>
-        <translation type="vanished">工具栏toolBar</translation>
+        <translation>工具栏toolBar</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation type="vanished">关于BrewTargetAbout &amp;BrewTarget</translation>
+        <translation>关于BrewTargetAbout &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
-        <translation type="vanished">关于BrewtargetAbout Brewtarget</translation>
+        <translation>关于BrewtargetAbout Brewtarget</translation>
     </message>
     <message>
         <source>&amp;Export Recipe</source>
@@ -5050,19 +5565,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Fermentables</source>
-        <translation type="vanished">发酵物&amp;Fermentables</translation>
+        <translation>发酵物&amp;Fermentables</translation>
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation type="vanished">按Ctrl+ FCtrl+F</translation>
+        <translation>按Ctrl+ FCtrl+F</translation>
     </message>
     <message>
         <source>&amp;Hops</source>
-        <translation type="vanished">啤酒花&amp;Hops</translation>
+        <translation>啤酒花&amp;Hops</translation>
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation type="vanished">按Ctrl+ HCtrl+H</translation>
+        <translation>按Ctrl+ HCtrl+H</translation>
     </message>
     <message>
         <source>&amp;Miscs</source>
@@ -5070,31 +5585,31 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation type="vanished">按Ctrl+ MCtrl+M</translation>
+        <translation>按Ctrl+ MCtrl+M</translation>
     </message>
     <message>
         <source>&amp;Yeasts</source>
-        <translation type="vanished">酵母菌&amp;Yeasts</translation>
+        <translation>酵母菌&amp;Yeasts</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="vanished">按CTRL + Y</translation>
+        <translation>按CTRL + Y</translation>
     </message>
     <message>
         <source>&amp;Equipments</source>
-        <translation type="vanished">及设备</translation>
+        <translation>及设备</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation type="vanished">按Ctrl + E键</translation>
+        <translation>按Ctrl + E键</translation>
     </message>
     <message>
         <source>&amp;Styles</source>
-        <translation type="vanished">与样式</translation>
+        <translation>与样式</translation>
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation type="vanished">按Ctrl + T键</translation>
+        <translation>按Ctrl + T键</translation>
     </message>
     <message>
         <source>&amp;Exit</source>
@@ -5102,7 +5617,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Ctrl+Q</source>
-        <translation type="vanished">按Ctrl + Q</translation>
+        <translation>按Ctrl + Q</translation>
     </message>
     <message>
         <source>&amp;Import Recipes</source>
@@ -5114,55 +5629,55 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Manual</source>
-        <translation type="vanished">手动</translation>
+        <translation>手动</translation>
     </message>
     <message>
         <source>&amp;Scale Recipe</source>
-        <translation type="vanished">和规模配方</translation>
+        <translation>和规模配方</translation>
     </message>
     <message>
         <source>Recipe to Clipboard as &amp;Text</source>
-        <translation type="vanished">配方和文字到剪贴板</translation>
+        <translation>配方和文字到剪贴板</translation>
     </message>
     <message>
         <source>&amp;OG Correction Help</source>
-        <translation type="vanished">与OG校正帮助</translation>
+        <translation>与OG校正帮助</translation>
     </message>
     <message>
         <source>&amp;Convert Units</source>
-        <translation type="vanished">与转换单位</translation>
+        <translation>与转换单位</translation>
     </message>
     <message>
         <source>Backup Database</source>
-        <translation type="vanished">备份数据库Backup Database</translation>
+        <translation>备份数据库Backup Database</translation>
     </message>
     <message>
         <source>Restore Database</source>
-        <translation type="vanished">还原数据库</translation>
+        <translation>还原数据库</translation>
     </message>
     <message>
         <source>&amp;Copy Recipe</source>
-        <translation type="vanished">复制配方</translation>
+        <translation>复制配方</translation>
     </message>
     <message>
         <source>Pr&amp;iming Calculator</source>
-        <translation type="vanished">公关及即时通信计算器Pr&amp;iming Calculator</translation>
+        <translation>公关及即时通信计算器Pr&amp;iming Calculator</translation>
     </message>
     <message>
         <source>&amp;Refractometer Tools</source>
-        <translation type="vanished">折射工具</translation>
+        <translation>折射工具</translation>
     </message>
     <message>
         <source>&amp;Pitch Rate Calculator</source>
-        <translation type="vanished">间距率计算器</translation>
+        <translation>间距率计算器</translation>
     </message>
     <message>
         <source>Merge Databases</source>
-        <translation type="vanished">合并数据库</translation>
+        <translation>合并数据库</translation>
     </message>
     <message>
         <source>Select another database to merge into the current one.</source>
-        <translation type="vanished">选择另一个数据库合并到当前。</translation>
+        <translation>选择另一个数据库合并到当前。</translation>
     </message>
     <message>
         <source>&amp;Print</source>
@@ -5182,19 +5697,19 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;Backup</source>
-        <translation type="vanished">与备份</translation>
+        <translation>与备份</translation>
     </message>
     <message>
         <source>Save all recipes, ingredients, etc. to a backup folder</source>
-        <translation type="vanished">所有的配方，配料等保存到备份文件夹</translation>
+        <translation>所有的配方，配料等保存到备份文件夹</translation>
     </message>
     <message>
         <source>&amp;Restore</source>
-        <translation type="vanished">和恢复</translation>
+        <translation>和恢复</translation>
     </message>
     <message>
         <source>Restore recipes, ingredients, etc. from a previous backup</source>
-        <translation type="vanished">恢复配方，配料，从以前的备份等</translation>
+        <translation>恢复配方，配料，从以前的备份等</translation>
     </message>
     <message>
         <source>&amp;Merge</source>
@@ -5206,7 +5721,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>&amp;New Recipe</source>
-        <translation type="vanished">新配方&amp;New Recipe</translation>
+        <translation>新配方&amp;New Recipe</translation>
     </message>
     <message>
         <source>Timers</source>
@@ -5214,38 +5729,158 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Show timers</source>
-        <translation type="vanished">显示计时器Show timers</translation>
+        <translation>显示计时器Show timers</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">节省Save</translation>
+        <translation>节省Save</translation>
     </message>
     <message>
         <source>Delete selected</source>
-        <translation type="vanished">删除选定的Delete selected</translation>
+        <translation>删除选定的Delete selected</translation>
     </message>
     <message>
         <source>Delete recipe</source>
-        <translation type="vanished">删除配方Delete recipe</translation>
+        <translation>删除配方Delete recipe</translation>
     </message>
     <message>
         <source>&amp;Mashs</source>
-        <translation type="vanished">&amp;Mashs</translation>
+        <translation>&amp;Mashs</translation>
     </message>
     <message>
         <source>Mashes</source>
-        <translation type="vanished">捣烂Mashes</translation>
+        <translation>捣烂Mashes</translation>
     </message>
     <message>
         <source>1.0</source>
-        <translation type="vanished">1.0</translation>
+        <translation>1.0</translation>
+    </message>
+    <message>
+        <source>tab_recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to &amp;BBCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Boil Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;quipment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get Boil Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Batch Si&amp;ze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Efficiency (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Size</source>
+        <translation type="unfinished">批次大小Batch Size</translation>
+    </message>
+    <message>
+        <source>Boil Size</source>
+        <translation type="unfinished">煮沸尺寸Boil Size</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Export to File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;iscs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Print and preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Import from File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optio&amp;ns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ti&amp;mers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strike &amp;Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Hydrometer Temp Adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alcohol Percentage Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Water &amp;Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ancestors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brew It!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashDesigner</name>
     <message>
         <source>Mash Designer</source>
-        <translation type="vanished">混搭设计Mash Designer</translation>
+        <translation>混搭设计Mash Designer</translation>
     </message>
     <message>
         <source>Name</source>
@@ -5261,7 +5896,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">时间Time</translation>
+        <translation>时间Time</translation>
     </message>
     <message>
         <source>Batch Sparge</source>
@@ -5269,275 +5904,311 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Next</source>
-        <translation type="vanished">下一步</translation>
+        <translation>下一步</translation>
     </message>
     <message>
         <source>Finish</source>
-        <translation type="vanished">完成Finish</translation>
+        <translation>完成Finish</translation>
     </message>
     <message>
         <source>Infusion/Decoction Amount</source>
-        <translation type="vanished">输液/汤量Infusion/Decoction Amount</translation>
+        <translation>输液/汤量Infusion/Decoction Amount</translation>
     </message>
     <message>
         <source>min</source>
-        <translation type="vanished">分钟min</translation>
+        <translation>分钟min</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="vanished">最大max</translation>
+        <translation>最大max</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="vanished">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Infusion Temp</source>
-        <translation type="vanished">灌注温度Infusion Temp</translation>
+        <translation>灌注温度Infusion Temp</translation>
     </message>
     <message>
         <source>Total Collected Wort</source>
-        <translation type="vanished">总收集麦芽汁Total Collected Wort</translation>
+        <translation>总收集麦芽汁Total Collected Wort</translation>
     </message>
     <message>
         <source>vol</source>
-        <translation type="vanished">卷vol</translation>
+        <translation>卷vol</translation>
     </message>
     <message>
         <source>Tun Fullness</source>
-        <translation type="vanished">桶丰满Tun Fullness</translation>
+        <translation>桶丰满Tun Fullness</translation>
     </message>
     <message>
         <source>tunVol</source>
-        <translation type="vanished">tunVol</translation>
+        <translation>tunVol</translation>
     </message>
     <message>
         <source>thickness</source>
-        <translation type="vanished">厚度thickness</translation>
+        <translation>厚度thickness</translation>
+    </message>
+    <message>
+        <source>&amp;Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tar&amp;get temp.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mashEditor</name>
     <message>
         <source>Mash Editor</source>
-        <translation type="vanished">混搭编辑器Mash Editor</translation>
+        <translation>混搭编辑器Mash Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">初始晶粒温度Initial grain temp</translation>
+        <translation>初始晶粒温度Initial grain temp</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">吹扫温度Sparge temp</translation>
+        <translation>吹扫温度Sparge temp</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">吹扫温度目标Sparge temp target</translation>
+        <translation>吹扫温度目标Sparge temp target</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">喷雾pHSparge pH</translation>
+        <translation>喷雾pHSparge pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">说明Notes</translation>
+        <translation>说明Notes</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">桶Tun</translation>
+        <translation>桶Tun</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">初始桶温度Initial tun temp</translation>
+        <translation>初始桶温度Initial tun temp</translation>
     </message>
     <message>
         <source>Get following parameters from the recipe&apos;s equipment.</source>
-        <translation type="vanished">以下参数配方的设备。Get following parameters from the recipe&apos;s equipment.</translation>
+        <translation>以下参数配方的设备。Get following parameters from the recipe&apos;s equipment.</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">设备From Equipment</translation>
+        <translation>设备From Equipment</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">桶质量Tun mass</translation>
+        <translation>桶质量Tun mass</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">桶sp热Tun sp. heat</translation>
+        <translation>桶sp热Tun sp. heat</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">桶比热(cal /(g * K))Tun specific heat (cal/(g*K))</translation>
+        <translation>桶比热(cal /(g * K))Tun specific heat (cal/(g*K))</translation>
     </message>
 </context>
 <context>
     <name>mashStepEditor</name>
     <message>
         <source>Mash Step Editor</source>
-        <translation type="vanished">麦芽浆步骤编辑Mash Step Editor</translation>
+        <translation>麦芽浆步骤编辑Mash Step Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">类型Type</translation>
+        <translation>类型Type</translation>
     </message>
     <message>
         <source>Infusion</source>
-        <translation type="vanished">注入Infusion</translation>
+        <translation>注入Infusion</translation>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">温度</translation>
+        <translation>温度</translation>
     </message>
     <message>
         <source>Decoction</source>
-        <translation type="vanished">煎煮Decoction</translation>
+        <translation>煎煮Decoction</translation>
     </message>
     <message>
         <source>Target temp.</source>
-        <translation type="vanished">目标温度。Target temp.</translation>
+        <translation>目标温度。Target temp.</translation>
     </message>
     <message>
         <source>Target temp. of this step</source>
-        <translation type="vanished">目标温度Target temp. of this step</translation>
+        <translation>目标温度Target temp. of this step</translation>
     </message>
     <message>
         <source>Infuse Amount</source>
-        <translation type="vanished">注入量Infuse Amount</translation>
+        <translation>注入量Infuse Amount</translation>
     </message>
     <message>
         <source>Amount of water to infuse</source>
-        <translation type="vanished">量的水注入Amount of water to infuse</translation>
+        <translation>量的水注入Amount of water to infuse</translation>
     </message>
     <message>
         <source>Infuse temp.</source>
-        <translation type="vanished">注入温度。Infuse temp.</translation>
+        <translation>注入温度。Infuse temp.</translation>
     </message>
     <message>
         <source>Temperature of infusion water</source>
-        <translation type="vanished">注入水的温度Temperature of infusion water</translation>
+        <translation>注入水的温度Temperature of infusion water</translation>
     </message>
     <message>
         <source>Decoction Amount</source>
-        <translation type="vanished">汤量Decoction Amount</translation>
+        <translation>汤量Decoction Amount</translation>
     </message>
     <message>
         <source>Amount of mash to decoct</source>
-        <translation type="vanished">数量的麦芽浆来煎Amount of mash to decoct</translation>
+        <translation>数量的麦芽浆来煎Amount of mash to decoct</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">时间Time</translation>
+        <translation>时间Time</translation>
     </message>
     <message>
         <source>Time to conduct the step</source>
-        <translation type="vanished">时间进行的步骤Time to conduct the step</translation>
+        <translation>时间进行的步骤Time to conduct the step</translation>
     </message>
     <message>
         <source>Temp. lag time</source>
-        <translation type="vanished">临时滞后时间Temp. lag time</translation>
+        <translation>临时滞后时间Temp. lag time</translation>
     </message>
     <message>
         <source>Lag time</source>
-        <translation type="vanished">滞后时间Lag time</translation>
+        <translation>滞后时间Lag time</translation>
     </message>
     <message>
         <source>End temp.</source>
-        <translation type="vanished">结束临时End temp.</translation>
+        <translation>结束临时End temp.</translation>
     </message>
     <message>
         <source>Final temp. of this step</source>
-        <translation type="vanished">最后这一步的临时工Final temp. of this step</translation>
+        <translation>最后这一步的临时工Final temp. of this step</translation>
+    </message>
+    <message>
+        <source>Fly Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batch Sparge</source>
+        <translation type="unfinished">批喷雾Batch Sparge</translation>
     </message>
 </context>
 <context>
     <name>mashWizard</name>
     <message>
         <source>Mash Wizard</source>
-        <translation type="vanished">糖化向导Mash Wizard</translation>
+        <translation>糖化向导Mash Wizard</translation>
     </message>
     <message>
         <source>Mash thickness (L/kg)</source>
-        <translation type="vanished">麦芽浆厚度(L /公斤)Mash thickness (L/kg)</translation>
+        <translation>麦芽浆厚度(L /公斤)Mash thickness (L/kg)</translation>
     </message>
     <message>
         <source>Mash thickness (do not enter any units)</source>
         <translation type="vanished">麦芽浆厚度(不输入任何单位)Mash thickness (do not enter any units)</translation>
+    </message>
+    <message>
+        <source>No Spar&amp;ge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fl&amp;y Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ba&amp;tch Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Batches</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>miscEditor</name>
     <message>
         <source>Misc Editor</source>
-        <translation type="vanished">其他编辑器</translation>
+        <translation>其他编辑器</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">类型Type</translation>
+        <translation>类型Type</translation>
     </message>
     <message>
         <source>Spice</source>
-        <translation type="vanished">香料Spice</translation>
+        <translation>香料Spice</translation>
     </message>
     <message>
         <source>Fining</source>
-        <translation type="vanished">罚款Fining</translation>
+        <translation>罚款Fining</translation>
     </message>
     <message>
         <source>Water Agent</source>
-        <translation type="vanished">水剂Water Agent</translation>
+        <translation>水剂Water Agent</translation>
     </message>
     <message>
         <source>Herb</source>
-        <translation type="vanished">草本植物Herb</translation>
+        <translation>草本植物Herb</translation>
     </message>
     <message>
         <source>Flavor</source>
-        <translation type="vanished">味Flavor</translation>
+        <translation>味Flavor</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="vanished">其他</translation>
+        <translation>其他</translation>
     </message>
     <message>
         <source>Use</source>
-        <translation type="vanished">使用Use</translation>
+        <translation>使用Use</translation>
     </message>
     <message>
         <source>Boil</source>
-        <translation type="vanished">熬Boil</translation>
+        <translation>熬Boil</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">糖化Mash</translation>
+        <translation>糖化Mash</translation>
     </message>
     <message>
         <source>Primary</source>
-        <translation type="vanished">主要</translation>
+        <translation>主要</translation>
     </message>
     <message>
         <source>Secondary</source>
-        <translation type="vanished">次要Secondary</translation>
+        <translation>次要Secondary</translation>
     </message>
     <message>
         <source>Bottling</source>
-        <translation type="vanished">装瓶</translation>
+        <translation>装瓶</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="vanished">时间Time</translation>
+        <translation>时间Time</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -5545,15 +6216,15 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Check it if the amount listed is in kg instead of L.</source>
-        <translation type="vanished">检查如果上市量（公斤）代替L。</translation>
+        <translation>检查如果上市量（公斤）代替L。</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">金额重量？Amount is weight?</translation>
+        <translation>金额重量？Amount is weight?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">检查，如果给定的量是重量，而不是数量</translation>
+        <translation>检查，如果给定的量是重量，而不是数量</translation>
     </message>
     <message>
         <source>Use for:</source>
@@ -5563,186 +6234,222 @@ The final volume in the primary is %1.</source>
         <source>Notes:</source>
         <translation type="vanished">附注：Notes:</translation>
     </message>
+    <message>
+        <source>Amount in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">说明Notes</translation>
+    </message>
+    <message>
+        <source>New misc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>namedMashEditor</name>
     <message>
         <source>Named Mash Editor</source>
-        <translation type="vanished">命名混搭编辑器Named Mash Editor</translation>
+        <translation>命名混搭编辑器Named Mash Editor</translation>
     </message>
     <message>
         <source>Mash</source>
-        <translation type="vanished">糖化Mash</translation>
+        <translation>糖化Mash</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">删除选定的风格</translation>
+        <translation>删除选定的风格</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Initial grain temp</source>
-        <translation type="vanished">初始晶粒温度</translation>
+        <translation>初始晶粒温度</translation>
     </message>
     <message>
         <source>Sparge temp</source>
-        <translation type="vanished">吹扫温度Sparge temp</translation>
+        <translation>吹扫温度Sparge temp</translation>
     </message>
     <message>
         <source>Sparge temp target</source>
-        <translation type="vanished">吹扫温度目标Sparge temp target</translation>
+        <translation>吹扫温度目标Sparge temp target</translation>
     </message>
     <message>
         <source>Sparge pH</source>
-        <translation type="vanished">喷雾pHSparge pH</translation>
+        <translation>喷雾pHSparge pH</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">说明Notes</translation>
+        <translation>说明Notes</translation>
     </message>
     <message>
         <source>Tun</source>
-        <translation type="vanished">桶Tun</translation>
+        <translation>桶Tun</translation>
     </message>
     <message>
         <source>Initial tun temp</source>
-        <translation type="vanished">初始桶温度Initial tun temp</translation>
+        <translation>初始桶温度Initial tun temp</translation>
     </message>
     <message>
         <source>From Equipment</source>
-        <translation type="vanished">设备From Equipment</translation>
+        <translation>设备From Equipment</translation>
     </message>
     <message>
         <source>Tun mass</source>
-        <translation type="vanished">桶质量Tun mass</translation>
+        <translation>桶质量Tun mass</translation>
     </message>
     <message>
         <source>Tun sp. heat</source>
-        <translation type="vanished">桶sp热Tun sp. heat</translation>
+        <translation>桶sp热Tun sp. heat</translation>
     </message>
     <message>
         <source>Tun specific heat (cal/(g*K))</source>
-        <translation type="vanished">桶比热(cal /(g * K))Tun specific heat (cal/(g*K))</translation>
+        <translation>桶比热(cal /(g * K))Tun specific heat (cal/(g*K))</translation>
     </message>
     <message>
         <source>Add mash step</source>
-        <translation type="vanished">添加醪步骤“Add mash step</translation>
+        <translation>添加醪步骤“Add mash step</translation>
     </message>
     <message>
         <source>Remove selected mash step</source>
-        <translation type="vanished">删除选定的醪步骤</translation>
+        <translation>删除选定的醪步骤</translation>
     </message>
     <message>
         <source>Mash step up</source>
-        <translation type="vanished">糖化加强Mash step up</translation>
+        <translation>糖化加强Mash step up</translation>
     </message>
     <message>
         <source>Mash step down</source>
-        <translation type="vanished">糖化下台下台醪Mash step down</translation>
+        <translation>糖化下台下台醪Mash step down</translation>
     </message>
 </context>
 <context>
     <name>ogAdjuster</name>
     <message>
         <source>Adjust Volume to Hit OG</source>
-        <translation type="vanished">调整音量命中OGAdjust Volume to Hit OG</translation>
+        <translation>调整音量命中OGAdjust Volume to Hit OG</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">输入Input</translation>
+        <translation>输入Input</translation>
     </message>
     <message>
         <source>SG</source>
-        <translation type="vanished">SG</translation>
+        <translation>SG</translation>
     </message>
     <message>
         <source>Measured gravity pre-boil</source>
-        <translation type="vanished">重力测量前熬</translation>
+        <translation>重力测量前熬</translation>
     </message>
     <message>
         <source>Temp</source>
-        <translation type="vanished">温度</translation>
+        <translation>温度</translation>
     </message>
     <message>
         <source>Temperature of SG reading</source>
-        <translation type="vanished">温度的SG阅读Temperature of SG reading</translation>
+        <translation>温度的SG阅读Temperature of SG reading</translation>
     </message>
     <message>
         <source>Calibration Temp</source>
-        <translation type="vanished">校准温度</translation>
+        <translation>校准温度</translation>
     </message>
     <message>
         <source>Temp to which the hydrometer is calibrated</source>
-        <translation type="vanished">温度，比重计校准</translation>
+        <translation>温度，比重计校准</translation>
     </message>
     <message>
         <source>-or-</source>
-        <translation type="vanished">- 或者 -</translation>
+        <translation>- 或者 -</translation>
     </message>
     <message>
         <source>Plato</source>
-        <translation type="vanished">柏拉图Plato</translation>
+        <translation>柏拉图Plato</translation>
     </message>
     <message>
         <source>Plato (percent by mass of equivalent sucrose)</source>
-        <translation type="vanished">柏拉图质量相当于蔗糖（％）Plato (percent by mass of equivalent sucrose)</translation>
+        <translation>柏拉图质量相当于蔗糖（％）Plato (percent by mass of equivalent sucrose)</translation>
     </message>
     <message>
         <source>Pre-Boil Volume</source>
-        <translation type="vanished">煮沸前成交量Pre-Boil Volume</translation>
+        <translation>煮沸前成交量Pre-Boil Volume</translation>
     </message>
     <message>
         <source>Measured pre-boil volume</source>
-        <translation type="vanished">测量前熬量Measured pre-boil volume</translation>
+        <translation>测量前熬量Measured pre-boil volume</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">产量Output</translation>
+        <translation>产量Output</translation>
     </message>
     <message>
         <source>OG w/o Correction</source>
-        <translation type="vanished">OG W / O型校正OG w/o Correction</translation>
+        <translation>OG W / O型校正OG w/o Correction</translation>
     </message>
     <message>
         <source>OG if you boil as planned</source>
-        <translation type="vanished">OG如果你熬计划OG if you boil as planned</translation>
+        <translation>OG如果你熬计划OG if you boil as planned</translation>
     </message>
     <message>
         <source>Add to Boil</source>
-        <translation type="vanished">添加煮Add to Boil</translation>
+        <translation>添加煮Add to Boil</translation>
     </message>
     <message>
         <source>Amount of water you need to add to hit planned OG (or boil off if negative)</source>
-        <translation type="vanished">适量的水，你需要添加打计划OG（如果为负或煮沸）Amount of water you need to add to hit planned OG (or boil off if negative)</translation>
+        <translation>适量的水，你需要添加打计划OG（如果为负或煮沸）Amount of water you need to add to hit planned OG (or boil off if negative)</translation>
     </message>
     <message>
         <source>Final Batch Size</source>
-        <translation type="vanished">F最后一批大小inal Batch Size</translation>
+        <translation>F最后一批大小inal Batch Size</translation>
     </message>
     <message>
         <source>Estimated batch size after correction</source>
-        <translation type="vanished">修正后的预计批量大小Estimated batch size after correction</translation>
+        <translation>修正后的预计批量大小Estimated batch size after correction</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">计算Calculate</translation>
+        <translation>计算Calculate</translation>
+    </message>
+    <message>
+        <source>ogAdjuster</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>optionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="vanished">选项</translation>
+        <translation>选项</translation>
     </message>
     <message>
         <source>Units</source>
-        <translation type="vanished">单位Units</translation>
+        <translation>单位Units</translation>
     </message>
     <message>
         <source>Weight</source>
-        <translation type="vanished">重量</translation>
+        <translation>重量</translation>
     </message>
     <message>
         <source>Use SI units</source>
@@ -5758,7 +6465,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Temperature</source>
-        <translation type="vanished">温度</translation>
+        <translation>温度</translation>
     </message>
     <message>
         <source>Celsius</source>
@@ -5770,11 +6477,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="vanished">量体积体积Volume</translation>
+        <translation>量体积体积Volume</translation>
     </message>
     <message>
         <source>Gravity</source>
-        <translation type="vanished">重力Gravity</translation>
+        <translation>重力Gravity</translation>
     </message>
     <message>
         <source>20C/20C Specific Gravity</source>
@@ -5786,7 +6493,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Color</source>
-        <translation type="vanished">颜色Color</translation>
+        <translation>颜色Color</translation>
     </message>
     <message>
         <source>Use SRM</source>
@@ -5798,7 +6505,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Formulas</source>
-        <translation type="vanished">公式</translation>
+        <translation>公式</translation>
     </message>
     <message>
         <source>Mosher&apos;s approximation</source>
@@ -5814,7 +6521,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>IBU</source>
-        <translation type="vanished">IBU</translation>
+        <translation>IBU</translation>
     </message>
     <message>
         <source>Tinseth&apos;s approximation</source>
@@ -5826,7 +6533,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>IBU Adjustments</source>
-        <translation type="vanished">IBU调整</translation>
+        <translation>IBU调整</translation>
     </message>
     <message>
         <source>% IBU adjustment</source>
@@ -5862,7 +6569,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">语言</translation>
+        <translation>语言</translation>
     </message>
     <message>
         <source>&lt;qt&gt;
@@ -5872,7 +6579,7 @@ The final volume in the primary is %1.</source>
   &lt;a href=&quot;https://sourceforge.net/sendmessage.php?touser=938941&quot;&gt;
   provide a translation&lt;/a&gt; so that your friends can use brewtarget!
 &lt;/qt&gt;</source>
-        <translation type="vanished">&lt;qt&gt;
+        <translation>&lt;qt&gt;
    &lt;b&gt;Know another language?&lt;/b&gt;
    &lt;br&gt;&lt;br&gt;
    Or, would you like to improve a translation? Help us out and
@@ -5882,7 +6589,43 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Date</source>
-        <translation type="vanished">日期</translation>
+        <translation>日期</translation>
+    </message>
+    <message>
+        <source>Forumulas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Hop (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First Wort (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Engines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RDBMS Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hostname</source>
@@ -5965,6 +6708,54 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Diastatic power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logging Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Default location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recipe Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Automatic Snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes all the snapshots too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes only the recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always show snapshots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>How many times Brewtarget needs to be run to trigger another backup: 1 means always backup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5973,306 +6764,418 @@ The final volume in the primary is %1.</source>
     <name>pitchDialog</name>
     <message>
         <source>Pitch Rate Calculator</source>
-        <translation type="vanished">间距率计算器Pitch Rate Calculator</translation>
+        <translation>间距率计算器Pitch Rate Calculator</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">输入Input</translation>
+        <translation>输入Input</translation>
     </message>
     <message>
         <source>Wort Volume</source>
-        <translation type="vanished">麦汁体积Wort Volume</translation>
+        <translation>麦汁体积Wort Volume</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>For ales, 0.75-1. For lagers, 1.5-2.</source>
-        <translation type="vanished">适用于0.75-1啤酒，。对于啤酒，1.5-2。For ales, 0.75-1. For lagers, 1.5-2.</translation>
+        <translation>适用于0.75-1啤酒，。对于啤酒，1.5-2。For ales, 0.75-1. For lagers, 1.5-2.</translation>
     </message>
     <message>
         <source>Pitch Rate (M cells)/(mL*P)</source>
-        <translation type="vanished">距率(M细胞)/(mL * P)Pitch Rate (M cells)/(mL*P)</translation>
+        <translation>距率(M细胞)/(mL * P)Pitch Rate (M cells)/(mL*P)</translation>
     </message>
     <message>
         <source>Aeration Method</source>
-        <translation type="vanished">曝气法Aeration Method</translation>
+        <translation>曝气法Aeration Method</translation>
     </message>
     <message>
         <source>Yeast Production Date</source>
-        <translation type="vanished">酵母生产日期Yeast Production Date</translation>
+        <translation>酵母生产日期Yeast Production Date</translation>
     </message>
     <message>
         <source>Yeast Viability</source>
-        <translation type="vanished">酵母活力Yeast Viability</translation>
+        <translation>酵母活力Yeast Viability</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="vanished">无None</translation>
+        <translation>无None</translation>
     </message>
     <message>
         <source>O2 At Start</source>
-        <translation type="vanished">O2在开始O2 At Start</translation>
+        <translation>O2在开始O2 At Start</translation>
     </message>
     <message>
         <source>Stir Plate</source>
-        <translation type="vanished">搅拌板Stir Plate</translation>
+        <translation>搅拌板Stir Plate</translation>
     </message>
     <message>
         <source>MM/dd/yyyy</source>
-        <translation type="vanished">MM / DD /年MM/dd/yyyy</translation>
+        <translation>MM / DD /年MM/dd/yyyy</translation>
     </message>
     <message>
         <source>%</source>
-        <translation type="vanished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="vanished">文本标签TextLabel</translation>
+        <translation>文本标签TextLabel</translation>
     </message>
     <message>
         <source>Calculate Viability From Date</source>
-        <translation type="vanished">计算从日期的可行性Calculate Viability From Date</translation>
+        <translation>计算从日期的可行性Calculate Viability From Date</translation>
     </message>
     <message>
         <source># Vials/Smack Packs Pitched</source>
-        <translation type="vanished">啪＃瓶/包投# Vials/Smack Packs Pitched</translation>
+        <translation>啪＃瓶/包投# Vials/Smack Packs Pitched</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">产量Output</translation>
+        <translation>产量Output</translation>
     </message>
     <message>
         <source>Billions of Yeast Cells Required</source>
-        <translation type="vanished">酵母细胞所需的数十亿Billions of Yeast Cells Required</translation>
+        <translation>酵母细胞所需的数十亿Billions of Yeast Cells Required</translation>
     </message>
     <message>
         <source># Vials/Smack Packs w/o Starter</source>
-        <translation type="vanished">#瓶/打包w / o起动器# Vials/Smack Packs w/o Starter</translation>
+        <translation>#瓶/打包w / o起动器# Vials/Smack Packs w/o Starter</translation>
     </message>
     <message>
         <source>Dry Yeast</source>
-        <translation type="vanished">干酵母Dry Yeast</translation>
+        <translation>干酵母Dry Yeast</translation>
     </message>
     <message>
         <source>Starter Volume</source>
-        <translation type="vanished">起动器体积Starter Volume</translation>
+        <translation>起动器体积Starter Volume</translation>
+    </message>
+    <message>
+        <source>Volume of wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting gravity of the wort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aeration method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Production date (Best By date less three months)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Estimated viability of the yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Desired pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of vials/smack packs added to starter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How much yeast you will need</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many smack packs or vials required to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of dry yeast needed to reach pitch rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starter size to reach pitch rate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>primingDialog</name>
     <message>
         <source>Priming Calculator</source>
-        <translation type="vanished">启动计算器Priming Calculator</translation>
+        <translation>启动计算器Priming Calculator</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="vanished">输入Input</translation>
+        <translation>输入Input</translation>
     </message>
     <message>
         <source>Collected Beer Volume</source>
-        <translation type="vanished">收集啤酒销量Collected Beer Volume</translation>
+        <translation>收集啤酒销量Collected Beer Volume</translation>
     </message>
     <message>
         <source>Amount of beer to prime</source>
-        <translation type="vanished">数量的啤酒主要Amount of beer to prime</translation>
+        <translation>数量的啤酒主要Amount of beer to prime</translation>
     </message>
     <message>
         <source>Beer Temperature</source>
-        <translation type="vanished">啤酒温度Beer Temperature</translation>
+        <translation>啤酒温度Beer Temperature</translation>
     </message>
     <message>
         <source>Temp of the beer</source>
-        <translation type="vanished">气温啤酒Temp of the beer</translation>
+        <translation>气温啤酒Temp of the beer</translation>
     </message>
     <message>
         <source>Desired Volumes</source>
-        <translation type="vanished">所需的量Desired Volumes</translation>
+        <translation>所需的量Desired Volumes</translation>
     </message>
     <message>
         <source>How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</source>
-        <translation type="vanished">你想要多少体积的CO2（1 L CO2 @ STP每升啤酒）How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</translation>
+        <translation>你想要多少体积的CO2（1 L CO2 @ STP每升啤酒）How many volumes of CO2 you want (1 L CO2 @ STP per L beer)</translation>
     </message>
     <message>
         <source>Glucose Monohydrate (corn sugar)</source>
-        <translation type="vanished">葡萄糖一水合物（玉米糖）Glucose Monohydrate (corn sugar)</translation>
+        <translation>葡萄糖一水合物（玉米糖）Glucose Monohydrate (corn sugar)</translation>
     </message>
     <message>
         <source>Anhydrous Glucose</source>
-        <translation type="vanished">无水葡萄糖Anhydrous Glucose</translation>
+        <translation>无水葡萄糖Anhydrous Glucose</translation>
     </message>
     <message>
         <source>Sucrose (table sugar)</source>
-        <translation type="vanished">蔗糖（蔗糖）Sucrose (table sugar)</translation>
+        <translation>蔗糖（蔗糖）Sucrose (table sugar)</translation>
     </message>
     <message>
         <source>Dry Malt Extract</source>
-        <translation type="vanished">干燥的麦芽提取物Dry Malt Extract</translation>
+        <translation>干燥的麦芽提取物Dry Malt Extract</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="vanished">产量Output</translation>
+        <translation>产量Output</translation>
     </message>
     <message>
         <source>Prime with</source>
-        <translation type="vanished">主要与Prime with</translation>
+        <translation>主要与Prime with</translation>
     </message>
     <message>
         <source>How much priming ingredient to use</source>
-        <translation type="vanished">使用多少吸成分How much priming ingredient to use</translation>
+        <translation>使用多少吸成分How much priming ingredient to use</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">计算Calculate</translation>
+        <translation>计算Calculate</translation>
     </message>
 </context>
 <context>
     <name>recipeExtrasWidget</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">形式Form</translation>
+        <translation>形式Form</translation>
     </message>
     <message>
         <source>Brewer</source>
-        <translation type="vanished">布鲁尔Brewer</translation>
+        <translation>布鲁尔Brewer</translation>
     </message>
     <message>
         <source>Asst. Brewer</source>
-        <translation type="vanished">助理。布鲁尔Asst. Brewer</translation>
+        <translation>助理。布鲁尔Asst. Brewer</translation>
     </message>
     <message>
         <source>Taste Rating</source>
-        <translation type="vanished">味道等级Taste Rating</translation>
+        <translation>味道等级Taste Rating</translation>
     </message>
     <message>
         <source>Primary Age (days)</source>
-        <translation type="vanished">小学年龄（天）Primary Age (days)</translation>
+        <translation>小学年龄（天）Primary Age (days)</translation>
     </message>
     <message>
         <source>Primary Temp</source>
-        <translation type="vanished">初级温度</translation>
+        <translation>初级温度</translation>
     </message>
     <message>
         <source>Secondary Age (days)</source>
-        <translation type="vanished">中学时代（天）Secondary Age (days)</translation>
+        <translation>中学时代（天）Secondary Age (days)</translation>
     </message>
     <message>
         <source>Secondary Temp</source>
-        <translation type="vanished">二次温度Secondary Temp</translation>
+        <translation>二次温度Secondary Temp</translation>
     </message>
     <message>
         <source>Tertiary Age (days)</source>
-        <translation type="vanished">第三纪（天）Tertiary Age (days)</translation>
+        <translation>第三纪（天）Tertiary Age (days)</translation>
     </message>
     <message>
         <source>Tertiary Temp</source>
-        <translation type="vanished">第三温度Tertiary Temp</translation>
+        <translation>第三温度Tertiary Temp</translation>
     </message>
     <message>
         <source>Bottle/Keg Age (days)</source>
-        <translation type="vanished">瓶/桶年龄（天）Bottle/Keg Age (days)</translation>
+        <translation>瓶/桶年龄（天）Bottle/Keg Age (days)</translation>
     </message>
     <message>
         <source>Bottle/Keg Temp</source>
-        <translation type="vanished">瓶/桶温度Bottle/Keg Temp</translation>
+        <translation>瓶/桶温度Bottle/Keg Temp</translation>
     </message>
     <message>
         <source>Date First Brewed</source>
-        <translation type="vanished">首先酿造的日期Date First Brewed</translation>
+        <translation>首先酿造的日期Date First Brewed</translation>
     </message>
     <message>
         <source>dd MMM yyyy</source>
-        <translation type="vanished">dd MMM yyyy</translation>
+        <translation>dd MMM yyyy</translation>
     </message>
     <message>
         <source>Carbonation Volumes</source>
-        <translation type="vanished">碳化卷Carbonation Volumes</translation>
+        <translation>碳化卷Carbonation Volumes</translation>
     </message>
     <message>
         <source>Taste Notes</source>
-        <translation type="vanished">味道注意事项Taste Notes</translation>
+        <translation>味道注意事项Taste Notes</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">说明Notes</translation>
+        <translation>说明Notes</translation>
     </message>
 </context>
 <context>
     <name>refractoDialog</name>
     <message>
         <source>Refractometer Tools</source>
-        <translation type="vanished">折射工具</translation>
+        <translation>折射工具</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="vanished">输入</translation>
+        <translation>输入</translation>
     </message>
     <message>
         <source>Original Plato</source>
-        <translation type="vanished">原柏拉图Original Plato</translation>
+        <translation>原柏拉图Original Plato</translation>
     </message>
     <message>
         <source>OG (20 C)</source>
-        <translation type="vanished">OG（20°C）</translation>
+        <translation>OG（20°C）</translation>
     </message>
     <message>
         <source>Current Plato</source>
-        <translation type="vanished">当前柏拉图Current Plato</translation>
+        <translation>当前柏拉图Current Plato</translation>
     </message>
     <message>
         <source>Calculate</source>
-        <translation type="vanished">计算Calculate</translation>
+        <translation>计算Calculate</translation>
     </message>
     <message>
         <source>Outputs</source>
-        <translation type="vanished">输出</translation>
+        <translation>输出</translation>
     </message>
     <message>
         <source>SG (20C)</source>
-        <translation type="vanished">SG（20C）</translation>
+        <translation>SG（20C）</translation>
     </message>
     <message>
         <source>ABV</source>
-        <translation type="vanished">ABV</translation>
+        <translation>ABV</translation>
     </message>
     <message>
         <source>ABW</source>
-        <translation type="vanished">ABW</translation>
+        <translation>ABW</translation>
     </message>
     <message>
         <source>Refractive Index</source>
-        <translation type="vanished">折光指数</translation>
+        <translation>折光指数</translation>
     </message>
     <message>
         <source>Real Extract (Plato)</source>
-        <translation type="vanished">实时提取物（柏拉图）</translation>
+        <translation>实时提取物（柏拉图）</translation>
     </message>
     <message>
         <source>OG (20C)</source>
-        <translation type="vanished">OG (20C)</translation>
+        <translation>OG (20C)</translation>
+    </message>
+    <message>
+        <source>Measured original plato</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measured original gravity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current measured plato</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>strikeWaterDialog</name>
     <message>
+        <source>Strike Water Calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initial Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original Grain Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weight of Grain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mash Infusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Volume of Water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grain Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Actual Mash Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infusion Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Calculate</source>
-        <translation type="vanished">计算Calculate</translation>
+        <translation>计算Calculate</translation>
+    </message>
+    <message>
+        <source>Strike Water Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume to add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note: This calculator assumes a preheated mash tun.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>styleEditor</name>
     <message>
         <source>Style Editor</source>
-        <translation type="vanished">样式编辑器</translation>
+        <translation>样式编辑器</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="vanished">样式Style</translation>
+        <translation>样式Style</translation>
     </message>
     <message>
         <source>Delete selected style</source>
-        <translation type="vanished">删除选定的风格</translation>
+        <translation>删除选定的风格</translation>
     </message>
     <message>
         <source>Basic Information</source>
@@ -6280,55 +7183,55 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="vanished">类别</translation>
+        <translation>类别</translation>
     </message>
     <message>
         <source>Category number</source>
-        <translation type="vanished">类别号Category number</translation>
+        <translation>类别号Category number</translation>
     </message>
     <message>
         <source>Style letter</source>
-        <translation type="vanished">样式Style letter</translation>
+        <translation>样式Style letter</translation>
     </message>
     <message>
         <source>Style guide</source>
-        <translation type="vanished">风格指南Style guide</translation>
+        <translation>风格指南Style guide</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">类型Type</translation>
+        <translation>类型Type</translation>
     </message>
     <message>
         <source>Type of beverage</source>
-        <translation type="vanished">饮料类型Type of beverage</translation>
+        <translation>饮料类型Type of beverage</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">拉格Lager</translation>
+        <translation>拉格Lager</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">爱尔Ale</translation>
+        <translation>爱尔Ale</translation>
     </message>
     <message>
         <source>Mead</source>
-        <translation type="vanished">蜂蜜酒Mead</translation>
+        <translation>蜂蜜酒Mead</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">小麦Wheat</translation>
+        <translation>小麦Wheat</translation>
     </message>
     <message>
         <source>Mixed</source>
-        <translation type="vanished">混合Mixed</translation>
+        <translation>混合Mixed</translation>
     </message>
     <message>
         <source>Cider</source>
-        <translation type="vanished">苹果汁Cider</translation>
+        <translation>苹果汁Cider</translation>
     </message>
     <message>
         <source>Vital Statistics</source>
@@ -6336,51 +7239,51 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Max</source>
-        <translation type="vanished">最大Max</translation>
+        <translation>最大Max</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="vanished">分钟Min</translation>
+        <translation>分钟Min</translation>
     </message>
     <message>
         <source>OG</source>
-        <translation type="vanished">OG</translation>
+        <translation>OG</translation>
     </message>
     <message>
         <source>FG</source>
-        <translation type="vanished">FG</translation>
+        <translation>FG</translation>
     </message>
     <message>
         <source>IBUs</source>
-        <translation type="vanished">IBUs</translation>
+        <translation>IBUs</translation>
     </message>
     <message>
         <source>Color (SRM)</source>
-        <translation type="vanished">颜色（SR​​ M）</translation>
+        <translation>颜色（SR​​ M）</translation>
     </message>
     <message>
         <source>Carb (vols)</source>
-        <translation type="vanished">碳水化合物（卷）Carb (vols)</translation>
+        <translation>碳水化合物（卷）Carb (vols)</translation>
     </message>
     <message>
         <source>ABV (pct)</source>
-        <translation type="vanished">ABV (pct)</translation>
+        <translation>ABV (pct)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="vanished">配置文件</translation>
+        <translation>配置文件</translation>
     </message>
     <message>
         <source>Ingredients</source>
-        <translation type="vanished">成分Ingredients</translation>
+        <translation>成分Ingredients</translation>
     </message>
     <message>
         <source>Examples</source>
-        <translation type="vanished">例子Examples</translation>
+        <translation>例子Examples</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">说明Notes</translation>
+        <translation>说明Notes</translation>
     </message>
     <message>
         <source>New</source>
@@ -6394,6 +7297,50 @@ The final volume in the primary is %1.</source>
         <source>Cancel</source>
         <translation type="vanished">取消</translation>
     </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleLetter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>styleGuide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>categoryNumber</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerListDialog</name>
@@ -6401,12 +7348,207 @@ The final volume in the primary is %1.</source>
         <source>Timers</source>
         <translation type="vanished">定时器Timers</translation>
     </message>
+    <message>
+        <source>Addition Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>timerWidget</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">形式Form</translation>
+        <translation type="unfinished">形式Form</translation>
+    </message>
+    <message>
+        <source>Add:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">停止</translation>
+    </message>
+    <message>
+        <source>Set Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Play Alarm Sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>waterDialog</name>
+    <message>
+        <source>Water Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Mash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Target Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PushButton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>% RO in Sparge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>totalSalts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ca</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>so4ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cappm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hco3ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>pH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Na</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>clppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCl&lt;sub&gt;2&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MgSO&lt;sub&gt;4&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mgso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaCl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nacl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CaSO&lt;sub&gt;4&lt;?sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>caso4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NaHCO&lt;sub&gt;3&lt;/sub&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nahco3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Salts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add a salt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected salt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6417,18 +7559,22 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translation type="vanished">说明Notes</translation>
+        <translation>说明Notes</translation>
+    </message>
+    <message>
+        <source>Edit Water</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>yeastEditor</name>
     <message>
         <source>Yeast Editor</source>
-        <translation type="vanished">酵母编辑</translation>
+        <translation>酵母编辑</translation>
     </message>
     <message>
         <source>Required Fields</source>
@@ -6436,51 +7582,51 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Name</source>
-        <translation type="vanished">名Name</translation>
+        <translation>名Name</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="vanished">类型Type</translation>
+        <translation>类型Type</translation>
     </message>
     <message>
         <source>Ale</source>
-        <translation type="vanished">爱尔Ale</translation>
+        <translation>爱尔Ale</translation>
     </message>
     <message>
         <source>Lager</source>
-        <translation type="vanished">拉格Lager</translation>
+        <translation>拉格Lager</translation>
     </message>
     <message>
         <source>Wheat</source>
-        <translation type="vanished">小麦Wheat</translation>
+        <translation>小麦Wheat</translation>
     </message>
     <message>
         <source>Wine</source>
-        <translation type="vanished">酒Wine</translation>
+        <translation>酒Wine</translation>
     </message>
     <message>
         <source>Champagne</source>
-        <translation type="vanished">香槟Champagne</translation>
+        <translation>香槟Champagne</translation>
     </message>
     <message>
         <source>Form</source>
-        <translation type="vanished">形式Form</translation>
+        <translation>形式Form</translation>
     </message>
     <message>
         <source>Liquid</source>
-        <translation type="vanished">Liquid液体</translation>
+        <translation>Liquid液体</translation>
     </message>
     <message>
         <source>Dry</source>
-        <translation type="vanished">Dry干</translation>
+        <translation>Dry干</translation>
     </message>
     <message>
         <source>Slant</source>
-        <translation type="vanished">Slant偏</translation>
+        <translation>Slant偏</translation>
     </message>
     <message>
         <source>Culture</source>
-        <translation type="vanished">Culture文化</translation>
+        <translation>Culture文化</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -6488,91 +7634,91 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Check it if the amount given is in kg instead of L.</source>
-        <translation type="vanished">如果给定的数量是公斤代替L.检查Check it if the amount given is in kg instead of L.</translation>
+        <translation>如果给定的数量是公斤代替L.检查Check it if the amount given is in kg instead of L.</translation>
     </message>
     <message>
         <source>Amount is weight?</source>
-        <translation type="vanished">金额重量？Amount is weight?</translation>
+        <translation>金额重量？Amount is weight?</translation>
     </message>
     <message>
         <source>Checked if the given amount is weight instead of volume</source>
-        <translation type="vanished">检查，如果给定的量是重量，而不是数量</translation>
+        <translation>检查，如果给定的量是重量，而不是数量</translation>
     </message>
     <message>
         <source>Lab</source>
-        <translation type="vanished">实验室Lab</translation>
+        <translation>实验室Lab</translation>
     </message>
     <message>
         <source>Product ID</source>
-        <translation type="vanished">产品IDProduct ID</translation>
+        <translation>产品IDProduct ID</translation>
     </message>
     <message>
         <source>Min Temp</source>
-        <translation type="vanished">最低温度Min Temp</translation>
+        <translation>最低温度Min Temp</translation>
     </message>
     <message>
         <source>Min temp</source>
-        <translation type="vanished">最小温度Min temp</translation>
+        <translation>最小温度Min temp</translation>
     </message>
     <message>
         <source>Max Temp</source>
-        <translation type="vanished">最高温度Max Temp</translation>
+        <translation>最高温度Max Temp</translation>
     </message>
     <message>
         <source>Max temp</source>
-        <translation type="vanished">最高温度Max temp</translation>
+        <translation>最高温度Max temp</translation>
     </message>
     <message>
         <source>Flocculation</source>
-        <translation type="vanished">絮凝Flocculation</translation>
+        <translation>絮凝Flocculation</translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="vanished">低</translation>
+        <translation>低</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="vanished">Medium中</translation>
+        <translation>Medium中</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="vanished">High高</translation>
+        <translation>High高</translation>
     </message>
     <message>
         <source>Very High</source>
-        <translation type="vanished">Very High非常高</translation>
+        <translation>Very High非常高</translation>
     </message>
     <message>
         <source>Attenuation (%)</source>
-        <translation type="vanished">衰减（%）Attenuation (%)</translation>
+        <translation>衰减（%）Attenuation (%)</translation>
     </message>
     <message>
         <source>Apparent attenuation as percentage of OG points</source>
-        <translation type="vanished">明显的衰减为OG点的百分比Apparent attenuation as percentage of OG points</translation>
+        <translation>明显的衰减为OG点的百分比Apparent attenuation as percentage of OG points</translation>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation type="vanished">时间再培养Times Recultured</translation>
+        <translation>时间再培养Times Recultured</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation type="vanished">这种酵母已培养Times this yeast has been recultured</translation>
+        <translation>这种酵母已培养Times this yeast has been recultured</translation>
     </message>
     <message>
         <source>Max Recultures</source>
-        <translation type="vanished">最大Recultures的Max Recultures</translation>
+        <translation>最大Recultures的Max Recultures</translation>
     </message>
     <message>
         <source>Max recultures</source>
-        <translation type="vanished">Max reculturesMax recultures</translation>
+        <translation>Max reculturesMax recultures</translation>
     </message>
     <message>
         <source>Add to Secondary</source>
-        <translation type="vanished">加入二次Add to Secondary</translation>
+        <translation>加入二次Add to Secondary</translation>
     </message>
     <message>
         <source>Checked means add this yeast to secondary instead of primary</source>
-        <translation type="vanished">检查手段添加酵母二次代替原Checked means add this yeast to secondary instead of primary</translation>
+        <translation>检查手段添加酵母二次代替原Checked means add this yeast to secondary instead of primary</translation>
     </message>
     <message>
         <source>Best For:</source>
@@ -6581,6 +7727,42 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Notes:</source>
         <translation type="vanished">附注：Notes:</translation>
+    </message>
+    <message>
+        <source>Quanta in Inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quanta in inventory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation type="unfinished">额外Extras</translation>
+    </message>
+    <message>
+        <source>Best For</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished">说明Notes</translation>
+    </message>
+    <message>
+        <source>New yeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save and close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard and close</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Previous PR had a bug that meant it was pulling translation strings only from .cpp files and not also from .ui files.  Have fixed this here.  From a quick test, seems like French translations are working better now!