### PR TITLE
Fix for old DBs where fermentable->inventory_id is double instead of int

### DIFF
--- a/src/database/ObjectStore.cpp
+++ b/src/database/ObjectStore.cpp
@@ -511,11 +511,13 @@ namespace {
     *            case of SQLite).
     *          - Some integer foreign key columns were created without a type in SQLite, which means they get treated as
     *            strings
+    *          - In another case, a foreign key was created as a double instead of an int
     *        Rather than just say anything goes, we store the known problem columns here and log a warning about them.
     */
    QMap<TableColumnAndType, QVector<int>> const legacyBadTypes {
       {{"equipment",   "calc_boil_volume", ObjectStore::FieldType::Bool}, {QMetaType::QString}},
       {{"fermentable", "add_after_boil"  , ObjectStore::FieldType::Bool}, {QMetaType::QString}},
+      {{"fermentable", "inventory_id"    , ObjectStore::FieldType::Int }, {QMetaType::Double }},
       {{"fermentable", "is_mashed"       , ObjectStore::FieldType::Bool}, {QMetaType::QString}},
       {{"fermentable", "recommend_mash"  , ObjectStore::FieldType::Bool}, {QMetaType::QString}},
       {{"mash",        "equip_adjust"    , ObjectStore::FieldType::Bool}, {QMetaType::QString}},

--- a/src/unitTests/Testing.cpp
+++ b/src/unitTests/Testing.cpp
@@ -719,9 +719,9 @@ void Testing::testNamedParameterBundle() {
 void Testing::testNumberDisplayAndParsing() {
    // Per comment above, we should be seeing number formats in French locale here
    // Eg: 1,234.56 in US locale = 1.234,56 in French locale
-   QVERIFY(1.23 == Measurement::extractRawFromString<double>("1,23 %"));
-   QVERIFY(3.45 == Measurement::extractRawFromString<double>("  03,45 srm  "));
-   QVERIFY(6.78 == Measurement::extractRawFromString<double>("\t6,78000000    bananas!"));
+   QVERIFY(fuzzyComp(1.23, Measurement::extractRawFromString<double>("1,23 %"                  ), 0.0000000001));
+   QVERIFY(fuzzyComp(3.45, Measurement::extractRawFromString<double>("  03,45 srm  "           ), 0.0000000001));
+   QVERIFY(fuzzyComp(6.78, Measurement::extractRawFromString<double>("\t6,78000000    bananas!"), 0.0000000001));
    QVERIFY(1    == Measurement::extractRawFromString<int>   ("1,23 %"));
    QVERIFY(3    == Measurement::extractRawFromString<int>   ("  03,45 srm  "));
    QVERIFY(6    == Measurement::extractRawFromString<int>   ("\t6,78000000    bananas!"));


### PR DESCRIPTION
This should, I hope, fix https://github.com/Brewtarget/brewtarget/issues/751 (which is also one of the problems mentioned in https://github.com/Brewtarget/brewtarget/issues/738).