### PR TITLE
Error recovery for string-in-boolean field in DB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 #============================================== Project name and Version ===============================================
 #=======================================================================================================================
 # It's simplest to keep the project name all lower-case as it means we can use a lot more of the default settings for
-# Linux packaging (where directory names etc are expected to be all lower-case)
+# Linux packaging (where directory names etc are expected to be all lower-case).
 project(brewtarget VERSION 3.0.10 LANGUAGES CXX)
 message(STATUS "Building ${PROJECT_NAME} version ${PROJECT_VERSION}")
 message(STATUS "PROJECT_SOURCE_DIR is ${PROJECT_SOURCE_DIR}")

--- a/schemas/beerxml/v1/BeerXml.xsd
+++ b/schemas/beerxml/v1/BeerXml.xsd
@@ -182,11 +182,21 @@
 
    <!-- BeerXML 1.0 wants all boolean values to be IN CAPITALS.
         The W3C XML Schema specification wants them to be in lower case.
-        So we have to roll our own shouty boolean type for BeerXML. -->
-   <xs:simpleType name="CapsBoolean">
+        So we have to roll our own shouty boolean type for BeerXML.
+
+        But wait, it gets better.  Some brewing software ignores the (admitedly bonkers) BeerXML specifications and
+        writes out booleans in lower case.  So, in the spirit of Postel's Law, we ought to support that too.
+
+        And since we're being all liberal about what we accept, let's cover off "True" and "False", just in case.
+         -->
+   <xs:simpleType name="RobustBoolean">
       <xs:restriction base="xs:string">
          <xs:enumeration value="TRUE"/>
          <xs:enumeration value="FALSE"/>
+         <xs:enumeration value="true"/>
+         <xs:enumeration value="false"/>
+         <xs:enumeration value="True"/>
+         <xs:enumeration value="False"/>
       </xs:restriction>
    </xs:simpleType>
 
@@ -323,7 +333,7 @@
          <xs:element name="TRUB_CHILLER_LOSS" type="VolumeInLiters" minOccurs="0" maxOccurs="1"/>
          <xs:element name="EVAP_RATE" type="SimplePercentage" minOccurs="0" maxOccurs="1"/> <!-- % of wort lost to evaporation per hour of the boil -->
          <xs:element name="BOIL_TIME" type="DurationInMinutes" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="CALC_BOIL_VOLUME" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="CALC_BOIL_VOLUME" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
          <xs:element name="LAUTER_DEADSPACE" type="VolumeInLiters" minOccurs="0" maxOccurs="1"/>
          <xs:element name="TOP_UP_KETTLE" type="VolumeInLiters" minOccurs="0" maxOccurs="1"/>
          <xs:element name="HOP_UTILIZATION" type="xs:decimal" minOccurs="0" maxOccurs="1"/> <!-- This is a percentage but can be greater than 100% -->
@@ -441,7 +451,7 @@
          <xs:element name="AMOUNT" type="xs:decimal"/> <!-- In kg -->
          <xs:element name="YIELD" type="SimplePercentage"/>
          <xs:element name="COLOR" type="xs:decimal"/> <!-- In Lovibond Units (SRM for liquid extracts) -->
-         <xs:element name="ADD_AFTER_BOIL" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="ADD_AFTER_BOIL" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
          <xs:element name="ORIGIN" type="xs:string" minOccurs="0" maxOccurs="1"/>
          <xs:element name="SUPPLIER" type="xs:string" minOccurs="0" maxOccurs="1"/>
          <xs:element name="NOTES" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -453,7 +463,7 @@
          <xs:element name="PROTEIN" type="NullableSimplePercentage" minOccurs="0" maxOccurs="1"/>
 
          <xs:element name="MAX_IN_BATCH" type="SimplePercentage" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="RECOMMEND_MASH" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="RECOMMEND_MASH" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
 
          <!-- The next field is only appropriate for a "Extract" type, otherwise its value is ignored -->
          <xs:element name="IBU_GAL_PER_LB" type="xs:decimal" minOccurs="0" maxOccurs="1"/> <!-- The BeerXML standard does not say why this field is not in a metric measurement -->
@@ -467,7 +477,7 @@
          <!-- ***********************************************************************************
               *** Extra field not included in the BeerXML 1.0 standard but used by Brewtarget ***
               *********************************************************************************** -->
-         <xs:element name="IS_MASHED" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="IS_MASHED" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
       </xs:all>
    </xs:complexType>
 
@@ -514,7 +524,7 @@
          <xs:element name="TIME" type="DurationInMinutes"/>
          <xs:element name="AMOUNT" type="xs:decimal"/> <!-- In liters (litres) unless next field is present and set to TRUE, in which case in kg.
                                                             NB: We ingore the obvious nonsensical error in the BeerXML description of this field. -->
-         <xs:element name="AMOUNT_IS_WEIGHT" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="AMOUNT_IS_WEIGHT" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
          <xs:element name="USE_FOR" type="xs:string" minOccurs="0" maxOccurs="1"/>
          <xs:element name="NOTES" type="xs:string" minOccurs="0" maxOccurs="1"/>
 
@@ -565,7 +575,7 @@
             </xs:simpleType>
          </xs:element>
          <xs:element name="AMOUNT" type="xs:decimal"/> <!-- In liters (litres) unless next field is present and set to TRUE, in which case in kg. -->
-         <xs:element name="AMOUNT_IS_WEIGHT" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="AMOUNT_IS_WEIGHT" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
          <xs:element name="LABORATORY" type="xs:string" minOccurs="0" maxOccurs="1"/>
          <xs:element name="PRODUCT_ID" type="xs:string" minOccurs="0" maxOccurs="1"/>
          <xs:element name="MIN_TEMPERATURE" type="TemperatureInCelsius" minOccurs="0" maxOccurs="1"/>
@@ -585,7 +595,7 @@
          <xs:element name="BEST_FOR" type="xs:string" minOccurs="0" maxOccurs="1"/>
          <xs:element name="TIMES_CULTURED" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1"/>
          <xs:element name="MAX_REUSE" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="ADD_TO_SECONDARY" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="ADD_TO_SECONDARY" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
 
          <!-- The next five fields are listed under "Yeast Extensions" in the BeerXML 1.0 standard -->
          <xs:element name="DISPLAY_AMOUNT" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -704,7 +714,7 @@
          <xs:element name="PH" type="AcidityOrBasicityIn_pH" minOccurs="0" maxOccurs="1"/>
          <xs:element name="TUN_WEIGHT" type="WeightInKg" minOccurs="0" maxOccurs="1"/>
          <xs:element name="TUN_SPECIFIC_HEAT" type="xs:decimal" minOccurs="0" maxOccurs="1"/> <!-- In calories per gram-degree C -->
-         <xs:element name="EQUIP_ADJUST" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="EQUIP_ADJUST" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
 
          <!-- The next four fields are listed under "Mash Extensions" in the BeerXML 1.0 standard -->
          <xs:element name="DISPLAY_GRAIN_TEMP" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -733,9 +743,9 @@
          <xs:element name="NAME" type="NonBlankString"/>
          <xs:element name="VERSION" type="xs:positiveInteger"/>
          <xs:element name="directions" type="xs:string"/>
-         <xs:element name="hasTimer" type="CapsBoolean"/>
+         <xs:element name="hasTimer" type="RobustBoolean"/>
          <xs:element name="timervalue" type="xs:string"/> <!-- NB lowercase not camelCase. AFAICT this is a display-only value and should be blank if hasTimer is FALSE -->
-         <xs:element name="completed" type="CapsBoolean"/>
+         <xs:element name="completed" type="RobustBoolean"/>
          <xs:element name="interval" type="DurationInMinutes"/>
       </xs:all>
    </xs:complexType>
@@ -862,7 +872,7 @@
          <xs:element name="AGE_TEMP" type="TemperatureInCelsius" minOccurs="0" maxOccurs="1"/>
          <xs:element name="DATE" type="xs:string" minOccurs="0" maxOccurs="1"/> <!-- Has to be string as BeerXML Standard only says "in [an] easily recognizable format" -->
          <xs:element name="CARBONATION" type="xs:decimal" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="FORCED_CARBONATION" type="CapsBoolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="FORCED_CARBONATION" type="RobustBoolean" minOccurs="0" maxOccurs="1"/>
          <!-- The next field should only be present if the previous one was present and set to TRUE
               See comments elsewhere about the desirability of enforcing this in future via xs:assert tags -->
          <xs:element name="PRIMING_SUGAR_NAME" type="xs:string" minOccurs="0" maxOccurs="1"/>

