### PR TITLE
Add case insensitive matching for unit names + Mac packaging fixes

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -47,17 +47,12 @@ jobs:
       # elsewhere we use the echo trick to ensure that a non-zero return value from these diagnostic commands is not
       # treated as a build script failure.
       #
-      # We install the tree command here as, although it's not needed to do the build itself, it's useful for diagnosing
-      # certain build problems (eg to see what changes certain parts of the build have made to the build directory
-      # tree) when the build is running as a GitHub action.  (If need be, you can also download the entire build
-      # directory within a day of a failed build running, but you need a decent internet connection for this as it's
-      # quite large.)
+      # Running `bt setup all` will, amongst other things install the tree command.
       #
       - name: Install Frameworks and Libraries, and set up Meson build environment
         run: |
            echo "Output from brew doctor: $(brew doctor)"
            echo "Output from xcode-select -p: $(xcode-select -p)"
-           brew install tree
            brew install python@3.11
            echo "Python3 ($(which python3)) version"
            /usr/bin/env python3 --version
@@ -149,8 +144,8 @@ jobs:
           path: |
              ${{github.workspace}}/build/brewtarget*.dmg
              ${{github.workspace}}/build/brewtarget*.dmg.sha256
-             ${{github.workspace}}/mbuild/packages/darwin/Brewtarget*.dmg
-             ${{github.workspace}}/mbuild/packages/darwin/Brewtarget*.dmg.sha256sum
+             ${{github.workspace}}/mbuild/packages/darwin/brewtarget*.dmg
+             ${{github.workspace}}/mbuild/packages/darwin/brewtarget*.dmg.sha256sum
           retention-days: 7
 
       - name: Post-processing on any core dump

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -11,9 +11,20 @@ format therein, otherwise you'll get, eg, no-changelogname-tag error from rpmlin
 
 * We'll list new features here...
 
