### PR TITLE
Water chemistry fixes (mostly)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -133,7 +133,7 @@
 #   - Meson 0.60.0 or newer to use + to append items to lists (aka 'list.<plus>' feature -- at least that's what the
 #     warning message says if you've specified a lower minimum version of Meson)
 # We would/will need:
-#   - Meson 0.62.0 or newer for dep 'dl' custom lookup
+#   - Meson 0.62.0 or newer for dep 'dl' custom lookup, but current version of Meson on Ubuntu 22.04 LTS is only 0.61.2
 #
 # NB: Per https://mesonbuild.com/Reference-manual_functions.html#project the default_options settings "are only used
 #     when running Meson for the first time"!  So if you change any of the default_options settings you *MUST* delete
@@ -585,8 +585,8 @@ commonSourceFiles = files([
    'src/Application.cpp',
    'src/BeerColorWidget.cpp',
    'src/boiltime.cpp',
-   'src/BrewDayScrollWidget.cpp',
    'src/BrewDayFormatter.cpp',
+   'src/BrewDayScrollWidget.cpp',
    'src/BrewNoteWidget.cpp',
    'src/BtColor.cpp',
    'src/BtDatePopup.cpp',
@@ -707,6 +707,7 @@ commonSourceFiles = files([
    'src/utils/EnumStringMapping.cpp',
    'src/utils/ImportRecordCount.cpp',
    'src/utils/TimerUtils.cpp',
+   'src/utils/TypeLookup.cpp',
    'src/WaterButton.cpp',
    'src/WaterDialog.cpp',
    'src/WaterEditor.cpp',
@@ -727,7 +728,7 @@ commonSourceFiles = files([
    'src/xml/XmlRecord.cpp',
    'src/YeastDialog.cpp',
    'src/YeastEditor.cpp',
-   'src/YeastSortFilterProxyModel.cpp'
+   'src/YeastSortFilterProxyModel.cpp',
 ])
 
 applicationMainSourceFile = files([
@@ -892,7 +893,7 @@ uiFiles = files([
    'ui/timerWidget.ui',
    'ui/waterDialog.ui',
    'ui/waterEditor.ui',
-   'ui/yeastEditor.ui'
+   'ui/yeastEditor.ui',
 ])
 
 #
@@ -1442,6 +1443,21 @@ endif
 #=======================================================================================================================
 #========================================== Linker-specific settings & flags ===========================================
 #=======================================================================================================================
+#
+# On MacOS, there are some extra linker flags to tell the OS where to look for shared libraries that we ship in the app
+# bundle.  These are passed in via the install_rpath parameter on Meson's `executable` function.  We don't want to pass
+# this parameter on Windows or Linux.  (I think it's harmless on Windows but might have some undesirable effect on
+# Linux.)  Fortunately we can put additional arguments in a platform-specific dictionary that can be passed to any
+# Meson function via the special 'kwargs' argument (provided there is no overlap between arguments specified directly in
+# the function call and those included in the dictionary).
+#
+# See comments in the `bt` build tool script for more on where/how MacOS searches for shared libraries.
+#
+if host_machine.system() == 'darwin'
+   platformSpecificArgs = {'install_rpath': '@executable_path/../Frameworks'}
+else
+   platformSpecificArgs = {}
+endif
 
 #=======================================================================================================================
 #===================================================== Main builds =====================================================
@@ -1465,6 +1481,7 @@ mainExecutable = executable(mainExecutableTargetName,
                             include_directories : includeDirs,
                             dependencies : mainExeDependencies,
                             link_with : commonCodeStaticLib,
+                            kwargs : platformSpecificArgs,
                             install : true)
 
 testRunner = executable(testRunnerTargetName,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,8 +47,8 @@ set(filesToCompile_cpp
     ${repoDir}/src/Application.cpp
     ${repoDir}/src/BeerColorWidget.cpp
     ${repoDir}/src/boiltime.cpp
-    ${repoDir}/src/BrewDayScrollWidget.cpp
     ${repoDir}/src/BrewDayFormatter.cpp
+    ${repoDir}/src/BrewDayScrollWidget.cpp
     ${repoDir}/src/BrewNoteWidget.cpp
     ${repoDir}/src/BtColor.cpp
     ${repoDir}/src/BtDatePopup.cpp
@@ -169,6 +169,7 @@ set(filesToCompile_cpp
     ${repoDir}/src/utils/EnumStringMapping.cpp
     ${repoDir}/src/utils/ImportRecordCount.cpp
     ${repoDir}/src/utils/TimerUtils.cpp
+    ${repoDir}/src/utils/TypeLookup.cpp
     ${repoDir}/src/WaterButton.cpp
     ${repoDir}/src/WaterDialog.cpp
     ${repoDir}/src/WaterEditor.cpp

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1921,7 +1921,7 @@ void MainWindow::exportRecipe() {
    BeerXML & bxml = BeerXML::getInstance();
    bxml.createXmlFile(*outFile);
 
-   QList<Recipe *> recipes{recipeObs};
+   QList<Recipe const *> recipes{recipeObs};
    bxml.toXml(recipes, *outFile);
 
    outFile->close();
@@ -2954,14 +2954,14 @@ void MainWindow::exportSelected() {
    // We therefore gather all the selected things together so that we write out all the Hops together, all the Styles
    // together and so on, because BeerXML wants them all in group tags (<HOPS>...</HOPS>, etc).
    //
-   QList<Equipment *>   equipments;
-   QList<Fermentable *> fermentables;
-   QList<Hop *>         hops;
-   QList<Misc *>        miscs;
-   QList<Recipe *>      recipes;
-   QList<Style *>       styles;
-   QList<Water *>       waters;
-   QList<Yeast *>       yeasts;
+   QList<Equipment   const *> equipments;
+   QList<Fermentable const *> fermentables;
+   QList<Hop         const *> hops;
+   QList<Misc        const *> miscs;
+   QList<Recipe      const *> recipes;
+   QList<Style       const *> styles;
+   QList<Water       const *> waters;
+   QList<Yeast       const *> yeasts;
 
    int count = 0;
    for (auto & selection : selected) {

--- a/src/RecipeExtrasWidget.cpp
+++ b/src/RecipeExtrasWidget.cpp
@@ -35,30 +35,26 @@ RecipeExtrasWidget::RecipeExtrasWidget(QWidget* parent) : QWidget(parent), recip
 
    ratingChanged = false;
 
-   connect(lineEdit_age,        &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateAge);
-   connect(lineEdit_ageTemp,    &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateAgeTemp);
-   connect(lineEdit_asstBrewer, &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateBrewerAsst );
-   connect(lineEdit_brewer,     &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateBrewer );
-   connect(lineEdit_carbVols,   &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateCarbonation );
-   connect(lineEdit_primaryAge, &BtLineEdit::textModified, this, &RecipeExtrasWidget::updatePrimaryAge );
-   connect(lineEdit_primaryTemp,&BtLineEdit::textModified, this, &RecipeExtrasWidget::updatePrimaryTemp );
-   connect(lineEdit_secAge,     &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateSecondaryAge );
-   connect(lineEdit_secTemp,    &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateSecondaryTemp );
-   connect(lineEdit_tertAge,    &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateTertiaryAge );
-   connect(lineEdit_tertTemp,   &BtLineEdit::textModified, this, &RecipeExtrasWidget::updateTertiaryTemp );
-
-   connect(spinBox_tasteRating, SIGNAL(valueChanged(int)), this, SLOT(changeRatings(int)) );
-   connect(spinBox_tasteRating, &QAbstractSpinBox::editingFinished, this, &RecipeExtrasWidget::updateTasteRating );
-
-   connect(dateEdit_date, &QDateTimeEdit::dateChanged, this, &RecipeExtrasWidget::updateDate );
-
-   connect(btTextEdit_notes, &BtTextEdit::textModified, this, &RecipeExtrasWidget::updateNotes);
-   connect(btTextEdit_tasteNotes, &BtTextEdit::textModified, this, &RecipeExtrasWidget::updateTasteNotes);
-
+   connect(lineEdit_age,          &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateAge          );
+   connect(lineEdit_ageTemp,      &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateAgeTemp      );
+   connect(lineEdit_asstBrewer,   &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateBrewerAsst   );
+   connect(lineEdit_brewer,       &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateBrewer       );
+   connect(lineEdit_carbVols,     &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateCarbonation  );
+   connect(lineEdit_primaryAge,   &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updatePrimaryAge   );
+   connect(lineEdit_primaryTemp,  &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updatePrimaryTemp  );
+   connect(lineEdit_secAge,       &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateSecondaryAge );
+   connect(lineEdit_secTemp,      &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateSecondaryTemp);
+   connect(lineEdit_tertAge,      &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateTertiaryAge  );
+   connect(lineEdit_tertTemp,     &BtLineEdit::textModified                  , this, &RecipeExtrasWidget::updateTertiaryTemp );
+   connect(spinBox_tasteRating,   QOverload<int>::of(&QSpinBox::valueChanged), this, &RecipeExtrasWidget::changeRatings      );
+   connect(spinBox_tasteRating,   &QAbstractSpinBox::editingFinished         , this, &RecipeExtrasWidget::updateTasteRating  );
+   connect(dateEdit_date,         &QDateTimeEdit::dateChanged                , this, &RecipeExtrasWidget::updateDate         );
+   connect(btTextEdit_notes,      &BtTextEdit::textModified                  , this, &RecipeExtrasWidget::updateNotes        );
+   connect(btTextEdit_tasteNotes, &BtTextEdit::textModified                  , this, &RecipeExtrasWidget::updateTasteNotes   );
+   return;
 }
 
-void RecipeExtrasWidget::setRecipe(Recipe* rec)
-{
+void RecipeExtrasWidget::setRecipe(Recipe* rec) {
    if (this->recipe) {
       disconnect(this->recipe, 0, this, 0);
    }
@@ -71,19 +67,14 @@ void RecipeExtrasWidget::setRecipe(Recipe* rec)
    return;
 }
 
-void RecipeExtrasWidget::updateBrewer()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updateBrewer() {
+   if (!this->recipe) { return;}
    MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::brewer, lineEdit_brewer->text(), tr("Change Brewer"));
+   return;
 }
 
-void RecipeExtrasWidget::updateBrewerAsst()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updateBrewerAsst() {
+   if (!this->recipe) { return;}
    if ( lineEdit_asstBrewer->isModified() ) {
       MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::asstBrewer, lineEdit_asstBrewer->text(), tr("Change Assistant Brewer"));
    }
@@ -92,86 +83,58 @@ void RecipeExtrasWidget::updateBrewerAsst()
 
 void RecipeExtrasWidget::changeRatings([[maybe_unused]] int rating) { ratingChanged = true; }
 
-void RecipeExtrasWidget::updateTasteRating()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updateTasteRating() {
+   if (!this->recipe) { return;}
    if ( ratingChanged )
    {
       MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::tasteRating, spinBox_tasteRating->value(), tr("Change Taste Rating"));
       ratingChanged = false;
    }
+   return;
 }
 
-void RecipeExtrasWidget::updatePrimaryAge()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updatePrimaryAge() {
+   if (!this->recipe) { return;}
    MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::primaryAge_days, lineEdit_primaryAge->toCanonical().quantity(), tr("Change Primary Age"));
 }
 
-void RecipeExtrasWidget::updatePrimaryTemp()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updatePrimaryTemp() {
+   if (!this->recipe) { return;}
    MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::primaryTemp_c, lineEdit_primaryTemp->toCanonical().quantity(), tr("Change Primary Temp"));
 }
 
-void RecipeExtrasWidget::updateSecondaryAge()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updateSecondaryAge() {
+   if (!this->recipe) { return;}
    MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::secondaryAge_days, lineEdit_secAge->toCanonical().quantity(), tr("Change Secondary Age"));
 }
 
-void RecipeExtrasWidget::updateSecondaryTemp()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updateSecondaryTemp() {
+   if (!this->recipe) { return;}
    MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::secondaryTemp_c, lineEdit_secTemp->toCanonical().quantity(), tr("Change Secondary Temp"));
 }
 
-void RecipeExtrasWidget::updateTertiaryAge()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updateTertiaryAge() {
+   if (!this->recipe) { return;}
    MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::tertiaryAge_days, lineEdit_tertAge->toCanonical().quantity(), tr("Change Tertiary Age"));
 }
 
-void RecipeExtrasWidget::updateTertiaryTemp()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updateTertiaryTemp() {
+   if (!this->recipe) { return;}
    MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::tertiaryTemp_c, lineEdit_tertTemp->toCanonical().quantity(), tr("Change Tertiary Temp"));
 }
 
-void RecipeExtrasWidget::updateAge()
-{
-   if( recipe == 0 )
-      return;
-
-   MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::age, lineEdit_age->toCanonical().quantity(), tr("Change Age"));
+void RecipeExtrasWidget::updateAge() {
+   if (!this->recipe) { return;}
+   MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::age_days, lineEdit_age->toCanonical().quantity(), tr("Change Age"));
 }
 
-void RecipeExtrasWidget::updateAgeTemp()
-{
-   if( recipe == 0 )
-      return;
-
+void RecipeExtrasWidget::updateAgeTemp() {
+   if (!this->recipe) { return;}
    MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::ageTemp_c, lineEdit_ageTemp->toCanonical().quantity(), tr("Change Age Temp"));
 }
 
 void RecipeExtrasWidget::updateDate(QDate const & date) {
-   if (!this->recipe) {
-      return;
-   }
+   if (!this->recipe) { return;}
 
    if (date.isNull()) {
       MainWindow::instance().doOrRedoUpdate(*recipe, PropertyNames::Recipe::date, dateEdit_date->date(), tr("Change Date"));
@@ -186,10 +149,8 @@ void RecipeExtrasWidget::updateDate(QDate const & date) {
    return;
 }
 
-void RecipeExtrasWidget::updateCarbonation()
-{
-   if( recipe == 0 )
-      return;
+void RecipeExtrasWidget::updateCarbonation() {
+   if (!this->recipe) { return;}
 
    MainWindow::instance().doOrRedoUpdate(*recipe,
                                          PropertyNames::Recipe::carbonation_vols,
@@ -197,10 +158,8 @@ void RecipeExtrasWidget::updateCarbonation()
                                          tr("Change Carbonation"));
 }
 
-void RecipeExtrasWidget::updateTasteNotes()
-{
-   if( recipe == 0 )
-      return;
+void RecipeExtrasWidget::updateTasteNotes() {
+   if (!this->recipe) { return;}
 
    MainWindow::instance().doOrRedoUpdate(*recipe,
                                          PropertyNames::Recipe::tasteNotes,
@@ -208,10 +167,8 @@ void RecipeExtrasWidget::updateTasteNotes()
                                          tr("Edit Taste Notes"));
 }
 
-void RecipeExtrasWidget::updateNotes()
-{
-   if( recipe == 0 )
-      return;
+void RecipeExtrasWidget::updateNotes() {
+   if (!this->recipe) { return;}
 
    MainWindow::instance().doOrRedoUpdate(*recipe,
                                          PropertyNames::Recipe::notes,
@@ -219,16 +176,16 @@ void RecipeExtrasWidget::updateNotes()
                                          tr("Edit Notes"));
 }
 
-void RecipeExtrasWidget::changed(QMetaProperty prop, QVariant /*val*/)
-{
-   if( sender() != recipe )
+void RecipeExtrasWidget::changed(QMetaProperty prop, QVariant /*val*/) {
+   if (sender() != this->recipe) {
       return;
+   }
 
    showChanges(&prop);
+   return;
 }
 
-void RecipeExtrasWidget::saveAll()
-{
+void RecipeExtrasWidget::saveAll() {
    //recObs->disableNotification();
 
    updateBrewer();
@@ -251,21 +208,18 @@ void RecipeExtrasWidget::saveAll()
    //recObs->forceNotify();
 
    hide();
+   return;
 }
 
-void RecipeExtrasWidget::showChanges(QMetaProperty* prop)
-{
-   bool updateAll = (prop == 0);
-   QString propName;
-   QVariant val;
-   if( prop )
-   {
-      propName = prop->name();
-      val = prop->read(recipe);
-   }
+void RecipeExtrasWidget::showChanges(QMetaProperty* prop) {
+   if (!this->recipe) { return;}
 
-   if( ! recipe )
-      return;
+   bool updateAll = true;
+   QString propName;
+   if (prop) {
+      updateAll = false;
+      propName = prop->name();
+   }
 
    // I think we may be going circular here? LineEdit says "change is made",
    // which signals the widget which changes the db, which signals "change is
@@ -273,55 +227,21 @@ void RecipeExtrasWidget::showChanges(QMetaProperty* prop)
    // "change is made" ... rinse, lather, repeat
    // Unlike other editors, this one needs to read from recipe when it gets an
    // updateAll
-   if ( updateAll )
-   {
+   if (updateAll || propName == PropertyNames::Recipe::age_days         ) { lineEdit_age         ->setText     (recipe->age_days         ()); }
+   if (updateAll || propName == PropertyNames::Recipe::ageTemp_c        ) { lineEdit_ageTemp     ->setText     (recipe->ageTemp_c        ()); }
+   if (updateAll || propName == PropertyNames::Recipe::asstBrewer       ) { lineEdit_asstBrewer  ->setText     (recipe->asstBrewer       ()); }
+   if (updateAll || propName == PropertyNames::Recipe::brewer           ) { lineEdit_brewer      ->setText     (recipe->brewer           ()); }
+   if (updateAll || propName == PropertyNames::Recipe::carbonation_vols ) { lineEdit_carbVols    ->setText     (recipe->carbonation_vols ()); }
+   if (updateAll || propName == PropertyNames::Recipe::primaryAge_days  ) { lineEdit_primaryAge  ->setText     (recipe->primaryAge_days  ()); }
+   if (updateAll || propName == PropertyNames::Recipe::primaryTemp_c    ) { lineEdit_primaryTemp ->setText     (recipe->primaryTemp_c    ()); }
+   if (updateAll || propName == PropertyNames::Recipe::secondaryAge_days) { lineEdit_secAge      ->setText     (recipe->secondaryAge_days()); }
+   if (updateAll || propName == PropertyNames::Recipe::secondaryTemp_c  ) { lineEdit_secTemp     ->setText     (recipe->secondaryTemp_c  ()); }
+   if (updateAll || propName == PropertyNames::Recipe::tertiaryAge_days ) { lineEdit_tertAge     ->setText     (recipe->tertiaryAge_days ()); }
+   if (updateAll || propName == PropertyNames::Recipe::tertiaryTemp_c   ) { lineEdit_tertTemp    ->setText     (recipe->tertiaryTemp_c   ()); }
+   if (updateAll || propName == PropertyNames::Recipe::tasteRating      ) { spinBox_tasteRating  ->setValue    (recipe->tasteRating      ()); }
+   if (updateAll || propName == PropertyNames::Recipe::date             ) { dateEdit_date        ->setDate     (recipe->date             ()); }
+   if (updateAll || propName == PropertyNames::Recipe::notes            ) { btTextEdit_notes     ->setPlainText(recipe->notes            ()); }
+   if (updateAll || propName == PropertyNames::Recipe::tasteNotes       ) { btTextEdit_tasteNotes->setPlainText(recipe->tasteNotes       ()); }
 
-      lineEdit_age->setText(recipe);
-      lineEdit_ageTemp->setText(recipe);
-      lineEdit_asstBrewer->setText(recipe);
-      lineEdit_brewer->setText(recipe);
-      lineEdit_carbVols->setText(recipe);
-      lineEdit_primaryAge->setText(recipe);
-      lineEdit_primaryTemp->setText(recipe);
-
-      lineEdit_secAge->setText(recipe);
-      lineEdit_secTemp->setText(recipe);
-      lineEdit_tertAge->setText(recipe);
-      lineEdit_tertTemp->setText(recipe);
-      spinBox_tasteRating->setValue((int)(recipe->tasteRating()));
-      dateEdit_date->setDate(recipe->date());
-      btTextEdit_notes->setPlainText(recipe->notes());
-      btTextEdit_tasteNotes->setPlainText(recipe->tasteNotes());
-   }
-   else if( propName == "age_days" )
-      lineEdit_age->setText(recipe);
-   else if( propName == PropertyNames::Recipe::ageTemp_c )
-      lineEdit_ageTemp->setText(recipe);
-   else if( propName == PropertyNames::Recipe::asstBrewer )
-      lineEdit_asstBrewer->setText(recipe);
-   else if( propName == PropertyNames::Recipe::brewer )
-      lineEdit_brewer->setText(recipe);
-   else if( propName == PropertyNames::Recipe::carbonation_vols )
-      lineEdit_carbVols->setText(recipe);
-   else if( propName == PropertyNames::Recipe::primaryAge_days )
-      lineEdit_primaryAge->setText(recipe);
-   else if( propName == PropertyNames::Recipe::primaryTemp_c )
-      lineEdit_primaryTemp->setText(recipe);
-   else if( propName == PropertyNames::Recipe::secondaryAge_days )
-      lineEdit_secAge->setText(recipe);
-   else if( propName == PropertyNames::Recipe::secondaryTemp_c )
-      lineEdit_secTemp->setText(recipe);
-   else if( propName == PropertyNames::Recipe::tertiaryAge_days )
-      lineEdit_tertAge->setText(recipe);
-   else if( propName == PropertyNames::Recipe::tertiaryTemp_c )
-      lineEdit_tertTemp->setText(recipe);
-   else if( propName == PropertyNames::Recipe::tasteRating )
-      spinBox_tasteRating->setValue( val.toInt() );
-   else if( propName == PropertyNames::Recipe::date )
-      dateEdit_date->setDate( val.toDate() );
-   else if( propName == "notes" )
-      btTextEdit_notes->setPlainText( val.toString() );
-   else if( propName == PropertyNames::Recipe::tasteNotes )
-      btTextEdit_tasteNotes->setPlainText( val.toString() );
-
+   return;
 }

--- a/src/WaterEditor.cpp
+++ b/src/WaterEditor.cpp
@@ -172,53 +172,25 @@ void WaterEditor::showChanges(QMetaProperty const * prop) {
    if (prop == nullptr) {
       qDebug() << Q_FUNC_INFO << this->pimpl->editorName << ": Update all";
       updateAll = true;
-   }
-   else {
+   } else {
       propName = prop->name();
       qDebug() << Q_FUNC_INFO << this->pimpl->editorName << ": Changed" << propName;
    }
 
-   if (propName == PropertyNames::NamedEntity::name || updateAll) {
-      lineEdit_name->setText(this->pimpl->observedWater->name());
-      if (!updateAll) return;
-   }
-   if (propName == PropertyNames::Water::calcium_ppm || updateAll) {
-      lineEdit_ca->setText(this->pimpl->observedWater->calcium_ppm(),2);
-      if (!updateAll) return;
-   }
-   if (propName == PropertyNames::Water::magnesium_ppm || updateAll) {
-      lineEdit_mg->setText(this->pimpl->observedWater->magnesium_ppm(),2);
-      if (!updateAll) return;
-   }
-   if (propName == PropertyNames::Water::sulfate_ppm || updateAll) {
-      lineEdit_so4->setText(this->pimpl->observedWater->sulfate_ppm(),2);
-      if (!updateAll) return;
-   }
-   if (propName == PropertyNames::Water::sodium_ppm || updateAll) {
-      lineEdit_na->setText(this->pimpl->observedWater->sodium_ppm(),2);
-      if (!updateAll) return;
-   }
-   if (propName == PropertyNames::Water::chloride_ppm || updateAll) {
-      lineEdit_cl->setText(this->pimpl->observedWater->chloride_ppm(),2);
-      if (!updateAll) return;
-   }
-   if (propName == PropertyNames::Water::bicarbonate_ppm || updateAll) {
-      lineEdit_alk->setText(this->pimpl->observedWater->bicarbonate_ppm(),2);
-      if (!updateAll) return;
-   }
-   if (propName == PropertyNames::Water::ph || updateAll) {
-      lineEdit_ph->setText(this->pimpl->observedWater->ph(),2);
-      if (!updateAll) return;
-   }
-   if (propName == PropertyNames::Water::alkalinityAsHCO3 || updateAll) {
+   if (updateAll || propName == PropertyNames::NamedEntity::name      ) {lineEdit_name->setText(this->pimpl->observedWater->name()              ); if (!updateAll) { return; } }
+   if (updateAll || propName == PropertyNames::Water::calcium_ppm     ) {lineEdit_ca  ->setText(this->pimpl->observedWater->calcium_ppm()    , 2); if (!updateAll) { return; } }
+   if (updateAll || propName == PropertyNames::Water::magnesium_ppm   ) {lineEdit_mg  ->setText(this->pimpl->observedWater->magnesium_ppm()  , 2); if (!updateAll) { return; } }
+   if (updateAll || propName == PropertyNames::Water::sulfate_ppm     ) {lineEdit_so4 ->setText(this->pimpl->observedWater->sulfate_ppm()    , 2); if (!updateAll) { return; } }
+   if (updateAll || propName == PropertyNames::Water::sodium_ppm      ) {lineEdit_na  ->setText(this->pimpl->observedWater->sodium_ppm()     , 2); if (!updateAll) { return; } }
+   if (updateAll || propName == PropertyNames::Water::chloride_ppm    ) {lineEdit_cl  ->setText(this->pimpl->observedWater->chloride_ppm()   , 2); if (!updateAll) { return; } }
+   if (updateAll || propName == PropertyNames::Water::bicarbonate_ppm ) {lineEdit_alk ->setText(this->pimpl->observedWater->bicarbonate_ppm(), 2); if (!updateAll) { return; } }
+   if (updateAll || propName == PropertyNames::Water::ph              ) {lineEdit_ph  ->setText(this->pimpl->observedWater->ph()             , 2); if (!updateAll) { return; } }
+   if (updateAll || propName == PropertyNames::Water::alkalinityAsHCO3) {
       bool typeless = this->pimpl->observedWater->alkalinityAsHCO3();
       comboBox_alk->setCurrentIndex(comboBox_alk->findText(typeless ? "HCO3" : "CaCO3"));
       if (!updateAll) return;
    }
-   if (propName == PropertyNames::Water::notes || updateAll) {
-      plainTextEdit_notes->setPlainText(this->pimpl->observedWater->notes());
-      if (!updateAll) return;
-   }
+   if (updateAll || propName == PropertyNames::Water::notes           ) { plainTextEdit_notes->setPlainText(this->pimpl->observedWater->notes() ); if (!updateAll) { return; } }
 
    return;
 }
@@ -241,17 +213,17 @@ void WaterEditor::inputFieldModified() {
       // .:TBD:. Need to get to the bottom of the relationship between Water::alkalinity and Water::bicarbonate_ppm.  It
       //         feels wrong that we just set both from the same input, but probably needs some more profound thought
       //         about what exactly correct behaviour should be.
-      if      (signalSender == this->comboBox_alk)         {this->pimpl->editedWater->setAlkalinityAsHCO3(this->comboBox_alk->currentText() == QString("HCO3"));}
-      else if (signalSender == this->lineEdit_alk)         {this->pimpl->editedWater->setBicarbonate_ppm (this->lineEdit_alk->toCanonical().quantity());  // NB continues on next line!
-                                                            this->pimpl->editedWater->setAlkalinity      (this->lineEdit_alk->toCanonical().quantity());                 }
-      else if (signalSender == this->lineEdit_ca)          {this->pimpl->editedWater->setCalcium_ppm     (this->lineEdit_ca->toCanonical().quantity());                  }
-      else if (signalSender == this->lineEdit_cl)          {this->pimpl->editedWater->setChloride_ppm    (this->lineEdit_cl->toCanonical().quantity());                  }
-      else if (signalSender == this->lineEdit_mg)          {this->pimpl->editedWater->setMagnesium_ppm   (this->lineEdit_mg->toCanonical().quantity());                  }
-      else if (signalSender == this->lineEdit_na)          {this->pimpl->editedWater->setSodium_ppm      (this->lineEdit_na->toCanonical().quantity());                  }
-      else if (signalSender == this->lineEdit_name)        {this->pimpl->editedWater->setName            (this->lineEdit_name->text());                         }
-      else if (signalSender == this->lineEdit_ph)          {this->pimpl->editedWater->setPh              (this->lineEdit_ph->toCanonical().quantity());                  }
-      else if (signalSender == this->lineEdit_so4)         {this->pimpl->editedWater->setSulfate_ppm     (this->lineEdit_so4->toCanonical().quantity());                 }
-      else if (signalSender == this->plainTextEdit_notes)  {this->pimpl->editedWater->setNotes           (this->plainTextEdit_notes->toPlainText());            }
+      if      (signalSender == this->comboBox_alk)         {this->pimpl->editedWater->setAlkalinityAsHCO3(this->comboBox_alk ->currentText() == QString("HCO3"));}
+      else if (signalSender == this->lineEdit_alk)         {this->pimpl->editedWater->setBicarbonate_ppm (this->lineEdit_alk ->toCanonical().quantity());  // NB continues on next line!
+                                                            this->pimpl->editedWater->setAlkalinity      (this->lineEdit_alk ->toCanonical().quantity());        }
+      else if (signalSender == this->lineEdit_ca)          {this->pimpl->editedWater->setCalcium_ppm     (this->lineEdit_ca  ->toCanonical().quantity());        }
+      else if (signalSender == this->lineEdit_cl)          {this->pimpl->editedWater->setChloride_ppm    (this->lineEdit_cl  ->toCanonical().quantity());        }
+      else if (signalSender == this->lineEdit_mg)          {this->pimpl->editedWater->setMagnesium_ppm   (this->lineEdit_mg  ->toCanonical().quantity());        }
+      else if (signalSender == this->lineEdit_na)          {this->pimpl->editedWater->setSodium_ppm      (this->lineEdit_na  ->toCanonical().quantity());        }
+      else if (signalSender == this->lineEdit_name)        {this->pimpl->editedWater->setName            (this->lineEdit_name->text());                          }
+      else if (signalSender == this->lineEdit_ph)          {this->pimpl->editedWater->setPh              (this->lineEdit_ph  ->toCanonical().quantity());        }
+      else if (signalSender == this->lineEdit_so4)         {this->pimpl->editedWater->setSulfate_ppm     (this->lineEdit_so4 ->toCanonical().quantity());        }
+      else if (signalSender == this->plainTextEdit_notes)  {this->pimpl->editedWater->setNotes           (this->plainTextEdit_notes->toPlainText());             }
       else {
          // If we get here, it's probably a coding error
          qWarning() << Q_FUNC_INFO << "Unrecognised child";
@@ -293,13 +265,15 @@ void WaterEditor::saveAndClose() {
          ":" << this->pimpl->observedWater->name();
    }
 
-   // This is deliberately commented out for now at least as, when we're called from WaterDialog, it is that window that
-   // is responsible for adding new Water objects to the Recipe (which results in the Water object being saved in the
-   // DB).  If we save the Water object here then the current logic in WaterDialog won't pick up that it needs to be added to the Recipe.
-//   if (this->pimpl->observedWater->key() < 0) {
-//      qDebug() << Q_FUNC_INFO << "Writing new Water:" << this->pimpl->observedWater->name();
-//      ObjectStoreWrapper::insert(this->pimpl->observedWater);
-//   }
+   //
+   // TBD: When we're called from WaterDialog, it is that window that is responsible for adding new Water objects to the
+   //      Recipe (which results in the Water object being saved in the DB).  Saving the Water object means the current
+   //      logic in WaterDialog won't pick up that it needs to be added to the Recipe.
+   //
+   if (this->pimpl->observedWater->key() < 0) {
+      qDebug() << Q_FUNC_INFO << "Writing new Water:" << this->pimpl->observedWater->name();
+      ObjectStoreWrapper::insert(this->pimpl->observedWater);
+   }
 
    setVisible(false);
    return;

--- a/src/database/DatabaseSchemaHelper.cpp
+++ b/src/database/DatabaseSchemaHelper.cpp
@@ -210,7 +210,7 @@ namespace {
       return executeSqlQueries(q, migrationQueries);
    }
 
-   bool migrate_to_5(Database & db, BtSqlQuery q) {
+   bool migrate_to_5([[maybe_unused]] Database & db, BtSqlQuery q) {
       QVector<QueryAndParameters> const migrationQueries{
          // Drop the previous bugged TRIGGER
          {QString("DROP TRIGGER dec_ins_num")},
@@ -227,13 +227,12 @@ namespace {
    }
 
    //
-   bool migrate_to_6(Database & db, BtSqlQuery q) {
-      bool ret = true;
+   bool migrate_to_6([[maybe_unused]] Database & db, [[maybe_unused]] BtSqlQuery q) {
       // I drop this table in version 8. There is no sense doing anything here, and it breaks other things.
-      return ret;
+      return true;
    }
 
-   bool migrate_to_7(Database & db, BtSqlQuery q) {
+   bool migrate_to_7([[maybe_unused]] Database & db, BtSqlQuery q) {
       QVector<QueryAndParameters> const migrationQueries{
          // Add "attenuation" to brewnote table
          {"ALTER TABLE brewnote ADD COLUMN attenuation real"} // Previously DEFAULT 0.0
@@ -575,7 +574,7 @@ namespace {
       }
 
       // Set the db version
-      if( oldVersion > 3 )
+      if (oldVersion > 3 )
       {
          QString queryString{"UPDATE settings SET version=:version WHERE id=1"};
          sqlQuery.prepare(queryString);
@@ -644,7 +643,7 @@ bool DatabaseSchemaHelper::create(Database & database, QSqlDatabase connection) 
 }
 
 bool DatabaseSchemaHelper::migrate(Database & database, int oldVersion, int newVersion, QSqlDatabase connection) {
-   if( oldVersion >= newVersion || newVersion > dbVersion ) {
+   if (oldVersion >= newVersion || newVersion > dbVersion ) {
       qDebug() << Q_FUNC_INFO <<
          QString("Requested backwards migration from %1 to %2: You are an imbecile").arg(oldVersion).arg(newVersion);
       return false;
@@ -676,7 +675,7 @@ int DatabaseSchemaHelper::currentVersion(QSqlDatabase db) {
    // We'll read it into a QVariant and then work out whether it's a string or an integer
    BtSqlQuery q("SELECT version FROM settings WHERE id=1", db);
    QVariant ver;
-   if( q.next() ) {
+   if (q.next() ) {
       ver = q.value("version");
    } else {
       // No settings table in version 2.0.0
@@ -693,15 +692,15 @@ int DatabaseSchemaHelper::currentVersion(QSqlDatabase db) {
       return ver.toInt();
    }
 
-   if( stringVer == "2.0.0" ) {
+   if (stringVer == "2.0.0" ) {
       return 1;
    }
 
-   if( stringVer == "2.0.2" ) {
+   if (stringVer == "2.0.2" ) {
       return 2;
    }
 
-   if( stringVer == "2.1.0" ) {
+   if (stringVer == "2.1.0" ) {
       return 3;
    }
 

--- a/src/database/ObjectStore.h
+++ b/src/database/ObjectStore.h
@@ -1,6 +1,6 @@
 /*
  * database/ObjectStore.h is part of Brewtarget, and is copyright the following
- * authors 2021-2022:
+ * authors 2021-2023:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
@@ -29,19 +29,20 @@
 #include <QString>
 #include <QVector>
 
+#include "model/NamedEntity.h"
 #include "utils/BtStringConst.h"
 #include "utils/EnumStringMapping.h"
+#include "utils/TypeLookup.h"
 
 class Database;
 class NamedParameterBundle;
-
 
 /**
  * \brief Base class for storing objects (of a given class) in (a) the database and (b) a local in-memory cache.
  *
  *        This class does all the generic work and, by virtue of being a non-template class, can have most of its
  *        implementation private.  The template class \c ObjectStoreTyped then does the class-specific work (eg
- *        call constructor for the right type of object) and provides a class- specific interface (so that callers
+ *        call constructor for the right type of object) and provides a class-specific interface (so that callers
  *        don't have to downcast return values etc).
  *
  *        A further namespace \c ObjectStoreWrapper slightly simplifies the syntax of calls into \c ObjectStoreTyped
@@ -65,21 +66,26 @@ public:
    /**
     * \brief The different field types that can be stored directly in an object's DB table.
     *
-    *        Note that older versions of the code do a lot of special handling for boolean because SQLite has no native
+    *        Note that older versions of the code did a lot of special handling for boolean because SQLite has no native
     *        boolean type and therefore stores bools as integers (0 or 1).  However, since bugs in this area of Qt were
     *        fixed back in 2012 -- see https://bugreports.qt.io/browse/QTBUG-23895 (and
     *        https://bugreports.qt.io/browse/QTBUG-15640) -- I believe we are now safe to rely on QVariant to do all
     *        the right conversions for us.
     */
-   enum FieldType {
+   enum class FieldType {
       Bool,
       Int,
       UInt,
       Double,
       String,
       Date,
-      Enum   // Stored as a string in the DB
+      Enum,          // Stored as a string in the DB
    };
+
+   /**
+    * \brief Convenience function for logging
+    */
+   static QString getDisplayName(FieldType const fieldType);
 
    //
    // It's a bit tedious having to create constructors for structs but we need them to allow BtStringConst members to be
@@ -92,17 +98,17 @@ public:
 
    struct TableDefinition;
    struct TableField {
-      FieldType const                 fieldType;
-      BtStringConst const             columnName;   // Shouldn't ever be empty in practice
-      BtStringConst const             propertyName; // Can be empty in a junction table (see below)
+      FieldType                 const fieldType;
+      BtStringConst             const columnName;   // Shouldn't ever be empty in practice
+      BtStringConst             const propertyName; // Can be empty in a junction table (see below)
       EnumStringMapping const * const enumMapping;  // Only needed if fieldType is Enum
-      TableDefinition const * const   foreignKeyTo;
+      TableDefinition   const * const foreignKeyTo;
       //! Constructor
-      TableField(FieldType const                 fieldType,
-                 char const * const              columnName = nullptr,
-                 BtStringConst const &           propertyName = BtString::NULL_STR,
-                 EnumStringMapping const * const enumMapping = nullptr,
-                 TableDefinition const * const   foreignKeyTo = nullptr) :
+      TableField(FieldType                 const   fieldType,
+                 char              const * const   columnName   = nullptr,
+                 BtStringConst             const & propertyName = BtString::NULL_STR,
+                 EnumStringMapping const * const   enumMapping  = nullptr,
+                 TableDefinition   const * const   foreignKeyTo = nullptr) :
          fieldType{fieldType},
          columnName{columnName},
          propertyName{propertyName},
@@ -186,17 +192,19 @@ public:
 
    };
 
-
    // This isn't strictly necessary, but it makes various declarations more concise
    typedef QVector<JunctionTableDefinition> JunctionTableDefinitions;
 
    /**
     * \brief Constructor sets up mappings but does not read in data from DB
     *
+    * \param typeLookup The \c TypeLookup object that, amongst other things allows us to tell whether Qt properties on
+    *                   this object type are "optional" (ie wrapped in \c std::optional)
     * \param primaryTable  First in the list should be the primary key
     * \param junctionTables  Optional
     */
-   ObjectStore(TableDefinition const &          primaryTable,
+   ObjectStore(TypeLookup               const & typeLookup,
+               TableDefinition          const & primaryTable,
                JunctionTableDefinitions const & junctionTables = JunctionTableDefinitions{});
 
    ~ObjectStore();
@@ -501,5 +509,14 @@ private:
 
 };
 
+
+/**
+ * \brief Convenience function for logging
+ */
+template<class S>
+S & operator<<(S & stream, ObjectStore::FieldType const fieldType) {
+   stream << "FieldType #" << static_cast<int>(fieldType) << ": (" << ObjectStore::getDisplayName(fieldType) << ")";
+   return stream;
+}
 
 #endif

--- a/src/database/ObjectStoreTyped.cpp
+++ b/src/database/ObjectStoreTyped.cpp
@@ -1,6 +1,6 @@
 /*
  * database/ObjectStoreTyped.cpp is part of Brewtarget, and is copyright the
- * following authors 2021-2022:
+ * following authors 2021-2023:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
@@ -119,27 +119,27 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Fermentable> {
       "fermentable",
       {
-         {ObjectStore::FieldType::Int,    "id",               PropertyNames::NamedEntity::key},
-         {ObjectStore::FieldType::String, "name",             PropertyNames::NamedEntity::name},
-         {ObjectStore::FieldType::Bool,   "deleted",          PropertyNames::NamedEntity::deleted},
-         {ObjectStore::FieldType::Bool,   "display",          PropertyNames::NamedEntity::display},
-         {ObjectStore::FieldType::String, "folder",           PropertyNames::NamedEntity::folder},
-         {ObjectStore::FieldType::Int,    "inventory_id",     PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,                   &PRIMARY_TABLE<InventoryFermentable>},
-         {ObjectStore::FieldType::Bool,   "add_after_boil",   PropertyNames::Fermentable::addAfterBoil},
+         {ObjectStore::FieldType::Int,    "id"              , PropertyNames::NamedEntity::key                           },
+         {ObjectStore::FieldType::String, "name"            , PropertyNames::NamedEntity::name                          },
+         {ObjectStore::FieldType::Bool,   "deleted"         , PropertyNames::NamedEntity::deleted                       },
+         {ObjectStore::FieldType::Bool,   "display"         , PropertyNames::NamedEntity::display                       },
+         {ObjectStore::FieldType::String, "folder"          , PropertyNames::NamedEntity::folder                        },
+         {ObjectStore::FieldType::Int,    "inventory_id"    , PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,                          &PRIMARY_TABLE<InventoryFermentable>},
+         {ObjectStore::FieldType::Bool,   "add_after_boil"  , PropertyNames::Fermentable::addAfterBoil                  },
          {ObjectStore::FieldType::Double, "amount",           PropertyNames::Fermentable::amount_kg},
-         {ObjectStore::FieldType::Double, "coarse_fine_diff", PropertyNames::Fermentable::coarseFineDiff_pct},
-         {ObjectStore::FieldType::Double, "color",            PropertyNames::Fermentable::color_srm},
-         {ObjectStore::FieldType::Double, "diastatic_power",  PropertyNames::Fermentable::diastaticPower_lintner},
+         {ObjectStore::FieldType::Double, "coarse_fine_diff", PropertyNames::Fermentable::coarseFineDiff_pct            },
+         {ObjectStore::FieldType::Double, "color"           , PropertyNames::Fermentable::color_srm                     },
+         {ObjectStore::FieldType::Double, "diastatic_power" , PropertyNames::Fermentable::diastaticPower_lintner        },
          {ObjectStore::FieldType::Enum,   "ftype",            PropertyNames::Fermentable::type,                     &DB_FERMENTABLE_TYPE_ENUM},
-         {ObjectStore::FieldType::Bool,   "is_mashed",        PropertyNames::Fermentable::isMashed},
-         {ObjectStore::FieldType::Double, "ibu_gal_per_lb",   PropertyNames::Fermentable::ibuGalPerLb},
-         {ObjectStore::FieldType::Double, "max_in_batch",     PropertyNames::Fermentable::maxInBatch_pct},
-         {ObjectStore::FieldType::Double, "moisture",         PropertyNames::Fermentable::moisture_pct},
-         {ObjectStore::FieldType::String, "notes",            PropertyNames::Fermentable::notes},
-         {ObjectStore::FieldType::String, "origin",           PropertyNames::Fermentable::origin},
-         {ObjectStore::FieldType::String, "supplier",         PropertyNames::Fermentable::supplier},
-         {ObjectStore::FieldType::Double, "protein",          PropertyNames::Fermentable::protein_pct},
-         {ObjectStore::FieldType::Bool,   "recommend_mash",   PropertyNames::Fermentable::recommendMash},
+         {ObjectStore::FieldType::Bool,   "is_mashed"       , PropertyNames::Fermentable::isMashed                      },
+         {ObjectStore::FieldType::Double, "ibu_gal_per_lb"  , PropertyNames::Fermentable::ibuGalPerLb                   },
+         {ObjectStore::FieldType::Double, "max_in_batch"    , PropertyNames::Fermentable::maxInBatch_pct                },
+         {ObjectStore::FieldType::Double, "moisture"        , PropertyNames::Fermentable::moisture_pct                  },
+         {ObjectStore::FieldType::String, "notes"           , PropertyNames::Fermentable::notes                         },
+         {ObjectStore::FieldType::String, "origin"          , PropertyNames::Fermentable::origin                        },
+         {ObjectStore::FieldType::String, "supplier"        , PropertyNames::Fermentable::supplier                      },
+         {ObjectStore::FieldType::Double, "protein"         , PropertyNames::Fermentable::protein_pct                   },
+         {ObjectStore::FieldType::Bool,   "recommend_mash"  , PropertyNames::Fermentable::recommendMash                 },
          {ObjectStore::FieldType::Double, "yield",            PropertyNames::Fermentable::yield_pct}
       }
    };
@@ -167,6 +167,9 @@ namespace {
    };
    template<> ObjectStore::JunctionTableDefinitions const JUNCTION_TABLES<InventoryHop> {};
 
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   // Database field mappings for Hop
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Hop> {
       "hop",
       {
@@ -548,7 +551,7 @@ namespace {
          {ObjectStore::FieldType::Bool,   "deleted",             PropertyNames::NamedEntity::deleted        },
          {ObjectStore::FieldType::Bool,   "display",             PropertyNames::NamedEntity::display        },
          {ObjectStore::FieldType::String, "folder",              PropertyNames::NamedEntity::folder         },
-         {ObjectStore::FieldType::Double, "age",                 PropertyNames::Recipe::age                 },
+         {ObjectStore::FieldType::Double, "age",                 PropertyNames::Recipe::age_days                 },
          {ObjectStore::FieldType::Double, "age_temp",            PropertyNames::Recipe::ageTemp_c           },
          {ObjectStore::FieldType::String, "assistant_brewer",    PropertyNames::Recipe::asstBrewer          },
          {ObjectStore::FieldType::Double, "batch_size",          PropertyNames::Recipe::batchSize_l         },
@@ -578,7 +581,7 @@ namespace {
          {ObjectStore::FieldType::Double, "taste_rating",        PropertyNames::Recipe::tasteRating         },
          {ObjectStore::FieldType::Double, "tertiary_age",        PropertyNames::Recipe::tertiaryAge_days    },
          {ObjectStore::FieldType::Double, "tertiary_temp",       PropertyNames::Recipe::tertiaryTemp_c      },
-         {ObjectStore::FieldType::Enum,   "type",                PropertyNames::Recipe::recipeType,           &RECIPE_STEP_TYPE_ENUM},
+         {ObjectStore::FieldType::Enum,   "type",                PropertyNames::Recipe::type,           &RECIPE_STEP_TYPE_ENUM},
          {ObjectStore::FieldType::Int,    "ancestor_id",         PropertyNames::Recipe::ancestorId,           nullptr,                &PRIMARY_TABLE<Recipe>},
          {ObjectStore::FieldType::Bool,   "locked",              PropertyNames::Recipe::locked              }
       }
@@ -698,7 +701,7 @@ namespace {
    //
    // This should give us all the singleton instances
    //
-   template<class NE> ObjectStoreTyped<NE> ostSingleton{PRIMARY_TABLE<NE>, JUNCTION_TABLES<NE>};
+   template<class NE> ObjectStoreTyped<NE> ostSingleton{NE::typeLookup, PRIMARY_TABLE<NE>, JUNCTION_TABLES<NE>};
 
 }
 

--- a/src/database/ObjectStoreTyped.h
+++ b/src/database/ObjectStoreTyped.h
@@ -1,6 +1,6 @@
 /*
  * database/ObjectStoreTyped.h is part of Brewtarget, and is copyright the
- * following authors 2021-2022:
+ * following authors 2021-2023:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
@@ -39,9 +39,10 @@ public:
     *
     * \param primaryTable First in the list of fields in this table defn should be the primary key
     */
-   ObjectStoreTyped(TableDefinition const & primaryTable,
+   ObjectStoreTyped(TypeLookup               const & typeLookup,
+                    TableDefinition          const & primaryTable,
                     JunctionTableDefinitions const & junctionTables = JunctionTableDefinitions{}) :
-      ObjectStore(primaryTable, junctionTables) {
+      ObjectStore(typeLookup, primaryTable, junctionTables) {
       return;
    }
 
@@ -53,6 +54,8 @@ public:
     * \brief Get the singleton instance of this class
     */
    static ObjectStoreTyped<NE> & getInstance();
+
+   using ObjectStore::insert;
 
    /**
     * \brief Insert a new object in the DB (and in our cache list)
@@ -104,6 +107,8 @@ public:
       std::shared_ptr<NE> nePointer{&ne};
       return this->insert(nePointer);
    }
+
+   using ObjectStore::insertOrUpdate;
 
    /**
     * \brief Convenience function that calls either \c insert or \c update, depending on whether the object is already
@@ -241,7 +246,8 @@ public:
    /**
     * \brief Search the set of all cached objects with a lambda.
     *
-    * \param matchFunction Takes a pointer to an object and returns \c true if the object is a match or \c false otherwise.
+    * \param matchFunction Takes a pointer to an object and returns \c true if the object is a match or \c false
+    *                      otherwise.
     *
     * \return List of shared pointers to all the objects that give a \c true result to \c matchFunction (and thus an
     *         empty list if none does).
@@ -378,9 +384,12 @@ private:
 
    //! No copy constructor, as never want anyone, not even our friends, to make copies of a singleton
    ObjectStoreTyped(ObjectStoreTyped const &) = delete;
-   //! No assignment operator , as never want anyone, not even our friends, to make copies of a singleton.
+   //! No copy assignment operator, as never want anyone, not even our friends, to make copies of a singleton.
    ObjectStoreTyped & operator=(ObjectStoreTyped const &) = delete;
-
+   //! No move constructor
+   ObjectStoreTyped(ObjectStoreTyped && other) = delete;
+   //! No move assignment operator
+   ObjectStoreTyped& operator=(ObjectStoreTyped&& other) = delete;
 };
 
 /**

--- a/src/model/BrewNote.cpp
+++ b/src/model/BrewNote.cpp
@@ -71,6 +71,46 @@ ObjectStore & BrewNote::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<BrewNote>::getInstance();
 }
 
+TypeLookup const BrewNote::typeLookup {
+   "BrewNote",
+   {
+      // Note that we need Enums to be treated as ints for the purposes of type lookup
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::abv              , BrewNote::m_abv              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::attenuation      , BrewNote::m_attenuation      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::boilOff_l        , BrewNote::m_boilOff_l        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::brewDate         , BrewNote::m_brewDate         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::brewhouseEff_pct , BrewNote::m_brewhouseEff_pct ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::effIntoBK_pct    , BrewNote::m_effIntoBK_pct    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::fermentDate      , BrewNote::m_fermentDate      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::fg               , BrewNote::m_fg               ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::finalVolume_l    , BrewNote::m_finalVolume_l    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::mashFinTemp_c    , BrewNote::m_mashFinTemp_c    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::notes            , BrewNote::m_notes            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::og               , BrewNote::m_og               ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::pitchTemp_c      , BrewNote::m_pitchTemp_c      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::postBoilVolume_l , BrewNote::m_postBoilVolume_l ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projABV_pct      , BrewNote::m_projABV_pct      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projAtten        , BrewNote::m_projAtten        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projBoilGrav     , BrewNote::m_projBoilGrav     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projEff_pct      , BrewNote::m_projEff_pct      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projFermPoints   , BrewNote::m_projFermPoints   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projFg           , BrewNote::m_projFg           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projMashFinTemp_c, BrewNote::m_projMashFinTemp_c),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projOg           , BrewNote::m_projOg           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projPoints       , BrewNote::m_projPoints       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projStrikeTemp_c , BrewNote::m_projStrikeTemp_c ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projVolIntoBK_l  , BrewNote::m_projVolIntoBK_l  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::projVolIntoFerm_l, BrewNote::m_projVolIntoFerm_l),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::recipeId         , BrewNote::m_recipeId         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::sg               , BrewNote::m_sg               ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::strikeTemp_c     , BrewNote::m_strikeTemp_c     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::volumeIntoBK_l   , BrewNote::m_volumeIntoBK_l   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::BrewNote::volumeIntoFerm_l , BrewNote::m_volumeIntoFerm_l ),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
+
 // Initializers
 BrewNote::BrewNote(QString name) : BrewNote(QDate(), name) {
    return;

--- a/src/model/BrewNote.h
+++ b/src/model/BrewNote.h
@@ -82,6 +82,12 @@ class BrewNote : public NamedEntity {
    Q_OBJECT
 
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
+
    BrewNote(QString name = "");
    BrewNote(Recipe const & recipe);
    BrewNote(QDate dateNow, QString const & name = "");

--- a/src/model/Equipment.cpp
+++ b/src/model/Equipment.cpp
@@ -50,6 +50,30 @@ ObjectStore & Equipment::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Equipment>::getInstance();
 }
 
+TypeLookup const Equipment::typeLookup {
+   "Equipment",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::batchSize_l          , Equipment::m_batchSize_l          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::boilingPoint_c       , Equipment::m_boilingPoint_c       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::boilSize_l           , Equipment::m_boilSize_l           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::boilTime_min         , Equipment::m_boilTime_min         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::calcBoilVolume       , Equipment::m_calcBoilVolume       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::evapRate_lHr         , Equipment::m_evapRate_lHr         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::evapRate_pctHr       , Equipment::m_evapRate_pctHr       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::grainAbsorption_LKg  , Equipment::m_grainAbsorption_LKg  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::hopUtilization_pct   , Equipment::m_hopUtilization_pct   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::lauterDeadspace_l    , Equipment::m_lauterDeadspace_l    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::notes                , Equipment::m_notes                ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::topUpKettle_l        , Equipment::m_topUpKettle_l        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::topUpWater_l         , Equipment::m_topUpWater_l         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::trubChillerLoss_l    , Equipment::m_trubChillerLoss_l    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::tunSpecificHeat_calGC, Equipment::m_tunSpecificHeat_calGC),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::tunVolume_l          , Equipment::m_tunVolume_l          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Equipment::tunWeight_kg         , Equipment::m_tunWeight_kg         ),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
 
 //=============================CONSTRUCTORS=====================================
 Equipment::Equipment(QString t_name) :

--- a/src/model/Equipment.h
+++ b/src/model/Equipment.h
@@ -60,10 +60,14 @@ AddPropertyName(tunWeight_kg         )
  */
 class Equipment : public NamedEntity {
    Q_OBJECT
-
-public:
    Q_CLASSINFO("signal", "equipments")
 
+public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    Equipment(QString t_name = "");
    Equipment(NamedParameterBundle const & namedParameterBundle);

--- a/src/model/Fermentable.cpp
+++ b/src/model/Fermentable.cpp
@@ -55,10 +55,35 @@ ObjectStore & Fermentable::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Fermentable>::getInstance();
 }
 
+TypeLookup const Fermentable::typeLookup {
+   "Fermentable",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::type                  , Fermentable::m_type                  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::amount_kg             , Fermentable::m_amountKg              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::yield_pct             , Fermentable::m_yieldPct              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::color_srm             , Fermentable::m_colorSrm              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::addAfterBoil          , Fermentable::m_isAfterBoil           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::origin                , Fermentable::m_origin                ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::supplier              , Fermentable::m_supplier              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::notes                 , Fermentable::m_notes                 ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::coarseFineDiff_pct    , Fermentable::m_coarseFineDiff        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::moisture_pct          , Fermentable::m_moisturePct           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::diastaticPower_lintner, Fermentable::m_diastaticPower        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::protein_pct           , Fermentable::m_proteinPct            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::maxInBatch_pct        , Fermentable::m_maxInBatchPct         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::recommendMash         , Fermentable::m_recommendMash         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::ibuGalPerLb           , Fermentable::m_ibuGalPerLb           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Fermentable::isMashed              , Fermentable::m_isMashed              ),
+   },
+   // Parent class lookup.  NB: NamedEntityWithInventory not NamedEntity!
+   &NamedEntityWithInventory::typeLookup
+};
+static_assert(std::is_base_of<NamedEntityWithInventory, Fermentable>::value);
+
 Fermentable::Fermentable(QString name) :
    NamedEntityWithInventory{name, true},
    m_typeStr       {QString()         },
-   m_type          {Fermentable::Type::Grain},
+   m_type                  {Fermentable::Type::Grain},
    m_amountKg      {0.0               },
    m_yieldPct      {0.0               },
    m_colorSrm      {0.0               },
@@ -71,8 +96,8 @@ Fermentable::Fermentable(QString name) :
    m_diastaticPower{0.0               },
    m_proteinPct    {0.0               },
    m_maxInBatchPct {100.0             },
-   m_recommendMash {false             },
-   m_ibuGalPerLb   {0.0               },
+   m_recommendMash         {false                   },
+   m_ibuGalPerLb           {0.0                     },
    m_isMashed      {false             } {
    return;
 }
@@ -80,43 +105,43 @@ Fermentable::Fermentable(QString name) :
 Fermentable::Fermentable(NamedParameterBundle const & namedParameterBundle) :
    NamedEntityWithInventory{namedParameterBundle},
    m_typeStr               {QString()},
-   m_type                  {namedParameterBundle.val<Fermentable::Type>(PropertyNames::Fermentable::type                             )},
+   m_type                  {namedParameterBundle.val<Fermentable::Type             >(PropertyNames::Fermentable::type                             )},
    m_amountKg              {namedParameterBundle.val<double           >(PropertyNames::Fermentable::amount_kg                        )},
    m_yieldPct              {namedParameterBundle.val<double           >(PropertyNames::Fermentable::yield_pct                        )},
    m_colorSrm              {namedParameterBundle.val<double           >(PropertyNames::Fermentable::color_srm                        )},
    m_isAfterBoil           {namedParameterBundle.val<bool             >(PropertyNames::Fermentable::addAfterBoil                     )},
-   m_origin                {namedParameterBundle.val<QString          >(PropertyNames::Fermentable::origin                , QString())},
-   m_supplier              {namedParameterBundle.val<QString          >(PropertyNames::Fermentable::supplier              , QString())},
-   m_notes                 {namedParameterBundle.val<QString          >(PropertyNames::Fermentable::notes                 , QString())},
+   m_origin                {namedParameterBundle.val<QString                       >(PropertyNames::Fermentable::origin                , QString())},
+   m_supplier              {namedParameterBundle.val<QString                       >(PropertyNames::Fermentable::supplier              , QString())},
+   m_notes                 {namedParameterBundle.val<QString                       >(PropertyNames::Fermentable::notes                 , QString())},
    m_coarseFineDiff        {namedParameterBundle.val<double           >(PropertyNames::Fermentable::coarseFineDiff_pct               )},
    m_moisturePct           {namedParameterBundle.val<double           >(PropertyNames::Fermentable::moisture_pct                     )},
    m_diastaticPower        {namedParameterBundle.val<double           >(PropertyNames::Fermentable::diastaticPower_lintner           )},
    m_proteinPct            {namedParameterBundle.val<double           >(PropertyNames::Fermentable::protein_pct                      )},
    m_maxInBatchPct         {namedParameterBundle.val<double           >(PropertyNames::Fermentable::maxInBatch_pct                   )},
-   m_recommendMash         {namedParameterBundle.val<bool             >(PropertyNames::Fermentable::recommendMash                    )},
-   m_ibuGalPerLb           {namedParameterBundle.val<double           >(PropertyNames::Fermentable::ibuGalPerLb                      )},
+   m_recommendMash         {namedParameterBundle.val<bool                          >(PropertyNames::Fermentable::recommendMash                    )},
+   m_ibuGalPerLb           {namedParameterBundle.val<double                        >(PropertyNames::Fermentable::ibuGalPerLb                      )},
    m_isMashed              {namedParameterBundle.val<bool             >(PropertyNames::Fermentable::isMashed              , false    )} {
    return;
 }
 
 Fermentable::Fermentable(Fermentable const & other) :
-   NamedEntityWithInventory{other                 },
+   NamedEntityWithInventory{other                         },
    m_typeStr       {other.m_typeStr       },
-   m_type          {other.m_type          },
+   m_type                  {other.m_type                  },
    m_amountKg      {other.m_amountKg      },
    m_yieldPct      {other.m_yieldPct      },
    m_colorSrm      {other.m_colorSrm      },
    m_isAfterBoil   {other.m_isAfterBoil   },
-   m_origin        {other.m_origin        },
-   m_supplier      {other.m_supplier      },
-   m_notes         {other.m_notes         },
+   m_origin                {other.m_origin                },
+   m_supplier              {other.m_supplier              },
+   m_notes                 {other.m_notes                 },
    m_coarseFineDiff{other.m_coarseFineDiff},
    m_moisturePct   {other.m_moisturePct   },
    m_diastaticPower{other.m_diastaticPower},
    m_proteinPct    {other.m_proteinPct    },
    m_maxInBatchPct {other.m_maxInBatchPct },
-   m_recommendMash {other.m_recommendMash },
-   m_ibuGalPerLb   {other.m_ibuGalPerLb   },
+   m_recommendMash         {other.m_recommendMash         },
+   m_ibuGalPerLb           {other.m_ibuGalPerLb           },
    m_isMashed      {other.m_isMashed      } {
    return;
 }
@@ -235,7 +260,7 @@ void Fermentable::setOrigin( const QString& str ) {
 
 void Fermentable::setSupplier( const QString& str) {
    this->setAndNotify( PropertyNames::Fermentable::supplier, this->m_supplier, str);
-}
+   }
 
 void Fermentable::setNotes( const QString& str ) {
    this->setAndNotify( PropertyNames::Fermentable::notes, this->m_notes, str);
@@ -260,7 +285,7 @@ double Fermentable::equivSucrose_kg() const {
    if (type() == Fermentable::Type::Grain && !isMashed() )
       return 0.60 * ret; // Reduce the yield by 60%.
    else
-      return ret;
+   return ret;
 }
 
 void Fermentable::setAmount_kg( double var ) {
@@ -283,7 +308,7 @@ void Fermentable::setYield_pct(double var) {
 
 void Fermentable::setColor_srm(double var) {
    this->setAndNotify(PropertyNames::Fermentable::color_srm, this->m_colorSrm, this->enforceMin(var, "color"));
-}
+   }
 
 void Fermentable::setCoarseFineDiff_pct(double var) {
    this->setAndNotify(PropertyNames::Fermentable::coarseFineDiff_pct, this->m_coarseFineDiff, this->enforceMinAndMax(var, "coarseFineDiff", 0.0, 100.0));

--- a/src/model/Fermentable.h
+++ b/src/model/Fermentable.h
@@ -70,6 +70,11 @@ class Fermentable : public NamedEntityWithInventory {
 
    friend class FermentableDialog;
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    //! \brief The type of Fermentable.
    enum Type {Grain, Sugar, Extract, Dry_Extract, Adjunct};

--- a/src/model/Hop.cpp
+++ b/src/model/Hop.cpp
@@ -93,6 +93,30 @@ ObjectStore & Hop::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Hop>::getInstance();
 }
 
+TypeLookup const Hop::typeLookup {
+   "Hop",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::use                  , Hop::m_use                  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::type                 , Hop::m_type                 ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::form                 , Hop::m_form                 ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::alpha_pct            , Hop::m_alpha_pct            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::amount_kg            , Hop::m_amount_kg            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::time_min             , Hop::m_time_min             ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::notes                , Hop::m_notes                ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::beta_pct             , Hop::m_beta_pct             ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::hsi_pct              , Hop::m_hsi_pct              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::origin               , Hop::m_origin               ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::substitutes          , Hop::m_substitutes          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::humulene_pct         , Hop::m_humulene_pct         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::caryophyllene_pct    , Hop::m_caryophyllene_pct    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::cohumulone_pct       , Hop::m_cohumulone_pct       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::myrcene_pct          , Hop::m_myrcene_pct          ),
+   },
+   // Parent class lookup.  NB: NamedEntityWithInventory not NamedEntity!
+   &NamedEntityWithInventory::typeLookup
+};
+static_assert(std::is_base_of<NamedEntityWithInventory, Hop>::value);
+
 Hop::Hop(QString name) :
    NamedEntityWithInventory{name, true},
    m_use                  {Hop::Use::Mash},
@@ -115,20 +139,20 @@ Hop::Hop(QString name) :
 
 Hop::Hop(NamedParameterBundle const & namedParameterBundle) :
    NamedEntityWithInventory{namedParameterBundle},
-   m_use                  {namedParameterBundle.val<Hop::Use >(PropertyNames::Hop::use                  )},
-   m_type                 {namedParameterBundle.val<Hop::Type>(PropertyNames::Hop::type                 )},
-   m_form                 {namedParameterBundle.val<Hop::Form>(PropertyNames::Hop::form                 )},
-   m_alpha_pct            {namedParameterBundle.val<double   >(PropertyNames::Hop::alpha_pct            )},
-   m_amount_kg            {namedParameterBundle.val<double   >(PropertyNames::Hop::amount_kg            )},
-   m_time_min             {namedParameterBundle.val<double   >(PropertyNames::Hop::time_min             )},
-   m_notes                {namedParameterBundle.val<QString  >(PropertyNames::Hop::notes                )},
-   m_beta_pct             {namedParameterBundle.val<double   >(PropertyNames::Hop::beta_pct             )},
-   m_hsi_pct              {namedParameterBundle.val<double   >(PropertyNames::Hop::hsi_pct              )},
-   m_origin               {namedParameterBundle.val<QString  >(PropertyNames::Hop::origin               )},
-   m_substitutes          {namedParameterBundle.val<QString  >(PropertyNames::Hop::substitutes          )},
-   m_humulene_pct         {namedParameterBundle.val<double   >(PropertyNames::Hop::humulene_pct         )},
-   m_caryophyllene_pct    {namedParameterBundle.val<double   >(PropertyNames::Hop::caryophyllene_pct    )},
-   m_cohumulone_pct       {namedParameterBundle.val<double   >(PropertyNames::Hop::cohumulone_pct       )},
+   m_use                  {namedParameterBundle.val<Hop::Use             >(PropertyNames::Hop::use                  )},
+   m_type                 {namedParameterBundle.val<Hop::Type            >(PropertyNames::Hop::type                 )},
+   m_form                 {namedParameterBundle.val<Hop::Form            >(PropertyNames::Hop::form                 )},
+   m_alpha_pct            {namedParameterBundle.val<double               >(PropertyNames::Hop::alpha_pct            )},
+   m_amount_kg            {namedParameterBundle.val<double               >(PropertyNames::Hop::amount_kg            )},
+   m_time_min             {namedParameterBundle.val<double               >(PropertyNames::Hop::time_min             )},
+   m_notes                {namedParameterBundle.val<QString              >(PropertyNames::Hop::notes                )},
+   m_beta_pct             {namedParameterBundle.val<double               >(PropertyNames::Hop::beta_pct             )},
+   m_hsi_pct              {namedParameterBundle.val<double               >(PropertyNames::Hop::hsi_pct              )},
+   m_origin               {namedParameterBundle.val<QString              >(PropertyNames::Hop::origin               )},
+   m_substitutes          {namedParameterBundle.val<QString              >(PropertyNames::Hop::substitutes          )},
+   m_humulene_pct         {namedParameterBundle.val<double               >(PropertyNames::Hop::humulene_pct         )},
+   m_caryophyllene_pct    {namedParameterBundle.val<double               >(PropertyNames::Hop::caryophyllene_pct    )},
+   m_cohumulone_pct       {namedParameterBundle.val<double               >(PropertyNames::Hop::cohumulone_pct       )},
    m_myrcene_pct          {namedParameterBundle.val<double   >(PropertyNames::Hop::myrcene_pct          )} {
    return;
 }
@@ -156,42 +180,42 @@ Hop::Hop(Hop const & other) :
 Hop::~Hop() = default;
 
 //============================="GET" METHODS====================================
-Hop::Use  Hop::use()                   const { return this->m_use;                   }
-QString   Hop::notes()                 const { return this->m_notes;                 }
-Hop::Type Hop::type()                  const { return this->m_type;                  }
-Hop::Form Hop::form()                  const { return this->m_form;                  }
-QString   Hop::origin()                const { return this->m_origin;                }
-QString   Hop::substitutes()           const { return this->m_substitutes;           }
-double    Hop::alpha_pct()             const { return this->m_alpha_pct;             }
-double    Hop::amount_kg()             const { return this->m_amount_kg;             }
-double    Hop::time_min()              const { return this->m_time_min;              }
-double    Hop::beta_pct()              const { return this->m_beta_pct;              }
-double    Hop::hsi_pct()               const { return this->m_hsi_pct;               }
-double    Hop::humulene_pct()          const { return this->m_humulene_pct;          }
-double    Hop::caryophyllene_pct()     const { return this->m_caryophyllene_pct;     }
-double    Hop::cohumulone_pct()        const { return this->m_cohumulone_pct;        }
-double    Hop::myrcene_pct()           const { return this->m_myrcene_pct;           }
+Hop::Use              Hop::use()                   const { return this->m_use;                   }
+QString               Hop::notes()                 const { return this->m_notes;                 }
+Hop::Type             Hop::type()                  const { return this->m_type;                  }
+Hop::Form             Hop::form()                  const { return this->m_form;                  }
+QString               Hop::origin()                const { return this->m_origin;                }
+QString               Hop::substitutes()           const { return this->m_substitutes;           }
+double                Hop::alpha_pct()             const { return this->m_alpha_pct;             }
+double                Hop::amount_kg()             const { return this->m_amount_kg;             }
+double                Hop::time_min()              const { return this->m_time_min;              }
+double                Hop::beta_pct()              const { return this->m_beta_pct;              }
+double                Hop::hsi_pct()               const { return this->m_hsi_pct;               }
+double                Hop::humulene_pct()          const { return this->m_humulene_pct;          }
+double                Hop::caryophyllene_pct()     const { return this->m_caryophyllene_pct;     }
+double                Hop::cohumulone_pct()        const { return this->m_cohumulone_pct;        }
+double                Hop::myrcene_pct()           const { return this->m_myrcene_pct;           }
 
 double Hop::inventory() const {
    return InventoryUtils::getAmount(*this);
 }
 
 //============================="SET" METHODS====================================
-void Hop::setAlpha_pct            (double    const   val) { this->setAndNotify(PropertyNames::Hop::alpha_pct,             this->m_alpha_pct,             this->enforceMinAndMax(val, "alpha",                 0.0, 100.0)); }
-void Hop::setAmount_kg            (double    const   val) { this->setAndNotify(PropertyNames::Hop::amount_kg,             this->m_amount_kg,             this->enforceMin      (val, "amount")                           ); }
-void Hop::setUse                  (Hop::Use  const   val) { this->setAndNotify(PropertyNames::Hop::use,                   this->m_use,                   val                                                             ); }
-void Hop::setTime_min             (double    const   val) { this->setAndNotify(PropertyNames::Hop::time_min,              this->m_time_min,              this->enforceMin      (val, "time")                             ); }
-void Hop::setNotes                (QString   const & val) { this->setAndNotify(PropertyNames::Hop::notes,                 this->m_notes,                 val                                                             ); }
-void Hop::setType                 (Hop::Type const   val) { this->setAndNotify(PropertyNames::Hop::type,                  this->m_type,                  val                                                             ); }
-void Hop::setForm                 (Hop::Form const   val) { this->setAndNotify(PropertyNames::Hop::form,                  this->m_form,                  val                                                             ); }
-void Hop::setBeta_pct             (double    const   val) { this->setAndNotify(PropertyNames::Hop::beta_pct,              this->m_beta_pct,              this->enforceMinAndMax(val, "beta",                  0.0, 100.0)); }
-void Hop::setHsi_pct              (double    const   val) { this->setAndNotify(PropertyNames::Hop::hsi_pct,               this->m_hsi_pct,               this->enforceMinAndMax(val, "hsi",                   0.0, 100.0)); }
-void Hop::setOrigin               (QString   const & val) { this->setAndNotify(PropertyNames::Hop::origin,                this->m_origin,                val                                                             ); }
-void Hop::setSubstitutes          (QString   const & val) { this->setAndNotify(PropertyNames::Hop::substitutes,           this->m_substitutes,           val                                                             ); }
-void Hop::setHumulene_pct         (double    const   val) { this->setAndNotify(PropertyNames::Hop::humulene_pct,          this->m_humulene_pct,          this->enforceMinAndMax(val, "humulene",              0.0, 100.0)); }
-void Hop::setCaryophyllene_pct    (double    const   val) { this->setAndNotify(PropertyNames::Hop::caryophyllene_pct,     this->m_caryophyllene_pct,     this->enforceMinAndMax(val, "caryophyllene",         0.0, 100.0)); }
-void Hop::setCohumulone_pct       (double    const   val) { this->setAndNotify(PropertyNames::Hop::cohumulone_pct,        this->m_cohumulone_pct,        this->enforceMinAndMax(val, "cohumulone",            0.0, 100.0)); }
-void Hop::setMyrcene_pct          (double    const   val) { this->setAndNotify(PropertyNames::Hop::myrcene_pct,           this->m_myrcene_pct,           this->enforceMinAndMax(val, "myrcene",               0.0, 100.0)); }
+void Hop::setAlpha_pct            (double                const   val) { this->setAndNotify(PropertyNames::Hop::alpha_pct,             this->m_alpha_pct,             this->enforceMinAndMax(val, "alpha",                 0.0, 100.0)); }
+void Hop::setAmount_kg            (double                const   val) { this->setAndNotify(PropertyNames::Hop::amount_kg,             this->m_amount_kg,             this->enforceMin      (val, "amount")                           ); }
+void Hop::setUse                  (Hop::Use              const   val) { this->setAndNotify(PropertyNames::Hop::use,                   this->m_use,                   val                                                             ); }
+void Hop::setTime_min             (double                const   val) { this->setAndNotify(PropertyNames::Hop::time_min,              this->m_time_min,              this->enforceMin      (val, "time")                             ); }
+void Hop::setNotes                (QString               const & val) { this->setAndNotify(PropertyNames::Hop::notes,                 this->m_notes,                 val                                                             ); }
+void Hop::setType                 (Hop::Type             const   val) { this->setAndNotify(PropertyNames::Hop::type,                  this->m_type,                  val                                                             ); }
+void Hop::setForm                 (Hop::Form             const   val) { this->setAndNotify(PropertyNames::Hop::form,                  this->m_form,                  val                                                             ); }
+void Hop::setBeta_pct             (double                const   val) { this->setAndNotify(PropertyNames::Hop::beta_pct,              this->m_beta_pct,              this->enforceMinAndMax(val, "beta",                  0.0, 100.0)); }
+void Hop::setHsi_pct              (double                const   val) { this->setAndNotify(PropertyNames::Hop::hsi_pct,               this->m_hsi_pct,               this->enforceMinAndMax(val, "hsi",                   0.0, 100.0)); }
+void Hop::setOrigin               (QString               const & val) { this->setAndNotify(PropertyNames::Hop::origin,                this->m_origin,                val                                                             ); }
+void Hop::setSubstitutes          (QString               const & val) { this->setAndNotify(PropertyNames::Hop::substitutes,           this->m_substitutes,           val                                                             ); }
+void Hop::setHumulene_pct         (double                const   val) { this->setAndNotify(PropertyNames::Hop::humulene_pct,          this->m_humulene_pct,          this->enforceMinAndMax(val, "humulene",              0.0, 100.0)); }
+void Hop::setCaryophyllene_pct    (double                const   val) { this->setAndNotify(PropertyNames::Hop::caryophyllene_pct,     this->m_caryophyllene_pct,     this->enforceMinAndMax(val, "caryophyllene",         0.0, 100.0)); }
+void Hop::setCohumulone_pct       (double                const   val) { this->setAndNotify(PropertyNames::Hop::cohumulone_pct,        this->m_cohumulone_pct,        this->enforceMinAndMax(val, "cohumulone",            0.0, 100.0)); }
+void Hop::setMyrcene_pct          (double                const   val) { this->setAndNotify(PropertyNames::Hop::myrcene_pct,           this->m_myrcene_pct,           this->enforceMinAndMax(val, "myrcene",               0.0, 100.0)); }
 
 void Hop::setInventoryAmount(double num) { InventoryUtils::setAmount(*this, num); }
 

--- a/src/model/Hop.h
+++ b/src/model/Hop.h
@@ -64,6 +64,11 @@ class Hop : public NamedEntityWithInventory {
    Q_CLASSINFO("signal", "hops")
 
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    //! \brief The type of hop, meaning for what properties it is used.
    enum class Type {Bittering, Aroma, Both};

--- a/src/model/Instruction.cpp
+++ b/src/model/Instruction.cpp
@@ -83,20 +83,22 @@ ObjectStore & Instruction::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Instruction>::getInstance();
 }
 
-Instruction::Instruction(Instruction const & other) :
-   NamedEntity {other},
-   pimpl       {new impl{*this}},
-   m_directions{other.m_directions},
-   m_hasTimer  {other.m_hasTimer  },
-   m_timerValue{other.m_timerValue},
-   m_completed {other.m_completed },
-   m_interval  {other.m_interval  } {
-   return;
-}
+TypeLookup const Instruction::typeLookup {
+   "Instruction",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Instruction::completed , Instruction::m_completed ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Instruction::directions, Instruction::m_directions),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Instruction::hasTimer  , Instruction::m_hasTimer  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Instruction::interval  , Instruction::m_interval  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Instruction::timerValue, Instruction::m_timerValue),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
 
 Instruction::Instruction(QString name) :
    NamedEntity (name, true),
-   pimpl       {new impl{*this}},
+   pimpl       {std::make_unique<impl>(*this)},
    m_directions(""),
    m_hasTimer  (false),
    m_timerValue(""),
@@ -113,6 +115,17 @@ Instruction::Instruction(NamedParameterBundle const & namedParameterBundle) :
    m_timerValue{namedParameterBundle.val<QString>(PropertyNames::Instruction::timerValue)},
    m_completed {namedParameterBundle.val<bool   >(PropertyNames::Instruction::completed )},
    m_interval  {namedParameterBundle.val<double >(PropertyNames::Instruction::interval  )} {
+   return;
+}
+
+Instruction::Instruction(Instruction const & other) :
+   NamedEntity {other},
+   pimpl       {std::make_unique<impl>(*this)},
+   m_directions{other.m_directions},
+   m_hasTimer  {other.m_hasTimer  },
+   m_timerValue{other.m_timerValue},
+   m_completed {other.m_completed },
+   m_interval  {other.m_interval  } {
    return;
 }
 

--- a/src/model/Instruction.h
+++ b/src/model/Instruction.h
@@ -34,10 +34,10 @@
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::Instruction { BtStringConst const property{#property}; }
-AddPropertyName(completed)
+AddPropertyName(completed )
 AddPropertyName(directions)
-AddPropertyName(hasTimer)
-AddPropertyName(interval)
+AddPropertyName(hasTimer  )
+AddPropertyName(interval  )
 AddPropertyName(timerValue)
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
@@ -57,6 +57,12 @@ class Instruction : public NamedEntity {
 
 
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
+
    Instruction(QString name = "");
    Instruction(NamedParameterBundle const & namedParameterBundle);
    Instruction(Instruction const & other);

--- a/src/model/Inventory.cpp
+++ b/src/model/Inventory.cpp
@@ -24,6 +24,7 @@
 #include "model/Misc.h"
 #include "model/NamedParameterBundle.h"
 #include "model/Yeast.h"
+#include "utils/TypeLookup.h"
 
 namespace {
 
@@ -90,6 +91,21 @@ Inventory::Inventory(NamedParameterBundle const & namedParameterBundle) :
    return;
 }
 
+TypeLookup const Inventory::typeLookup {
+   "Inventory",
+   {
+      // Note that we need Enums to be treated as ints for the purposes of type lookup
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Inventory::amount               , Inventory::impl::amount),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Inventory::id                   , Inventory::impl::id    ),
+   },
+   // Parent class lookup
+   // Note that Inventory does _not_ inherit from NamedEntity, so this is intentionally null
+   nullptr
+};
+
+// Strictly speaking a QObject is not allowed to be copied, which would mean that since we do not use any state in the
+// QObject from which we inherit, we allow Inventory to be copied and just default-initialise the QObject base class in
+// the copy.  Hopefully this will never come back to bite us...
 Inventory::Inventory(Inventory const & other) :
    QObject{},
    pimpl{std::make_unique<impl>(*other.pimpl)} {

--- a/src/model/Inventory.h
+++ b/src/model/Inventory.h
@@ -27,6 +27,7 @@
 #include "model/NamedParameterBundle.h"
 
 class ObjectStore;
+class TypeLookup;
 
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
@@ -63,6 +64,12 @@ AddPropertyName(amount)
 class Inventory : public QObject {
    Q_OBJECT
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
+
    Inventory();
    Inventory(NamedParameterBundle const & namedParameterBundle);
    Inventory(Inventory const & other);

--- a/src/model/Mash.cpp
+++ b/src/model/Mash.cpp
@@ -83,6 +83,25 @@ ObjectStore & Mash::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Mash>::getInstance();
 }
 
+TypeLookup const Mash::typeLookup {
+   "Mash",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::equipAdjust          , Mash::m_equipAdjust          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::grainTemp_c          , Mash::m_grainTemp_c          ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::mashSteps            , Mash::m_mashSteps            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::notes                , Mash::m_notes                ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::ph                   , Mash::m_ph                   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::spargeTemp_c         , Mash::m_spargeTemp_c         ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::totalMashWater_l     , Mash::m_totalMashWater_l     ), // Calculated, not stored
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::totalTime            , Mash::m_totalTime            ), // Calculated, not stored
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::tunSpecificHeat_calGC, Mash::m_tunSpecificHeat_calGC),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::tunTemp_c            , Mash::m_tunTemp_c            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Mash::tunWeight_kg         , Mash::m_tunWeight_kg         ),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
+
 Mash::Mash(QString name) :
    NamedEntity{name, true},
    pimpl{std::make_unique<impl>(*this)},

--- a/src/model/Mash.h
+++ b/src/model/Mash.h
@@ -38,17 +38,17 @@
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::Mash { BtStringConst const property{#property}; }
-AddPropertyName(equipAdjust)
-AddPropertyName(grainTemp_c)
-AddPropertyName(mashSteps)
-AddPropertyName(notes)
-AddPropertyName(ph)
-AddPropertyName(spargeTemp_c)
-AddPropertyName(totalMashWater_l)
-AddPropertyName(totalTime)
+AddPropertyName(equipAdjust          )
+AddPropertyName(grainTemp_c          )
+AddPropertyName(mashSteps            )
+AddPropertyName(notes                )
+AddPropertyName(ph                   )
+AddPropertyName(spargeTemp_c         )
+AddPropertyName(totalMashWater_l     )
+AddPropertyName(totalTime            )
 AddPropertyName(tunSpecificHeat_calGC)
-AddPropertyName(tunTemp_c)
-AddPropertyName(tunWeight_kg)
+AddPropertyName(tunTemp_c            )
+AddPropertyName(tunWeight_kg         )
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
 //======================================================================================================================
@@ -70,6 +70,12 @@ class Mash : public NamedEntity {
    Q_CLASSINFO("signal", "mashs")
 
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
+
    Mash(QString name = "");
    Mash(NamedParameterBundle const & namedParameterBundle);
    Mash(Mash const & other);

--- a/src/model/MashStep.cpp
+++ b/src/model/MashStep.cpp
@@ -53,6 +53,25 @@ ObjectStore & MashStep::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<MashStep>::getInstance();
 }
 
+TypeLookup const MashStep::typeLookup {
+   "MashStep",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::decoctionAmount_l, MashStep::m_decoctionAmount_l),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::endTemp_c        , MashStep::m_endTemp_c        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::infuseAmount_l   , MashStep::m_infuseAmount_l   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::infuseTemp_c     , MashStep::m_infuseTemp_c     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::mashId           , MashStep::m_mashId           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::rampTime_min     , MashStep::m_rampTime_min     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::stepNumber       , MashStep::m_stepNumber       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::stepTemp_c       , MashStep::m_stepTemp_c       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::stepTime_min     , MashStep::m_stepTime_min     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::type             , MashStep::m_type             ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::MashStep::typeString       , MashStep::m_typeString       ),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
+
 //==============================CONSTRUCTORS====================================
 
 MashStep::MashStep(QString name) :

--- a/src/model/MashStep.h
+++ b/src/model/MashStep.h
@@ -32,16 +32,16 @@
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::MashStep { BtStringConst const property{#property}; }
 AddPropertyName(decoctionAmount_l)
-AddPropertyName(endTemp_c)
-AddPropertyName(infuseAmount_l)
-AddPropertyName(infuseTemp_c)
-AddPropertyName(mashId)
-AddPropertyName(rampTime_min)
-AddPropertyName(stepNumber)
-AddPropertyName(stepTemp_c)
-AddPropertyName(stepTime_min)
-AddPropertyName(typeString)
-AddPropertyName(type)
+AddPropertyName(endTemp_c        )
+AddPropertyName(infuseAmount_l   )
+AddPropertyName(infuseTemp_c     )
+AddPropertyName(mashId           )
+AddPropertyName(rampTime_min     )
+AddPropertyName(stepNumber       )
+AddPropertyName(stepTemp_c       )
+AddPropertyName(stepTime_min     )
+AddPropertyName(type             )
+AddPropertyName(typeString       )
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
 //======================================================================================================================
@@ -57,7 +57,6 @@ class MashStep : public NamedEntity {
    Q_CLASSINFO("signal", "mashsteps")
 
    // this seems to be a class with a lot of friends
-
    friend class MashStepItemDelegate;
    friend class MashWizard;
    friend class MashDesigner;
@@ -65,8 +64,15 @@ class MashStep : public NamedEntity {
 public:
 
    //! \brief The type of step.
-   enum Type { Infusion, Temperature, Decoction, flySparge, batchSparge };
+   enum class Type { Infusion, Temperature, Decoction, flySparge, batchSparge };
+   // This allows us to store the above enum class in a QVariant
    Q_ENUM(Type)
+
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    MashStep(QString name = "");
    MashStep(NamedParameterBundle const & namedParameterBundle);
@@ -141,7 +147,7 @@ protected:
    virtual ObjectStore & getObjectStoreTypedInstance() const;
 
 private:
-   Type m_type;
+   Type   m_type;
    double m_infuseAmount_l;
    double m_stepTemp_c;
    double m_stepTime_min;
@@ -149,8 +155,8 @@ private:
    double m_endTemp_c;
    double m_infuseTemp_c;
    double m_decoctionAmount_l;
-   int m_stepNumber;
-   int m_mashId;
+   int    m_stepNumber;
+   int    m_mashId;
 };
 
 #endif

--- a/src/model/Misc.cpp
+++ b/src/model/Misc.cpp
@@ -58,6 +58,25 @@ ObjectStore & Misc::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Misc>::getInstance();
 }
 
+TypeLookup const Misc::typeLookup {
+   "Misc",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::amount        , Misc::m_amount        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::amountIsWeight, Misc::m_amountIsWeight),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::amountType    , Misc::m_amountType    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::notes         , Misc::m_notes         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::time          , Misc::m_time          ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::typeString    , Misc::m_typeString    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::type          , Misc::m_type          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::useFor        , Misc::m_useFor        ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::useString     , Misc::m_useString     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Misc::use           , Misc::m_use           ),
+   },
+   // Parent class lookup.  NB: NamedEntityWithInventory not NamedEntity!
+   &NamedEntityWithInventory::typeLookup
+};
+static_assert(std::is_base_of<NamedEntityWithInventory, Misc>::value);
+
 //============================CONSTRUCTORS======================================
 
 Misc::Misc(QString name) :

--- a/src/model/Misc.h
+++ b/src/model/Misc.h
@@ -32,16 +32,16 @@
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::Misc { BtStringConst const property{#property}; }
-AddPropertyName(amount)
+AddPropertyName(amount        )
 AddPropertyName(amountIsWeight)
-AddPropertyName(amountType)
-AddPropertyName(notes)
-AddPropertyName(time)
-AddPropertyName(typeString)
-AddPropertyName(type)
-AddPropertyName(useFor)
-AddPropertyName(useString)
-AddPropertyName(use)
+AddPropertyName(amountType    )
+AddPropertyName(notes         )
+AddPropertyName(time          )
+AddPropertyName(typeString    )
+AddPropertyName(type          )
+AddPropertyName(useFor        )
+AddPropertyName(useString     )
+AddPropertyName(use           )
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
 //======================================================================================================================
@@ -60,13 +60,24 @@ public:
 
    //! \brief The type of ingredient.
    enum class Type {Spice, Fining, Water_Agent, Herb, Flavor, Other};
+   // This allows us to store the above enum class in a QVariant
+   Q_ENUM(Type)
+
    //! \brief Where the ingredient is used.
    enum class Use { Boil, Mash, Primary, Secondary, Bottling };
+   // This allows us to store the above enum class in a QVariant
+   Q_ENUM(Use)
+
    //! \brief What is the type of amount.
    enum class AmountType { Weight, Volume };
-   Q_ENUM(Type)
-   Q_ENUM(Use)
+   // This allows us to store the above enum class in a QVariant
    Q_ENUM(AmountType)
+
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    Misc(QString name = "");
    Misc(NamedParameterBundle const & namedParameterBundle);
@@ -152,7 +163,7 @@ private:
    Use  m_use;  // Primarily valid in "Use Of" instance
    double m_time;
    double m_amount;
-   bool m_amountIsWeight;
+   bool   m_amountIsWeight;
    QString m_useFor;
    QString m_notes;
 

--- a/src/model/NamedEntity.cpp
+++ b/src/model/NamedEntity.cpp
@@ -99,6 +99,24 @@ void NamedEntity::swap(NamedEntity & other) noexcept {
    return;
 }
 
+TypeLookup const NamedEntity::typeLookup {
+   "NamedEntity",
+   {
+      // As long as we map each property name to its corresponding member variable, the compiler should be able to work
+      // everything else out.  The only exception is that, for enums, we have to pretend they are stored as int, because
+      // that's what's going to come out of the Qt property system (and it would significantly complicate other bits of
+      // the code to separately register every different enum that we use.)
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::NamedEntity::deleted  , NamedEntity::m_display),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::NamedEntity::display  , NamedEntity::m_display),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::NamedEntity::folder   , NamedEntity::m_folder ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::NamedEntity::key      , NamedEntity::m_key    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::NamedEntity::name     , NamedEntity::m_name   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::NamedEntity::parentKey, NamedEntity::parentKey),
+   },
+   // Parent class lookup - none as we're top of the tree
+   nullptr
+};
+
 NamedEntity::~NamedEntity() = default;
 
 void NamedEntity::makeChild(NamedEntity const & copiedFrom) {

--- a/src/model/NamedEntityWithInventory.cpp
+++ b/src/model/NamedEntityWithInventory.cpp
@@ -23,6 +23,18 @@
 #include "model/Inventory.h"
 #include "model/NamedParameterBundle.h"
 
+
+TypeLookup const NamedEntityWithInventory::typeLookup {
+   "NamedEntityWithInventory",
+   {
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::NamedEntityWithInventory::inventory, NamedEntityWithInventory::m_inventory   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::NamedEntityWithInventory::inventoryId, NamedEntityWithInventory::m_inventory_id),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
+static_assert(std::is_base_of<NamedEntity, NamedEntityWithInventory>::value);
+
 NamedEntityWithInventory::NamedEntityWithInventory(QString t_name,
                                                    bool t_display,
                                                    QString folder) :

--- a/src/model/NamedEntityWithInventory.h
+++ b/src/model/NamedEntityWithInventory.h
@@ -25,7 +25,7 @@
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::NamedEntityWithInventory { BtStringConst const property{#property}; }
-AddPropertyName(inventory)
+AddPropertyName(inventory  )
 AddPropertyName(inventoryId)
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
@@ -40,6 +40,12 @@ AddPropertyName(inventoryId)
 class NamedEntityWithInventory : public NamedEntity {
    Q_OBJECT
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
+
    NamedEntityWithInventory(QString t_name, bool t_display = false, QString folder = QString());
    NamedEntityWithInventory(NamedEntityWithInventory const & other);
    NamedEntityWithInventory(NamedParameterBundle const & namedParameterBundle);
@@ -47,9 +53,9 @@ public:
    virtual ~NamedEntityWithInventory();
 
    //! \brief The amount in inventory (usually in kg)
-   Q_PROPERTY( double inventory              READ inventory              WRITE setInventoryAmount        /*NOTIFY changed*/ /*changedInventory*/ )
+   Q_PROPERTY(double inventory    READ inventory    WRITE setInventoryAmount)
    //! \brief The inventory table id, needed for signals
-   Q_PROPERTY( double inventoryId            READ inventoryId            WRITE setInventoryId            /*NOTIFY changed*/ /*changedInventoryId*/ )
+   Q_PROPERTY(int    inventoryId  READ inventoryId  WRITE setInventoryId    )
 
    /**
     * \brief Override \c NamedEntity::makeChild() as we have additional work to do for objects with inventory.

--- a/src/model/Recipe.cpp
+++ b/src/model/Recipe.cpp
@@ -359,10 +359,82 @@ ObjectStore & Recipe::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Recipe>::getInstance();
 }
 
+TypeLookup const Recipe::typeLookup {
+   "Recipe",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::ABV_pct           , Recipe::m_ABV_pct           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::age_days               , Recipe::m_age               ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::ageTemp_c         , Recipe::m_ageTemp_c         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::ancestorId        , Recipe::m_ancestor_id       ), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::asstBrewer        , Recipe::m_asstBrewer        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::batchSize_l       , Recipe::m_batchSize_l       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::boilGrav          , Recipe::m_boilGrav          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::boilSize_l        , Recipe::m_boilSize_l        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::boilTime_min      , Recipe::m_boilTime_min      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::boilVolume_l      , Recipe::m_boilVolume_l      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::brewer            , Recipe::m_brewer            ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::brewNotes         , Recipe::m_brewNotes         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::calories          , Recipe::m_calories          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::carbonationTemp_c , Recipe::m_carbonationTemp_c ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::carbonation_vols  , Recipe::m_carbonation_vols  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::color_srm         , Recipe::m_color_srm         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::date              , Recipe::m_date              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::efficiency_pct    , Recipe::m_efficiency_pct    ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::equipment         , Recipe::m_equipment         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::equipmentId       , Recipe::equipmentId         ), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::fermentableIds    , Recipe::impl::fermentableIds),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::fermentables      , Recipe::m_fermentables      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::fermentationStages, Recipe::m_fermentationStages),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::fg                , Recipe::m_fg                ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::finalVolume_l     , Recipe::m_finalVolume_l     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::forcedCarbonation , Recipe::m_forcedCarbonation ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::grainsInMash_kg   , Recipe::m_grainsInMash_kg   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::grains_kg         , Recipe::m_grains_kg         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::hopIds            , Recipe::impl::hopIds            ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::hops              , Recipe::m_hops              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::IBU               , Recipe::m_IBU               ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::IBUs              , Recipe::m_IBUs              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::instructionIds    , Recipe::impl::instructionIds),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::instructions      , Recipe::m_instructions      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::kegPrimingFactor  , Recipe::m_kegPrimingFactor  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::locked            , Recipe::m_locked            ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::mash              , Recipe::m_mash              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::mashId            , Recipe::mashId              ), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::miscIds           , Recipe::impl::miscIds           ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::miscs             , Recipe::m_miscs             ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::notes             , Recipe::m_notes             ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::og                , Recipe::m_og                ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::points            , Recipe::m_points            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::postBoilVolume_l  , Recipe::m_postBoilVolume_l  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::primaryAge_days   , Recipe::m_primaryAge_days   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::primaryTemp_c     , Recipe::m_primaryTemp_c     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::primingSugarEquiv , Recipe::m_primingSugarEquiv ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::primingSugarName  , Recipe::m_primingSugarName  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::saltIds           , Recipe::impl::saltIds       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::secondaryAge_days , Recipe::m_secondaryAge_days ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::secondaryTemp_c   , Recipe::m_secondaryTemp_c   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::SRMColor          , Recipe::m_SRMColor          ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::style             , Recipe::m_style             ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::styleId           , Recipe::styleId             ), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::tasteNotes        , Recipe::m_tasteNotes        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::tasteRating       , Recipe::m_tasteRating       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::tertiaryAge_days  , Recipe::m_tertiaryAge_days  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::tertiaryTemp_c    , Recipe::m_tertiaryTemp_c    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::type              , Recipe::m_type              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::waterIds          , Recipe::impl::waterIds      ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::waters            , Recipe::m_waters            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::wortFromMash_l    , Recipe::m_wortFromMash_l    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::yeastIds          , Recipe::impl::yeastIds      ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Recipe::yeasts            , Recipe::m_yeasts            ),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
+
 Recipe::Recipe(QString name) :
    NamedEntity         {name, true                   },
    pimpl               {std::make_unique<impl>(*this)},
-   m_type              {"All Grain"                  },
+   m_type              {Recipe::Type::AllGrain       },
    m_brewer            {""                           },
    m_asstBrewer        {"Brewtarget: free beer software"},
    m_batchSize_l       {0.0                          },
@@ -403,10 +475,7 @@ Recipe::Recipe(QString name) :
 Recipe::Recipe(NamedParameterBundle const & namedParameterBundle) :
    NamedEntity         {namedParameterBundle         },
    pimpl               {std::make_unique<impl>(*this)},
-   m_type              {
-      // .:TODO:. Change so we store enum not string!
-      RECIPE_TYPE_STRING_TO_TYPE.key(namedParameterBundle.val<Recipe::Type>(PropertyNames::Recipe::recipeType))
-   },
+   m_type              {namedParameterBundle.val<Recipe::Type>(PropertyNames::Recipe::type              )},
    m_brewer            {namedParameterBundle.val<QString     >(PropertyNames::Recipe::brewer            )},
    m_asstBrewer        {namedParameterBundle.val<QString     >(PropertyNames::Recipe::asstBrewer        )},
    m_batchSize_l       {namedParameterBundle.val<double      >(PropertyNames::Recipe::batchSize_l       )},
@@ -420,7 +489,7 @@ Recipe::Recipe(NamedParameterBundle const & namedParameterBundle) :
    m_secondaryTemp_c   {namedParameterBundle.val<double      >(PropertyNames::Recipe::secondaryTemp_c   )},
    m_tertiaryAge_days  {namedParameterBundle.val<double      >(PropertyNames::Recipe::tertiaryAge_days  )},
    m_tertiaryTemp_c    {namedParameterBundle.val<double      >(PropertyNames::Recipe::tertiaryTemp_c    )},
-   m_age               {namedParameterBundle.val<double      >(PropertyNames::Recipe::age               )},
+   m_age               {namedParameterBundle.val<double      >(PropertyNames::Recipe::age_days          )},
    m_ageTemp_c         {namedParameterBundle.val<double      >(PropertyNames::Recipe::ageTemp_c         )},
    m_date              {namedParameterBundle.val<QDate       >(PropertyNames::Recipe::date              )},
    m_carbonation_vols  {namedParameterBundle.val<double      >(PropertyNames::Recipe::carbonation_vols  )},
@@ -1505,20 +1574,8 @@ void Recipe::setYeastIds(QVector<int> yeastIds) {
 
 
 //==============================="SET" METHODS=================================
-void Recipe::setRecipeType(Recipe::Type var) {
-   this->setType(RECIPE_TYPE_STRING_TO_TYPE.key(var));
-   return;
-}
-
-void Recipe::setType(const QString & var) {
-   QString tmp;
-   if (! isValidType(var)) {
-      qWarning() << QString("Recipe: invalid type: %1").arg(var);
-      tmp = "All Grain";
-   } else {
-      tmp = QString(var);
-   }
-   this->setAndNotify(PropertyNames::Recipe::type, this->m_type, tmp);
+void Recipe::setType(Recipe::Type const val) {
+   this->setAndNotify(PropertyNames::Recipe::type, this->m_type, val);
    return;
 }
 
@@ -1642,7 +1699,7 @@ void Recipe::setTertiaryTemp_c(double var) {
 }
 
 void Recipe::setAge_days(double var) {
-   this->setAndNotify(PropertyNames::Recipe::age, this->m_age, this->enforceMin(var, "age"));
+   this->setAndNotify(PropertyNames::Recipe::age_days, this->m_age, this->enforceMin(var, "age"));
    return;
 }
 
@@ -2000,10 +2057,7 @@ QVector<int>         Recipe::getSaltIds()        const { return this->pimpl->sal
 int                  Recipe::getAncestorId()     const { return this->m_ancestor_id;                     }
 
 //==============================Getters===================================
-Recipe::Type Recipe::recipeType() const {
-   return RECIPE_TYPE_STRING_TO_TYPE.value(this->type());
-}
-QString Recipe::type() const               { return m_type;               }
+Recipe::Type Recipe::type()          const { return m_type;               }
 QString Recipe::brewer()             const { return m_brewer;             }
 QString Recipe::asstBrewer()         const { return m_asstBrewer;         }
 QString Recipe::notes()              const { return m_notes;              }
@@ -2622,7 +2676,7 @@ double Recipe::ibuFromHop(Hop const * hop) {
    // up for plugs and pellets.
    //
    // - http://www.realbeer.com/hops/FAQ.html
-   // - https://groups.google.com/forum/#!topic"Application.h"lp/mv2qvWBC4sU
+   // - https://groups.google.com/forum/#!topic"brewtarget.h"lp/mv2qvWBC4sU
    switch (hop->form()) {
       case Hop::Form::Plug:
          hopUtilization *= 1.02;
@@ -2785,7 +2839,7 @@ void Recipe::acceptChangeToContainedObject([[maybe_unused]] QMetaProperty prop,
 double Recipe::targetCollectedWortVol_l() {
 
    // Need to account for extract/sugar volume also.
-   float postMashAdditionVolume_l = 0;
+   double postMashAdditionVolume_l = 0;
 
    QList<Fermentable *> ferms = fermentables();
    foreach (Fermentable * f, ferms) {
@@ -2800,9 +2854,9 @@ double Recipe::targetCollectedWortVol_l() {
    }
 
    if (equipment()) {
-      return boilSize_l() - equipment()->topUpKettle_l() - static_cast<double>(postMashAdditionVolume_l);
+      return boilSize_l() - equipment()->topUpKettle_l() - postMashAdditionVolume_l;
    } else {
-      return boilSize_l() - static_cast<double>(postMashAdditionVolume_l);
+      return boilSize_l() - postMashAdditionVolume_l;
    }
 }
 

--- a/src/model/Recipe.h
+++ b/src/model/Recipe.h
@@ -44,71 +44,70 @@
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::Recipe { BtStringConst const property{#property}; }
-AddPropertyName(ABV_pct)
-AddPropertyName(age)
-AddPropertyName(ageTemp_c)
-AddPropertyName(ancestorId)
-AddPropertyName(asstBrewer)
-AddPropertyName(batchSize_l)
-AddPropertyName(boilGrav)
-AddPropertyName(boilSize_l)
-AddPropertyName(boilTime_min)
-AddPropertyName(boilVolume_l)
-AddPropertyName(brewer)
-AddPropertyName(brewNotes)
-AddPropertyName(calories)
-AddPropertyName(carbonationTemp_c)
-AddPropertyName(carbonation_vols)
-AddPropertyName(color_srm)
-AddPropertyName(date)
-AddPropertyName(efficiency_pct)
-AddPropertyName(equipment)
-AddPropertyName(equipmentId)
-AddPropertyName(fermentableIds)
-AddPropertyName(fermentables)
+AddPropertyName(ABV_pct           )
+AddPropertyName(age_days          )
+AddPropertyName(ageTemp_c         )
+AddPropertyName(ancestorId        )
+AddPropertyName(asstBrewer        )
+AddPropertyName(batchSize_l       )
+AddPropertyName(boilGrav          )
+AddPropertyName(boilSize_l        )
+AddPropertyName(boilTime_min      )
+AddPropertyName(boilVolume_l      )
+AddPropertyName(brewer            )
+AddPropertyName(brewNotes         )
+AddPropertyName(calories          )
+AddPropertyName(carbonationTemp_c )
+AddPropertyName(carbonation_vols  )
+AddPropertyName(color_srm         )
+AddPropertyName(date              )
+AddPropertyName(efficiency_pct    )
+AddPropertyName(equipment         )
+AddPropertyName(equipmentId       )
+AddPropertyName(fermentableIds    )
+AddPropertyName(fermentables      )
 AddPropertyName(fermentationStages)
-AddPropertyName(fg)
-AddPropertyName(finalVolume_l)
-AddPropertyName(forcedCarbonation)
-AddPropertyName(grainsInMash_kg)
-AddPropertyName(grains_kg)
-AddPropertyName(hopIds)
-AddPropertyName(hops)
-AddPropertyName(IBU)
-AddPropertyName(IBUs)
-AddPropertyName(instructionIds)
-AddPropertyName(instructions)
-AddPropertyName(kegPrimingFactor)
-AddPropertyName(locked)
-AddPropertyName(mash)
-AddPropertyName(mashId)
-AddPropertyName(miscIds)
-AddPropertyName(miscs)
-AddPropertyName(notes)
-AddPropertyName(og)
-AddPropertyName(points)
-AddPropertyName(postBoilVolume_l)
-AddPropertyName(primaryAge_days)
-AddPropertyName(primaryTemp_c)
-AddPropertyName(primingSugarEquiv)
-AddPropertyName(primingSugarName)
-AddPropertyName(recipeType)
-AddPropertyName(saltIds)
-AddPropertyName(secondaryAge_days)
-AddPropertyName(secondaryTemp_c)
-AddPropertyName(SRMColor)
-AddPropertyName(style)
-AddPropertyName(styleId)
-AddPropertyName(tasteNotes)
-AddPropertyName(tasteRating)
-AddPropertyName(tertiaryAge_days)
-AddPropertyName(tertiaryTemp_c)
-AddPropertyName(type)
-AddPropertyName(waterIds)
-AddPropertyName(waters)
-AddPropertyName(wortFromMash_l)
-AddPropertyName(yeastIds)
-AddPropertyName(yeasts)
+AddPropertyName(fg                )
+AddPropertyName(finalVolume_l     )
+AddPropertyName(forcedCarbonation )
+AddPropertyName(grainsInMash_kg   )
+AddPropertyName(grains_kg         )
+AddPropertyName(hopIds            )
+AddPropertyName(hops              )
+AddPropertyName(IBU               )
+AddPropertyName(IBUs              )
+AddPropertyName(instructionIds    )
+AddPropertyName(instructions      )
+AddPropertyName(kegPrimingFactor  )
+AddPropertyName(locked            )
+AddPropertyName(mash              )
+AddPropertyName(mashId            )
+AddPropertyName(miscIds           )
+AddPropertyName(miscs             )
+AddPropertyName(notes             )
+AddPropertyName(og                )
+AddPropertyName(points            )
+AddPropertyName(postBoilVolume_l  )
+AddPropertyName(primaryAge_days   )
+AddPropertyName(primaryTemp_c     )
+AddPropertyName(primingSugarEquiv )
+AddPropertyName(primingSugarName  )
+AddPropertyName(saltIds           )
+AddPropertyName(secondaryAge_days )
+AddPropertyName(secondaryTemp_c   )
+AddPropertyName(SRMColor          )
+AddPropertyName(style             )
+AddPropertyName(styleId           )
+AddPropertyName(tasteNotes        )
+AddPropertyName(tasteRating       )
+AddPropertyName(tertiaryAge_days  )
+AddPropertyName(tertiaryTemp_c    )
+AddPropertyName(type              )
+AddPropertyName(waterIds          )
+AddPropertyName(waters            )
+AddPropertyName(wortFromMash_l    )
+AddPropertyName(yeastIds          )
+AddPropertyName(yeasts            )
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
 //======================================================================================================================
@@ -137,6 +136,11 @@ class Recipe : public NamedEntity {
 
    friend class MainWindow;
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    Recipe(QString name);
    Recipe(NamedParameterBundle const & namedParameterBundle);
@@ -152,14 +156,11 @@ public:
 
    //! \brief The type of recipe
    enum class Type { Extract, PartialMash, AllGrain };
+   // This allows us to store the above enum class in a QVariant
    Q_ENUM(Type)
 
    //! \brief The \b Type
-   Q_PROPERTY(Type recipeType READ recipeType WRITE setRecipeType /*NOTIFY changed*/ /*changedType*/)
-
-   //! \brief The type (extract, partial mash, all grain) stored as a string
-   //         TBD (MY 2021-01-18) Not sure why this is stored as a string rather than an enum.  Have created an enum wrapper above
-   Q_PROPERTY(QString type READ type WRITE setType /*NOTIFY changed*/ /*changedType*/)
+   Q_PROPERTY(Type type READ type WRITE setType /*NOTIFY changed*/ /*changedType*/)
    //! \brief The brewer.
    Q_PROPERTY(QString brewer READ brewer WRITE setBrewer /*NOTIFY changed*/ /*changedBrewer*/)
    //! \brief The batch size in liters.
@@ -193,7 +194,7 @@ public:
    //! \brief The temp in C in tertiary.
    Q_PROPERTY(double tertiaryTemp_c READ tertiaryTemp_c WRITE setTertiaryTemp_c /*NOTIFY changed*/ /*changedTertiaryTemp_c*/)
    //! \brief The number of days to age the beer after bottling.
-   Q_PROPERTY(double age READ age_days WRITE setAge_days /*NOTIFY changed*/ /*changedAge_days*/)
+   Q_PROPERTY(double age_days READ age_days WRITE setAge_days /*NOTIFY changed*/ /*changedAge_days*/)
    //! \brief The temp in C as beer is aging after bottling.
    Q_PROPERTY(double ageTemp_c READ ageTemp_c WRITE setAgeTemp_c /*NOTIFY changed*/ /*changedAgeTemp_c*/)
    //! \brief The date the recipe was created or brewed. I'm not sure yet.
@@ -384,36 +385,35 @@ public:
    Recipe * revertToPreviousVersion();
 
    // Getters
-   Type recipeType() const;
-   QString type() const;
-   QString brewer() const;
-   double batchSize_l() const;
-   double boilSize_l() const;
-   double boilTime_min() const;
-   double efficiency_pct() const;
-   QString asstBrewer() const;
-   QString notes() const;
-   QString tasteNotes() const;
-   double tasteRating() const;
-   double og();
-   double fg();
-   int fermentationStages() const;
-   double primaryAge_days() const;
-   double primaryTemp_c() const;
-   double secondaryAge_days() const;
-   double secondaryTemp_c() const;
-   double tertiaryAge_days() const;
-   double tertiaryTemp_c() const;
-   double age_days() const;
-   double ageTemp_c() const;
-   QDate date() const;
-   double carbonation_vols() const;
-   bool forcedCarbonation() const;
-   QString primingSugarName() const;
-   double carbonationTemp_c() const;
-   double primingSugarEquiv() const;
-   double kegPrimingFactor() const;
-   bool locked() const;
+   Type    type()               const;
+   QString brewer()             const;
+   double  batchSize_l()        const;
+   double  boilSize_l()         const;
+   double  boilTime_min()       const;
+   double  efficiency_pct()     const;
+   QString asstBrewer()         const;
+   QString notes()              const;
+   QString tasteNotes()         const;
+   double  tasteRating()        const;
+   double  og();
+   double  fg();
+   int     fermentationStages() const;
+   double  primaryAge_days()    const;
+   double  primaryTemp_c()      const;
+   double  secondaryAge_days()  const;
+   double  secondaryTemp_c()    const;
+   double  tertiaryAge_days()   const;
+   double  tertiaryTemp_c()     const;
+   double  age_days()           const;
+   double  ageTemp_c()          const;
+   QDate   date()               const;
+   double  carbonation_vols()   const;
+   bool    forcedCarbonation()  const;
+   QString primingSugarName()   const;
+   double  carbonationTemp_c()  const;
+   double  primingSugarEquiv()  const;
+   double  kegPrimingFactor()   const;
+   bool    locked()             const;
 
    // Calculated getters.
    double points();
@@ -436,31 +436,31 @@ public:
 
    // Relational getters
    template<typename NE> QList< std::shared_ptr<NE> > getAll() const;
-   QList<Hop *> hops() const;
-   QVector<int> getHopIds() const;
-   QList<Instruction *> instructions() const;
-   QVector<int> getInstructionIds() const;
-   QList<Fermentable *> fermentables() const;
-   QVector<int> getFermentableIds() const;
-   QList<Misc *>  miscs() const;
-   QVector<int> getMiscIds() const;
-   QList<Yeast *> yeasts() const;
-   QVector<int> getYeastIds() const;
-   QList<Water *> waters() const;
-   QVector<int> getWaterIds() const;
-   QList<Salt *>  salts() const;
-   QVector<int> getSaltIds() const;
-   QList<BrewNote *> brewNotes() const;
-   QList<Recipe *> ancestors() const;
-   std::shared_ptr<Mash> getMash() const;
-   Mash * mash() const;
-   int getMashId() const;
-   Equipment * equipment() const;
-   int getEquipmentId() const;
-   Style * style() const;
-   int getStyleId() const;
+   QList<Hop *>          hops()                                const;
+   QVector<int>          getHopIds()                           const;
+   QList<Instruction *>  instructions()                        const;
+   QVector<int>          getInstructionIds()                   const;
+   QList<Fermentable *>  fermentables()                        const;
+   QVector<int>          getFermentableIds()                   const;
+   QList<Misc *>         miscs()                               const;
+   QVector<int>          getMiscIds()                          const;
+   QList<Yeast *>        yeasts()                              const;
+   QVector<int>          getYeastIds()                         const;
+   QList<Water *>        waters()                              const;
+   QVector<int>          getWaterIds()                         const;
+   QList<Salt *>         salts()                               const;
+   QVector<int>          getSaltIds()                          const;
+   QList<BrewNote *>     brewNotes()                           const;
+   QList<Recipe *>       ancestors()                           const;
+   std::shared_ptr<Mash> getMash()                             const;
+   Mash *                mash()                                const;
+   int                   getMashId()                           const;
+   Equipment *           equipment()                           const;
+   int                   getEquipmentId()                      const;
+   Style *               style()                               const;
+   int                   getStyleId()                          const;
 
-   int getAncestorId() const;
+   int                   getAncestorId()                       const;
 
    // Relational setters
    void setEquipment(Equipment * equipment);
@@ -472,17 +472,17 @@ public:
    // The following calls are intended for use by the ObjectStore when pulling data from the database.  As such they do
    // not do additional work (eg to ensure that an ingredient being added is a child).
    //
-   void setEquipmentId(int equipmentId);
-   void setMashId(int mashId);
-   void setStyleId(int styleId);
+   void setEquipmentId   (int equipmentId);
+   void setMashId        (int mashId);
+   void setStyleId       (int styleId);
    void setFermentableIds(QVector<int> fermentableIds);
-   void setHopIds(QVector<int> hopIds);
+   void setHopIds        (QVector<int> hopIds);
    void setInstructionIds(QVector<int> instructionIds);
-   void setMiscIds(QVector<int> miscIds);
-   void setSaltIds(QVector<int> saltIds);
-   void setWaterIds(QVector<int> waterIds);
-   void setYeastIds(QVector<int> yeastIds);
-   void setAncestorId(int ancestorId, bool notify = true);
+   void setMiscIds       (QVector<int> miscIds);
+   void setSaltIds       (QVector<int> saltIds);
+   void setWaterIds      (QVector<int> waterIds);
+   void setYeastIds      (QVector<int> yeastIds);
+   void setAncestorId    (int ancestorId, bool notify = true);
 
    // Other junk.
    QVector<PreInstruction> mashInstructions(double timeRemaining, double totalWaterAdded_l, unsigned int size);
@@ -512,37 +512,36 @@ public:
    QHash<QString, double> calcTotalPoints();
 
    // Setters that are not slots
-   void setRecipeType(Type var);
-   void setType(const QString & var);
-   void setBrewer(const QString & var);
-   void setBatchSize_l(double var);
-   void setBoilSize_l(double var);
-   void setBoilTime_min(double var);
-   void setEfficiency_pct(double var);
-   void setAsstBrewer(const QString & var);
-   void setNotes(const QString & var);
-   void setTasteNotes(const QString & var);
-   void setTasteRating(double var);
-   void setOg(double var);
-   void setFg(double var);
-   void setFermentationStages(int var);
-   void setPrimaryAge_days(double var);
-   void setPrimaryTemp_c(double var);
-   void setSecondaryAge_days(double var);
-   void setSecondaryTemp_c(double var);
-   void setTertiaryAge_days(double var);
-   void setTertiaryTemp_c(double var);
-   void setAge_days(double var);
-   void setAgeTemp_c(double var);
-   void setDate(const QDate & var);
-   void setCarbonation_vols(double var);
-   void setForcedCarbonation(bool var);
-   void setPrimingSugarName(const QString & var);
-   void setCarbonationTemp_c(double var);
-   void setPrimingSugarEquiv(double var);
-   void setKegPrimingFactor(double var);
-   void setLocked(bool isLocked);
-   void setHasDescendants(bool spawned);
+   void setType              (Type    const   val);
+   void setBrewer            (QString const & val);
+   void setBatchSize_l       (double  const   val);
+   void setBoilSize_l        (double  const   val);
+   void setBoilTime_min      (double  const   val);
+   void setEfficiency_pct    (double  const   val);
+   void setAsstBrewer        (QString const & val);
+   void setNotes             (QString const & val);
+   void setTasteNotes        (QString const & val);
+   void setTasteRating       (double  const   val);
+   void setOg                (double  const   val);
+   void setFg                (double  const   val);
+   void setFermentationStages(int     const   val);
+   void setPrimaryAge_days   (double  const   val);
+   void setPrimaryTemp_c     (double  const   val);
+   void setSecondaryAge_days (double  const   val);
+   void setSecondaryTemp_c   (double  const   val);
+   void setTertiaryAge_days  (double  const   val);
+   void setTertiaryTemp_c    (double  const   val);
+   void setAge_days          (double  const   val);
+   void setAgeTemp_c         (double  const   val);
+   void setDate              (QDate   const & val);
+   void setCarbonation_vols  (double  const   val);
+   void setForcedCarbonation (bool    const   val);
+   void setPrimingSugarName  (QString const & val);
+   void setCarbonationTemp_c (double  const   val);
+   void setPrimingSugarEquiv (double  const   val);
+   void setKegPrimingFactor  (double  const   val);
+   void setLocked            (bool    const   val);
+   void setHasDescendants    (bool    const   val);
 
    virtual Recipe * getOwningRecipe();
 
@@ -573,7 +572,7 @@ private:
    std::unique_ptr<impl> pimpl;
 
    // Cached properties that are written directly to db
-   QString m_type;
+   Type m_type;
    QString m_brewer;
    QString m_asstBrewer;
    double m_batchSize_l;

--- a/src/model/Salt.cpp
+++ b/src/model/Salt.cpp
@@ -39,11 +39,25 @@ ObjectStore & Salt::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Salt>::getInstance();
 }
 
+TypeLookup const Salt::typeLookup {
+   "Salt",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Salt::amount        , Salt::m_amount        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Salt::amountIsWeight, Salt::m_amount_is_weight),  //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Salt::isAcid        , Salt::m_is_acid        ), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Salt::percentAcid   , Salt::m_percent_acid   ), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Salt::type          , Salt::m_type          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Salt::addTo         , Salt::m_add_to        ),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
+
 Salt::Salt(QString name) :
    NamedEntity       {name, true},
    m_amount          {0.0},
-   m_add_to          {NEVER},
-   m_type            {NONE},
+   m_add_to          {Salt::WhenToAdd::NEVER},
+   m_type            {Salt::Types::NONE},
    m_amount_is_weight{true},
    m_percent_acid    {0.0},
    m_is_acid         {false} {
@@ -87,8 +101,8 @@ void Salt::setAddTo(Salt::WhenToAdd var) {
 // amount_is_weight flags here.
 void Salt::setType(Salt::Types type) {
    this->setAndNotify(PropertyNames::Salt::type,           this->m_type, type);
-   this->setAndNotify(PropertyNames::Salt::isAcid,         this->m_is_acid, (type > NAHCO3));
-   this->setAndNotify(PropertyNames::Salt::amountIsWeight, this->m_amount_is_weight, !(type == LACTIC || type == H3PO4));
+   this->setAndNotify(PropertyNames::Salt::isAcid,         this->m_is_acid, (type > Salt::Types::NAHCO3));
+   this->setAndNotify(PropertyNames::Salt::amountIsWeight, this->m_amount_is_weight, !(type == Salt::Types::LACTIC || type == Salt::Types::H3PO4));
 }
 
 void Salt::setAmountIsWeight(bool var) {
@@ -128,68 +142,68 @@ double Salt::percentAcid() const { return m_percent_acid; }
 // for this part
 double Salt::Ca() const
 {
-   if ( m_add_to == Salt::NEVER ) {
+   if ( m_add_to == Salt::WhenToAdd::NEVER ) {
       return 0.0;
    }
 
    switch (m_type) {
-      case Salt::CACL2: return 272.0 * m_amount * 1000.0;
-      case Salt::CACO3: return 200.0 * m_amount * 1000.0;
-      case Salt::CASO4: return 232.0 * m_amount * 1000.0;
+      case Salt::Types::CACL2: return 272.0 * m_amount * 1000.0;
+      case Salt::Types::CACO3: return 200.0 * m_amount * 1000.0;
+      case Salt::Types::CASO4: return 232.0 * m_amount * 1000.0;
       default: return 0.0;
    }
 }
 
 double Salt::Cl() const
 {
-   if ( m_add_to == Salt::NEVER )
+   if ( m_add_to == Salt::WhenToAdd::NEVER )
       return 0.0;
    switch (m_type) {
-      case Salt::CACL2: return 483 * m_amount * 1000.0;
-      case Salt::NACL: return 607 * m_amount * 1000.0;
+      case Salt::Types::CACL2: return 483 * m_amount * 1000.0;
+      case Salt::Types::NACL: return 607 * m_amount * 1000.0;
       default: return 0.0;
    }
 }
 
 double Salt::CO3() const
 {
-   if ( m_add_to == Salt::NEVER )
+   if ( m_add_to == Salt::WhenToAdd::NEVER )
       return 0.0;
-   return m_type == Salt::CACO3 ? 610.0  * m_amount * 1000.0: 0.0;
-}
+   return m_type == Salt::Types::CACO3 ? 610.0  * m_amount * 1000.0: 0.0;
+   }
 
 double Salt::HCO3() const
 {
-   if ( m_add_to == Salt::NEVER )
+   if ( m_add_to == Salt::WhenToAdd::NEVER )
       return 0.0;
-   return m_type == Salt::NAHCO3 ? 726.0 * m_amount * 1000.0: 0.0;
-}
+   return m_type == Salt::Types::NAHCO3 ? 726.0 * m_amount * 1000.0: 0.0;
+   }
 
 double Salt::Mg() const
 {
-   if ( m_add_to == Salt::NEVER )
+   if ( m_add_to == Salt::WhenToAdd::NEVER )
       return 0.0;
-   return m_type == Salt::MGSO4 ? 99.0 * m_amount * 1000.0: 0.0;
+   return m_type == Salt::Types::MGSO4 ? 99.0 * m_amount * 1000.0: 0.0;
 }
 
 double Salt::Na() const
 {
-   if ( m_add_to == Salt::NEVER )
+   if ( m_add_to == Salt::WhenToAdd::NEVER )
       return 0.0;
    switch (m_type) {
-      case Salt::NACL: return 393.0 * m_amount * 1000.0;
-      case Salt::NAHCO3: return 274.0 * m_amount * 1000.0;
+      case Salt::Types::NACL: return 393.0 * m_amount * 1000.0;
+      case Salt::Types::NAHCO3: return 274.0 * m_amount * 1000.0;
       default: return 0.0;
    }
 }
 
 double Salt::SO4() const
 {
-   if ( m_add_to == Salt::NEVER )
+   if ( m_add_to == Salt::WhenToAdd::NEVER )
       return 0.0;
    switch (m_type) {
-      case Salt::CASO4: return 558.0 * m_amount * 1000.0;
-      case Salt::MGSO4: return 389.0 * m_amount * 1000.0;
+      case Salt::Types::CASO4: return 558.0 * m_amount * 1000.0;
+      case Salt::Types::MGSO4: return 389.0 * m_amount * 1000.0;
       default: return 0.0;
    }
 }

--- a/src/model/Salt.h
+++ b/src/model/Salt.h
@@ -32,11 +32,11 @@
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::Salt { BtStringConst const property{#property}; }
-AddPropertyName(amount)
+AddPropertyName(amount        )
 AddPropertyName(amountIsWeight)
 AddPropertyName(type)
-AddPropertyName(isAcid)
-AddPropertyName(percentAcid)
+AddPropertyName(isAcid        )
+AddPropertyName(percentAcid   )
 AddPropertyName(addTo)
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
@@ -52,20 +52,19 @@ class Salt : public NamedEntity {
    Q_OBJECT
    Q_CLASSINFO("signal", "salts")
 
-
-   friend class WaterDialog;
-   friend class SaltTableModel;
 public:
 
-   enum WhenToAdd {
+   enum class WhenToAdd {
       NEVER,
       MASH,
       SPARGE,
       RATIO,
       EQUAL
    };
+   // This allows us to store the above enum class in a QVariant
+   Q_ENUM(WhenToAdd)
 
-   enum Types {
+   enum class Types {
       NONE,
       CACL2,
       CACO3,
@@ -78,9 +77,14 @@ public:
       ACIDMLT,
       numTypes
    };
-
-   Q_ENUM(WhenToAdd)
+   // This allows us to store the above enum class in a QVariant
    Q_ENUM(Types)
+
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    Salt(QString name = "");
    Salt(NamedParameterBundle const & namedParameterBundle);
@@ -102,13 +106,13 @@ public:
    //! \brief Is this an acid or salt?
    Q_PROPERTY( bool isAcid READ isAcid WRITE setIsAcid /*NOTIFY changed*/ /*changedIsAcid*/ )
 
-   double amount() const;
+   double          amount()         const;
    Salt::WhenToAdd addTo() const;
-   Salt::Types type() const;
-   bool amountIsWeight() const;
-   double percentAcid() const;
-   bool isAcid() const;
-   int miscId() const;
+   Salt::Types     type()           const;
+   bool            amountIsWeight() const;
+   double          percentAcid()    const;
+   bool            isAcid()         const;
+   int             miscId()         const;
 
    void setAmount( double var );
    void setAddTo( Salt::WhenToAdd var );
@@ -117,13 +121,13 @@ public:
    void setPercentAcid(double var);
    void setIsAcid( bool var );
 
-   double Ca() const;
-   double Cl() const;
-   double CO3() const;
+   double Ca  () const;
+   double Cl  () const;
+   double CO3 () const;
    double HCO3() const;
-   double Mg() const;
-   double Na() const;
-   double SO4() const;
+   double Mg  () const;
+   double Na  () const;
+   double SO4 () const;
 
    virtual Recipe * getOwningRecipe();
 

--- a/src/model/Style.cpp
+++ b/src/model/Style.cpp
@@ -47,6 +47,36 @@ ObjectStore & Style::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Style>::getInstance();
 }
 
+TypeLookup const Style::typeLookup {
+   "Style",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::abvMax_pct    , Style::m_abvMax_pct    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::abvMin_pct    , Style::m_abvMin_pct    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::carbMax_vol   , Style::m_carbMax_vol   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::carbMin_vol   , Style::m_carbMin_vol   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::category      , Style::m_category      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::categoryNumber, Style::m_categoryNumber),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::colorMax_srm  , Style::m_colorMax_srm  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::colorMin_srm  , Style::m_colorMin_srm  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::examples      , Style::m_examples      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::fgMax         , Style::m_fgMax         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::fgMin         , Style::m_fgMin         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::ibuMax        , Style::m_ibuMax        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::ibuMin        , Style::m_ibuMin        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::ingredients   , Style::m_ingredients   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::notes         , Style::m_notes         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::ogMax         , Style::m_ogMax         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::ogMin         , Style::m_ogMin         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::profile       , Style::m_profile       ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::styleGuide    , Style::m_styleGuide    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::styleLetter   , Style::m_styleLetter   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::type          , Style::m_type          ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Style::typeString    , Style::m_typeString    ),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
+
 //====== Constructors =========
 
 // suitable for something that will be written to the db later

--- a/src/model/Style.h
+++ b/src/model/Style.h
@@ -32,28 +32,28 @@
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::Style { BtStringConst const property{#property}; }
-AddPropertyName(abvMax_pct)
-AddPropertyName(abvMin_pct)
-AddPropertyName(carbMax_vol)
-AddPropertyName(carbMin_vol)
-AddPropertyName(category)
+AddPropertyName(abvMax_pct    )
+AddPropertyName(abvMin_pct    )
+AddPropertyName(carbMax_vol   )
+AddPropertyName(carbMin_vol   )
+AddPropertyName(category      )
 AddPropertyName(categoryNumber)
-AddPropertyName(colorMax_srm)
-AddPropertyName(colorMin_srm)
-AddPropertyName(examples)
-AddPropertyName(fgMax)
-AddPropertyName(fgMin)
-AddPropertyName(ibuMax)
-AddPropertyName(ibuMin)
-AddPropertyName(ingredients)
-AddPropertyName(notes)
-AddPropertyName(ogMax)
-AddPropertyName(ogMin)
-AddPropertyName(profile)
-AddPropertyName(styleGuide)
-AddPropertyName(styleLetter)
-AddPropertyName(type)
-AddPropertyName(typeString)
+AddPropertyName(colorMax_srm  )
+AddPropertyName(colorMin_srm  )
+AddPropertyName(examples      )
+AddPropertyName(fgMax         )
+AddPropertyName(fgMin         )
+AddPropertyName(ibuMax        )
+AddPropertyName(ibuMin        )
+AddPropertyName(ingredients   )
+AddPropertyName(notes         )
+AddPropertyName(ogMax         )
+AddPropertyName(ogMin         )
+AddPropertyName(profile       )
+AddPropertyName(styleGuide    )
+AddPropertyName(styleLetter   )
+AddPropertyName(type          )
+AddPropertyName(typeString    )
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
 //======================================================================================================================
@@ -68,9 +68,13 @@ class Style : public NamedEntity {
    Q_OBJECT
    Q_CLASSINFO("signal", "styles")
 
-
-   friend class StyleEditor;
 public:
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
+
    Style(QString t_name = "");
    Style(NamedParameterBundle const & namedParameterBundle);
    Style(Style const & other);
@@ -78,7 +82,7 @@ public:
    virtual ~Style();
 
    //! \brief The type of beverage.
-   enum Type {Lager, Ale, Mead, Wheat, Mixed, Cider};
+   enum class Type {Lager, Ale, Mead, Wheat, Mixed, Cider};
    Q_ENUM(Type)
 
    //! \brief The category.

--- a/src/model/Water.cpp
+++ b/src/model/Water.cpp
@@ -42,6 +42,29 @@ ObjectStore & Water::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Water>::getInstance();
 }
 
+TypeLookup const Water::typeLookup {
+   "Water",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::alkalinity      , Water::m_alkalinity      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::alkalinityAsHCO3, Water::m_alkalinity_as_hco3), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::amount          , Water::m_amount          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::bicarbonate_ppm , Water::m_bicarbonate_ppm ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::calcium_ppm     , Water::m_calcium_ppm     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::chloride_ppm    , Water::m_chloride_ppm    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::magnesium_ppm   , Water::m_magnesium_ppm   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::mashRO          , Water::m_mash_ro          ), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::notes           , Water::m_notes           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::ph              , Water::m_ph              ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::sodium_ppm      , Water::m_sodium_ppm      ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::spargeRO        , Water::m_sparge_ro        ), //<<
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::sulfate_ppm     , Water::m_sulfate_ppm     ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Water::type            , Water::m_type            ),
+   },
+   // Parent class lookup
+   &NamedEntity::typeLookup
+};
+
+
 Water::Water(QString name) :
    NamedEntity         {name, true},
    m_amount            {0.0               },
@@ -149,12 +172,12 @@ Water & Water::operator=(Water other) {
    if (this->m_amount             != other.m_amount            ) { this->propagatePropertyChange(PropertyNames::Water::amount          ); }
    if (this->m_calcium_ppm        != other.m_calcium_ppm       ) { this->propagatePropertyChange(PropertyNames::Water::calcium_ppm     ); }
    if (this->m_bicarbonate_ppm    != other.m_bicarbonate_ppm   ) { this->propagatePropertyChange(PropertyNames::Water::bicarbonate_ppm ); }
-   if (this->m_sulfate_ppm        != other.m_sulfate_ppm       ) { this->propagatePropertyChange(PropertyNames::Water::chloride_ppm    ); }
-   if (this->m_chloride_ppm       != other.m_chloride_ppm      ) { this->propagatePropertyChange(PropertyNames::Water::sodium_ppm      ); }
-   if (this->m_sodium_ppm         != other.m_sodium_ppm        ) { this->propagatePropertyChange(PropertyNames::Water::magnesium_ppm   ); }
-   if (this->m_magnesium_ppm      != other.m_magnesium_ppm     ) { this->propagatePropertyChange(PropertyNames::Water::ph              ); }
-   if (this->m_ph                 != other.m_ph                ) { this->propagatePropertyChange(PropertyNames::Water::alkalinity      ); }
-   if (this->m_alkalinity         != other.m_alkalinity        ) { this->propagatePropertyChange(PropertyNames::Water::sulfate_ppm     ); }
+   if (this->m_sulfate_ppm        != other.m_sulfate_ppm       ) { this->propagatePropertyChange(PropertyNames::Water::sulfate_ppm     ); }
+   if (this->m_chloride_ppm       != other.m_chloride_ppm      ) { this->propagatePropertyChange(PropertyNames::Water::chloride_ppm    ); }
+   if (this->m_sodium_ppm         != other.m_sodium_ppm        ) { this->propagatePropertyChange(PropertyNames::Water::sodium_ppm      ); }
+   if (this->m_magnesium_ppm      != other.m_magnesium_ppm     ) { this->propagatePropertyChange(PropertyNames::Water::magnesium_ppm   ); }
+   if (this->m_ph                 != other.m_ph                ) { this->propagatePropertyChange(PropertyNames::Water::ph              ); }
+   if (this->m_alkalinity         != other.m_alkalinity        ) { this->propagatePropertyChange(PropertyNames::Water::alkalinity      ); }
    if (this->m_notes              != other.m_notes             ) { this->propagatePropertyChange(PropertyNames::Water::notes           ); }
    if (this->m_type               != other.m_type              ) { this->propagatePropertyChange(PropertyNames::Water::type            ); }
    if (this->m_mash_ro            != other.m_mash_ro           ) { this->propagatePropertyChange(PropertyNames::Water::mashRO          ); }
@@ -165,39 +188,39 @@ Water & Water::operator=(Water other) {
 }
 
 //================================"SET" METHODS=================================
-void Water::setAmount(double var)          { this->setAndNotify(PropertyNames::Water::amount,           this->m_amount,             var); }
-void Water::setCalcium_ppm(double var)     { this->setAndNotify(PropertyNames::Water::calcium_ppm,      this->m_calcium_ppm,        var); }
-void Water::setBicarbonate_ppm(double var) { this->setAndNotify(PropertyNames::Water::bicarbonate_ppm,  this->m_bicarbonate_ppm,    var); }
-void Water::setChloride_ppm(double var)    { this->setAndNotify(PropertyNames::Water::chloride_ppm,     this->m_chloride_ppm,       var); }
-void Water::setSodium_ppm(double var)      { this->setAndNotify(PropertyNames::Water::sodium_ppm,       this->m_sodium_ppm,         var); }
-void Water::setMagnesium_ppm(double var)   { this->setAndNotify(PropertyNames::Water::magnesium_ppm,    this->m_magnesium_ppm,      var); }
-void Water::setPh(double var)              { this->setAndNotify(PropertyNames::Water::ph,               this->m_ph,                 var); }
-void Water::setAlkalinity(double var)      { this->setAndNotify(PropertyNames::Water::alkalinity,       this->m_alkalinity,         var); }
-void Water::setSulfate_ppm(double var)     { this->setAndNotify(PropertyNames::Water::sulfate_ppm,      this->m_sulfate_ppm,        var); }
-void Water::setNotes(QString const & var)  { this->setAndNotify(PropertyNames::Water::notes,            this->m_notes,              var); }
-void Water::setType(Types var)             { this->setAndNotify(PropertyNames::Water::type,             this->m_type,               var); }
-void Water::setMashRO(double var)          { this->setAndNotify(PropertyNames::Water::mashRO,           this->m_mash_ro,            var); }
-void Water::setSpargeRO(double var)        { this->setAndNotify(PropertyNames::Water::spargeRO,         this->m_sparge_ro,          var); }
-void Water::setAlkalinityAsHCO3(bool var)  { this->setAndNotify(PropertyNames::Water::alkalinityAsHCO3, this->m_alkalinity_as_hco3, var); }
+void Water::setAmount          (double var         ) { this->setAndNotify(PropertyNames::Water::amount          , this->m_amount            , var); }
+void Water::setCalcium_ppm     (double var         ) { this->setAndNotify(PropertyNames::Water::calcium_ppm     , this->m_calcium_ppm       , var); }
+void Water::setBicarbonate_ppm (double var         ) { this->setAndNotify(PropertyNames::Water::bicarbonate_ppm , this->m_bicarbonate_ppm   , var); }
+void Water::setSulfate_ppm     (double var         ) { this->setAndNotify(PropertyNames::Water::sulfate_ppm     , this->m_sulfate_ppm       , var); }
+void Water::setChloride_ppm    (double var         ) { this->setAndNotify(PropertyNames::Water::chloride_ppm    , this->m_chloride_ppm      , var); }
+void Water::setSodium_ppm      (double var         ) { this->setAndNotify(PropertyNames::Water::sodium_ppm      , this->m_sodium_ppm        , var); }
+void Water::setMagnesium_ppm   (double var         ) { this->setAndNotify(PropertyNames::Water::magnesium_ppm   , this->m_magnesium_ppm     , var); }
+void Water::setPh              (double var         ) { this->setAndNotify(PropertyNames::Water::ph              , this->m_ph                , var); }
+void Water::setAlkalinity      (double var         ) { this->setAndNotify(PropertyNames::Water::alkalinity      , this->m_alkalinity        , var); }
+void Water::setNotes           (QString const & var) { this->setAndNotify(PropertyNames::Water::notes           , this->m_notes             , var); }
+void Water::setType            (Types var          ) { this->setAndNotify(PropertyNames::Water::type            , this->m_type              , var); }
+void Water::setMashRO          (double var         ) { this->setAndNotify(PropertyNames::Water::mashRO          , this->m_mash_ro           , var); }
+void Water::setSpargeRO        (double var         ) { this->setAndNotify(PropertyNames::Water::spargeRO        , this->m_sparge_ro         , var); }
+void Water::setAlkalinityAsHCO3(bool var           ) { this->setAndNotify(PropertyNames::Water::alkalinityAsHCO3, this->m_alkalinity_as_hco3, var); }
 
 //=========================="GET" METHODS=======================================
-QString      Water::notes()            const { return this->m_notes;              }
-double       Water::sulfate_ppm()      const { return this->m_sulfate_ppm;        }
-double       Water::amount()           const { return this->m_amount;             }
-double       Water::calcium_ppm()      const { return this->m_calcium_ppm;        }
-double       Water::bicarbonate_ppm()  const { return this->m_bicarbonate_ppm;    }
-double       Water::chloride_ppm()     const { return this->m_chloride_ppm;       }
-double       Water::sodium_ppm()       const { return this->m_sodium_ppm;         }
-double       Water::magnesium_ppm()    const { return this->m_magnesium_ppm;      }
-double       Water::ph()               const { return this->m_ph;                 }
-double       Water::alkalinity()       const { return this->m_alkalinity;         }
-Water::Types Water::type()             const { return this->m_type;               }
-double       Water::mashRO()           const { return this->m_mash_ro;            }
-double       Water::spargeRO()         const { return this->m_sparge_ro;          }
+double       Water::amount          () const { return this->m_amount            ; }
+double       Water::calcium_ppm     () const { return this->m_calcium_ppm       ; }
+double       Water::bicarbonate_ppm () const { return this->m_bicarbonate_ppm   ; }
+double       Water::sulfate_ppm     () const { return this->m_sulfate_ppm       ; }
+double       Water::chloride_ppm    () const { return this->m_chloride_ppm      ; }
+double       Water::sodium_ppm      () const { return this->m_sodium_ppm        ; }
+double       Water::magnesium_ppm   () const { return this->m_magnesium_ppm     ; }
+double       Water::ph              () const { return this->m_ph                ; }
+double       Water::alkalinity      () const { return this->m_alkalinity        ; }
+QString      Water::notes           () const { return this->m_notes             ; }
+Water::Types Water::type            () const { return this->m_type              ; }
+double       Water::mashRO          () const { return this->m_mash_ro           ; }
+double       Water::spargeRO        () const { return this->m_sparge_ro         ; }
 bool         Water::alkalinityAsHCO3() const { return this->m_alkalinity_as_hco3; }
 
 double Water::ppm(Water::Ions const ion) const {
-   switch(ion) {
+   switch (ion) {
       case Water::Ions::Ca:   return this->m_calcium_ppm;
       case Water::Ions::Cl:   return this->m_chloride_ppm;
       case Water::Ions::HCO3: return this->m_bicarbonate_ppm;

--- a/src/model/Water.h
+++ b/src/model/Water.h
@@ -66,6 +66,8 @@ public:
       BASE,
       TARGET
    };
+   // This allows us to store the above enum class in a QVariant
+   Q_ENUM(Types)
 
    enum class Ions {
       Ca,
@@ -76,9 +78,14 @@ public:
       SO4,
       numIons
    };
-
-   Q_ENUM(Types)
+   // This allows us to store the above enum class in a QVariant
    Q_ENUM(Ions)
+
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    Water(QString name = "");
    Water(NamedParameterBundle const & namedParameterBundle);

--- a/src/model/Yeast.cpp
+++ b/src/model/Yeast.cpp
@@ -32,6 +32,19 @@ namespace {
    QStringList const types{"Ale", "Lager", "Wheat", "Wine", "Champagne"};
    QStringList const forms{"Liquid", "Dry", "Slant", "Culture"};
    QStringList const flocculations{"Low", "Medium", "High", "Very High"};
+   QStringList const typesTr{Yeast::tr("Ale"),
+                             Yeast::tr("Lager"),
+                             Yeast::tr("Wheat"),
+                             Yeast::tr("Wine"),
+                             Yeast::tr("Champagne")};
+   QStringList const formsTr {Yeast::tr("Liquid"),
+                              Yeast::tr("Dry"),
+                              Yeast::tr("Slant"),
+                              Yeast::tr("Culture")};
+   QStringList const flocculationsTr{Yeast::tr("Low"),
+                                     Yeast::tr("Medium"),
+                                     Yeast::tr("High"),
+                                     Yeast::tr("Very High")};
 }
 
 bool Yeast::isEqualTo(NamedEntity const & other) const {
@@ -50,6 +63,34 @@ bool Yeast::isEqualTo(NamedEntity const & other) const {
 ObjectStore & Yeast::getObjectStoreTypedInstance() const {
    return ObjectStoreTyped<Yeast>::getInstance();
 }
+
+TypeLookup const Yeast::typeLookup {
+   "Yeast",
+   {
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::addToSecondary    , Yeast::m_addToSecondary    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::amount            , Yeast::m_amount            ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::amountIsWeight    , Yeast::m_amountIsWeight    ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::attenuation_pct   , Yeast::m_attenuation_pct   ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::bestFor           , Yeast::m_bestFor           ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::flocculation      , Yeast::m_flocculation      ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::flocculationString, Yeast::m_flocculationString),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::form              , Yeast::m_form              ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::formString        , Yeast::m_formString        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::laboratory        , Yeast::m_laboratory        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::maxReuse          , Yeast::m_maxReuse          ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::maxTemperature_c  , Yeast::m_maxTemperature_c  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::minTemperature_c  , Yeast::m_minTemperature_c  ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::notes             , Yeast::m_notes             ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::productID         , Yeast::m_productID         ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::timesCultured     , Yeast::m_timesCultured     ),
+//      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::typeString        , Yeast::m_typeString        ),
+      PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Yeast::type              , Yeast::m_type              ),
+   },
+   // Parent class lookup.  NB: NamedEntityWithInventory not NamedEntity!
+   &NamedEntityWithInventory::typeLookup
+};
+static_assert(std::is_base_of<NamedEntityWithInventory, Yeast>::value);
+
 
 //============================CONSTRUCTORS======================================
 
@@ -157,38 +198,24 @@ Yeast::Flocculation Yeast::flocculation() const { return m_flocculation; }
 Yeast::Type Yeast::type() const { return m_type; }
 
 const QString Yeast::typeStringTr() const {
-   static QStringList typesTr = QStringList() << QObject::tr("Ale")
-                                       << QObject::tr("Lager")
-                                       << QObject::tr("Wheat")
-                                       << QObject::tr("Wine")
-                                       << QObject::tr("Champagne");
-
-   if ( m_type < typesTr.size() && m_type >= 0 ) {
-      return typesTr.at(m_type);
-   }
-   return typesTr.at(0);
+   int myType = static_cast<int>(this->m_type);
+   Q_ASSERT(myType >= 0);
+   Q_ASSERT(myType < typesTr.size());
+   return typesTr.at(myType);
 }
 
 const QString Yeast::formStringTr() const {
-   static QStringList formsTr = QStringList() << QObject::tr("Liquid")
-                                       << QObject::tr("Dry")
-                                       << QObject::tr("Slant")
-                                       << QObject::tr("Culture");
-   if ( m_form < formsTr.size() && m_form >= 0  ) {
-      return formsTr.at(m_form);
-   }
-   return formsTr.at(0);
+   int myForm = static_cast<int>(this->m_form);
+   Q_ASSERT(myForm >= 0);
+   Q_ASSERT(myForm < formsTr.size());
+   return formsTr.at(myForm);
 }
 
 const QString Yeast::flocculationStringTr() const {
-   static QStringList flocculationsTr = QStringList() << QObject::tr("Low")
-                                               << QObject::tr("Medium")
-                                               << QObject::tr("High")
-                                               << QObject::tr("Very High");
-   if ( m_flocculation < flocculationsTr.size() && m_flocculation >= 0 ) {
-      return flocculationsTr.at(m_flocculation);
-   }
-   return flocculationsTr.at(0);
+   int myFlocculation = static_cast<int>(this->m_flocculation);
+   Q_ASSERT(myFlocculation >= 0);
+   Q_ASSERT(myFlocculation < flocculationsTr.size());
+   return flocculationsTr.at(myFlocculation);
 }
 
 //============================="SET" METHODS====================================

--- a/src/model/Yeast.h
+++ b/src/model/Yeast.h
@@ -33,24 +33,24 @@
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
 #define AddPropertyName(property) namespace PropertyNames::Yeast { BtStringConst const property{#property}; }
-AddPropertyName(addToSecondary)
-AddPropertyName(amount)
-AddPropertyName(amountIsWeight)
-AddPropertyName(attenuation_pct)
-AddPropertyName(bestFor)
-AddPropertyName(flocculation)
+AddPropertyName(addToSecondary    )
+AddPropertyName(amount            )
+AddPropertyName(amountIsWeight    )
+AddPropertyName(attenuation_pct   )
+AddPropertyName(bestFor           )
+AddPropertyName(flocculation      )
 AddPropertyName(flocculationString)
-AddPropertyName(form)
-AddPropertyName(formString)
-AddPropertyName(laboratory)
-AddPropertyName(maxReuse)
-AddPropertyName(maxTemperature_c)
-AddPropertyName(minTemperature_c)
-AddPropertyName(notes)
-AddPropertyName(productID)
-AddPropertyName(timesCultured)
-AddPropertyName(typeString)
-AddPropertyName(type)
+AddPropertyName(form              )
+AddPropertyName(formString        )
+AddPropertyName(laboratory        )
+AddPropertyName(maxReuse          )
+AddPropertyName(maxTemperature_c  )
+AddPropertyName(minTemperature_c  )
+AddPropertyName(notes             )
+AddPropertyName(productID         )
+AddPropertyName(timesCultured     )
+AddPropertyName(typeString        )
+AddPropertyName(type              )
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
 //======================================================================================================================
@@ -65,18 +65,27 @@ class Yeast : public NamedEntityWithInventory {
    Q_OBJECT
    Q_CLASSINFO("signal", "yeasts")
 
-
-   friend class YeastDialog;
 public:
    //! \brief What beverage the yeast is for.
-   enum Type {Ale, Lager, Wheat, Wine, Champagne};
-   //! \brief What form the yeast comes in.
-   enum Form {Liquid, Dry, Slant, Culture};
-   //! \brief How flocculant the strain is.
-   enum Flocculation {Low, Medium, High, Very_High}; // NOTE: BeerXML expects a space in "Very High", but not possible with enum. What to do?
+   enum class Type {Ale, Lager, Wheat, Wine, Champagne};
+   // This allows us to store the above enum class in a QVariant
    Q_ENUM(Type)
+
+   //! \brief What form the yeast comes in.
+   enum class Form {Liquid, Dry, Slant, Culture};
+   // This allows us to store the above enum class in a QVariant
    Q_ENUM(Form)
+
+   //! \brief How flocculant the strain is.
+   enum class Flocculation {Low, Medium, High, Very_High};
+   // This allows us to store the above enum class in a QVariant
    Q_ENUM(Flocculation)
+
+   /**
+    * \brief Mapping of names to types for the Qt properties of this class.  See \c NamedEntity::typeLookup for more
+    *        info.
+    */
+   static TypeLookup const typeLookup;
 
    Yeast(QString name = "");
    Yeast(NamedParameterBundle const & namedParameterBundle);

--- a/src/tableModels/MashStepTableModel.cpp
+++ b/src/tableModels/MashStepTableModel.cpp
@@ -353,7 +353,7 @@ bool MashStepTableModel::setData(QModelIndex const & index, QVariant const & val
          if (value.canConvert(QVariant::Int)) {
             MainWindow::instance().doOrRedoUpdate(*row,
                                                   PropertyNames::MashStep::type,
-                                                  static_cast<MashStep::Type>(value.toInt()),
+                                                  value.toInt(),
                                                   tr("Change Mash Step Type"));
             return true;
          }

--- a/src/tableModels/WaterTableModel.cpp
+++ b/src/tableModels/WaterTableModel.cpp
@@ -44,14 +44,14 @@ WaterTableModel::WaterTableModel(WaterTableWidget * parent) :
    BtTableModelRecipeObserver{
       parent,
       false,
-      {  {WATERNAMECOL,        {tr("Name"),              NonPhysicalQuantity::String,           ""      }},
-         {WATERAMOUNTCOL,      {tr("Amount"),            Measurement::PhysicalQuantity::Volume, "amount"}},
-         {WATERCALCIUMCOL,     {tr("Calcium (ppm)"),     NonPhysicalQuantity::Count,            ""      }},
-         {WATERBICARBONATECOL, {tr("Bicarbonate (ppm)"), NonPhysicalQuantity::Count,            ""      }},
-         {WATERSULFATECOL,     {tr("Sulfate (ppm)"),     NonPhysicalQuantity::Count,            ""      }},
-         {WATERCHLORIDECOL,    {tr("Chloride (ppm)"),    NonPhysicalQuantity::Count,            ""      }},
-         {WATERSODIUMCOL,      {tr("Sodium (ppm)"),      NonPhysicalQuantity::Count,            ""      }},
-         {WATERMAGNESIUMCOL,   {tr("Magnesium (ppm)"),   NonPhysicalQuantity::Count,            ""      }}}
+      {{WATERNAMECOL,        {tr("Name"),              NonPhysicalQuantity::String          , ""                           }},
+       {WATERAMOUNTCOL,      {tr("Amount"),            Measurement::PhysicalQuantity::Volume, *PropertyNames::Water::amount}},
+       {WATERCALCIUMCOL,     {tr("Calcium (ppm)"),     NonPhysicalQuantity::Count           , ""                           }},
+       {WATERBICARBONATECOL, {tr("Bicarbonate (ppm)"), NonPhysicalQuantity::Count           , ""                           }},
+       {WATERSULFATECOL,     {tr("Sulfate (ppm)"),     NonPhysicalQuantity::Count           , ""                           }},
+       {WATERCHLORIDECOL,    {tr("Chloride (ppm)"),    NonPhysicalQuantity::Count           , ""                           }},
+       {WATERSODIUMCOL,      {tr("Sodium (ppm)"),      NonPhysicalQuantity::Count           , ""                           }},
+       {WATERMAGNESIUMCOL,   {tr("Magnesium (ppm)"),   NonPhysicalQuantity::Count           , ""                           }}}
    },
    BtTableModelData<Water>{} {
    return;

--- a/src/tableModels/YeastTableModel.cpp
+++ b/src/tableModels/YeastTableModel.cpp
@@ -48,13 +48,13 @@ YeastTableModel::YeastTableModel(QTableView * parent, bool editable) :
    BtTableModelInventory{
       parent,
       editable,
-      {{YEASTNAMECOL,      {tr("Name"),       NonPhysicalQuantity::String,          ""      }},
-       {YEASTLABCOL,       {tr("Laboratory"), NonPhysicalQuantity::String,          ""      }},
-       {YEASTPRODIDCOL,    {tr("Product ID"), NonPhysicalQuantity::String,          ""      }},
-       {YEASTTYPECOL,      {tr("Type"),       NonPhysicalQuantity::String,          ""      }},
-       {YEASTFORMCOL,      {tr("Form"),       NonPhysicalQuantity::String,          ""      }},
+      {{YEASTNAMECOL,      {tr("Name"),       NonPhysicalQuantity::String                   , ""                           }},
+       {YEASTLABCOL,       {tr("Laboratory"), NonPhysicalQuantity::String                   , ""                           }},
+       {YEASTPRODIDCOL,    {tr("Product ID"), NonPhysicalQuantity::String                   , ""                           }},
+       {YEASTTYPECOL,      {tr("Type"),       NonPhysicalQuantity::String                   , ""                           }},
+       {YEASTFORMCOL,      {tr("Form"),       NonPhysicalQuantity::String                   , ""                           }},
        {YEASTAMOUNTCOL,    {tr("Amount"),     Measurement::PhysicalQuantity::Mixed, "amount"}},
-       {YEASTINVENTORYCOL, {tr("Inventory"),  NonPhysicalQuantity::Count,           ""      }}}
+       {YEASTINVENTORYCOL, {tr("Inventory"),  NonPhysicalQuantity::Count                    , ""                           }}}
    },
    BtTableModelData<Yeast>{} {
 
@@ -361,7 +361,7 @@ bool YeastTableModel::setData(QModelIndex const & index, QVariant const & value,
          }
          MainWindow::instance().doOrRedoUpdate(*row,
                                                PropertyNames::Yeast::type,
-                                               static_cast<Yeast::Type>(value.toInt()),
+                                               value.toInt(),
                                                tr("Change Yeast Type"));
          break;
       case YEASTFORMCOL:
@@ -370,7 +370,7 @@ bool YeastTableModel::setData(QModelIndex const & index, QVariant const & value,
          }
          MainWindow::instance().doOrRedoUpdate(*row,
                                                PropertyNames::Yeast::form,
-                                               static_cast<Yeast::Form>(value.toInt()),
+                                               value.toInt(),
                                                tr("Change Yeast Form"));
          break;
       case YEASTINVENTORYCOL:

--- a/src/utils/TypeLookup.cpp
+++ b/src/utils/TypeLookup.cpp
@@ -1,0 +1,74 @@
+/*
+ * utils/TypeLookup.cpp is part of Brewtarget, and is Copyright the following
+ * authors 2023
+ * - Matt Young <mfsy@yahoo.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "utils/TypeLookup.h"
+
+#include <typeinfo>
+#include <type_traits>
+
+#include <QDate>
+#include <QDebug>
+#include <QString>
+
+#include "Logging.h"
+#include "measurement/Amount.h"
+
+bool TypeInfo::isOptional() const {
+   if (this->classification == TypeInfo::Classification::OptionalEnum ||
+       this->classification == TypeInfo::Classification::OptionalOther) {
+      return true;
+   }
+   return false;
+}
+
+TypeLookup::TypeLookup(char       const * const                                 className,
+                       std::initializer_list<TypeLookup::LookupMap::value_type> initializerList,
+                       TypeLookup const * const                                 parentClassLookup) :
+   className{className},
+   lookupMap{initializerList},
+   parentClassLookup{parentClassLookup} {
+   return;
+}
+
+TypeInfo const & TypeLookup::getType(BtStringConst const & propertyName) const {
+   auto match = std::find_if(
+      this->lookupMap.begin(),
+      this->lookupMap.end(),
+      [& propertyName](auto const & record) { return propertyName == *record.first; }
+   );
+
+   if (match != this->lookupMap.end()) {
+      return match->second;
+   }
+
+   if (this->parentClassLookup) {
+      return this->parentClassLookup->getType(propertyName);
+   }
+
+   // It's a coding error if we tried to look up a property that we don't know about
+   qCritical() << Q_FUNC_INFO << "Can't find type info for property" << *propertyName << "of class" << this->className;
+   qCritical().noquote() << Q_FUNC_INFO << "Stack trace:" << Logging::getStackTrace();
+   Q_ASSERT(false);
+   throw std::bad_typeid();
+}
+
+bool TypeLookup::isOptional(BtStringConst const & propertyName) const {
+   // This call to getType() will throw std::bad_typeid if there's no info for propertyName, so we don't have to handle
+   // that case here
+   return this->getType(propertyName).isOptional();
+}

--- a/src/utils/TypeLookup.h
+++ b/src/utils/TypeLookup.h
@@ -1,0 +1,190 @@
+/*
+ * utils/TypeLookup.h is part of Brewtarget, and is Copyright the following
+ * authors 2023
+ * - Matt Young <mfsy@yahoo.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef UTILS_TYPELOOKUP_H
+#define UTILS_TYPELOOKUP_H
+#pragma once
+
+#include <map>
+#include <optional>
+#include <typeindex>
+#include <typeinfo>
+
+#include "utils/BtStringConst.h"
+
+/**
+ * \brief Together with \c std::is_enum from \c <type_traits>, the \c is_optional and \c is_optional_enum templates
+ *        defined here give us a generic way at compile time to determine whether a type T is:
+ *           1. an enum
+ *           2. an instance of std::optional< U > for some enum U
+ *           3. an instance of std::optional< U > for some other type U
+ *           4. neither an instance of std::optional nor an enum
+ *        The four cases:
+ *
+ *           --------------------------------------------------------------------------------
+ *           |     T               | std::is_enum<T> | is_optional<T> | is_optional_enum<T> |
+ *           --------------------------------------------------------------------------------
+ *           |                     |                 |                |                     |
+ *           | an enum             |      true       |     false      |        false        |
+ *           |                     |                 |                |                     |
+ *           | other non optional  |      false      |     false      |        false        |
+ *           |                     |                 |                |                     |
+ *           | std::optional enum  |      false      |     true       |        true         |
+ *           |                     |                 |                |                     |
+ *           | other std::optional |      false      |     true       |        false        |
+ *           |                     |                 |                |                     |
+ *           --------------------------------------------------------------------------------
+ *
+ *        Template metaprogramming is sometimes very useful but can be a bit painful to follow.  What we've done here
+ *        (at the simple end of things!) is somewhat inspired by the examples at:
+ *        https://www.boost.org/doc/libs/1_81_0/libs/type_traits/doc/html/boost_typetraits/background.html
+ *
+ *        Normally we shouldn't need to use these templates directly outside of the \c TypeLookup class because the
+ *        \c PROPERTY_TYPE_LOOKUP_ENTRY macro below takes care of everything for constructor calls where you would
+ *        otherwise need them.
+ */
+template <typename T>
+struct is_optional : public std::false_type{};
+template <typename T>
+struct is_optional< std::optional<T> > : public std::true_type{};
+
+template <typename T>
+struct is_optional_enum : public std::false_type{};
+template <typename T>
+struct is_optional_enum< std::optional<T> > : public std::is_enum<T>{};
+
+/**
+ * \brief Extends \c std::type_index with some other info we need about a type for serialisation, specifically whether
+ *        it is an enum and/or whether it is \c std::optional.
+ */
+struct TypeInfo {
+   /**
+    * \brief \c std::type_index is essentially a wrapper around pointer to \c std::type_info.  It is guaranteed unique
+    *        for each different type and guaranteed to compare equal for two properties of the same type.  (This is
+    *        better than using raw pointers as they are not guaranteed to be identical for two properties of the same
+    *        type.)
+    *
+    *        Note that we cannot use \c std::type_info::name() for this purpose as "the returned string can be identical
+    *        for several types".
+    */
+   std::type_index typeIndex;
+
+   /**
+    * \brief This classification covers the main special cases we need to deal with, viz whether a property is optional
+    *        (so we have to deal with std::optional wrapper around the underlying type) and whether it is an enum (where
+    *        we treat it as an int for generic handling because it makes the serialisation code a lot simpler).
+    */
+   enum class Classification {
+      RequiredEnum,
+      RequiredOther,
+      OptionalEnum,
+      OptionalOther
+   };
+   Classification classification;
+
+   bool isOptional() const;
+
+   /**
+    * \brief Factory function to construct a \c TypeInfo for a given type.
+    *
+    *        TODO: We could probably do this via a bunch of template specialisations...
+    */
+   template <typename T>
+   const static TypeInfo construct() {
+      if (std::is_enum<T>::value) {
+         return TypeInfo{typeid(T), Classification::RequiredEnum};
+      }
+      if (!is_optional<T>::value) {
+         return TypeInfo{typeid(T), Classification::RequiredOther};
+      }
+      if (is_optional_enum<T>::value) {
+         return TypeInfo{typeid(T), Classification::OptionalEnum};
+      }
+      return TypeInfo{typeid(T), Classification::OptionalOther};
+   }
+};
+
+/**
+ * \class TypeLookup allows us to get \c TypeInfo for a property.
+ *
+ *        With the advent of BeerJSON, we have a lot more "optional" fields on objects.  We don't want to extend three
+ *        different serialisation models (database, BeerXML and BeerJSON) with an extra flag, especially as the
+ *        (subclass of) \c NamedEntity ought to know itself whether a field is optional/nullable.  This is enough for
+ *        serialisation (where we just need to know eg whether we're reading/writing `double` or
+ *        `std::optional<double>`).
+ *
+ *        In principle we might be able to avoid the need for this class and instead construct a look-up table at run
+ *        time by making a bunch of calls to \c qRegisterMetaType(std::optional<T>) during start-up for all types \c T
+ *        and storing the resulting IDs in a set or list that we then consult to discover whether a property is
+ *        of type \c T or \c std::optional<T>.  But I _think_ the approach here is easier to debug.
+ */
+class TypeLookup {
+public:
+
+   /**
+    * \brief If we want to change from using std::map in future, it's easier if we have a typedef alias for it
+    */
+   using LookupMap = std::map<BtStringConst const *, TypeInfo>;
+
+   /**
+    * \brief Construct a \c TypeLookup that optinoally extends an existing one (typically from the parent class)
+    *
+    * \param className Name of the class for which this is the property type lookup.  Eg for the \c TypeLookup for
+    *                  \c Hop, this should be "Hop".  Used for error logging.
+    * \param initializerList The mappings for this \c TypeLookup.  Eg for the \c TypeLookup for \c Hop, this would be
+    *                        the type mappings for PropertyNames::Hop::... properties (but not the
+    *                        PropertyNames::NamedEntity::... properties
+    * \param parentClassLookup Pointer to the \c TypeLookup for the parent class, or \c nullptr if there is none.  Eg
+    *                          for the \c TypeLookup for \c Hop,
+    *                          this should point to the \c TypeLookup for \c NamedEntity because \c Hop inherits from
+    *                          \c NamedEntity.
+    */
+   TypeLookup(char       const * const                     className,
+              std::initializer_list<LookupMap::value_type> initializerList,
+              TypeLookup const * const                     parentClassLookup = nullptr);
+
+   /**
+    * \brief Get the type ID (and whether it's an enum) for a given property name
+    */
+   TypeInfo const & getType(BtStringConst const & propertyName) const;
+
+   /**
+    * \brief Returns whether the attribute for a given property name is optional (ie std::optional<T> rather than T)
+    */
+   bool isOptional(BtStringConst const & propertyName) const;
+
+private:
+   char       const * const className;
+   LookupMap          const lookupMap;
+   TypeLookup const * const parentClassLookup;
+};
+
+/**
+ * \brief This macro simplifies the entries in the \c initializerList parameter of a \c TypeLookup constructor call.  It
+ *        also makes it easier for us to modify the structure of \c LookupMapEntry or \c LookupMap in future if we need
+ *        to.
+ *
+ *        For the purposes of calling the \c TypeLookup constructor, the caller doesn't have to worry about what we
+ *        are storing or how.  For each property, you just provide the name of the property and the member variable in
+ *        which it is stored, eg:
+ *           PROPERTY_TYPE_LOOKUP_ENTRY(PropertyNames::Hop::alpha_pct, Hop::m_alpha_pct)
+ *        The macro and the templates above etc then do the necessary.
+ */
+#define PROPERTY_TYPE_LOOKUP_ENTRY(propNameConstVar, memberVar) {&propNameConstVar, TypeInfo::construct<decltype(memberVar)>()}
+
+#endif

--- a/src/xml/BeerXml.cpp
+++ b/src/xml/BeerXml.cpp
@@ -123,10 +123,10 @@ namespace {
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> QString const BEER_XML_RECORD_NAME<Fermentable>{"FERMENTABLE"};
    EnumStringMapping const BEER_XML_FERMENTABLE_TYPE_MAPPER {
-      {"Grain",       Fermentable::Type::Grain},
-      {"Sugar",       Fermentable::Type::Sugar},
-      {"Extract",     Fermentable::Type::Extract},
-      {"Dry Extract", Fermentable::Type::Dry_Extract},
+      {"Grain",               Fermentable::Type::Grain},
+      {"Sugar",               Fermentable::Type::Sugar},
+      {"Extract",             Fermentable::Type::Extract},
+      {"Dry Extract",         Fermentable::Type::Dry_Extract},
       {"Adjunct",     Fermentable::Type::Adjunct}
    };
    template<> XmlRecord::FieldDefinitions const BEER_XML_RECORD_FIELDS<Fermentable> {
@@ -473,7 +473,7 @@ namespace {
       // Type                                  XPath                       Q_PROPERTY                                 Enum Mapper
       {XmlRecord::FieldType::String,           "NAME",                     PropertyNames::NamedEntity::name,          nullptr},
       {XmlRecord::FieldType::RequiredConstant, "VERSION",                  VERSION1,                                  nullptr},
-      {XmlRecord::FieldType::Enum,             "TYPE",                     PropertyNames::Recipe::recipeType,         &BEER_XML_RECIPE_STEP_TYPE_MAPPER},
+      {XmlRecord::FieldType::Enum,             "TYPE",                     PropertyNames::Recipe::type,               &BEER_XML_RECIPE_STEP_TYPE_MAPPER},
       {XmlRecord::FieldType::RecordSimple,     "STYLE",                    PropertyNames::Recipe::style,              nullptr},
       {XmlRecord::FieldType::RecordSimple,     "EQUIPMENT",                PropertyNames::Recipe::equipment,          nullptr},
       {XmlRecord::FieldType::String,           "BREWER",                   PropertyNames::Recipe::brewer,             nullptr},
@@ -502,7 +502,7 @@ namespace {
       {XmlRecord::FieldType::Double,           "SECONDARY_TEMP",           PropertyNames::Recipe::secondaryTemp_c,    nullptr},
       {XmlRecord::FieldType::Double,           "TERTIARY_AGE",             PropertyNames::Recipe::tertiaryAge_days,   nullptr},
       {XmlRecord::FieldType::Double,           "TERTIARY_TEMP",            PropertyNames::Recipe::tertiaryTemp_c,     nullptr},
-      {XmlRecord::FieldType::Double,           "AGE",                      PropertyNames::Recipe::age,                nullptr},
+      {XmlRecord::FieldType::Double,           "AGE",                      PropertyNames::Recipe::age_days,           nullptr},
       {XmlRecord::FieldType::Double,           "AGE_TEMP",                 PropertyNames::Recipe::ageTemp_c,          nullptr},
       {XmlRecord::FieldType::Date,             "DATE",                     PropertyNames::Recipe::date,               nullptr},
       {XmlRecord::FieldType::Double,           "CARBONATION",              PropertyNames::Recipe::carbonation_vols,   nullptr},
@@ -717,7 +717,7 @@ BeerXML & BeerXML::getInstance() {
 }
 
 
-BeerXML::BeerXML() : pimpl{ new impl{} } {
+BeerXML::BeerXML() : pimpl{std::make_unique<impl>()} {
    return;
 }
 
@@ -741,7 +741,7 @@ void BeerXML::createXmlFile(QFile & outFile) const {
    return;
 }
 
-template<class NE> void BeerXML::toXml(QList<NE *> const & nes, QFile & outFile) const {
+template<class NE> void BeerXML::toXml(QList<NE const *> const & nes, QFile & outFile) const {
    // We don't want to output empty container records
    if (nes.empty()) {
       return;
@@ -768,18 +768,18 @@ template<class NE> void BeerXML::toXml(QList<NE *> const & nes, QFile & outFile)
 // (This is all just a trick to allow the template definition to be here in the .cpp file and not in the header, which
 // means, amongst other things, that we can reference the pimpl.)
 //
-template void BeerXML::toXml(QList<Hop *> const &        nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Fermentable *> const &nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Yeast *> const &      nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Misc *> const &       nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Water *> const &      nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Style *> const &      nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<MashStep *> const &   nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Mash *> const &       nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Equipment *> const &  nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Instruction *> const &nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<BrewNote *> const &   nes, QFile & outFile) const;
-template void BeerXML::toXml(QList<Recipe *> const &     nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Hop         const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Fermentable const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Yeast       const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Misc        const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Water       const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Style       const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<MashStep    const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Mash        const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Equipment   const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Instruction const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<BrewNote    const *> const & nes, QFile & outFile) const;
+template void BeerXML::toXml(QList<Recipe      const *> const & nes, QFile & outFile) const;
 
 // fromXml ====================================================================
 bool BeerXML::importFromXML(QString const & filename, QTextStream & userMessage) {

--- a/src/xml/BeerXml.h
+++ b/src/xml/BeerXml.h
@@ -53,7 +53,7 @@ public:
    /**
     * \brief Write a list of objects to the supplied file
     */
-   template<class NE> void toXml(QList<NE *> const & nes, QFile & outFile) const;
+   template<class NE> void toXml(QList<NE const *> const & nes, QFile & outFile) const;
 
    /*! Import ingredients, recipes, etc from BeerXML documents.
     * \param filename

--- a/translations/bt_ca.ts
+++ b/translations/bt_ca.ts
@@ -5841,7 +5841,7 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>Quant a &amp;Brewtarget</translation>
+        <translation type="vanished">Quant a &amp;Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6169,6 +6169,10 @@ El volum final al primari és de %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_cs.ts
+++ b/translations/bt_cs.ts
@@ -5803,7 +5803,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>&amp;O aplikaci Brewtarget</translation>
+        <translation type="vanished">&amp;O aplikaci Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6131,6 +6131,10 @@ Celkový objem pro hlavní kvašení je %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_de.ts
+++ b/translations/bt_de.ts
@@ -5809,7 +5809,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>Über &amp;Brewtarget</translation>
+        <translation type="vanished">Über &amp;Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6137,6 +6137,10 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_el.ts
+++ b/translations/bt_el.ts
@@ -5801,7 +5801,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>Σχετικά &amp;BrewTarget</translation>
+        <translation type="vanished">Σχετικά &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6129,6 +6129,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_en.ts
+++ b/translations/bt_en.ts
@@ -5036,10 +5036,6 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>About &amp;BrewTarget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>About Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5313,6 +5309,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_es.ts
+++ b/translations/bt_es.ts
@@ -5841,7 +5841,7 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>Sobre &amp;Brewtarget</translation>
+        <translation type="vanished">Sobre &amp;Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6165,6 +6165,10 @@ El volumen final en el primario es %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_et.ts
+++ b/translations/bt_et.ts
@@ -5102,10 +5102,6 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>About &amp;BrewTarget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>About Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5379,6 +5375,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_eu.ts
+++ b/translations/bt_eu.ts
@@ -5114,10 +5114,6 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>About &amp;BrewTarget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>About Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5391,6 +5387,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_fr.ts
+++ b/translations/bt_fr.ts
@@ -5843,7 +5843,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>À propos de &amp;Brewtarget</translation>
+        <translation type="vanished">À propos de &amp;Brewtarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6171,6 +6171,10 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_gl.ts
+++ b/translations/bt_gl.ts
@@ -5237,10 +5237,6 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>About &amp;BrewTarget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>About Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5514,6 +5510,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_hu.ts
+++ b/translations/bt_hu.ts
@@ -5805,7 +5805,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>A Brewtargetről</translation>
+        <translation type="vanished">A Brewtargetről</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6133,6 +6133,10 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_it.ts
+++ b/translations/bt_it.ts
@@ -5845,7 +5845,7 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>About &amp;BrewTarget</translation>
+        <translation type="vanished">About &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6173,6 +6173,10 @@ Il Volume finale del primo è %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_lv.ts
+++ b/translations/bt_lv.ts
@@ -5181,10 +5181,6 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>About &amp;BrewTarget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>About Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5458,6 +5454,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_nb.ts
+++ b/translations/bt_nb.ts
@@ -5801,7 +5801,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>Om &amp;BrewTarget</translation>
+        <translation type="vanished">Om &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6129,6 +6129,10 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_nl.ts
+++ b/translations/bt_nl.ts
@@ -5779,7 +5779,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>Over &amp;BrewTarget</translation>
+        <translation type="vanished">Over &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6099,6 +6099,10 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_pl.ts
+++ b/translations/bt_pl.ts
@@ -5801,7 +5801,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>O &amp;BrewTarget</translation>
+        <translation type="vanished">O &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6129,6 +6129,10 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_pt.ts
+++ b/translations/bt_pt.ts
@@ -5817,7 +5817,7 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>Sobre &amp;BrewTarget</translation>
+        <translation type="vanished">Sobre &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6145,6 +6145,10 @@ O volume final do fermentador primário é %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_ru.ts
+++ b/translations/bt_ru.ts
@@ -5845,7 +5845,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>&amp;О BrewTarget</translation>
+        <translation type="vanished">&amp;О BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6169,6 +6169,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_sr.ts
+++ b/translations/bt_sr.ts
@@ -5441,10 +5441,6 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>About &amp;BrewTarget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>About Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5718,6 +5714,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_sv.ts
+++ b/translations/bt_sv.ts
@@ -5801,7 +5801,7 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>Om &amp;BrewTarget</translation>
+        <translation type="vanished">Om &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6133,6 +6133,10 @@ Primärens slutgiltiga volym är %1.</translation>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_tr.ts
+++ b/translations/bt_tr.ts
@@ -5213,7 +5213,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>&amp;BrewTarget Hakkında</translation>
+        <translation type="vanished">&amp;BrewTarget Hakkında</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -5489,6 +5489,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_zh.ts
+++ b/translations/bt_zh.ts
@@ -5781,7 +5781,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>About &amp;BrewTarget</source>
-        <translation>关于BrewTargetAbout &amp;BrewTarget</translation>
+        <translation type="vanished">关于BrewTargetAbout &amp;BrewTarget</translation>
     </message>
     <message>
         <source>About Brewtarget</source>
@@ -6105,6 +6105,10 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>application/x-brewtarget-folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About &amp;Brewtarget</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Fix for https://github.com/Brewtarget/brewtarget/issues/736, plus a bit more currently unused code that will allow us to have optional fields (for BeerJSON).

Key change is in database/ObjectStore.cpp, where `unwrapAndMapAsNeeded` and `wrapAndUnmapAsNeeded` handle converting between how we store things in the database and how we store them in memory.  In particular, they now:
- force the `QVariant` to be of the "right" type, which should address the issue discussed in the ticket about how `QVariant` can present an `enum` as either a string or an integer depending on how you ask it;
- check that the Qt property type matches what we've said the database type is (so we should spot problems sooner where, eg, something that's supposed be an `int` is declared as a `double` for its Qt property interface;
- handles conversion to and from `NULL` for optional fields (of which there aren't any yet but lots will soon be arriving when we do BeerJSON).

The other, currently mostly unused, thing added is the static `typeLookup` function on all the model classes.  The fiddly stuff to make this work is in `utils/TypeLookup.h` and `utils/TypeLookup.cpp`.  Basically the idea is that, for any given Qt property on the model classes, we want to be able to know whether it's a strongly-typed `enum` and whether it's a type wrapped in `std::optional`.  This is needed to avoid additional complexity in all the serialisation code (including to BeerJSON and BeerXML).  Eg, we don't want to have to add new types or flags to all the mappings to say whether something is optional if we can figure it out almost completely automatically.

Also, there were some bugs in the `Water` assignment operator.  I've tried to make sure all the member variables are accessed in the same order in all the constructors etc.

Sorry to make it a bigger change that it needed to be.  I was merging stuff back from Brewken and I didn't want to unpick all the `std::optional` handling that's already coded there.   