--- a/src/database/ObjectStoreTyped.cpp
+++ b/src/database/ObjectStoreTyped.cpp
@@ -51,30 +51,37 @@ namespace {
    template<class NE> ObjectStore::TableDefinition const PRIMARY_TABLE;
    template<class NE> ObjectStore::JunctionTableDefinitions const JUNCTION_TABLES;
 
+   //
+   // NOTE: Unlike C++, SQL is generally case-insensitive, so we have slightly different naming conventions.
+   //       Specifically, we use snake_case rather than camelCase for field and table names.  By convention, we also
+   //       use upper case for SQL keywords and lower case for everything else.  This is in pursuit of making SQL
+   //       slightly more readable.
+   //
+
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    // Database field mappings for Equipment
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Equipment> {
       "equipment",
       {
-         {ObjectStore::FieldType::Int,    "id",                PropertyNames::NamedEntity::key},
-         {ObjectStore::FieldType::String, "name",              PropertyNames::NamedEntity::name},
-         {ObjectStore::FieldType::Bool,   "display",           PropertyNames::NamedEntity::display},
-         {ObjectStore::FieldType::Bool,   "deleted",           PropertyNames::NamedEntity::deleted},
-         {ObjectStore::FieldType::String, "folder",            PropertyNames::NamedEntity::folder},
+         {ObjectStore::FieldType::Int   , "id"                            , PropertyNames::NamedEntity::key                      },
+         {ObjectStore::FieldType::String, "name"                          , PropertyNames::NamedEntity::name                     },
+         {ObjectStore::FieldType::Bool  , "display"                       , PropertyNames::NamedEntity::display                  },
+         {ObjectStore::FieldType::Bool  , "deleted"                       , PropertyNames::NamedEntity::deleted                  },
+         {ObjectStore::FieldType::String, "folder"                        , PropertyNames::NamedEntity::folder                   },
          {ObjectStore::FieldType::Double, "batch_size",        PropertyNames::Equipment::batchSize_l},
-         {ObjectStore::FieldType::Double, "boiling_point",     PropertyNames::Equipment::boilingPoint_c},
+         {ObjectStore::FieldType::Double, "boiling_point"                 , PropertyNames::Equipment::boilingPoint_c             },
          {ObjectStore::FieldType::Double, "boil_size",         PropertyNames::Equipment::boilSize_l},
-         {ObjectStore::FieldType::Double, "boil_time",         PropertyNames::Equipment::boilTime_min},
-         {ObjectStore::FieldType::Bool,   "calc_boil_volume",  PropertyNames::Equipment::calcBoilVolume},
+         {ObjectStore::FieldType::Double, "boil_time"                     , PropertyNames::Equipment::boilTime_min               },
+         {ObjectStore::FieldType::Bool  , "calc_boil_volume"              , PropertyNames::Equipment::calcBoilVolume             },
          {ObjectStore::FieldType::Double, "real_evap_rate",    PropertyNames::Equipment::evapRate_lHr},
-         {ObjectStore::FieldType::Double, "evap_rate",         PropertyNames::Equipment::evapRate_pctHr},
+         {ObjectStore::FieldType::Double, "evap_rate"                     , PropertyNames::Equipment::evapRate_pctHr             },
          {ObjectStore::FieldType::Double, "absorption",        PropertyNames::Equipment::grainAbsorption_LKg},
-         {ObjectStore::FieldType::Double, "hop_utilization",   PropertyNames::Equipment::hopUtilization_pct},
+         {ObjectStore::FieldType::Double, "hop_utilization"               , PropertyNames::Equipment::hopUtilization_pct         },
          {ObjectStore::FieldType::Double, "lauter_deadspace",  PropertyNames::Equipment::lauterDeadspace_l},
          {ObjectStore::FieldType::String, "notes",             PropertyNames::Equipment::notes},
-         {ObjectStore::FieldType::Double, "top_up_kettle",     PropertyNames::Equipment::topUpKettle_l},
-         {ObjectStore::FieldType::Double, "top_up_water",      PropertyNames::Equipment::topUpWater_l},
+         {ObjectStore::FieldType::Double, "top_up_kettle"                 , PropertyNames::Equipment::topUpKettle_l              },
+         {ObjectStore::FieldType::Double, "top_up_water"                  , PropertyNames::Equipment::topUpWater_l               },
          {ObjectStore::FieldType::Double, "trub_chiller_loss", PropertyNames::Equipment::trubChillerLoss_l},
          {ObjectStore::FieldType::Double, "tun_specific_heat", PropertyNames::Equipment::tunSpecificHeat_calGC},
          {ObjectStore::FieldType::Double, "tun_volume",        PropertyNames::Equipment::tunVolume_l},
@@ -119,27 +126,27 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Fermentable> {
       "fermentable",
       {
-         {ObjectStore::FieldType::Int,    "id"              , PropertyNames::NamedEntity::key                           },
-         {ObjectStore::FieldType::String, "name"            , PropertyNames::NamedEntity::name                          },
-         {ObjectStore::FieldType::Bool,   "deleted"         , PropertyNames::NamedEntity::deleted                       },
-         {ObjectStore::FieldType::Bool,   "display"         , PropertyNames::NamedEntity::display                       },
-         {ObjectStore::FieldType::String, "folder"          , PropertyNames::NamedEntity::folder                        },
-         {ObjectStore::FieldType::Int,    "inventory_id"    , PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,                          &PRIMARY_TABLE<InventoryFermentable>},
-         {ObjectStore::FieldType::Bool,   "add_after_boil"  , PropertyNames::Fermentable::addAfterBoil                  },
+         {ObjectStore::FieldType::Int   , "id"                            , PropertyNames::NamedEntity::key                      },
+         {ObjectStore::FieldType::String, "name"                          , PropertyNames::NamedEntity::name                     },
+         {ObjectStore::FieldType::Bool  , "deleted"                       , PropertyNames::NamedEntity::deleted                  },
+         {ObjectStore::FieldType::Bool  , "display"                       , PropertyNames::NamedEntity::display                  },
+         {ObjectStore::FieldType::String, "folder"                        , PropertyNames::NamedEntity::folder                   },
+         {ObjectStore::FieldType::Int   , "inventory_id"                  , PropertyNames::NamedEntityWithInventory::inventoryId , nullptr, &PRIMARY_TABLE<InventoryFermentable>},
+         {ObjectStore::FieldType::Bool  , "add_after_boil"                , PropertyNames::Fermentable::addAfterBoil             },
          {ObjectStore::FieldType::Double, "amount",           PropertyNames::Fermentable::amount_kg},
-         {ObjectStore::FieldType::Double, "coarse_fine_diff", PropertyNames::Fermentable::coarseFineDiff_pct            },
-         {ObjectStore::FieldType::Double, "color"           , PropertyNames::Fermentable::color_srm                     },
-         {ObjectStore::FieldType::Double, "diastatic_power" , PropertyNames::Fermentable::diastaticPower_lintner        },
+         {ObjectStore::FieldType::Double, "coarse_fine_diff"              , PropertyNames::Fermentable::coarseFineDiff_pct       },
+         {ObjectStore::FieldType::Double, "color"                         , PropertyNames::Fermentable::color_srm                },
+         {ObjectStore::FieldType::Double, "diastatic_power"               , PropertyNames::Fermentable::diastaticPower_lintner   },
          {ObjectStore::FieldType::Enum,   "ftype",            PropertyNames::Fermentable::type,                     &DB_FERMENTABLE_TYPE_ENUM},
-         {ObjectStore::FieldType::Bool,   "is_mashed"       , PropertyNames::Fermentable::isMashed                      },
-         {ObjectStore::FieldType::Double, "ibu_gal_per_lb"  , PropertyNames::Fermentable::ibuGalPerLb                   },
-         {ObjectStore::FieldType::Double, "max_in_batch"    , PropertyNames::Fermentable::maxInBatch_pct                },
-         {ObjectStore::FieldType::Double, "moisture"        , PropertyNames::Fermentable::moisture_pct                  },
-         {ObjectStore::FieldType::String, "notes"           , PropertyNames::Fermentable::notes                         },
-         {ObjectStore::FieldType::String, "origin"          , PropertyNames::Fermentable::origin                        },
-         {ObjectStore::FieldType::String, "supplier"        , PropertyNames::Fermentable::supplier                      },
-         {ObjectStore::FieldType::Double, "protein"         , PropertyNames::Fermentable::protein_pct                   },
-         {ObjectStore::FieldType::Bool,   "recommend_mash"  , PropertyNames::Fermentable::recommendMash                 },
+         {ObjectStore::FieldType::Bool  , "is_mashed"                     , PropertyNames::Fermentable::isMashed                 },
+         {ObjectStore::FieldType::Double, "ibu_gal_per_lb"                , PropertyNames::Fermentable::ibuGalPerLb              },
+         {ObjectStore::FieldType::Double, "max_in_batch"                  , PropertyNames::Fermentable::maxInBatch_pct           },
+         {ObjectStore::FieldType::Double, "moisture"                      , PropertyNames::Fermentable::moisture_pct             },
+         {ObjectStore::FieldType::String, "notes"                         , PropertyNames::Fermentable::notes                    },
+         {ObjectStore::FieldType::String, "origin"                        , PropertyNames::Fermentable::origin                   },
+         {ObjectStore::FieldType::String, "supplier"                      , PropertyNames::Fermentable::supplier                 },
+         {ObjectStore::FieldType::Double, "protein"                       , PropertyNames::Fermentable::protein_pct              },
+         {ObjectStore::FieldType::Bool  , "recommend_mash"                , PropertyNames::Fermentable::recommendMash            },
          {ObjectStore::FieldType::Double, "yield",            PropertyNames::Fermentable::yield_pct}
       }
    };
@@ -161,7 +168,7 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<InventoryHop> {
       "hop_in_inventory",
       {
-         {ObjectStore::FieldType::Int,    "id",               PropertyNames::Inventory::id},
+         {ObjectStore::FieldType::Int,    "id",               PropertyNames::Inventory::id    },
          {ObjectStore::FieldType::Double, "amount",           PropertyNames::Inventory::amount}
       }
    };
@@ -173,27 +180,27 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Hop> {
       "hop",
       {
-         {ObjectStore::FieldType::Int,    "id",                    PropertyNames::NamedEntity::key                       },
-         {ObjectStore::FieldType::String, "name",                  PropertyNames::NamedEntity::name                      },
-         {ObjectStore::FieldType::Bool,   "display",               PropertyNames::NamedEntity::display                   },
-         {ObjectStore::FieldType::Bool,   "deleted",               PropertyNames::NamedEntity::deleted                   },
-         {ObjectStore::FieldType::String, "folder",                PropertyNames::NamedEntity::folder                    },
-         {ObjectStore::FieldType::Int,    "inventory_id",          PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,           &PRIMARY_TABLE<InventoryHop>},
-         {ObjectStore::FieldType::Double, "alpha",                 PropertyNames::Hop::alpha_pct                         },
-         {ObjectStore::FieldType::Double, "amount",                PropertyNames::Hop::amount_kg                         },
-         {ObjectStore::FieldType::Double, "beta",                  PropertyNames::Hop::beta_pct                          },
-         {ObjectStore::FieldType::Double, "caryophyllene",         PropertyNames::Hop::caryophyllene_pct                 },
-         {ObjectStore::FieldType::Double, "cohumulone",            PropertyNames::Hop::cohumulone_pct                    },
-         {ObjectStore::FieldType::Enum,   "form",                  PropertyNames::Hop::form,                             &Hop::formStringMapping},
-         {ObjectStore::FieldType::Double, "hsi",                   PropertyNames::Hop::hsi_pct                           },
-         {ObjectStore::FieldType::Double, "humulene",              PropertyNames::Hop::humulene_pct                      },
-         {ObjectStore::FieldType::Double, "myrcene",               PropertyNames::Hop::myrcene_pct                       },
-         {ObjectStore::FieldType::String, "notes",                 PropertyNames::Hop::notes                             },
-         {ObjectStore::FieldType::String, "origin",                PropertyNames::Hop::origin                            },
-         {ObjectStore::FieldType::String, "substitutes",           PropertyNames::Hop::substitutes                       },
-         {ObjectStore::FieldType::Double, "time",                  PropertyNames::Hop::time_min                          },
-         {ObjectStore::FieldType::Enum,   "htype",                 PropertyNames::Hop::type,                             &Hop::typeStringMapping},
-         {ObjectStore::FieldType::Enum,   "use",                   PropertyNames::Hop::use,                              &Hop::useStringMapping},
+         {ObjectStore::FieldType::Int   , "id"                   , PropertyNames::NamedEntity::key                     },
+         {ObjectStore::FieldType::String, "name"                 , PropertyNames::NamedEntity::name                    },
+         {ObjectStore::FieldType::Bool  , "display"              , PropertyNames::NamedEntity::display                 },
+         {ObjectStore::FieldType::Bool  , "deleted"              , PropertyNames::NamedEntity::deleted                 },
+         {ObjectStore::FieldType::String, "folder"               , PropertyNames::NamedEntity::folder                  },
+         {ObjectStore::FieldType::Int   , "inventory_id"         , PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,           &PRIMARY_TABLE<InventoryHop>},
+         {ObjectStore::FieldType::Double, "alpha"                , PropertyNames::Hop::alpha_pct                       },
+         {ObjectStore::FieldType::Double, "amount"               , PropertyNames::Hop::amount_kg                       },
+         {ObjectStore::FieldType::Double, "beta"                 , PropertyNames::Hop::beta_pct                        },
+         {ObjectStore::FieldType::Double, "caryophyllene"        , PropertyNames::Hop::caryophyllene_pct               },
+         {ObjectStore::FieldType::Double, "cohumulone"           , PropertyNames::Hop::cohumulone_pct                  },
+         {ObjectStore::FieldType::Enum  , "form"                 , PropertyNames::Hop::form                            , &Hop::formStringMapping},
+         {ObjectStore::FieldType::Double, "hsi"                  , PropertyNames::Hop::hsi_pct                         },
+         {ObjectStore::FieldType::Double, "humulene"             , PropertyNames::Hop::humulene_pct                    },
+         {ObjectStore::FieldType::Double, "myrcene"              , PropertyNames::Hop::myrcene_pct                     },
+         {ObjectStore::FieldType::String, "notes"                , PropertyNames::Hop::notes                           },
+         {ObjectStore::FieldType::String, "origin"               , PropertyNames::Hop::origin                          },
+         {ObjectStore::FieldType::String, "substitutes"          , PropertyNames::Hop::substitutes                     },
+         {ObjectStore::FieldType::Double, "time"                 , PropertyNames::Hop::time_min                        },
+         {ObjectStore::FieldType::Enum  , "htype"                , PropertyNames::Hop::type                            , &Hop::typeStringMapping},
+         {ObjectStore::FieldType::Enum  , "use"                  , PropertyNames::Hop::use                             , &Hop::useStringMapping},
       }
    };
    template<> ObjectStore::JunctionTableDefinitions const JUNCTION_TABLES<Hop> {
@@ -215,14 +222,14 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Instruction> {
       "instruction",
       {
-         {ObjectStore::FieldType::Int,    "id",         PropertyNames::NamedEntity::key       },
-         {ObjectStore::FieldType::String, "name",       PropertyNames::NamedEntity::name      },
-         {ObjectStore::FieldType::Bool,   "display",    PropertyNames::NamedEntity::display   },
-         {ObjectStore::FieldType::Bool,   "deleted",    PropertyNames::NamedEntity::deleted   },
+         {ObjectStore::FieldType::Int   , "id"        , PropertyNames::NamedEntity::key       },
+         {ObjectStore::FieldType::String, "name"      , PropertyNames::NamedEntity::name      },
+         {ObjectStore::FieldType::Bool  , "display"   , PropertyNames::NamedEntity::display   },
+         {ObjectStore::FieldType::Bool  , "deleted"   , PropertyNames::NamedEntity::deleted   },
          {ObjectStore::FieldType::String, "directions", PropertyNames::Instruction::directions},
-         {ObjectStore::FieldType::Bool,   "hasTimer",   PropertyNames::Instruction::hasTimer  },
+         {ObjectStore::FieldType::Bool  , "hasTimer"  , PropertyNames::Instruction::hasTimer  },
          {ObjectStore::FieldType::String, "timervalue", PropertyNames::Instruction::timerValue},
-         {ObjectStore::FieldType::Bool,   "completed",  PropertyNames::Instruction::completed },
+         {ObjectStore::FieldType::Bool  , "completed" , PropertyNames::Instruction::completed },
          {ObjectStore::FieldType::Double, "interval",   PropertyNames::Instruction::interval  }
       }
    };
@@ -235,18 +242,18 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Mash> {
       "mash",
       {
-         {ObjectStore::FieldType::Int,    "id",                PropertyNames::NamedEntity::key           },
-         {ObjectStore::FieldType::String, "name",              PropertyNames::NamedEntity::name          },
-         {ObjectStore::FieldType::Bool,   "deleted",           PropertyNames::NamedEntity::deleted       },
-         {ObjectStore::FieldType::Bool,   "display",           PropertyNames::NamedEntity::display       },
-         {ObjectStore::FieldType::String, "folder",            PropertyNames::NamedEntity::folder        },
-         {ObjectStore::FieldType::Bool,   "equip_adjust",      PropertyNames::Mash::equipAdjust          },
-         {ObjectStore::FieldType::Double, "grain_temp",        PropertyNames::Mash::grainTemp_c          },
-         {ObjectStore::FieldType::String, "notes",             PropertyNames::Mash::notes                },
-         {ObjectStore::FieldType::Double, "ph",                PropertyNames::Mash::ph                   },
-         {ObjectStore::FieldType::Double, "sparge_temp",       PropertyNames::Mash::spargeTemp_c         },
+         {ObjectStore::FieldType::Int   , "id"               , PropertyNames::NamedEntity::key           },
+         {ObjectStore::FieldType::String, "name"             , PropertyNames::NamedEntity::name          },
+         {ObjectStore::FieldType::Bool  , "deleted"          , PropertyNames::NamedEntity::deleted       },
+         {ObjectStore::FieldType::Bool  , "display"          , PropertyNames::NamedEntity::display       },
+         {ObjectStore::FieldType::String, "folder"           , PropertyNames::NamedEntity::folder        },
+         {ObjectStore::FieldType::Bool  , "equip_adjust"     , PropertyNames::Mash::equipAdjust          },
+         {ObjectStore::FieldType::Double, "grain_temp"       , PropertyNames::Mash::grainTemp_c          },
+         {ObjectStore::FieldType::String, "notes"            , PropertyNames::Mash::notes                },
+         {ObjectStore::FieldType::Double, "ph"               , PropertyNames::Mash::ph                   },
+         {ObjectStore::FieldType::Double, "sparge_temp"      , PropertyNames::Mash::spargeTemp_c         },
          {ObjectStore::FieldType::Double, "tun_specific_heat", PropertyNames::Mash::tunSpecificHeat_calGC},
-         {ObjectStore::FieldType::Double, "tun_temp",          PropertyNames::Mash::tunTemp_c            },
+         {ObjectStore::FieldType::Double, "tun_temp"         , PropertyNames::Mash::tunTemp_c            },
          {ObjectStore::FieldType::Double, "tun_weight",        PropertyNames::Mash::tunWeight_kg         },
       }
    };
@@ -267,20 +274,20 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<MashStep> {
       "mashstep",
       {
-         {ObjectStore::FieldType::Int,     "id",               PropertyNames::NamedEntity::key           },
-         {ObjectStore::FieldType::String,  "name",             PropertyNames::NamedEntity::name          },
-         {ObjectStore::FieldType::Bool,    "deleted",          PropertyNames::NamedEntity::deleted       },
-         {ObjectStore::FieldType::Bool,    "display",          PropertyNames::NamedEntity::display       },
+         {ObjectStore::FieldType::Int   , "id"                       , PropertyNames::NamedEntity::key                },
+         {ObjectStore::FieldType::String, "name"                     , PropertyNames::NamedEntity::name               },
+         {ObjectStore::FieldType::Bool  , "deleted"                  , PropertyNames::NamedEntity::deleted            },
+         {ObjectStore::FieldType::Bool  , "display"                  , PropertyNames::NamedEntity::display            },
          // NB: MashSteps don't have folders, as each one is owned by a Mash
          {ObjectStore::FieldType::Double,  "decoction_amount", PropertyNames::MashStep::decoctionAmount_l},
-         {ObjectStore::FieldType::Double,  "end_temp",         PropertyNames::MashStep::endTemp_c        },
+         {ObjectStore::FieldType::Double, "end_temp"                 , PropertyNames::MashStep::endTemp_c             },
          {ObjectStore::FieldType::Double,  "infuse_amount",    PropertyNames::MashStep::infuseAmount_l   },
-         {ObjectStore::FieldType::Double,  "infuse_temp",      PropertyNames::MashStep::infuseTemp_c     },
-         {ObjectStore::FieldType::Int,     "mash_id",          PropertyNames::MashStep::mashId,            nullptr,              &PRIMARY_TABLE<Mash>},
+         {ObjectStore::FieldType::Double, "infuse_temp"              , PropertyNames::MashStep::infuseTemp_c          },
+         {ObjectStore::FieldType::Int   , "mash_id"                  , PropertyNames::MashStep::mashId                , nullptr, &PRIMARY_TABLE<Mash>},
          {ObjectStore::FieldType::Enum,    "mstype",           PropertyNames::MashStep::type,              &MASH_STEP_TYPE_ENUM},
-         {ObjectStore::FieldType::Double,  "ramp_time",        PropertyNames::MashStep::rampTime_min     },
-         {ObjectStore::FieldType::Int,     "step_number",      PropertyNames::MashStep::stepNumber       },
-         {ObjectStore::FieldType::Double,  "step_temp",        PropertyNames::MashStep::stepTemp_c       },
+         {ObjectStore::FieldType::Double, "ramp_time"                , PropertyNames::MashStep::rampTime_min          },
+         {ObjectStore::FieldType::Int   , "step_number"              , PropertyNames::MashStep::stepNumber            },
+         {ObjectStore::FieldType::Double, "step_temp"                , PropertyNames::MashStep::stepTemp_c            },
          {ObjectStore::FieldType::Double,  "step_time",        PropertyNames::MashStep::stepTime_min     }
       }
    };
@@ -293,7 +300,7 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<InventoryMisc> {
       "misc_in_inventory",
       {
-         {ObjectStore::FieldType::Int,    "id",               PropertyNames::Inventory::id},
+         {ObjectStore::FieldType::Int,    "id",               PropertyNames::Inventory::id    },
          {ObjectStore::FieldType::Double, "amount",           PropertyNames::Inventory::amount}
       }
    };
@@ -320,18 +327,18 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Misc> {
       "misc",
       {
-         {ObjectStore::FieldType::Int,    "id",               PropertyNames::NamedEntity::key                     },
-         {ObjectStore::FieldType::String, "name",             PropertyNames::NamedEntity::name                    },
-         {ObjectStore::FieldType::Bool,   "deleted",          PropertyNames::NamedEntity::deleted                 },
-         {ObjectStore::FieldType::Bool,   "display",          PropertyNames::NamedEntity::display                 },
-         {ObjectStore::FieldType::String, "folder",           PropertyNames::NamedEntity::folder                  },
-         {ObjectStore::FieldType::Int,    "inventory_id",     PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,         &PRIMARY_TABLE<InventoryMisc>},
+         {ObjectStore::FieldType::Int   , "id"              , PropertyNames::NamedEntity::key                     },
+         {ObjectStore::FieldType::String, "name"            , PropertyNames::NamedEntity::name                    },
+         {ObjectStore::FieldType::Bool  , "deleted"         , PropertyNames::NamedEntity::deleted                 },
+         {ObjectStore::FieldType::Bool  , "display"         , PropertyNames::NamedEntity::display                 },
+         {ObjectStore::FieldType::String, "folder"          , PropertyNames::NamedEntity::folder                  },
+         {ObjectStore::FieldType::Int   , "inventory_id"    , PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,         &PRIMARY_TABLE<InventoryMisc>},
          {ObjectStore::FieldType::Enum,   "mtype",            PropertyNames::Misc::type,                            &MISC_TYPE_ENUM},
          {ObjectStore::FieldType::Enum,   "use",              PropertyNames::Misc::use,                             &MISC_USE_ENUM},
          {ObjectStore::FieldType::Double, "time",             PropertyNames::Misc::time                           },
-         {ObjectStore::FieldType::Double, "amount",           PropertyNames::Misc::amount                         },
-         {ObjectStore::FieldType::Bool,   "amount_is_weight", PropertyNames::Misc::amountIsWeight                 },
-         {ObjectStore::FieldType::String, "use_for",          PropertyNames::Misc::useFor                         },
+         {ObjectStore::FieldType::Double, "amount"          , PropertyNames::Misc::amount                         },
+         {ObjectStore::FieldType::Bool  , "amount_is_weight", PropertyNames::Misc::amountIsWeight                 },
+         {ObjectStore::FieldType::String, "use_for"         , PropertyNames::Misc::useFor                         },
          {ObjectStore::FieldType::String, "notes",            PropertyNames::Misc::notes                          }
       }
    };
@@ -353,16 +360,16 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Salt> {
       "salt",
       {
-         {ObjectStore::FieldType::Int,    "id",               PropertyNames::NamedEntity::key     },
-         {ObjectStore::FieldType::String, "name",             PropertyNames::NamedEntity::name    },
-         {ObjectStore::FieldType::Bool,   "deleted",          PropertyNames::NamedEntity::deleted },
-         {ObjectStore::FieldType::Bool,   "display",          PropertyNames::NamedEntity::display },
-         {ObjectStore::FieldType::String, "folder",           PropertyNames::NamedEntity::folder  },
-         {ObjectStore::FieldType::Int,    "addTo",            PropertyNames::Salt::whenToAdd      }, // TODO: Really an Enum.  Would be less fragile to store this as text than a number.  Also, column name...
-         {ObjectStore::FieldType::Double, "amount",           PropertyNames::Salt::amount         },
-         {ObjectStore::FieldType::Bool,   "amount_is_weight", PropertyNames::Salt::amountIsWeight },
-         {ObjectStore::FieldType::Bool,   "is_acid",          PropertyNames::Salt::isAcid         },
-         {ObjectStore::FieldType::Double, "percent_acid",     PropertyNames::Salt::percentAcid    },
+         {ObjectStore::FieldType::Int   , "id"              , PropertyNames::NamedEntity::key     },
+         {ObjectStore::FieldType::String, "name"            , PropertyNames::NamedEntity::name    },
+         {ObjectStore::FieldType::Bool  , "deleted"         , PropertyNames::NamedEntity::deleted },
+         {ObjectStore::FieldType::Bool  , "display"         , PropertyNames::NamedEntity::display },
+         {ObjectStore::FieldType::String, "folder"          , PropertyNames::NamedEntity::folder  },
+         {ObjectStore::FieldType::Int   , "addTo"           , PropertyNames::Salt::whenToAdd      }, // TODO: Really an Enum.  Would be less fragile to store this as text than a number.  Also, column name...
+         {ObjectStore::FieldType::Double, "amount"          , PropertyNames::Salt::amount         },
+         {ObjectStore::FieldType::Bool  , "amount_is_weight", PropertyNames::Salt::amountIsWeight },
+         {ObjectStore::FieldType::Bool  , "is_acid"         , PropertyNames::Salt::isAcid         },
+         {ObjectStore::FieldType::Double, "percent_acid"    , PropertyNames::Salt::percentAcid    },
          {ObjectStore::FieldType::Int,    "stype",            PropertyNames::Salt::type           }  // TODO: Really an Enum.  Would be less fragile to store this as text than a number
       }
    };
@@ -383,31 +390,31 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Style> {
       "style",
       {
-         {ObjectStore::FieldType::Int,    "id",              PropertyNames::NamedEntity::key     },
-         {ObjectStore::FieldType::String, "name",            PropertyNames::NamedEntity::name    },
-         {ObjectStore::FieldType::Bool,   "display",         PropertyNames::NamedEntity::display },
-         {ObjectStore::FieldType::Bool,   "deleted",         PropertyNames::NamedEntity::deleted },
-         {ObjectStore::FieldType::String, "folder",          PropertyNames::NamedEntity::folder  },
-         {ObjectStore::FieldType::Double, "abv_max",         PropertyNames::Style::abvMax_pct    },
-         {ObjectStore::FieldType::Double, "abv_min",         PropertyNames::Style::abvMin_pct    },
-         {ObjectStore::FieldType::Double, "carb_max",        PropertyNames::Style::carbMax_vol   },
-         {ObjectStore::FieldType::Double, "carb_min",        PropertyNames::Style::carbMin_vol   },
-         {ObjectStore::FieldType::String, "category",        PropertyNames::Style::category      },
-         {ObjectStore::FieldType::String, "category_number", PropertyNames::Style::categoryNumber},
-         {ObjectStore::FieldType::Double, "color_max",       PropertyNames::Style::colorMax_srm  },
-         {ObjectStore::FieldType::Double, "color_min",       PropertyNames::Style::colorMin_srm  },
-         {ObjectStore::FieldType::String, "examples",        PropertyNames::Style::examples      },
-         {ObjectStore::FieldType::Double, "fg_max",          PropertyNames::Style::fgMax         },
-         {ObjectStore::FieldType::Double, "fg_min",          PropertyNames::Style::fgMin         },
-         {ObjectStore::FieldType::Double, "ibu_max",         PropertyNames::Style::ibuMax        },
-         {ObjectStore::FieldType::Double, "ibu_min",         PropertyNames::Style::ibuMin        },
-         {ObjectStore::FieldType::String, "ingredients",     PropertyNames::Style::ingredients   },
-         {ObjectStore::FieldType::String, "notes",           PropertyNames::Style::notes         },
-         {ObjectStore::FieldType::Double, "og_max",          PropertyNames::Style::ogMax         },
-         {ObjectStore::FieldType::Double, "og_min",          PropertyNames::Style::ogMin         },
+         {ObjectStore::FieldType::Int   , "id"                , PropertyNames::NamedEntity::key        },
+         {ObjectStore::FieldType::String, "name"              , PropertyNames::NamedEntity::name       },
+         {ObjectStore::FieldType::Bool  , "display"           , PropertyNames::NamedEntity::display    },
+         {ObjectStore::FieldType::Bool  , "deleted"           , PropertyNames::NamedEntity::deleted    },
+         {ObjectStore::FieldType::String, "folder"            , PropertyNames::NamedEntity::folder     },
+         {ObjectStore::FieldType::Double, "abv_max"           , PropertyNames::Style::abvMax_pct       },
+         {ObjectStore::FieldType::Double, "abv_min"           , PropertyNames::Style::abvMin_pct       },
+         {ObjectStore::FieldType::Double, "carb_max"          , PropertyNames::Style::carbMax_vol      },
+         {ObjectStore::FieldType::Double, "carb_min"          , PropertyNames::Style::carbMin_vol      },
+         {ObjectStore::FieldType::String, "category"          , PropertyNames::Style::category         },
+         {ObjectStore::FieldType::String, "category_number"   , PropertyNames::Style::categoryNumber   },
+         {ObjectStore::FieldType::Double, "color_max"         , PropertyNames::Style::colorMax_srm     },
+         {ObjectStore::FieldType::Double, "color_min"         , PropertyNames::Style::colorMin_srm     },
+         {ObjectStore::FieldType::String, "examples"          , PropertyNames::Style::examples         },
+         {ObjectStore::FieldType::Double, "fg_max"            , PropertyNames::Style::fgMax            },
+         {ObjectStore::FieldType::Double, "fg_min"            , PropertyNames::Style::fgMin            },
+         {ObjectStore::FieldType::Double, "ibu_max"           , PropertyNames::Style::ibuMax           },
+         {ObjectStore::FieldType::Double, "ibu_min"           , PropertyNames::Style::ibuMin           },
+         {ObjectStore::FieldType::String, "ingredients"       , PropertyNames::Style::ingredients      },
+         {ObjectStore::FieldType::String, "notes"             , PropertyNames::Style::notes            },
+         {ObjectStore::FieldType::Double, "og_max"            , PropertyNames::Style::ogMax            },
+         {ObjectStore::FieldType::Double, "og_min"            , PropertyNames::Style::ogMin            },
          {ObjectStore::FieldType::String, "profile",         PropertyNames::Style::profile       },
-         {ObjectStore::FieldType::String, "style_guide",     PropertyNames::Style::styleGuide    },
-         {ObjectStore::FieldType::String, "style_letter",    PropertyNames::Style::styleLetter   },
+         {ObjectStore::FieldType::String, "style_guide"       , PropertyNames::Style::styleGuide       },
+         {ObjectStore::FieldType::String, "style_letter"      , PropertyNames::Style::styleLetter      },
          {ObjectStore::FieldType::Enum,   "s_type",          PropertyNames::Style::type,           &STYLE_TYPE_ENUM}
       }
    };
@@ -429,22 +436,22 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Water> {
       "water",
       {
-         {ObjectStore::FieldType::Int,    "id",          PropertyNames::NamedEntity::key       },
-         {ObjectStore::FieldType::String, "name",        PropertyNames::NamedEntity::name      },
-         {ObjectStore::FieldType::Bool,   "display",     PropertyNames::NamedEntity::display   },
-         {ObjectStore::FieldType::Bool,   "deleted",     PropertyNames::NamedEntity::deleted   },
-         {ObjectStore::FieldType::String, "folder",      PropertyNames::NamedEntity::folder    },
-         {ObjectStore::FieldType::String, "notes",       PropertyNames::Water::notes           },
-         {ObjectStore::FieldType::Double, "amount",      PropertyNames::Water::amount          },
-         {ObjectStore::FieldType::Double, "calcium",     PropertyNames::Water::calcium_ppm     },
+         {ObjectStore::FieldType::Int   , "id"         , PropertyNames::NamedEntity::key       },
+         {ObjectStore::FieldType::String, "name"       , PropertyNames::NamedEntity::name      },
+         {ObjectStore::FieldType::Bool  , "display"    , PropertyNames::NamedEntity::display   },
+         {ObjectStore::FieldType::Bool  , "deleted"    , PropertyNames::NamedEntity::deleted   },
+         {ObjectStore::FieldType::String, "folder"     , PropertyNames::NamedEntity::folder    },
+         {ObjectStore::FieldType::String, "notes"      , PropertyNames::Water::notes           },
+         {ObjectStore::FieldType::Double, "amount"     , PropertyNames::Water::amount          },
+         {ObjectStore::FieldType::Double, "calcium"    , PropertyNames::Water::calcium_ppm     },
          {ObjectStore::FieldType::Double, "bicarbonate", PropertyNames::Water::bicarbonate_ppm },
-         {ObjectStore::FieldType::Double, "sulfate",     PropertyNames::Water::sulfate_ppm     },
-         {ObjectStore::FieldType::Double, "sodium",      PropertyNames::Water::sodium_ppm      },
-         {ObjectStore::FieldType::Double, "chloride",    PropertyNames::Water::chloride_ppm    },
-         {ObjectStore::FieldType::Double, "magnesium",   PropertyNames::Water::magnesium_ppm   },
-         {ObjectStore::FieldType::Double, "ph",          PropertyNames::Water::ph              },
+         {ObjectStore::FieldType::Double, "sulfate"    , PropertyNames::Water::sulfate_ppm     },
+         {ObjectStore::FieldType::Double, "sodium"     , PropertyNames::Water::sodium_ppm      },
+         {ObjectStore::FieldType::Double, "chloride"   , PropertyNames::Water::chloride_ppm    },
+         {ObjectStore::FieldType::Double, "magnesium"  , PropertyNames::Water::magnesium_ppm   },
+         {ObjectStore::FieldType::Double, "ph"         , PropertyNames::Water::ph              },
          {ObjectStore::FieldType::Double, "alkalinity",  PropertyNames::Water::alkalinity      },
-         {ObjectStore::FieldType::Int,    "wtype",       PropertyNames::Water::type            }, // TODO: Would be less fragile to store this as text than a number
+         {ObjectStore::FieldType::Int   , "wtype"      , PropertyNames::Water::type            }, // TODO: Would be less fragile to store this as text than a number
          {ObjectStore::FieldType::Double, "mash_ro",     PropertyNames::Water::mashRO          },
          {ObjectStore::FieldType::Double, "sparge_ro",   PropertyNames::Water::spargeRO        },
          {ObjectStore::FieldType::Bool,   "as_hco3",     PropertyNames::Water::alkalinityAsHCO3}
@@ -500,26 +507,26 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Yeast> {
       "yeast",
       {
-         {ObjectStore::FieldType::Int,    "id",               PropertyNames::NamedEntity::key                     },
-         {ObjectStore::FieldType::String, "name",             PropertyNames::NamedEntity::name                    },
-         {ObjectStore::FieldType::Bool,   "display",          PropertyNames::NamedEntity::display                 },
-         {ObjectStore::FieldType::Bool,   "deleted",          PropertyNames::NamedEntity::deleted                 },
-         {ObjectStore::FieldType::String, "folder",           PropertyNames::NamedEntity::folder                  },
-         {ObjectStore::FieldType::Int,    "inventory_id",     PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,                     &PRIMARY_TABLE<InventoryYeast>},
-         {ObjectStore::FieldType::Bool,   "add_to_secondary", PropertyNames::Yeast::addToSecondary                },
-         {ObjectStore::FieldType::Bool,   "amount_is_weight", PropertyNames::Yeast::amountIsWeight                },
-         {ObjectStore::FieldType::Double, "amount",           PropertyNames::Yeast::amount                        },
-         {ObjectStore::FieldType::Double, "attenuation",      PropertyNames::Yeast::attenuation_pct               },
-         {ObjectStore::FieldType::Double, "max_temperature",  PropertyNames::Yeast::maxTemperature_c              },
-         {ObjectStore::FieldType::Double, "min_temperature",  PropertyNames::Yeast::minTemperature_c              },
+         {ObjectStore::FieldType::Int   , "id"                          , PropertyNames::NamedEntity::key                },
+         {ObjectStore::FieldType::String, "name"                        , PropertyNames::NamedEntity::name               },
+         {ObjectStore::FieldType::Bool  , "display"                     , PropertyNames::NamedEntity::display            },
+         {ObjectStore::FieldType::Bool  , "deleted"                     , PropertyNames::NamedEntity::deleted            },
+         {ObjectStore::FieldType::String, "folder"                      , PropertyNames::NamedEntity::folder             },
+         {ObjectStore::FieldType::Int   , "inventory_id"                , PropertyNames::NamedEntityWithInventory::inventoryId, nullptr,                     &PRIMARY_TABLE<InventoryYeast>},
+         {ObjectStore::FieldType::Bool  , "add_to_secondary"            , PropertyNames::Yeast::addToSecondary           },
+         {ObjectStore::FieldType::Bool  , "amount_is_weight"            , PropertyNames::Yeast::amountIsWeight           },
+         {ObjectStore::FieldType::Double, "amount"                      , PropertyNames::Yeast::amount                   },
+         {ObjectStore::FieldType::Double, "attenuation"                 , PropertyNames::Yeast::attenuation_pct          },
+         {ObjectStore::FieldType::Double, "max_temperature"             , PropertyNames::Yeast::maxTemperature_c         },
+         {ObjectStore::FieldType::Double, "min_temperature"             , PropertyNames::Yeast::minTemperature_c         },
          {ObjectStore::FieldType::Enum,   "flocculation",     PropertyNames::Yeast::flocculation,                   &DB_YEAST_FLOCCULATION_ENUM},
          {ObjectStore::FieldType::Enum,   "form",             PropertyNames::Yeast::form,                           &DB_YEAST_FORM_ENUM        },
          {ObjectStore::FieldType::Enum,   "ytype",            PropertyNames::Yeast::type,                           &DB_YEAST_TYPE_ENUM        },
-         {ObjectStore::FieldType::Int,    "max_reuse",        PropertyNames::Yeast::maxReuse                      },
-         {ObjectStore::FieldType::Int,    "times_cultured",   PropertyNames::Yeast::timesCultured                 },
-         {ObjectStore::FieldType::String, "best_for",         PropertyNames::Yeast::bestFor                       },
-         {ObjectStore::FieldType::String, "laboratory",       PropertyNames::Yeast::laboratory                    },
-         {ObjectStore::FieldType::String, "notes",            PropertyNames::Yeast::notes                         },
+         {ObjectStore::FieldType::Int   , "max_reuse"                   , PropertyNames::Yeast::maxReuse                 },
+         {ObjectStore::FieldType::Int   , "times_cultured"              , PropertyNames::Yeast::timesCultured            },
+         {ObjectStore::FieldType::String, "best_for"                    , PropertyNames::Yeast::bestFor                  },
+         {ObjectStore::FieldType::String, "laboratory"                  , PropertyNames::Yeast::laboratory               },
+         {ObjectStore::FieldType::String, "notes"                       , PropertyNames::Yeast::notes                    },
          {ObjectStore::FieldType::String, "product_id",       PropertyNames::Yeast::productID                     } // Manufacturer's product ID, so, unlike other blah_id fields, not a foreign key!
       }
    };
@@ -546,43 +553,43 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<Recipe> {
       "recipe",
       {
-         {ObjectStore::FieldType::Int,    "id",                  PropertyNames::NamedEntity::key            },
-         {ObjectStore::FieldType::String, "name",                PropertyNames::NamedEntity::name           },
-         {ObjectStore::FieldType::Bool,   "deleted",             PropertyNames::NamedEntity::deleted        },
-         {ObjectStore::FieldType::Bool,   "display",             PropertyNames::NamedEntity::display        },
-         {ObjectStore::FieldType::String, "folder",              PropertyNames::NamedEntity::folder         },
-         {ObjectStore::FieldType::Double, "age",                 PropertyNames::Recipe::age_days                 },
-         {ObjectStore::FieldType::Double, "age_temp",            PropertyNames::Recipe::ageTemp_c           },
-         {ObjectStore::FieldType::String, "assistant_brewer",    PropertyNames::Recipe::asstBrewer          },
-         {ObjectStore::FieldType::Double, "batch_size",          PropertyNames::Recipe::batchSize_l         },
-         {ObjectStore::FieldType::Double, "boil_size",           PropertyNames::Recipe::boilSize_l          },
-         {ObjectStore::FieldType::Double, "boil_time",           PropertyNames::Recipe::boilTime_min        },
-         {ObjectStore::FieldType::String, "brewer",              PropertyNames::Recipe::brewer              },
-         {ObjectStore::FieldType::Double, "carb_volume",         PropertyNames::Recipe::carbonation_vols    },
-         {ObjectStore::FieldType::Double, "carbonationtemp_c",   PropertyNames::Recipe::carbonationTemp_c   },
-         {ObjectStore::FieldType::Date,   "date",                PropertyNames::Recipe::date                },
-         {ObjectStore::FieldType::Double, "efficiency",          PropertyNames::Recipe::efficiency_pct      },
-         {ObjectStore::FieldType::Int,    "equipment_id",        PropertyNames::Recipe::equipmentId,          nullptr,                &PRIMARY_TABLE<Equipment>},
-         {ObjectStore::FieldType::UInt,   "fermentation_stages", PropertyNames::Recipe::fermentationStages  },
-         {ObjectStore::FieldType::Double, "fg",                  PropertyNames::Recipe::fg                  },
-         {ObjectStore::FieldType::Bool,   "forced_carb",         PropertyNames::Recipe::forcedCarbonation   },
-         {ObjectStore::FieldType::Double, "keg_priming_factor",  PropertyNames::Recipe::kegPrimingFactor    },
-         {ObjectStore::FieldType::Int,    "mash_id",             PropertyNames::Recipe::mashId,               nullptr,                &PRIMARY_TABLE<Mash>},
-         {ObjectStore::FieldType::String, "notes",               PropertyNames::Recipe::notes               },
-         {ObjectStore::FieldType::Double, "og",                  PropertyNames::Recipe::og                  },
-         {ObjectStore::FieldType::Double, "primary_age",         PropertyNames::Recipe::primaryAge_days     },
-         {ObjectStore::FieldType::Double, "primary_temp",        PropertyNames::Recipe::primaryTemp_c       },
-         {ObjectStore::FieldType::Double, "priming_sugar_equiv", PropertyNames::Recipe::primingSugarEquiv   },
-         {ObjectStore::FieldType::String, "priming_sugar_name",  PropertyNames::Recipe::primingSugarName    },
-         {ObjectStore::FieldType::Double, "secondary_age",       PropertyNames::Recipe::secondaryAge_days   },
-         {ObjectStore::FieldType::Double, "secondary_temp",      PropertyNames::Recipe::secondaryTemp_c     },
-         {ObjectStore::FieldType::Int,    "style_id",            PropertyNames::Recipe::styleId,              nullptr,                &PRIMARY_TABLE<Style>},
-         {ObjectStore::FieldType::String, "taste_notes",         PropertyNames::Recipe::tasteNotes          },
-         {ObjectStore::FieldType::Double, "taste_rating",        PropertyNames::Recipe::tasteRating         },
-         {ObjectStore::FieldType::Double, "tertiary_age",        PropertyNames::Recipe::tertiaryAge_days    },
-         {ObjectStore::FieldType::Double, "tertiary_temp",       PropertyNames::Recipe::tertiaryTemp_c      },
+         {ObjectStore::FieldType::Int   , "id"                 , PropertyNames::NamedEntity::key          },
+         {ObjectStore::FieldType::String, "name"               , PropertyNames::NamedEntity::name         },
+         {ObjectStore::FieldType::Bool  , "deleted"            , PropertyNames::NamedEntity::deleted      },
+         {ObjectStore::FieldType::Bool  , "display"            , PropertyNames::NamedEntity::display      },
+         {ObjectStore::FieldType::String, "folder"             , PropertyNames::NamedEntity::folder       },
+         {ObjectStore::FieldType::Double, "age"                , PropertyNames::Recipe::age_days          },
+         {ObjectStore::FieldType::Double, "age_temp"           , PropertyNames::Recipe::ageTemp_c         },
+         {ObjectStore::FieldType::String, "assistant_brewer"   , PropertyNames::Recipe::asstBrewer        },
+         {ObjectStore::FieldType::Double, "batch_size"         , PropertyNames::Recipe::batchSize_l       },
+         {ObjectStore::FieldType::Double, "boil_size"          , PropertyNames::Recipe::boilSize_l        },
+         {ObjectStore::FieldType::Double, "boil_time"          , PropertyNames::Recipe::boilTime_min      },
+         {ObjectStore::FieldType::String, "brewer"             , PropertyNames::Recipe::brewer            },
+         {ObjectStore::FieldType::Double, "carb_volume"        , PropertyNames::Recipe::carbonation_vols  },
+         {ObjectStore::FieldType::Double, "carbonationtemp_c"  , PropertyNames::Recipe::carbonationTemp_c },
+         {ObjectStore::FieldType::Date  , "date"               , PropertyNames::Recipe::date              },
+         {ObjectStore::FieldType::Double, "efficiency"         , PropertyNames::Recipe::efficiency_pct    },
+         {ObjectStore::FieldType::Int   , "equipment_id"       , PropertyNames::Recipe::equipmentId       , nullptr,                &PRIMARY_TABLE<Equipment>},
+         {ObjectStore::FieldType::Int   , "fermentation_stages", PropertyNames::Recipe::fermentationStages}, // TBD: This could become UInt with corresponding changes in model/Recipe.h
+         {ObjectStore::FieldType::Double, "fg"                 , PropertyNames::Recipe::fg                },
+         {ObjectStore::FieldType::Bool  , "forced_carb"        , PropertyNames::Recipe::forcedCarbonation },
+         {ObjectStore::FieldType::Double, "keg_priming_factor" , PropertyNames::Recipe::kegPrimingFactor  },
+         {ObjectStore::FieldType::Int   , "mash_id"            , PropertyNames::Recipe::mashId            , nullptr,                &PRIMARY_TABLE<Mash>},
+         {ObjectStore::FieldType::String, "notes"              , PropertyNames::Recipe::notes             },
+         {ObjectStore::FieldType::Double, "og"                 , PropertyNames::Recipe::og                },
+         {ObjectStore::FieldType::Double, "primary_age"        , PropertyNames::Recipe::primaryAge_days   },
+         {ObjectStore::FieldType::Double, "primary_temp"       , PropertyNames::Recipe::primaryTemp_c     },
+         {ObjectStore::FieldType::Double, "priming_sugar_equiv", PropertyNames::Recipe::primingSugarEquiv },
+         {ObjectStore::FieldType::String, "priming_sugar_name" , PropertyNames::Recipe::primingSugarName  },
+         {ObjectStore::FieldType::Double, "secondary_age"      , PropertyNames::Recipe::secondaryAge_days },
+         {ObjectStore::FieldType::Double, "secondary_temp"     , PropertyNames::Recipe::secondaryTemp_c   },
+         {ObjectStore::FieldType::Int   , "style_id"           , PropertyNames::Recipe::styleId           , nullptr,                &PRIMARY_TABLE<Style>},
+         {ObjectStore::FieldType::String, "taste_notes"        , PropertyNames::Recipe::tasteNotes        },
+         {ObjectStore::FieldType::Double, "taste_rating"       , PropertyNames::Recipe::tasteRating       },
+         {ObjectStore::FieldType::Double, "tertiary_age"       , PropertyNames::Recipe::tertiaryAge_days  },
+         {ObjectStore::FieldType::Double, "tertiary_temp"      , PropertyNames::Recipe::tertiaryTemp_c    },
          {ObjectStore::FieldType::Enum,   "type",                PropertyNames::Recipe::type,           &RECIPE_STEP_TYPE_ENUM},
-         {ObjectStore::FieldType::Int,    "ancestor_id",         PropertyNames::Recipe::ancestorId,           nullptr,                &PRIMARY_TABLE<Recipe>},
+         {ObjectStore::FieldType::Int   , "ancestor_id"        , PropertyNames::Recipe::ancestorId        , nullptr,                &PRIMARY_TABLE<Recipe>},
          {ObjectStore::FieldType::Bool,   "locked",              PropertyNames::Recipe::locked              }
       }
    };
@@ -655,42 +662,42 @@ namespace {
    template<> ObjectStore::TableDefinition const PRIMARY_TABLE<BrewNote> {
       "brewnote",
       {
-         {ObjectStore::FieldType::Int,    "id",                      PropertyNames::NamedEntity::key           },
+         {ObjectStore::FieldType::Int   , "id"                     , PropertyNames::NamedEntity::key           },
          // NB: BrewNotes don't have names in DB
-         {ObjectStore::FieldType::Bool,   "display",                 PropertyNames::NamedEntity::display       },
-         {ObjectStore::FieldType::Bool,   "deleted",                 PropertyNames::NamedEntity::deleted       },
-         {ObjectStore::FieldType::String, "folder",                  PropertyNames::NamedEntity::folder        },
-         {ObjectStore::FieldType::Double, "abv",                     PropertyNames::BrewNote::abv              },
-         {ObjectStore::FieldType::Double, "attenuation",             PropertyNames::BrewNote::attenuation      },
-         {ObjectStore::FieldType::Double, "boil_off",                PropertyNames::BrewNote::boilOff_l        },
-         {ObjectStore::FieldType::Date,   "brewdate",                PropertyNames::BrewNote::brewDate         },
-         {ObjectStore::FieldType::Double, "brewhouse_eff",           PropertyNames::BrewNote::brewhouseEff_pct },
-         {ObjectStore::FieldType::Double, "eff_into_bk",             PropertyNames::BrewNote::effIntoBK_pct    },
-         {ObjectStore::FieldType::Date,   "fermentdate",             PropertyNames::BrewNote::fermentDate      },
-         {ObjectStore::FieldType::Double, "fg",                      PropertyNames::BrewNote::fg               },
-         {ObjectStore::FieldType::Double, "final_volume",            PropertyNames::BrewNote::finalVolume_l    },
+         {ObjectStore::FieldType::Bool  , "display"                , PropertyNames::NamedEntity::display       },
+         {ObjectStore::FieldType::Bool  , "deleted"                , PropertyNames::NamedEntity::deleted       },
+         {ObjectStore::FieldType::String, "folder"                 , PropertyNames::NamedEntity::folder        },
+         {ObjectStore::FieldType::Double, "abv"                    , PropertyNames::BrewNote::abv              },
+         {ObjectStore::FieldType::Double, "attenuation"            , PropertyNames::BrewNote::attenuation      },
+         {ObjectStore::FieldType::Double, "boil_off"               , PropertyNames::BrewNote::boilOff_l        },
+         {ObjectStore::FieldType::Date  , "brewdate"               , PropertyNames::BrewNote::brewDate         },
+         {ObjectStore::FieldType::Double, "brewhouse_eff"          , PropertyNames::BrewNote::brewhouseEff_pct },
+         {ObjectStore::FieldType::Double, "eff_into_bk"            , PropertyNames::BrewNote::effIntoBK_pct    },
+         {ObjectStore::FieldType::Date  , "fermentdate"            , PropertyNames::BrewNote::fermentDate      },
+         {ObjectStore::FieldType::Double, "fg"                     , PropertyNames::BrewNote::fg               },
+         {ObjectStore::FieldType::Double, "final_volume"           , PropertyNames::BrewNote::finalVolume_l    },
          // NB: BrewNotes don't have folders, as each one is owned by a Recipe
-         {ObjectStore::FieldType::Double, "mash_final_temp",         PropertyNames::BrewNote::mashFinTemp_c    },
-         {ObjectStore::FieldType::String, "notes",                   PropertyNames::BrewNote::notes            },
-         {ObjectStore::FieldType::Double, "og",                      PropertyNames::BrewNote::og               },
-         {ObjectStore::FieldType::Double, "pitch_temp",              PropertyNames::BrewNote::pitchTemp_c      },
-         {ObjectStore::FieldType::Double, "post_boil_volume",        PropertyNames::BrewNote::postBoilVolume_l },
-         {ObjectStore::FieldType::Double, "projected_abv",           PropertyNames::BrewNote::projABV_pct      },
-         {ObjectStore::FieldType::Double, "projected_atten",         PropertyNames::BrewNote::projAtten        },
-         {ObjectStore::FieldType::Double, "projected_boil_grav",     PropertyNames::BrewNote::projBoilGrav     },
-         {ObjectStore::FieldType::Double, "projected_eff",           PropertyNames::BrewNote::projEff_pct      },
-         {ObjectStore::FieldType::Double, "projected_ferm_points",   PropertyNames::BrewNote::projFermPoints   },
-         {ObjectStore::FieldType::Double, "projected_fg",            PropertyNames::BrewNote::projFg           },
+         {ObjectStore::FieldType::Double, "mash_final_temp"        , PropertyNames::BrewNote::mashFinTemp_c    },
+         {ObjectStore::FieldType::String, "notes"                  , PropertyNames::BrewNote::notes            },
+         {ObjectStore::FieldType::Double, "og"                     , PropertyNames::BrewNote::og               },
+         {ObjectStore::FieldType::Double, "pitch_temp"             , PropertyNames::BrewNote::pitchTemp_c      },
+         {ObjectStore::FieldType::Double, "post_boil_volume"       , PropertyNames::BrewNote::postBoilVolume_l },
+         {ObjectStore::FieldType::Double, "projected_abv"          , PropertyNames::BrewNote::projABV_pct      },
+         {ObjectStore::FieldType::Double, "projected_atten"        , PropertyNames::BrewNote::projAtten        },
+         {ObjectStore::FieldType::Double, "projected_boil_grav"    , PropertyNames::BrewNote::projBoilGrav     },
+         {ObjectStore::FieldType::Double, "projected_eff"          , PropertyNames::BrewNote::projEff_pct      },
+         {ObjectStore::FieldType::Double, "projected_ferm_points"  , PropertyNames::BrewNote::projFermPoints   },
+         {ObjectStore::FieldType::Double, "projected_fg"           , PropertyNames::BrewNote::projFg           },
          {ObjectStore::FieldType::Double, "projected_mash_fin_temp", PropertyNames::BrewNote::projMashFinTemp_c},
-         {ObjectStore::FieldType::Double, "projected_og",            PropertyNames::BrewNote::projOg           },
-         {ObjectStore::FieldType::Double, "projected_points",        PropertyNames::BrewNote::projPoints       },
-         {ObjectStore::FieldType::Double, "projected_strike_temp",   PropertyNames::BrewNote::projStrikeTemp_c },
-         {ObjectStore::FieldType::Double, "projected_vol_into_bk",   PropertyNames::BrewNote::projVolIntoBK_l  },
+         {ObjectStore::FieldType::Double, "projected_og"           , PropertyNames::BrewNote::projOg           },
+         {ObjectStore::FieldType::Double, "projected_points"       , PropertyNames::BrewNote::projPoints       },
+         {ObjectStore::FieldType::Double, "projected_strike_temp"  , PropertyNames::BrewNote::projStrikeTemp_c },
+         {ObjectStore::FieldType::Double, "projected_vol_into_bk"  , PropertyNames::BrewNote::projVolIntoBK_l  },
          {ObjectStore::FieldType::Double, "projected_vol_into_ferm", PropertyNames::BrewNote::projVolIntoFerm_l},
-         {ObjectStore::FieldType::Double, "sg",                      PropertyNames::BrewNote::sg               },
-         {ObjectStore::FieldType::Double, "strike_temp",             PropertyNames::BrewNote::strikeTemp_c     },
-         {ObjectStore::FieldType::Double, "volume_into_bk",          PropertyNames::BrewNote::volumeIntoBK_l   },
-         {ObjectStore::FieldType::Double, "volume_into_fermenter",   PropertyNames::BrewNote::volumeIntoFerm_l },
+         {ObjectStore::FieldType::Double, "sg"                     , PropertyNames::BrewNote::sg               },
+         {ObjectStore::FieldType::Double, "strike_temp"            , PropertyNames::BrewNote::strikeTemp_c     },
+         {ObjectStore::FieldType::Double, "volume_into_bk"         , PropertyNames::BrewNote::volumeIntoBK_l   },
+         {ObjectStore::FieldType::Double, "volume_into_fermenter"  , PropertyNames::BrewNote::volumeIntoFerm_l },
          {ObjectStore::FieldType::Int,    "recipe_id",               PropertyNames::BrewNote::recipeId,          nullptr, &PRIMARY_TABLE<Recipe>}
       }
    };
@@ -719,42 +726,42 @@ ObjectStoreTyped<NE> & ObjectStoreTyped<NE>::getInstance() {
 }
 
 // We have to make sure that each version of the above function gets instantiated
-template ObjectStoreTyped<BrewNote> &             ObjectStoreTyped<BrewNote>::getInstance();
-template ObjectStoreTyped<Equipment> &            ObjectStoreTyped<Equipment>::getInstance();
-template ObjectStoreTyped<Fermentable> &          ObjectStoreTyped<Fermentable>::getInstance();
-template ObjectStoreTyped<Hop> &                  ObjectStoreTyped<Hop>::getInstance();
-template ObjectStoreTyped<Instruction> &          ObjectStoreTyped<Instruction>::getInstance();
+template ObjectStoreTyped<BrewNote> &             ObjectStoreTyped<BrewNote            >::getInstance();
+template ObjectStoreTyped<Equipment> &            ObjectStoreTyped<Equipment           >::getInstance();
+template ObjectStoreTyped<Fermentable> &          ObjectStoreTyped<Fermentable         >::getInstance();
+template ObjectStoreTyped<Hop> &                  ObjectStoreTyped<Hop                 >::getInstance();
+template ObjectStoreTyped<Instruction> &          ObjectStoreTyped<Instruction         >::getInstance();
 template ObjectStoreTyped<InventoryFermentable> & ObjectStoreTyped<InventoryFermentable>::getInstance();
-template ObjectStoreTyped<InventoryHop> &         ObjectStoreTyped<InventoryHop>::getInstance();
-template ObjectStoreTyped<InventoryMisc> &        ObjectStoreTyped<InventoryMisc>::getInstance();
-template ObjectStoreTyped<InventoryYeast> &       ObjectStoreTyped<InventoryYeast>::getInstance();
-template ObjectStoreTyped<Mash> &                 ObjectStoreTyped<Mash>::getInstance();
-template ObjectStoreTyped<MashStep> &             ObjectStoreTyped<MashStep>::getInstance();
-template ObjectStoreTyped<Misc> &                 ObjectStoreTyped<Misc>::getInstance();
-template ObjectStoreTyped<Recipe> &               ObjectStoreTyped<Recipe>::getInstance();
-template ObjectStoreTyped<Salt> &                 ObjectStoreTyped<Salt>::getInstance();
-template ObjectStoreTyped<Style> &                ObjectStoreTyped<Style>::getInstance();
-template ObjectStoreTyped<Water> &                ObjectStoreTyped<Water>::getInstance();
-template ObjectStoreTyped<Yeast> &                ObjectStoreTyped<Yeast>::getInstance();
+template ObjectStoreTyped<InventoryHop> &         ObjectStoreTyped<InventoryHop        >::getInstance();
+template ObjectStoreTyped<InventoryMisc> &        ObjectStoreTyped<InventoryMisc       >::getInstance();
+template ObjectStoreTyped<InventoryYeast> &       ObjectStoreTyped<InventoryYeast      >::getInstance();
+template ObjectStoreTyped<Mash> &                 ObjectStoreTyped<Mash                >::getInstance();
+template ObjectStoreTyped<MashStep> &             ObjectStoreTyped<MashStep            >::getInstance();
+template ObjectStoreTyped<Misc> &                 ObjectStoreTyped<Misc                >::getInstance();
+template ObjectStoreTyped<Recipe> &               ObjectStoreTyped<Recipe              >::getInstance();
+template ObjectStoreTyped<Salt> &                 ObjectStoreTyped<Salt                >::getInstance();
+template ObjectStoreTyped<Style> &                ObjectStoreTyped<Style               >::getInstance();
+template ObjectStoreTyped<Water> &                ObjectStoreTyped<Water               >::getInstance();
+template ObjectStoreTyped<Yeast> &                ObjectStoreTyped<Yeast               >::getInstance();
 
 namespace {
    QVector<ObjectStore const *> AllObjectStores {
-      &ostSingleton<BrewNote>,
-      &ostSingleton<Equipment>,
-      &ostSingleton<Fermentable>,
-      &ostSingleton<Hop>,
-      &ostSingleton<Instruction>,
+      &ostSingleton<BrewNote            >,
+      &ostSingleton<Equipment           >,
+      &ostSingleton<Fermentable         >,
+      &ostSingleton<Hop                 >,
+      &ostSingleton<Instruction         >,
       &ostSingleton<InventoryFermentable>,
-      &ostSingleton<InventoryHop>,
-      &ostSingleton<InventoryMisc>,
-      &ostSingleton<InventoryYeast>,
-      &ostSingleton<Mash>,
-      &ostSingleton<MashStep>,
-      &ostSingleton<Misc>,
-      &ostSingleton<Recipe>,
-      &ostSingleton<Salt>,
-      &ostSingleton<Style>,
-      &ostSingleton<Water>,
+      &ostSingleton<InventoryHop        >,
+      &ostSingleton<InventoryMisc       >,
+      &ostSingleton<InventoryYeast      >,
+      &ostSingleton<Mash                >,
+      &ostSingleton<MashStep            >,
+      &ostSingleton<Misc                >,
+      &ostSingleton<Recipe              >,
+      &ostSingleton<Salt                >,
+      &ostSingleton<Style               >,
+      &ostSingleton<Water               >,
       &ostSingleton<Yeast>
    };
 }


### PR DESCRIPTION
Fix `src/database/ObjectStore.cpp` so that it can recover from the case where it finds a "true" or "false" **string** in a table field where it was expecting a boolean (or actually a 0 or 1, since SQLite doesn't have native booleans).

I'm not sure how we end up with a string in a boolean field, but it can happen -- see https://github.com/Brewtarget/brewtarget/issues/766.  Given that we can automatically recover (provided the string holds something sane), we should.

I've tested this locally by manually modifying my DB but, as ever, any corrections or comments are welcome!