+## v3.0.8
+Minor bug fixes for the 3.0.7 release (ie bugs in 3.0.7 are fixed in this 3.0.8 release).
+
+### New Features
+* Case insensitive matching of unit names (mL vs ml etc) [#725](https://github.com/Brewtarget/brewtarget/issues/725)
+
+### Bug Fixes
+* None
+
+### Release Timestamp
+Wed, 8 Mar 2023 11:29:08 +0100
 
 ## v3.0.7
-Minor bug fixes for the 3.0.5 release (ie bugs in 3.0.5 are fixed in this 3.0.6 release).
+Minor bug fixes for the 3.0.6 release (ie bugs in 3.0.6 are fixed in this 3.0.7 release).
 
 ### New Features
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 #=======================================================================================================================
 # It's simplest to keep the project name all lower-case as it means we can use a lot more of the default settings for
 # Linux packaging (where directory names etc are expected to be all lower-case)
-project(brewtarget VERSION 3.0.7 LANGUAGES CXX)
+project(brewtarget VERSION 3.0.8 LANGUAGES CXX)
 message(STATUS "Building ${PROJECT_NAME} version ${PROJECT_VERSION}")
 message(STATUS "PROJECT_SOURCE_DIR is ${PROJECT_SOURCE_DIR}")
 # Sometimes we do need the capitalised version of the project name

--- a/bt
+++ b/bt
@@ -940,7 +940,7 @@ def doSetup(setupOption):
    if (platform.system() == 'Linux'):
       print('   sudo meson install')
    else:
-   print('   meson install')
+      print('   meson install')
    print('   ' + projectName)
 
 

--- a/bt
+++ b/bt
@@ -271,6 +271,7 @@ def abortOnRunFail(runResult: subprocess.CompletedProcess):
 def copyFilesToDir(files, directory):
    os.makedirs(directory, exist_ok=True)
    for currentFile in files:
+      log.debug('Copying ' + currentFile + ' to ' + directory)
       shutil.copy2(currentFile, directory)
    return
 
@@ -705,7 +706,6 @@ def installDependencies():
                         'git',
                         'mingw-w64-' + arch + '-boost',
                         'mingw-w64-' + arch + '-cmake',
-#                        'mingw-w64-' + arch + '-dlfcn', MAYBE WE DON'T NEED THIS AFTER ALL...
                         'mingw-w64-' + arch + '-libbacktrace',
                         'mingw-w64-' + arch + '-meson',
                         'mingw-w64-' + arch + '-nsis',
@@ -767,6 +767,10 @@ def installDependencies():
          #         available!")  For the moment, we're just using Boost header files on Mac though, so this should be
          #         OK.
          #
+         # We install the tree command here as, although it's not needed to do the build itself, it's useful for
+         # diagnosing certain build problems (eg to see what changes certain parts of the build have made to the build
+         # directory tree) when the build is running as a GitHub action.
+         #
          installList = ['boost',
                         'cmake',
                         'coreutils',
@@ -777,6 +781,7 @@ def installDependencies():
                         'meson',
                         'ninja',
                         'pandoc',
+                        'tree',
                         'qt@5',
                         'xalan-c',
                         'xerces-c']
@@ -935,7 +940,7 @@ def doSetup(setupOption):
    if (platform.system() == 'Linux'):
       print('   sudo meson install')
    else:
-      print('   meson install')
+   print('   meson install')
    print('   ' + projectName)
 
 
@@ -1806,7 +1811,7 @@ def doPackage():
       #------------------------------------------------- Mac Packaging -------------------------------------------------
       #-----------------------------------------------------------------------------------------------------------------
       case 'Darwin':
-         log.debug('Mac Packaging - TODO!')
+         log.debug('Mac Packaging')
          #
          # See https://stackoverflow.com/questions/1596945/building-osx-app-bundle for essential info on building Mac
          # app bundles.  Also https://mesonbuild.com/Creating-OSX-packages.html suggests how to do this with Meson,
@@ -1893,6 +1898,7 @@ def doPackage():
          #            ├── en.lproj        <── Localized resources
          #            │   ├── COPYRIGHT ✅
          #            │   └── README.md ✅
+         #            ├── qt.conf ✅
          #            ├── sounds
          #            │   └── [All the filesToInstall_sounds .wav files] ✅
          #            └── translations_qm
@@ -2044,6 +2050,18 @@ def doPackage():
          #
          # Now let macdeployqt do most of the heavy lifting
          #
+         # Note that it is best to run macdeployqt in the directory that contains the [projectName]_[versionNumber].app
+         # folder (otherwise, eg, the dmg name it creates will be wrong, as explained at
+         # https://doc.qt.io/qt-6/macos-deployment.html.
+         #
+         # In a previous iteration of this script, I skipped the -dmg option and tried to build the disk image with
+         # dmgbuild (code at https://github.com/dmgbuild/dmgbuild, docs at
+         # https://dmgbuild.readthedocs.io/en/latest/index.html).  The advantages of this would be that it would make it
+         # possible to do further fix-up work on the directory tree (if needed) and, potentially, give us more control
+         # over the disk image (eg to specify an icon for it).  However, it seemed to be fiddly to get it to work.  It's
+         # a lot simpler to let macdeployqt create the disk image, and we currently don't think we need to do further
+         # fix-up work after it's run.  A custom icon on the disk image would be nice, but is far from essential.
+         #
          log.debug('Running macdeployqt')
          os.chdir(dir_packages_platform)
          abortOnRunFail(
@@ -2052,78 +2070,42 @@ def doPackage():
             # The -executable argument is to automatically alter the search path of the executable for the Qt libraries
             # (ie so the executable knows where to find them inside the bundle)
             #
-            # We do not use the -dmg option, partly because we might still have some more fix-up work to do before
-            # packaging up the directory tree (although so far I think we can do it all beforehand) and partly because
-            # we want more control over the dmg (eg to specify an icon for it).
-            #
             subprocess.run(['macdeployqt',
                             macBundleDirName,
                             '-verbose=2',        # 0 = no output, 1 = error/warning (default), 2 = normal, 3 = debug
-                            '-executable=' + macBundleDirName + '/Contents/MacOS/' + capitalisedProjectName],
+                            '-executable=' + macBundleDirName + '/Contents/MacOS/' + capitalisedProjectName,
+                            '-dmg'],
                            capture_output=False)
          )
+
+         #
+         # The result of specifying the `-dmg' flag should be a [projectName]_[versionNumber].dmg file
+         #
+         log.debug('Directory tree after running macdeployqt')
+         abortOnRunFail(subprocess.run(['tree', '-sh'], capture_output=False))
+         dmgFileName = macBundleDirName.replace('.app', '.dmg')
 
          log.debug('Running otool after macdeployqt')
          os.chdir(dir_packages_mac_bin)
          abortOnRunFail(subprocess.run(['otool', '-L', capitalisedProjectName], capture_output=False))
          abortOnRunFail(subprocess.run(['otool', '-l', capitalisedProjectName], capture_output=False))
 
