### PR TITLE
Fix for incorrect BrewNote calculation, plus small tidy-up of BtHorizontalTabs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 #
-# meson.build is part of Brewtarget, and is copyright the following authors 2022-2023:
+# meson.build is part of Brewtarget, and is copyright the following authors 2022-2024:
 #   • Matt Young <mfsy@yahoo.com>
 #
 # Brewtarget is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
@@ -591,6 +591,7 @@ commonSourceFiles = files([
    'src/BtDatePopup.cpp',
    'src/BtFieldType.cpp',
    'src/BtFolder.cpp',
+   'src/BtHorizontalTabs.cpp',
    'src/BtSplashScreen.cpp',
    'src/BtTabWidget.cpp',
    'src/BtTextEdit.cpp',

--- a/src/BtHorizontalTabs.cpp
+++ b/src/BtHorizontalTabs.cpp
@@ -1,0 +1,72 @@
+/*
+ * BtHorizontalTabs.cpp is part of Brewtarget, and is Copyright the following
+ * authors 2021-2024
+ * - Matt Young <mfsy@yahoo.com>
+ * - Mik Firestone <mikfire@gmail.com>
+ *
+ * Brewtarget is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Brewtarget is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "BtHorizontalTabs.h"
+
+#include <QDebug>
+#include <QStyleOptionTab>
+
+QSize BtHorizontalTabs::sizeFromContents(ContentsType type,
+                                         QStyleOption const * option,
+                                         QSize const & contentsSize,
+                                         QWidget const * widget) const {
+   // By default, we're just going to return the same size as our parent class...
+   QSize size = QProxyStyle::sizeFromContents(type, option, contentsSize, widget);
+   if (type == QStyle::CT_TabBarTab) {
+      // ...but, if it's a tab, then we want to swap the X and Y of the size rectangle we return
+//      qDebug() << Q_FUNC_INFO << "Transposing width:" << size.width() << ", height:" << size.height();
+      size.transpose();
+   }
+   return size;
+}
+
+void BtHorizontalTabs::drawControl(ControlElement element,
+                                   QStyleOption const * option,
+                                   QPainter * painter,
+                                   QWidget const * widget) const {
+   // Special handling is only for tabs
+   if (element == QStyle::CE_TabBarTabLabel) {
+      QStyleOptionTab const * tabOption = qstyleoption_cast<QStyleOptionTab const *>(option);
+      if (tabOption) {
+         QStyleOptionTab modifiedTabOption{*tabOption};
+         //
+         // Per https://doc.qt.io/qt-5/qtabbar.html#Shape-enum, the QTabBar::Shape enum type lists the built-in shapes
+         // supported by QTabBar.  In particular:
+         //   - QTabBar::RoundedNorth = The normal rounded look above the pages
+         //   - QTabBar::RoundedWest  = The normal rounded look on the left side of the pages
+         //
+         // Normally, when the tabs are on the left (QTabBar::RoundedWest), the text is rotated so that (in
+         // left-to-right languages such as English) it reads bottom-to-top.  If we change the shape attribute for
+         // drawing the tab label to QTabBar::RoundedNorth, then the text should be drawn unrotated as though the tab
+         // were above the widget.
+         //
+         // Normally keep the debug statements below commented out as they generates a lot of output!
+         //
+//         qDebug() << Q_FUNC_INFO << "Changing shape from" << modifiedTabOption.shape << "to" << QTabBar::RoundedNorth;
+         modifiedTabOption.shape = QTabBar::RoundedNorth;
+         QProxyStyle::drawControl(element, &modifiedTabOption, painter, widget);
+         return;
+      }
+   }
+
+   // For everything except tabs, just let the parent class do the drawing -- ie don't change anything
+   QProxyStyle::drawControl(element, option, painter, widget);
+   return;
+
+}

--- a/src/BtHorizontalTabs.h
+++ b/src/BtHorizontalTabs.h
@@ -1,6 +1,7 @@
 /*
  * BtHorizontalTabs.h is part of Brewtarget, and is Copyright the following
- * authors 2021-2025
+ * authors 2021-2024
+ * - Matt Young <mfsy@yahoo.com>
  * - Mik Firestone <mikfire@gmail.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify
@@ -23,37 +24,32 @@
 
 #include <QProxyStyle>
 #include <QStyleOption>
-#include <QStyleOptionTab>
 #include <QSize>
 
 /**
- * \brief A quick little bit to handle a tab bar with the tabs on the west.
+ * \brief A custom style class for \c QTabWidget with tabs on the left (\c QTabBar::RoundedWest) to rotate the tab so
+ *        that its text is horizontal instead of the default vertical.  This looks neater when we have potentially long
+ *        tab text on a widget that is not hugely tall.
  */
-class BtHorizontalTabs : public QProxyStyle
-{
+class BtHorizontalTabs : public QProxyStyle {
 public:
-   QSize sizeFromContents( ContentsType type, const QStyleOption* option,
-                           const QSize& size, const QWidget* widget ) const
-   {
-      QSize s = QProxyStyle::sizeFromContents(type,option,size,widget);
-      if ( type == QStyle::CT_TabBarTab ) {
-         s.transpose();
-      }
-      return s;
-   }
+   /**
+    * \brief Reimplements \c QStyle::sizeFromContents (and various derivatives thereof)
+    *
+    * \return the size of the element described by the specified option and type, based on the provided \c contentsSize.
+    */
+   virtual QSize sizeFromContents(ContentsType type,
+                                  QStyleOption const * option,
+                                  QSize const & contentsSize,
+                                  QWidget const * widget) const;
 
-   void drawControl( ControlElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget ) const
-   {
-      if ( element == CE_TabBarTabLabel ) {
-         if ( const QStyleOptionTab* tab = qstyleoption_cast<const QStyleOptionTab*>(option)) {
-            QStyleOptionTab opt(*tab);
-            // this looks wrong, but it isn't. No idea why.
-            opt.shape = QTabBar::RoundedNorth;
-            QProxyStyle::drawControl(element,&opt,painter,widget);
-            return;
-         }
-      }
-      QProxyStyle::drawControl(element,option,painter,widget);
-   }
+   /**
+    * \brief Reimplements \c QStyle::drawControl (and various derivatives thereof) to draw the given \c element with the
+    *        provided \c painter with the style options specified by \c option.
+    */
+   virtual void drawControl(ControlElement element,
+                            QStyleOption const * option,
+                            QPainter * painter,
+                            QWidget const * widget) const;
 };
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ set(filesToCompile_cpp
     ${repoDir}/src/BtDatePopup.cpp
     ${repoDir}/src/BtFieldType.cpp
     ${repoDir}/src/BtFolder.cpp
+    ${repoDir}/src/BtHorizontalTabs.cpp
     ${repoDir}/src/BtSplashScreen.cpp
     ${repoDir}/src/BtTabWidget.cpp
     ${repoDir}/src/BtTextEdit.cpp

--- a/src/model/BrewNote.cpp
+++ b/src/model/BrewNote.cpp
@@ -553,7 +553,7 @@ double BrewNote::pitchTemp_c() const { return m_pitchTemp_c; }
 double BrewNote::fg() const { return m_fg; }
 double BrewNote::finalVolume_l() const { return m_finalVolume_l; }
 double BrewNote::projBoilGrav() const { return m_projBoilGrav; }
-double BrewNote::projVolIntoBK_l() const { return m_projVolIntoFerm_l; }
+double BrewNote::projVolIntoBK_l() const { return m_projVolIntoBK_l; }
 double BrewNote::projStrikeTemp_c() const { return m_projStrikeTemp_c; }
 double BrewNote::projMashFinTemp_c() const { return m_projMashFinTemp_c; }
 double BrewNote::projOg() const { return m_projOg; }
@@ -569,22 +569,24 @@ int    BrewNote::getRecipeId() const { return this->m_recipeId; }
 
 // calculators -- these kind of act as both setters and getters.  Likely bad
 // form
-double BrewNote::calculateEffIntoBK_pct()
-{
-   double effIntoBK;
-   double maxPoints, actualPoints;
-
+double BrewNote::calculateEffIntoBK_pct() {
    // I don't think we need a lot of math here. Points has already been
    // translated from SG into pure glucose points
-   maxPoints = m_projPoints * m_projVolIntoBK_l;
+   double maxPoints = m_projPoints * m_projVolIntoBK_l;
+//   qDebug() <<
+//      Q_FUNC_INFO << "m_projPoints: " << m_projPoints << ", m_projVolIntoBK_l:" << m_projVolIntoBK_l <<
+//      ", maxPoints:" << maxPoints;
 
-   actualPoints = (m_sg - 1) * 1000 * m_volumeIntoBK_l;
-
+   double actualPoints = (m_sg - 1) * 1000 * m_volumeIntoBK_l;
+//   qDebug() <<
+//      Q_FUNC_INFO << "m_sg:" << m_sg << ", m_volumeIntoBK_l:" << m_volumeIntoBK_l << ", actualPoints:" << actualPoints;
    // this can happen under normal circumstances (eg, load)
-   if (maxPoints <= 0.0)
+   if (maxPoints <= 0.0) {
       return 0.0;
+   }
 
-   effIntoBK = actualPoints/maxPoints * 100;
+   double effIntoBK = actualPoints/maxPoints * 100;
+//   qDebug() << Q_FUNC_INFO << "effIntoBK:" << effIntoBK;
    setEffIntoBK_pct(effIntoBK);
 
    return effIntoBK;

--- a/translations/bt_ca.ts
+++ b/translations/bt_ca.ts
@@ -2706,6 +2706,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_cs.ts
+++ b/translations/bt_cs.ts
@@ -2647,6 +2647,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_de.ts
+++ b/translations/bt_de.ts
@@ -2682,6 +2682,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_el.ts
+++ b/translations/bt_el.ts
@@ -2647,6 +2647,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_en.ts
+++ b/translations/bt_en.ts
@@ -2187,6 +2187,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_es.ts
+++ b/translations/bt_es.ts
@@ -2702,6 +2702,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_et.ts
+++ b/translations/bt_et.ts
@@ -2238,6 +2238,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_eu.ts
+++ b/translations/bt_eu.ts
@@ -2246,6 +2246,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_fr.ts
+++ b/translations/bt_fr.ts
@@ -2706,6 +2706,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_gl.ts
+++ b/translations/bt_gl.ts
@@ -2376,6 +2376,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_hu.ts
+++ b/translations/bt_hu.ts
@@ -2686,6 +2686,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_it.ts
+++ b/translations/bt_it.ts
@@ -2710,6 +2710,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_lv.ts
+++ b/translations/bt_lv.ts
@@ -2301,6 +2301,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_nb.ts
+++ b/translations/bt_nb.ts
@@ -2647,6 +2647,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_nl.ts
+++ b/translations/bt_nl.ts
@@ -2717,19 +2717,31 @@ Log file may contain more details.</source>
     <name>QApplication</name>
     <message>
         <source>Application terminates</source>
-        <translation type="vanished">De applicatie stopt</translation>
+        <translation>De applicatie stopt</translation>
     </message>
     <message>
         <source>The application encountered a fatal error.
 Error message:
 %1</source>
-        <translation type="vanished">The applicatie kreeg een fatale fout.
+        <translation>The applicatie kreeg een fatale fout.
 Foutmelding:
 %1</translation>
     </message>
     <message>
         <source>The application encountered a fatal error.</source>
-        <translation type="vanished">The applicatie kreeg een fatale fout.</translation>
+        <translation>The applicatie kreeg een fatale fout.</translation>
+    </message>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/bt_pl.ts
+++ b/translations/bt_pl.ts
@@ -2647,6 +2647,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_pt.ts
+++ b/translations/bt_pt.ts
@@ -2670,6 +2670,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_ru.ts
+++ b/translations/bt_ru.ts
@@ -2690,6 +2690,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_sr.ts
+++ b/translations/bt_sr.ts
@@ -2531,6 +2531,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_sv.ts
+++ b/translations/bt_sv.ts
@@ -2710,6 +2710,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_tr.ts
+++ b/translations/bt_tr.ts
@@ -2356,6 +2356,35 @@ Günlük dosyası daha fazla detay içerebilir.</translation>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>

--- a/translations/bt_zh.ts
+++ b/translations/bt_zh.ts
@@ -2639,6 +2639,35 @@ Log file may contain more details.</source>
     </message>
 </context>
 <context>
+    <name>QApplication</name>
+    <message>
+        <source>Brewtarget is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of Brewtarget is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Invalid color formula type: %1</source>


### PR DESCRIPTION
Fix for https://github.com/Brewtarget/brewtarget/issues/789 is correcting the following line of `src/model/BrewNote.cpp`:

 `double BrewNote::projVolIntoBK_l() const { return m_projVolIntoFerm_l; }`

to:

`double BrewNote::projVolIntoBK_l() const { return m_projVolIntoBK_l; }`

The other changes are tidying up `BtHorizontalTabs` (specifically pulling code out of the header file into a .cpp file and adding some comments).  This doesn't change functionality but is part of investigating https://github.com/Brewtarget/brewtarget/issues/787.
