### PR TITLE
closes #703 - brewnote signal not found

### DIFF
--- a/src/BtTreeModel.cpp
+++ b/src/BtTreeModel.cpp
@@ -1408,7 +1408,7 @@ void BtTreeModel::observeElement(NamedEntity * d) {
    }
 
    if (qobject_cast<BrewNote *>(d)) {
-      connect(d, SIGNAL(brewDateChanged(QDateTime)), this, SLOT(elementChanged()));
+      connect(d, SIGNAL(brewDateChanged(const QDate &)), this, SLOT(elementChanged()));
    } else {
       connect(d, SIGNAL(changedName(QString)), this, SLOT(elementChanged()));
       connect(d, SIGNAL(changedFolder(QString)), this, SLOT(folderChanged(QString)));


### PR DESCRIPTION
The dates in the brewnotes were changed from QDateTime to QDate objects. The signature for the signal in BtTreeModel wasn't updated, so the signal was never properly connected.

It is now properly connected.