### PR TITLE
Improve keyboard usage and reduce boilsize by deadspace.

### DIFF
--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -48,8 +48,10 @@ MashDesigner::MashDesigner(QWidget * parent) : QDialog     {parent},
    this->label_zeroWort->setText(Measurement::displayAmount(Measurement::Amount{0, Measurement::Units::liters}));
 
    // Update temp slider when we move amount slider.
-   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateTempSlider);
-   // Update amount slider when we move temp slider.
+   //
+   // Here and below, we connect to valueChanged rather than sliderMoved as, otherwise, we don't receive any signal if
+   // the keyboard is used to move the slider.
+   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateTempSlider);   // Update amount slider when we move temp slider.
    connect(horizontalSlider_temp,   &QAbstractSlider::valueChanged, this, &MashDesigner::updateAmtSlider);
    // Update tun fullness bar when either slider moves.
    connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateFullness);

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -48,20 +48,20 @@ MashDesigner::MashDesigner(QWidget * parent) : QDialog     {parent},
    this->label_zeroWort->setText(Measurement::displayAmount(Measurement::Amount{0, Measurement::Units::liters}));
 
    // Update temp slider when we move amount slider.
-   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTempSlider);
+   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateTempSlider);
    // Update amount slider when we move temp slider.
-   connect(horizontalSlider_temp,   &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmtSlider);
+   connect(horizontalSlider_temp,   &QAbstractSlider::valueChanged, this, &MashDesigner::updateAmtSlider);
    // Update tun fullness bar when either slider moves.
-   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateFullness);
-   connect(horizontalSlider_temp,   &QAbstractSlider::sliderMoved, this, &MashDesigner::updateFullness);
+   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateFullness);
+   connect(horizontalSlider_temp,   &QAbstractSlider::valueChanged, this, &MashDesigner::updateFullness);
    // Update amount/temp text when sliders move.
-   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmt);
-   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTemp);
-   connect(horizontalSlider_temp,   &QAbstractSlider::sliderMoved, this, &MashDesigner::updateAmt);
-   connect(horizontalSlider_temp,   &QAbstractSlider::sliderMoved, this, &MashDesigner::updateTemp);
+   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateAmt);
+   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateTemp);
+   connect(horizontalSlider_temp,   &QAbstractSlider::valueChanged, this, &MashDesigner::updateAmt);
+   connect(horizontalSlider_temp,   &QAbstractSlider::valueChanged, this, &MashDesigner::updateTemp);
    // Update collected wort when sliders move.
-   connect(horizontalSlider_amount, &QAbstractSlider::sliderMoved, this, &MashDesigner::updateCollectedWort);
-   connect(horizontalSlider_temp,   &QAbstractSlider::sliderMoved, this, &MashDesigner::updateCollectedWort);
+   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateCollectedWort);
+   connect(horizontalSlider_temp,   &QAbstractSlider::valueChanged, this, &MashDesigner::updateCollectedWort);
    // Save the target temp whenever it's changed.
    connect(lineEdit_temp,           &SmartLineEdit::textModified,  this, &MashDesigner::saveTargetTemp);
    // Move to next step.

--- a/src/MashDesigner.cpp
+++ b/src/MashDesigner.cpp
@@ -51,7 +51,8 @@ MashDesigner::MashDesigner(QWidget * parent) : QDialog     {parent},
    //
    // Here and below, we connect to valueChanged rather than sliderMoved as, otherwise, we don't receive any signal if
    // the keyboard is used to move the slider.
-   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateTempSlider);   // Update amount slider when we move temp slider.
+   connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateTempSlider);
+   // Update amount slider when we move temp slider.
    connect(horizontalSlider_temp,   &QAbstractSlider::valueChanged, this, &MashDesigner::updateAmtSlider);
    // Update tun fullness bar when either slider moves.
    connect(horizontalSlider_amount, &QAbstractSlider::valueChanged, this, &MashDesigner::updateFullness);

--- a/src/model/Recipe.cpp
+++ b/src/model/Recipe.cpp
@@ -2785,7 +2785,7 @@ double Recipe::targetCollectedWortVol_l() {
    }
 
    if (equipment()) {
-      return boilSize_l() - equipment()->topUpKettle_l() - postMashAdditionVolume_l;
+      return boilSize_l() - equipment()->lauterDeadspace_l() - equipment()->topUpKettle_l() - postMashAdditionVolume_l;
    } else {
       return boilSize_l() - postMashAdditionVolume_l;
    }


### PR DESCRIPTION
When using keyboard to move slider for mash designer values are not updated.
I've switched the event that we connect to, so this usecase would be supported.

Boil size should also be reduced by the lauter deadspace in calculation.
I've simply substracted it if it's defined in the equipment.


Please take special consideration when reviewing this PR as I'm not a developer by profession.
I'm not aware if this has any impact or implications on other parts of Brewtarget.

Cheers! 