-         #
-         # Now that we have the app bundle directory structure, we need to compress it into a dmg file
-         #
-         # You can pass parameters in to dmgbuild on the command line, but it gets a bit unwieldy if you have a lot of
-         # them.  We use the alternative method of providing a configuration file (which is actually just a Python
-         # script).  So we generate that first.
-         #
-         # It would be neat if we could invoke dmgbuild directly from Python, but I haven't found a way to do this.
-         #
-         log.debug('Creating .dmg file')
+         log.info('Created ' + dmgFileName + ' in directory ' + dir_packages_platform.as_posix())
+         log.debug('Running hdiutil on ' + dmgFileName)
          os.chdir(dir_packages_platform)
-         settingsFileName = 'dmgSettings.py'
-         dmgFileName = capitalisedProjectName + '-' + buildConfig['CONFIG_VERSION_STRING'] + '.dmg'
-         with open(settingsFileName, 'wt') as sf:
-            sf.write('#------------------------------------------------------------------------------------\n')
-            sf.write('# Settings file for dmgbuild to generate ' + dmgFileName + '\n')
-            sf.write('#------------------------------------------------------------------------------------\n')
-            sf.write('\n')
-            sf.write('# Compressed (bzip2) format\n')
-            sf.write('format = "UDBZ"\n')
-            sf.write('\n')
-            sf.write('# This is the default file system, but no harm to be explicit\n')
-            sf.write('filesystem = "HFS+"\n')
-            sf.write('\n')
-            sf.write('# Disk image holds just one folder\n')
-            sf.write('file = "'+ macBundleDirName + '"\n')
-            sf.write('\n')
-            sf.write('# Icon used to badge the system’s standard external disk icon\n')
-            sf.write('# This is a convenient way to construct a suitable icon from your application\’s icon\n')
-            # Doco implies path should start with /Applications/, but this does not work
-            sf.write('badge_icon = "'+ macBundleDirName + '/Contents/Resources/' + capitalisedProjectName + 'Icon.icns"\n')
-            sf.write('\n')
-            sf.write('# Expected usage is drag to install, so default view of icons makes most sense\n')
-            sf.write('default_view = "icon-view"\n')
-         #
-         # Confusingly, although the .dmg file name and the volume name can be passed in via the settings file they are
-         # nonetheless required parameters on the command line.  Specifically, usage is:
-         #    dmgbuild [-h] [-s SETTINGS] [-D DEFINES] [--no-hidpi] volume-name output.dmg
-         #
          abortOnRunFail(
             subprocess.run(
-               ['dmgbuild',
-                '-s', settingsFileName,
-                capitalisedProjectName + ' ' + buildConfig['CONFIG_VERSION_STRING'],
-                dmgFileName],
-               capture_output=False
+               ['hdiutil', 'attach', '-verbose', dmgFileName]
             )
          )
-         os.chdir(previousWorkingDirectory)
-         log.info('Created ' + dmgFileName + ' in directory ' + dir_packages_platform.as_posix())
 
          #
          # Make the checksum file
          #
          log.info('Generating checksum file for ' + dmgFileName)
          writeSha256sum(dir_packages_platform, dmgFileName)
+
+         os.chdir(previousWorkingDirectory)
 
       case _:
          log.critical('Unrecognised platform: ' + platform.system())

--- a/bt
+++ b/bt
@@ -2026,6 +2026,22 @@ def doPackage():
          # We use otool to get the right name for libxalanMsg, which is typically listed as a relative path dependency
          # eg '@rpath/libxalanMsg.112.dylib'.
          #
