### PR TITLE
Putting the title back in brewtarget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ build/*
 
 .vagrant
 *.user
+
+# ccls files
+.ccls-cache/
+src/.ccls-cache/
+src/compile_commands.json

--- a/brewtarget.qrc
+++ b/brewtarget.qrc
@@ -75,6 +75,8 @@
       <file alias="images/smallYeast.svg">images/smallYeast.svg</file>
       <file alias="images/sound.png">images/sound.png</file>
       <file alias="images/testtube.svg">images/testtube.svg</file>
+      <file alias="images/title.svg">images/title.svg</file>
+      <file alias="images/title.png">images/title.png</file>
       <file alias="images/yeastVial.svg">images/yeastVial.svg</file>
       <file alias="schemas/beerxml/v1/BeerXml.xsd">schemas/beerxml/v1/BeerXml.xsd</file>
    </qresource>


### PR DESCRIPTION
Closes #697. 

The place to looks for the images is in brewtarget.qrc. It looks like the file got reworked a while back, and the two title images were dropped.