### PR TITLE
Fixes #701 drag and drop is broken

### DIFF
--- a/src/BtTreeView.cpp
+++ b/src/BtTreeView.cpp
@@ -266,15 +266,21 @@ QMimeData * BtTreeView::mimeData(QModelIndexList indexes) {
       stream << static_cast<int>(*itemType) << id << name;
    }
 
-   if (!itsa) {
-      // Everything other than folders get dropped on the ingredients pane
-      name = "application/x-brewtarget-ingredient";
-   } else if (*itsa == BtTreeItem::Type::RECIPE || *itsa == BtTreeItem::Type::STYLE || *itsa == BtTreeItem::Type::EQUIPMENT) {
+   if (*itsa == BtTreeItem::Type::RECIPE || *itsa == BtTreeItem::Type::STYLE || *itsa == BtTreeItem::Type::EQUIPMENT) {
       // Recipes, equipment and styles get dropped on the recipe pane
       name = "application/x-brewtarget-recipe";
-   } else {
+   } 
+   else if ( *itsa == BtTreeItem::Type::FOLDER ) {
       // folders will be handled by themselves.
       name = "application/x-brewtarget-folder";
+   }
+   else if ( *itsa != BtTreeItem::Type::WATER ) {
+      // Everything other than folders get dropped on the ingredients pane
+      name = "application/x-brewtarget-ingredient";
+   }
+   else {
+      // This isn't used yet, but maybe some day I will fix that
+      name = "application/x-brewtarget-water";
    }
 
    QMimeData * mimeData = new QMimeData();

--- a/ui/mainWindow.ui
+++ b/ui/mainWindow.ui
@@ -259,8 +259,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>849</width>
-           <height>462</height>
+           <width>853</width>
+           <height>437</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1114,8 +1114,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>849</width>
-           <height>324</height>
+           <width>853</width>
+           <height>356</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1154,6 +1154,9 @@
                <widget class="QTableView" name="fermentableTable">
                 <property name="contextMenuPolicy">
                  <enum>Qt::CustomContextMenu</enum>
+                </property>
+                <property name="acceptDrops">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>
@@ -1667,7 +1670,7 @@
      <x>0</x>
      <y>0</y>
      <width>1200</width>
-     <height>24</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuAbout">
@@ -1880,7 +1883,7 @@
     <string>Ctrl+T</string>
    </property>
   </action>
-    <action name="actionPrint">
+  <action name="actionPrint">
    <property name="icon">
     <iconset resource="../brewtarget.qrc">
      <normaloff>:/images/printer.png</normaloff>:/images/printer.png</iconset>
@@ -2192,11 +2195,6 @@
    <slots>
     <signal>(PreviousScaleInfo)</signal>
    </slots>
-  </customwidget>
-  <customwidget>
-   <class>BtGenericEdit</class>
-   <extends>QLineEdit</extends>
-   <header>BtLineEdit.h</header>
   </customwidget>
   <customwidget>
    <class>BtPercentageEdit</class>


### PR DESCRIPTION
The logic in BtTreeView::mimeData was broken. As we always set itsa, the std::optional variable would have never been false. This resulted in setting the mime type to `application/x-brewtarget-folder` for anything that wasn't a Recipe, Style or Folder. Since the tables are configured to only accept `application/x-brewtarget-ingredient`, they wouldn't accept the drop.

To fix it, I changed all the tests around. We test for Recipe, Style and Equipment; then we test for Folder; then we test to not be Water. That sets all of the mime types correct. I also added an `application/x-brewtarget-water` in case I ever want to get clever.