### PR TITLE
Fix for text in side tabs not displaying on Mac

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1,6 +1,6 @@
 /*
  * Application.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2022
+ * authors 2009-2024
  * - A.J. Drobnich <aj.drobnich@gmail.com>
  * - Dan Cavanagh <dan@dancavanagh.com>
  * - Matt Young <mfsy@yahoo.com>
@@ -326,7 +326,7 @@ namespace {
             "constant for resource dir:" << CONFIG_DATA_DIR;
          path = QString(CONFIG_DATA_DIR);
       }
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
       // === Mac ===
       // We should be inside an app bundle.
       path += "../Resources/";
@@ -345,7 +345,7 @@ namespace {
 }
 
 const QDir Application::getConfigDir() {
-#if defined(Q_OS_LINUX) || defined(Q_OS_MAC) // Linux OS or Mac OS.
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS) // Linux OS or Mac OS.
    QDir dir;
    QFileInfo fileInfo;
 
@@ -388,7 +388,7 @@ QDir Application::getUserDataDir() {
 }
 
 QDir Application::getDefaultUserDataDir() {
-#if defined(Q_OS_LINUX) || defined(Q_OS_MAC) // Linux OS or Mac OS.#if defined(Q_OS_LINUX) || defined(Q_OS_MAC) // Linux OS or Mac OS.
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS) // Linux OS or Mac OS
    return getConfigDir();
 #elif defined(Q_OS_WIN) // Windows OS.
    // On Windows the Programs directory is normally not writable so we need to get the appData path from the environment instead.
@@ -441,7 +441,7 @@ bool Application::initialize() {
 
    Localization::loadTranslations(); // Do internationalization.
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
    qt_set_sequence_auto_mnemonic(true); // turns on Mac Keyboard shortcuts
 #endif
 

--- a/src/BtHorizontalTabs.h
+++ b/src/BtHorizontalTabs.h
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 #ifndef BTHORIZONTALTABS_H
 #define BTHORIZONTALTABS_H
 #pragma once
@@ -27,12 +26,40 @@
 #include <QSize>
 
 /**
- * \brief A custom style class for \c QTabWidget with tabs on the left (\c QTabBar::RoundedWest) to rotate the tab so
- *        that its text is horizontal instead of the default vertical.  This looks neater when we have potentially long
- *        tab text on a widget that is not hugely tall.
+ * \brief A custom style class for \c QTabBar (eg of a \c QTabWidget with tabs on the left \c QTabBar::RoundedWest) to
+ *        rotate the tabs so that their text is horizontal instead of the default vertical.  This looks neater when we
+ *        have potentially long tab text on a widget that is not hugely tall.
+ *
+ *        To use on, say, \c myQTabWidget, a pointer to \c QTabWidget, call
+ *        \c myQTabWidget->tabBar()->setStyle(new BtHorizontalTabs);
+ *
+ *        NOTE: This is a commonly-used approach that works on Windows and Linux, but not entirely on Mac.  It's fine on
+ *              Mac for tabs with square icons in, but doesn't work properly for tabs with text. (If you look at the Qt
+ *              source code, eg https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/widgets/qtabbar.cpp?h=5.15,
+ *              you'll see some special handling for Mac OS, so perhaps this is something to do with it.)
+ *
+ *              If we wanted a more sure-fire way of achieving horizontal text in left-hand tabs, we could, in
+ *              principle, create our own classes that inherit from \c QTabWidget and \c QTabBar.  But I fear we'd end
+ *              up re-implementing a lot of the inner workings of those classes, which would be rather painful.  For
+ *              now, we leave text in its default orientation on Mac.
  */
 class BtHorizontalTabs : public QProxyStyle {
+
 public:
+
+   /**
+    * \brief This is a slightly horrible way of getting things to work on Mac OS
+    *
+    * \param forceRotate If set to \c true then the class will do it's stuff even on Mac, which is what you want
+    *                    for tabs with square icons in.  Otherwise, on Mac, the class will do nothing, leaving the
+    *                    default behaviour of side tabs, which is what you want for text tabs.
+    *
+    *                    NOTE that, on other platforms (ie Linux and Windows), this parameter has no effect -- ie we'll
+    *                    always try to rotate the side tab text to horizontal.
+    */
+   BtHorizontalTabs(bool const forceRotate = false);
+   virtual ~BtHorizontalTabs();
+
    /**
     * \brief Reimplements \c QStyle::sizeFromContents (and various derivatives thereof)
     *
@@ -51,5 +78,9 @@ public:
                             QStyleOption const * option,
                             QPainter * painter,
                             QWidget const * widget) const;
+
+private:
+   bool const m_forceRotate;
 };
+
 #endif

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,6 +1,6 @@
 /*
  * MainWindow.cpp is part of Brewtarget, and is Copyright the following
- * authors 2009-2023
+ * authors 2009-2024
  * - A.J. Drobnich <aj.drobnich@gmail.com>
  * - Dan Cavanagh <dan@dancavanagh.com>
  * - David Grundberg <individ@acc.umu.se>
@@ -368,8 +368,8 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), pimpl{std::make_u
    // Stop things looking ridiculously tiny on high DPI displays
    this->setSizesInPixelsBasedOnDpi();
 
-   // Horizontal tabs, please
-   tabWidget_Trees->tabBar()->setStyle(new BtHorizontalTabs);
+   // Horizontal tabs, please -- even on Mac OS, as the tabs contain square icons
+   tabWidget_Trees->tabBar()->setStyle(new BtHorizontalTabs(true));
 
    /* PLEASE DO NOT REMOVE.
     This code is left here, commented out, intentionally. The only way I can


### PR DESCRIPTION
This is a minimal fix for https://github.com/Brewtarget/brewtarget/issues/787.

Also changed current uses of `Q_OS_MAC` to `Q_OS_MACOS` as the former is deprecated according to https://doc.qt.io/qt-5/qtglobal.html#Q_OS_MAC.  