+         # Per https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html:
+         #
+         #    @executable_path - will expand at run time to the absolute path of the app bundle's executable directory,
+         #                       ie [projectName]_[versionNumber].app/Contents/MacOS for us
+         #
+         #    @loader_path     - will expand at run time to the absolute path of whatever is loading the library,
+         #                       typically either the executable directory (if it's the executable loading the library
+         #                       directly) or, for us, the [projectName]_[versionNumber].app/Contents/Frameworks
+         #                       directory if it's another shared library requesting the load
+         #
+         #    @rpath           - means search a list of locations specified at the point the application was linked (by
+         #                       means of the -rpath linker flag), so, eg, including
+         #                       '-rpath @executable_path/../Frameworks' at link time means, for us, that
+         #                       [projectName]_[versionNumber].app/Contents/Frameworks is one of the places to search
+         #                       when @rpath is specified
+         #
          log.debug('Running otool -L on ' + xalanLibName)
          otoolOutputXalan = abortOnRunFail(
             subprocess.run(['otool',
@@ -2046,6 +2062,24 @@ def doPackage():
             xalanMsgLibName = 'libxalanMsg.112.dylib'
          log.debug('Copying ' + xalanDir + xalanMsgLibName + ' to ' + dir_packages_mac_frm.as_posix())
          shutil.copy2(xalanDir + xalanMsgLibName, dir_packages_mac_frm)
+
+###         #
+###         # Let's copy libxalan-c.112.dylib to where it needs to go and hope that macdeployqt does not overwrite it
+###         #
+###         shutil.copy2(xalanDir + xalanLibName, dir_packages_mac_frm)
+###
+###         #
+###         # We need to fix up libxalan-c.112.dylib so that it looks for libxalanMsg.112.dylib in the right place.  Long
+###         # story short, this means changing '@rpath/libxalanMsg.112.dylib' to '@loader_path/libxalanMsg.112.dylib'
+###         #
+###         os.chdir(dir_packages_mac_frm)
+###         abortOnRunFail(
+###            subprocess.run(['install_name_tool',
+###                            '-change',
+###                            xalanMsgLibName,
+###                            '@loader_path/' + xalanMsgLibName],
+###                           capture_output=False)
+###         )
 
          #
          # Now let macdeployqt do most of the heavy lifting
@@ -2085,17 +2119,38 @@ def doPackage():
          abortOnRunFail(subprocess.run(['tree', '-sh'], capture_output=False))
          dmgFileName = macBundleDirName.replace('.app', '.dmg')
 
-         log.debug('Running otool after macdeployqt')
+         log.debug('Running otool on ' + capitalisedProjectName + ' executable after macdeployqt')
          os.chdir(dir_packages_mac_bin)
          abortOnRunFail(subprocess.run(['otool', '-L', capitalisedProjectName], capture_output=False))
          abortOnRunFail(subprocess.run(['otool', '-l', capitalisedProjectName], capture_output=False))
+         log.debug('Running otool on ' + xalanLibName + ' library after macdeployqt')
+         os.chdir(dir_packages_mac_frm)
+         abortOnRunFail(subprocess.run(['otool', '-L', xalanLibName], capture_output=False))
 
          log.info('Created ' + dmgFileName + ' in directory ' + dir_packages_platform.as_posix())
-         log.debug('Running hdiutil on ' + dmgFileName)
+
+         #
+         # We can now mount the disk image and check its contents.  (I don't think we can modify the contents though.)
+         #
+         # By default, a disk image called foobar.dmg will get mounted at /Volumes/foobar.
+         #
+         log.debug('Running hdiutil to mount ' + dmgFileName)
          os.chdir(dir_packages_platform)
          abortOnRunFail(
             subprocess.run(
                ['hdiutil', 'attach', '-verbose', dmgFileName]
+            )
+         )
+         mountPoint = '/Volumes/' + dmgFileName.replace('.dmg', '')
+         log.debug('Directory tree of disk image')
+         abortOnRunFail(
+            subprocess.run(['tree', '-sh', mountPoint], capture_output=False)
+         )
+         log.debug('Running hdiutil to unmount ' + mountPoint)
+         os.chdir(dir_packages_platform)
+         abortOnRunFail(
+            subprocess.run(
+               ['hdiutil', 'detach', '-verbose', mountPoint]
             )
          )
 

--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,10 @@
 #    sudo meson install
 # which avoids the pop-up window
 #
+# Note that, on Linux, using `sudo meson install` sometimes creates problems with file permissions - eg
+# mbuild/meson-logs/install-log.txt ends up being writable only by root and that results in an error when you run
+# `bt package`, but this should be fixed in Meson 1.1.0.
+#
 # To build source packages (in the meson-dist subdirectory of the build directory):
 #    meson dist
 # This will build a .tar.xz file and create a corresponding .tar.xz.sha256sum file for it.
@@ -448,43 +452,13 @@ message('Boost:', boostDependency.name(), 'found =', boostDependency.found(), 'v
 # then, on Mac for instance, dlDependency.found() can be true without there being any cmake variable such as
 # PACKAGE_LIBRARIES (because the library was found by Meson special case code, not by cmake).
 #
-# At this point, there's good news and bad news:
-#    - The good news is that, on Mac and Linux, there's a more elegant way of handling the dl dependency, which relies
-#      on the fact that opening a shared library is a POSIX operation with calls declared in a POSIX-defined header (see
-#      eg https://man7.org/linux/man-pages/man0/dlfcn.h.0p.html).  We just ask the compiler whether it has dlopen()
-#      built-in, and, if not, please can it tell us where to find it!
-#    - The bad news is that, Windows doesn't have the POSIX interface for shared library opening, so it does not ship
-#      with the dlfcn.h header.  I think/hope we can get round this by installing dlfcn-win32 (see
-#      https://github.com/dlfcn-win32/dlfcn-win32) via its MSYS2 package (see
-#      https://packages.msys2.org/base/mingw-w64-dlfcn and mentions of dlfcn in the `bt` build tool script)...
+# The good news is that, on Mac and Linux, there's a more elegant way of handling the dl dependency, which relies on the
+# fact that opening a shared library is a POSIX operation with calls declared in a POSIX-defined header (see eg
+# https://man7.org/linux/man-pages/man0/dlfcn.h.0p.html).  We just ask the compiler whether it has dlopen() built-in,
+# and, if not, please can it tell us where to find it!
 #
-# BUT MAYBE WE DON'T NEED DL AT ALL ON WINDOWS, SO LET'S TRY THAT!
-#
-# Previously, the code here was:
-#
-#    needLibdl = false
-#    if compiler.get_id() == 'gcc'
-#       lddOutput = run_command('ldd', '--version', check: true).stdout().strip()
-#       lddOutputLine1 = lddOutput.split('\n')[0]
-#       message('ldd --version gives:', lddOutputLine1)
-#       libcVersion = lddOutputLine1.split(' ')[-1]
-#       message('libc version is:', libcVersion)
-#       if libcVersion.version_compare('<2.34')
-#          needLibdl = true
-#       endif
-#    endif
-#    dlDependency = dependency('dl', required : needLibdl, static : true)
-#    if dlDependency.found()
-#       dlLibraryPath = dlDependency.get_variable(default_value : '', cmake : 'PACKAGE_LIBRARIES')
-#       message('dlLibraryPath is:', dlLibraryPath)
-#       if dlLibraryPath != ''
-#          sharedLibraryPaths += dlLibraryPath
-#       endif
-#    endif
-#
-# However, there is a neater approach, which relies on the fact that opening a shared library is a POSIX operation with
-# calls declared in a POSIX-defined header (see eg https://man7.org/linux/man-pages/man0/dlfcn.h.0p.html).  We just ask
-# the compiler whether it has dlopen() built-in, and, if not, please can it tell us where to find it!
+# (On Windows, we don't need the dl dependency because Windows doesn't have the POSIX interface for shared library
+# opening, and Boost Stacktrace doesn't seem to need anything in its place.)
 #
 dlDependency = declare_dependency()
 if host_machine.system() != 'windows'

--- a/meson.build
+++ b/meson.build
@@ -180,7 +180,7 @@
 #
 #
 project('brewtarget', 'cpp',
-        version: '3.0.7',
+        version: '3.0.8',
         license: 'GPL-3.0-or-later',
         meson_version: '>=0.60.0',
         default_options : ['cpp_std=c++20',

--- a/src/BtLineEdit.cpp
+++ b/src/BtLineEdit.cpp
@@ -233,7 +233,7 @@ void BtLineEdit::setText(QString amount, int precision) {
             Q_FUNC_INFO << "Could not convert" << amount << "(" << this->configSection << ":" << this->editField <<
             ") to double";
       }
-      this->setWidgetText(displayAmount(amt, precision));
+      this->setWidgetText(this->displayAmount(amt, precision));
    }
 
    this->setDisplaySize(force);

--- a/src/ConverterTool.cpp
+++ b/src/ConverterTool.cpp
@@ -1,6 +1,7 @@
 /*
  * ConverterTool.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2015
+ * authors 2009-2023
+ * - Matt Young <mfsy@yahoo.com>
  * - Philip Greggory Lee <rocketman768@gmail.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
@@ -28,12 +29,12 @@
 ConverterTool::ConverterTool(QWidget* parent) : QDialog(parent) {
    this->doLayout();
 
-   connect( pushButton_convert, &QAbstractButton::clicked, this, &ConverterTool::convert );
+   connect(pushButton_convert, &QAbstractButton::clicked, this, &ConverterTool::convert);
    return;
 }
 
 void ConverterTool::convert() {
-   this->outputLineEdit->setText(Measurement::Unit::convert(inputLineEdit->text(), outputUnitsLineEdit->text()));
+   this->outputLineEdit->setText(Measurement::Unit::convertWithoutContext(inputLineEdit->text(), outputUnitsLineEdit->text()));
    return;
 }
 

--- a/src/UiAmountWithUnits.h
+++ b/src/UiAmountWithUnits.h
@@ -49,8 +49,8 @@ struct PreviousScaleInfo {
 class UiAmountWithUnits {
 public:
    /**
-    * \param
-    * \param
+    * \param parent
+    * \param fieldType
     * \param units
     */
    UiAmountWithUnits(QWidget * parent,

--- a/src/unitTests/Testing.cpp
+++ b/src/unitTests/Testing.cpp
@@ -228,12 +228,12 @@ namespace {
 
 
    //! \brief True iff a <= c <= b
-   constexpr bool inRange(double c, double a, double b) {
+   constexpr bool inRange(double const c, double const a, double const b) {
       return (a <= c) && (c <= b);
    }
 
    //! \brief True iff b - tolerance <= a <= b + tolerance
-   bool fuzzyComp(double a, double b, double tolerance) {
+   bool fuzzyComp(double const a, double const b, double const tolerance) {
       bool ret = inRange(a, b - tolerance, b + tolerance);
       if (!ret) {
          qDebug() << Q_FUNC_INFO << "a:" << a << ", b:" << b << ", diff:" << abs(a - b) << ", tolerance:" << tolerance;
@@ -609,13 +609,18 @@ void Testing::testUnitConversions() {
                       0.001),
             "Unit conversion error (US gallons to Litres v2)");
    // "5.500 gal"
+   // This is an ambiguous case where the units could be US gallons or Imperial gallons.  At the moment, we say either
+   // interpretation is valid (in the absence of any other context).
+   // 5.5 US gallons       ≈ 20.820 litres
+   // 5.5 Imperial gallons ≈ 25.004 litres
    testInput.clear();
    testInputAsStream << "5" << decimalSeparator << "500 gal";
-   QVERIFY2(fuzzyComp(Measurement::qStringToSI(testInput, // "5.500 gal"
-                                               Measurement::PhysicalQuantity::Volume).quantity(),
-                      20.820,
-                      0.001),
-                      "Unit conversion error (US gallons to Litres v3)");
+   auto converted = Measurement::qStringToSI(testInput, // "5.500 gal"
+                                             Measurement::PhysicalQuantity::Volume);
+   qDebug() << Q_FUNC_INFO << testInput << "converted to" << converted;
+   QVERIFY2(fuzzyComp(converted.quantity(), 20.820, 0.001) ||
+            fuzzyComp(converted.quantity(), 25.004, 0.001),
+            "Unit conversion error (US or Imperial gallons to Litres v3)");
    // "9.994 P"
    testInput.clear();
    testInputAsStream << "9" << decimalSeparator << "994 P";

--- a/src/utils/EnumStringMapping.cpp
+++ b/src/utils/EnumStringMapping.cpp
@@ -33,7 +33,7 @@ std::optional<int> EnumStringMapping::stringToEnumAsInt(QString const & stringVa
                              [stringValue](EnumAndItsString const & ii){return stringValue == ii.string;});
    //
    // If we didn't find an exact match, we'll try a case-insensitive one if so-configured.  (We don't do this by
-   // default as the assumption is that it's rare we'll need the case insensitivity.
+   // default as the assumption is that it's rare we'll need the case insensitivity.)
    //
    if (match == this->end() && caseInensitiveFallback) {
       match = std::find_if(


### PR DESCRIPTION
This is for https://github.com/Brewtarget/brewtarget/issues/725

Also a bit more work on the Mac build/packaging trying to fix this library-not-found-even-though-it's-there issue. (Including realised the final step of the Mac packaging was creating an empty .dmg file, which this fixes.)

Also tidied up a few comments.

(I meant this to be two separate PRs, but did things in the wrong order on github.)

NB: I think the changes I've done on looking up unit names slightly change the behaviour when you enter an ambiguous unit name.  Eg, if you type '5 gal', there is sometimes no way for us to know whether you mean US gallons or Imperial gallons - eg because you are using the free-standing conversion tool or you have configured a field's default units to be metric.  At the moment, if there are no other clues to follow, you get whichever type of gallon the program happens to find first, which might be different than in previous versions of the software.  I don't use gallons (of either sort) myself, so, if anyone who does wants to tell me how the behaviour should be different, then I would be very happy to hear it. 

