### PR TITLE
Preparation for upgrade to Qt 6

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -289,10 +289,6 @@ jobs:
           # (which is not yet generated) uses a real certificate that will be supplied by Signpath and will be suitable
           # for signing released versions of the application.
           #
-          # For the moment, everything uses "test-signing".  Once that's working, we'll use the logic below.
-          #
-          # -=-=-=-=-=-=-=-=-=-=-
-          #
           # Select "release-signing" policy for things we're going to release and "test-signing" otherwise.
           #
           # Currently our main branch for releasing is called "develop", but we'll probably change it to "main" in the
@@ -301,11 +297,10 @@ jobs:
           # We don't do release branches per se, but, before we do a lot of commits for a major release, we'll usually
           # cut a "stable/" branch for the prior one.
           #
-          SIGNPATH_SIGNING_POLICY_SLUG: 'test-signing'
-#          SIGNPATH_SIGNING_POLICY_SLUG: |
-#            ${{ (github.ref == 'refs/heads/develop' ||
-#                 github.ref == 'refs/heads/main' ||
-#                 startsWith(github.ref, 'refs/heads/stable/')) && 'release-signing' || 'test-signing' }}
+          SIGNPATH_SIGNING_POLICY_SLUG: |
+            ${{ (github.ref == 'refs/heads/develop' ||
+                 github.ref == 'refs/heads/main' ||
+                 startsWith(github.ref, 'refs/heads/stable/')) && 'release-signing' || 'test-signing' }}
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -23,9 +23,10 @@ Bug fixes for the 4.0.5 release (ie bugs in 4.0.5 are fixed in this 4.0.6 releas
 * Ingredient inventory edits not saved [832](https://github.com/Brewtarget/brewtarget/issues/832)
 * Unsatisfied dependency for Brewtarget update in ubuntu 24.01 [840](https://github.com/Brewtarget/brewtarget/issues/840)
 * Cmake error on Linux Mint 22 Wilma [843](https://github.com/Brewtarget/brewtarget/issues/843)
+* Binaries are not signed on Windows [827](https://github.com/Brewtarget/brewtarget/issues/827)
 
 ### Release Timestamp
-Tue, 1 Oct 2024 04:00:06 +0100
+Wed, 2 Oct 2024 04:00:06 +0100
 
 ## v4.0.5
 Bug fixes for the 4.0.4 release (ie bugs in 4.0.4 are fixed in this 4.0.5 release).

--- a/scripts/buildTool.py
+++ b/scripts/buildTool.py
@@ -660,35 +660,37 @@ def installDependencies():
                   )
                )
 
-         #
-         # Ubuntu 20.04 packages only have Meson 0.53.2, and we need 0.60.0 or later.  In this case it means we have to
-         # install Meson via pip, which is not ideal on Linux.
-         #
-         # Specifically, as explained at https://mesonbuild.com/Getting-meson.html#installing-meson-with-pip, although
-         # using the pip3 install gets a newer version, we have to do the pip install as root (which is normally not
-         # recommended).  If we don't do this, then running `meson install` (or even `sudo meson install`) will barf on
-         # Linux (because we need to be able to install files into system directories).
-         #
-         # So, where a sufficiently recent version of Meson is available in the distro packages (eg
-         # `sudo apt install meson` on Ubuntu etc) it is much better to install this.   Installing via pip is a last
-         # resort.
-         #
-         # The distro ID we get from 'lsb_release -is' will be 'Ubuntu' for all the variants of Ubuntu (eg including
-         # Kubuntu).  Not sure what happens on derivatives such as Linux Mint though.
-         #
-         distroName = str(
-            btUtils.abortOnRunFail(subprocess.run(['lsb_release', '-is'], encoding = "utf-8", capture_output = True)).stdout
-         ).rstrip()
-         log.debug('Linux distro: ' + distroName)
-         if ('Ubuntu' == distroName):
-            ubuntuRelease = str(
-               btUtils.abortOnRunFail(subprocess.run(['lsb_release', '-rs'], encoding = "utf-8", capture_output = True)).stdout
-            ).rstrip()
-            log.debug('Ubuntu release: ' + ubuntuRelease)
-            if (Decimal(ubuntuRelease) < Decimal('22.04')):
-               log.info('Installing newer version of Meson the hard way')
-               btUtils.abortOnRunFail(subprocess.run(['sudo', 'apt', 'remove', '-y', 'meson']))
-               btUtils.abortOnRunFail(subprocess.run(['sudo', 'pip3', 'install', 'meson']))
+###         #
+###         # Commented this out as, as of 2024, we don't support Ubuntu 20.04 any more.
+###         #
+###         # Ubuntu 20.04 packages only have Meson 0.53.2, and we need 0.60.0 or later.  In this case it means we have to
+###         # install Meson via pip, which is not ideal on Linux.
+###         #
+###         # Specifically, as explained at https://mesonbuild.com/Getting-meson.html#installing-meson-with-pip, although
+###         # using the pip3 install gets a newer version, we have to do the pip install as root (which is normally not
+###         # recommended).  If we don't do this, then running `meson install` (or even `sudo meson install`) will barf on
+###         # Linux (because we need to be able to install files into system directories).
+###         #
+###         # So, where a sufficiently recent version of Meson is available in the distro packages (eg
+###         # `sudo apt install meson` on Ubuntu etc) it is much better to install this.   Installing via pip is a last
+###         # resort.
+###         #
+###         # The distro ID we get from 'lsb_release -is' will be 'Ubuntu' for all the variants of Ubuntu (eg including
+###         # Kubuntu).  Not sure what happens on derivatives such as Linux Mint though.
+###         #
+###         distroName = str(
+###            btUtils.abortOnRunFail(subprocess.run(['lsb_release', '-is'], encoding = "utf-8", capture_output = True)).stdout
+###         ).rstrip()
+###         log.debug('Linux distro: ' + distroName)
+###         if ('Ubuntu' == distroName):
+###            ubuntuRelease = str(
+###               btUtils.abortOnRunFail(subprocess.run(['lsb_release', '-rs'], encoding = "utf-8", capture_output = True)).stdout
+###            ).rstrip()
+###            log.debug('Ubuntu release: ' + ubuntuRelease)
+###            if (Decimal(ubuntuRelease) < Decimal('22.04')):
+###               log.info('Installing newer version of Meson the hard way')
+###               btUtils.abortOnRunFail(subprocess.run(['sudo', 'apt', 'remove', '-y', 'meson']))
+###               btUtils.abortOnRunFail(subprocess.run(['sudo', 'pip3', 'install', 'meson']))
 
       #-----------------------------------------------------------------------------------------------------------------
       #--------------------------------------------- Windows Dependencies ----------------------------------------------

--- a/src/AncestorDialog.cpp
+++ b/src/AncestorDialog.cpp
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * AncestorDialog.cpp is part of Brewtarget, and is copyright the following authors 2021-2023:
+ * AncestorDialog.cpp is part of Brewtarget, and is copyright the following authors 2021-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *   • Mik Firestone <mikfire@fastmail.com>
  *
@@ -18,9 +18,9 @@
 
 #include <algorithm>
 
+#include <QAction>
 #include <QDebug>
 #include <QtCore/QVariant>
-#include <QtWidgets/QAction>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QButtonGroup>
 #include <QtWidgets/QComboBox>

--- a/src/AncestorDialog.h
+++ b/src/AncestorDialog.h
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * AncestorDialog.h is part of Brewtarget, and is copyright the following authors 2021-2023:
+ * AncestorDialog.h is part of Brewtarget, and is copyright the following authors 2021-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *   • Mik Firestone <mikfire@fastmail.com>
  *
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <QtCore/QVariant>
-#include <QtWidgets/QAction>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QButtonGroup>
 #include <QtWidgets/QComboBox>

--- a/src/BtTabWidget.cpp
+++ b/src/BtTabWidget.cpp
@@ -23,12 +23,8 @@
 #include "trees/TreeNode.h"
 #include "database/ObjectStoreWrapper.h"
 #include "model/Equipment.h"
-#include "model/Fermentable.h"
-#include "model/Hop.h"
-#include "model/Misc.h"
 #include "model/Recipe.h"
 #include "model/Style.h"
-#include "model/Yeast.h"
 
 
 //! \brief set up the popup window.

--- a/src/BtTabWidget.h
+++ b/src/BtTabWidget.h
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * BtTabWidget.h is part of Brewtarget, and is copyright the following authors 2009-2022:
+ * BtTabWidget.h is part of Brewtarget, and is copyright the following authors 2009-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *   • Mik Firestone <mikfire@gmail.com>
  *   • Philip Greggory Lee <rocketman768@gmail.com>
@@ -21,13 +21,14 @@
 
 #include <QTabWidget>
 
+#include "model/Fermentable.h"
+#include "model/Hop.h"
+#include "model/Misc.h"
+#include "model/Yeast.h"
+
 class Equipment;
-class Fermentable;
-class Hop;
-class Misc;
 class Recipe;
 class Style;
-class Yeast;
 
 /*!
  * \class BtTabWdiget

--- a/src/Localization.cpp
+++ b/src/Localization.cpp
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * Localization.cpp is part of Brewtarget, and is copyright the following authors 2011-2023:
+ * Localization.cpp is part of Brewtarget, and is copyright the following authors 2011-2024:
  *   • Greg Meess <Daedalus12@gmail.com>
  *   • Matt Young <mfsy@yahoo.com>
  *   • Mik Firestone <mikfire@gmail.com>
@@ -25,6 +25,7 @@
 #include <QDir>
 #include <QLibraryInfo>
 #include <QLocale>
+#include <QRegularExpression>
 #include <QTranslator>
 
 #include "Application.h"
@@ -150,15 +151,16 @@ QString const & Localization::getSystemLanguage() {
 }
 
 bool Localization::hasUnits(QString qstr) {
-   QString decimal = QRegExp::escape(Localization::getLocale().decimalPoint());
-   QString grouping = QRegExp::escape(Localization::getLocale().groupSeparator());
+   QString decimal = QRegularExpression::escape(Localization::getLocale().decimalPoint());
+   QString grouping = QRegularExpression::escape(Localization::getLocale().groupSeparator());
 
-   QRegExp amtUnit("((?:\\d+" + grouping + ")?\\d+(?:" + decimal + "\\d+)?|" + decimal + "\\d+)\\s*(\\w+)?");
-   amtUnit.indexIn(qstr);
+   QRegularExpression amtUnit("((?:\\d+" + grouping + ")?\\d+(?:" + decimal + "\\d+)?|" + decimal + "\\d+)\\s*(\\w+)?");
+   QRegularExpressionMatch match = amtUnit.match(qstr);
 
-   bool result = amtUnit.cap(2).size() > 0;
-
-   qDebug() << Q_FUNC_INFO << qstr << (result ? "has" : "does not have") << "units";
+   // We could use hasCaptured here, but for debugging it's helpful to be able to show what we matched.
+   QString const units = match.captured(2);
+   bool const result = units.size() > 0;
+   qDebug() << Q_FUNC_INFO << qstr << (result ? "has" : "does not have") << "units:" << units;
 
    return result;
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -44,7 +44,6 @@
 
 #include <QAction>
 #include <QBrush>
-#include <QDesktopWidget>
 #include <QFile>
 #include <QFileDialog>
 #include <QIcon>
@@ -57,6 +56,7 @@
 #include <QMessageBox>
 #include <QPen>
 #include <QPixmap>
+#include <QScreen>
 #include <QSize>
 #include <QString>
 #include <QTextStream>
@@ -1276,13 +1276,14 @@ void MainWindow::restoreSavedState() {
       restoreState(PersistentSettings::value(PersistentSettings::Names::windowState).toByteArray());
    } else {
       // otherwise, guess a reasonable size at 1/4 of the screen.
-      QDesktopWidget *desktop = QApplication::desktop();
-      int width = desktop->width();
-      int height = desktop->height();
+      QScreen * screen = this->screen();
+      QRect const desktop = screen->availableGeometry();
+      int const width = desktop.width();
+      int const height = desktop.height();
       this->resize(width/2,height/2);
 
       // Or we could do the same in one line:
-      // this->resize(QDesktopWidget().availableGeometry(this).size() * 0.5);
+      // this->resize(this->screen().availableGeometry().size() * 0.5);
    }
 
    // If we saved the selected recipe name the last time we ran, select it and show it.

--- a/src/RadarChart.h
+++ b/src/RadarChart.h
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * RadarChart.h is part of Brewtarget, and is copyright the following authors 2021-2023:
+ * RadarChart.h is part of Brewtarget, and is copyright the following authors 2021-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
@@ -23,6 +23,7 @@
 #include <QString>
 #include <QVector>
 
+#include "model/NamedEntity.h"
 #include "utils/BtStringConst.h"
 
 /**
@@ -67,7 +68,10 @@ public:
     * @param color  Color in which to plot the series
     * @param values  The object whose properties are to be plotted for this series
     */
-   void addSeries(QString name, QColor color, QObject const & object);
+   void addSeries(QString name, QColor color, NamedEntity const & object);
+
+   //! \brief Remove the named series if present
+   void removeSeries(QString name);
 
    /**
     * @brief (Re)plot the graph.  Call this when there's a change to a property on an object being plotted, so that the

--- a/src/RangedSlider.cpp
+++ b/src/RangedSlider.cpp
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * RangedSlider.cpp is part of Brewtarget, and is copyright the following authors 2009-2022:
+ * RangedSlider.cpp is part of Brewtarget, and is copyright the following authors 2009-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *   • Mik Firestone <mikfire@gmail.com>
  *   • Philip Greggory Lee <rocketman768@gmail.com>
@@ -16,6 +16,8 @@
  * <http://www.gnu.org/licenses/>.
  ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌*/
 #include "RangedSlider.h"
+
+#include <algorithm>
 
 #include <QApplication>
 #include <QColor>
@@ -34,35 +36,35 @@
 
 RangedSlider::RangedSlider(QWidget* parent)
    : QWidget(parent),
-     _min(0.0),
-     _max(1.0),
-     _prefMin(0.25),
-     _prefMax(0.75),
-     _val(0.5),
-     _valText("0.500"),
-     _prec(3),
-     _tickInterval(0),
-     _secondaryTicks(1),
-     _tooltipText(""),
-     _bgBrush(QColor(255,255,255)),
-     _prefRangeBrush(QColor(0,0,0)),
-     _prefRangePen(Qt::NoPen),
-     _markerBrush(QColor(255,255,255)),
-     _markerTextIsValue(false),
-     valueTextFont("Arial",
-                   14,             // QFonts are specified in point size, so the hard-coded number is fine here.
-                   QFont::Black),  // Note that QFont::Black is a weight (more bold than ExtraBold), not a colour.
-     indicatorTextFont("Arial",
-                       10,
-                       QFont::Normal) // Previously we just did the indicator text in 'default' font
+     m_min(0.0),
+     m_max(1.0),
+     m_prefMin(0.25),
+     m_prefMax(0.75),
+     m_val(0.5),
+     m_valText("0.500"),
+     m_prec(3),
+     m_tickInterval(0),
+     m_secondaryTicks(1),
+     m_tooltipText(""),
+     m_bgBrush(QColor(255,255,255)),
+     m_prefRangeBrush(QColor(0,0,0)),
+     m_prefRangePen(Qt::NoPen),
+     m_markerBrush(QColor(255,255,255)),
+     m_markerTextIsValue(false),
+     m_valueTextFont("Arial",
+                     14,             // QFonts are specified in point size, so the hard-coded number is fine here.
+                     QFont::Black),  // Note that QFont::Black is a weight (more bold than ExtraBold), not a colour.
+     m_indicatorTextFont("Arial",
+                         10,
+                         QFont::Normal) // Previously we just did the indicator text in 'default' font
 {
-   // Ensure this->heightInPixels is properly initialised
+   // Ensure this->m_heightInPixels is properly initialised
    this->recalculateHeightInPixels();
 
    // In principle we want to set our min/max sizes etc here.  However, if, say, a maximumSize property has been set
    // for this object in a Designer UI File (eg ui/mainWindow.ui) then that setting will override this one, because it
    // will be applied later (in fact pretty much straight after this constructor returns).  So we also make this call
-   // inside setValue(), which will be invoked _after_ the setter calls that were auto-generated from the Designer UI
+   // inside setValue(), which will be invoked m_afterm_ the setter calls that were auto-generated from the Designer UI
    // File.
    this->setSizes();
 
@@ -70,42 +72,44 @@ RangedSlider::RangedSlider(QWidget* parent)
    this->setMouseTracking(true);
 
    this->repaint();
+   return;
 }
 
-void RangedSlider::setPreferredRange( double min, double max )
-{
-   _prefMin = min;
-   _prefMax = max;
+double RangedSlider::value() const { return m_val; }
+
+void RangedSlider::setPreferredRange(double min, double max) {
+   m_prefMin = min;
+   m_prefMax = max;
 
    // Only show tooltips if the range has nonzero size.
    setMouseTracking(min < max);
 
-   _tooltipText = QString("%1 - %2").arg(min, 0, 'f', _prec).arg(max, 0, 'f', _prec);
+   m_tooltipText = QString("%1 - %2").arg(min, 0, 'f', m_prec).arg(max, 0, 'f', m_prec);
 
    update();
+   return;
 }
 
-void RangedSlider::setPreferredRange(QPair<double,double> minmax)
-{
+void RangedSlider::setPreferredRange(QPair<double,double> minmax) {
    setPreferredRange( minmax.first, minmax.second );
+   return;
 }
 
-void RangedSlider::setRange( double min, double max )
-{
-   _min = min;
-   _max = max;
+void RangedSlider::setRange(double min, double max) {
+   m_min = min;
+   m_max = max;
    update();
+   return;
 }
 
-void RangedSlider::setRange(QPair<double,double> minmax)
-{
+void RangedSlider::setRange(QPair<double,double> minmax) {
    setRange( minmax.first, minmax.second );
+   return;
 }
 
-void RangedSlider::setValue(double value)
-{
-   _val = value;
-   _valText = QString("%1").arg(_val, 0, 'f', _prec);
+void RangedSlider::setValue(double value) {
+   m_val = value;
+   m_valText = QString("%1").arg(m_val, 0, 'f', m_prec);
    update();
 
    // See comment in constructor for why we call this here
@@ -113,54 +117,54 @@ void RangedSlider::setValue(double value)
    return;
 }
 
-void RangedSlider::setPrecision(int precision)
-{
-   _prec = precision;
+void RangedSlider::setPrecision(int precision) {
+   m_prec = precision;
    update();
+   return;
 }
 
-void RangedSlider::setBackgroundBrush( QBrush const& brush )
-{
-   _bgBrush = brush;
+void RangedSlider::setBackgroundBrush(QBrush const & brush) {
+   m_bgBrush = brush;
    update();
+   return;
 }
 
-void RangedSlider::setPreferredRangeBrush( QBrush const& brush )
-{
-   _prefRangeBrush = brush;
+void RangedSlider::setPreferredRangeBrush(QBrush const & brush) {
+   m_prefRangeBrush = brush;
    update();
+   return;
 }
 
-void RangedSlider::setPreferredRangePen( QPen const& pen )
-{
-   _prefRangePen = pen;
+void RangedSlider::setPreferredRangePen(QPen const & pen) {
+   m_prefRangePen = pen;
    update();
+   return;
 }
 
-void RangedSlider::setMarkerBrush( QBrush const& brush )
-{
-   _markerBrush = brush;
+void RangedSlider::setMarkerBrush(QBrush const & brush) {
+   m_markerBrush = brush;
    update();
+   return;
 }
 
-void RangedSlider::setMarkerText( QString const& text )
-{
-   _markerText = text;
+void RangedSlider::setMarkerText(QString const & text) {
+   m_markerText = text;
    update();
+   return;
 }
 
-void RangedSlider::setMarkerTextIsValue(bool val)
-{
-   _markerTextIsValue = val;
+void RangedSlider::setMarkerTextIsValue(bool val) {
+   m_markerTextIsValue = val;
    update();
+   return;
 }
 
-void RangedSlider::setTickMarks( double primaryInterval, int secondaryTicks )
-{
-   _secondaryTicks = (secondaryTicks<1)? 1 : secondaryTicks;
-   _tickInterval = primaryInterval/_secondaryTicks;
+void RangedSlider::setTickMarks(double primaryInterval, int secondaryTicks) {
+   m_secondaryTicks = (secondaryTicks<1)? 1 : secondaryTicks;
+   m_tickInterval = primaryInterval/m_secondaryTicks;
 
    update();
+   return;
 }
 
 void RangedSlider::recalculateHeightInPixels() const {
@@ -207,16 +211,16 @@ void RangedSlider::recalculateHeightInPixels() const {
    // assumptions about space below the baseline are locale-specific, so, say, using ascent() instead of lineSpacing()
    // could end up painting us into a corner.
    //
-   QFontMetrics indicatorTextFontMetrics(this->indicatorTextFont);
-   QFontMetrics valueTextFontMetrics(this->valueTextFont);
-   this->heightInPixels = indicatorTextFontMetrics.lineSpacing() + valueTextFontMetrics.lineSpacing();
+   QFontMetrics indicatorTextFontMetrics(this->m_indicatorTextFont);
+   QFontMetrics valueTextFontMetrics(this->m_valueTextFont);
+   this->m_heightInPixels = indicatorTextFontMetrics.lineSpacing() + valueTextFontMetrics.lineSpacing();
    return;
 }
 
 void RangedSlider::setSizes() {
    // Caller's responsibility to have recently called this->recalculateHeightInPixels().  (See comment in that function
    // for how we choose minimum width.)
-   this->setMinimumSize(2 * this->heightInPixels, this->heightInPixels);
+   this->setMinimumSize(2 * this->m_heightInPixels, this->m_heightInPixels);
 
    this->setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Fixed );
 
@@ -227,58 +231,68 @@ void RangedSlider::setSizes() {
    return;
 }
 
-QSize RangedSlider::sizeHint() const
-{
+QSize RangedSlider::sizeHint() const {
    this->recalculateHeightInPixels();
-   return QSize(4 * this->heightInPixels, this->heightInPixels);
+   return QSize(4 * this->m_heightInPixels, this->m_heightInPixels);
 }
 
-void RangedSlider::mouseMoveEvent(QMouseEvent* event)
-{
+void RangedSlider::mouseMoveEvent(QMouseEvent* event) {
    event->accept();
 
    QPoint tipPoint( mapToGlobal(QPoint(0,0)) );
-   QToolTip::showText( tipPoint, _tooltipText, this );
+   QToolTip::showText( tipPoint, m_tooltipText, this );
+   return;
 }
 
 void RangedSlider::paintEvent([[maybe_unused]] QPaintEvent * event) {
    //
    // Simplistically, the high-level layout of the slider is:
    //
-   //    |-------------------------------------------------------------|
-   //    |                   Indicator text               | B L A N K  |
-   //    |------------------------------------------------+------------|
-   //    | <--------------- Graphical Area -------------> | Value text |
-   //    |-------------------------------------------------------------|
+   //    ╔════════════════════════════════════════════════════════════════╗
+   //    ║                  Indicator text                   ┊ B L A N K  ║
+   //    ║┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈║
+   //    ║ ╭────────────────┲━━━━━━━━━━━━━━━━━━━━┱─────────╮ ┊            ║
+   //    ║ │                ┃            ┋       ┃         │ ┊ Value text ║
+   //    ║ ╰────────────────┺━━━━━━━━━━━━━━━━━━━━┹─────────╯ ┊            ║
+   //    ║ <---------------- Graphical Area ---------------> ┊            ║
+   //    ╚════════════════════════════════════════════════════════════════╝
+   //      ↑                ↑            ↑       ↑         ↑
+   //      m_min            m_prefMin    m_val   m_prefMax m_max
+   //      │                │            │       │         │
+   //      0.0              fgRectLeft   │       │         graphicalAreaWidth
+   //                                    │       │
+   //                                    │       fgRectLeft + fgRectWidth
+   //                                    │
+   //                                    indicatorLineMiddle
    //
    // The graphical area has:
-   //  - a background rectangle of the full width of the area, representing the range from this->_min to this->_max
-   //  - a foreground rectangle showing the sub-range of this background from this->_prefMin to this->_prefMax
-   //  - a line ("the indicator") showing where this->_val lies in the (this->_min to this->_max) range
+   //  - a background rectangle of the full width of the area, representing the range from this->m_min to this->m_max
+   //  - a foreground rectangle showing the sub-range of this background from this->m_prefMin to this->m_prefMax
+   //  - a line ("the indicator") showing where this->m_val lies in the (this->m_min to this->m_max) range
    //
-   // The indicator text sits above the indicator line and shows either its value (this->_valText) or some textual
-   // description (eg "Slightly Malty" on the IBU/GU scale) which comes from this->_markerText.
+   // The indicator text sits above the indicator line and shows either its value (this->m_valText) or some textual
+   // description (eg "Slightly Malty" on the IBU/GU scale) which comes from this->m_markerText.
    //
    // In principle, we could have the value text a slightly different height than the graphical area - eg to help
    // squeeze into smaller available vertical space on small screens (as we know there is blank space of
    // indicatorTextHeight pixels above the space for the value text).
    //
-   // The value text also shows this->_valText.
+   // The value text also shows this->m_valText.
    //
 
-   QFontMetrics indicatorTextFontMetrics(this->indicatorTextFont);
+   QFontMetrics indicatorTextFontMetrics(this->m_indicatorTextFont);
    int indicatorTextHeight = indicatorTextFontMetrics.lineSpacing();
 
    // The heights of the slider graphic and the value text are usually the same, but we calculate them differently in
    // case, in future, we want to squeeze things up a bit.
-   QFontMetrics valueTextFontMetrics(this->valueTextFont);
-   int valueTextHeight = valueTextFontMetrics.lineSpacing();
+   QFontMetrics valueTextFontMetrics(this->m_valueTextFont);
+   int const valueTextHeight = valueTextFontMetrics.lineSpacing();
 
-   int graphicalAreaHeight = this->height() - indicatorTextHeight;
+   int const graphicalAreaHeight = this->height() - indicatorTextHeight;
 
    // Although the Qt calls take an x- and a y- radius, we want the radius on the rectangle corners to be the same
    // vertically and horizontally, so only define one measure here.
-   int rectangleCornerRadius = graphicalAreaHeight / 4;
+   int const rectangleCornerRadius = graphicalAreaHeight / 4;
 
    static const QPalette palette(QApplication::palette());
    static const int indicatorLineWidth   = 4;
@@ -287,23 +301,17 @@ void RangedSlider::paintEvent([[maybe_unused]] QPaintEvent * event) {
    static const QColor valueTextColor(0,127,0);
 
    // We need to allow for the width of the text that displays to the right of the slider showing the current value.
-   // If there were just one slider, we might ask Qt for the width of this text with one of the following calls:
-   //    const int valueTextWidth = valueTextFontMetrics.width(_valText);              // Pre Qt 5.13
-   //    const int valueTextWidth = valueTextFontMetrics.horizontalAdvance(_valText);  // Since Qt 5.13
+   // If there were just one slider, we might ask Qt for the width of this text with the following call:
+   //    const int valueTextWidth = valueTextFontMetrics.horizontalAdvance(m_valText);  // Since Qt 5.13
    // However, we want all the sliders to have exact same width, so we choose some representative text to measure the
    // width of.  We assume that all sliders show no more than 4 digits and a decimal point, and then add a space to
    // ensure a gap between the value text and the graphical area.  (Note that digits are all the same width in the font
    // we are using.
-   int valueTextWidth =
-#if QT_VERSION < QT_VERSION_CHECK(5,13,0)
-      valueTextFontMetrics.width(" 1.000");
-#else
-      valueTextFontMetrics.horizontalAdvance(" 1.000");
-#endif
+   int valueTextWidth = valueTextFontMetrics.horizontalAdvance(" 1.000");
 
-   QLinearGradient glassGrad( QPointF(0,0), QPointF(0,graphicalAreaHeight) );
-   glassGrad.setColorAt( 0, QColor(255,255,255,127) );
-   glassGrad.setColorAt( 1, QColor(255,255,255,0) );
+   QLinearGradient glassGrad( QPointF(0, 0), QPointF(0, graphicalAreaHeight) );
+   glassGrad.setColorAt(0, QColor(255, 255, 255, 127));
+   glassGrad.setColorAt(1, QColor(255, 255, 255,   0));
    QBrush glassBrush(glassGrad);
 
    // Per https://doc.qt.io/qt-5/highdpi.html, for best High DPI display support, we need to:
@@ -312,51 +320,78 @@ void RangedSlider::paintEvent([[maybe_unused]] QPaintEvent * event) {
    //  • Replace hard-coded sizes in layouts and drawing code with values calculated from font metrics or screen size
    QPainter painter(this);
 
-   // Work out the left-to-right (ie x-coordinate) positions of things in the graphical area
-   double graphicalAreaWidth  = this->width() - valueTextWidth;
-   double range               = this->_max - this->_min;
-   double fgRectLeft          = graphicalAreaWidth * ((this->_prefMin - this->_min    )/range);
-   double fgRectWidth         = graphicalAreaWidth * ((this->_prefMax - this->_prefMin)/range);
-   double indicatorLineMiddle = graphicalAreaWidth * ((this->_val     - this->_min    )/range);
-   double indicatorLineLeft   = indicatorLineMiddle - (indicatorLineWidth / 2);
+   // Usually leave this debug log commented out unless trouble-shooting as it generates a lot of logging
+//   qDebug() <<
+//      Q_FUNC_INFO << "Width:" << this->width() << "; valueTextWidth:" << valueTextWidth << "; m_min:" << this->m_min <<
+//      "; m_max:" << this->m_max << "; m_prefMin:" << this->m_prefMin << "; m_prefMax:" << this->m_prefMax <<
+//      "; m_val" << this->m_val;
 
+   //
+   // Work out the left-to-right (ie x-coordinate) positions of things in the graphical area.  Note that we have to
+   // gracefully handle extreme cases -- eg where we do not have enough space to paint ourselves.  In particular, we
+   // have to be careful about using calculated values as the min and/or max parameters to qBound, because that function
+   // (quite reasonably) asserts at runtime that min < max, and it's easy to break that if you're doing simple
+   // calculations for how to draw the graphical area when there isn't really enough space to draw it.
+   //
+   double const graphicalAreaWidth  = static_cast<double>(std::max(0, this->width() - valueTextWidth));
+   double const range               = this->m_max - this->m_min;
+   double fgRectLeft          = std::max(0.0, graphicalAreaWidth * ((this->m_prefMin - this->m_min    )/range));
+   double fgRectWidth         = std::max(0.0, graphicalAreaWidth * ((this->m_prefMax - this->m_prefMin)/range));
+   double indicatorLineMiddle = std::max(0.0, graphicalAreaWidth * ((this->m_val     - this->m_min    )/range));
+   double indicatorLineLeft   = std::max(0.0, indicatorLineMiddle - (static_cast<double>(indicatorLineWidth) / 2.0));
+   // Usually leave this debug log commented out unless trouble-shooting as it generates a lot of logging
+//   qDebug() <<
+//      Q_FUNC_INFO << "graphicalAreaWidth:" << graphicalAreaWidth << "; range:" << range << "; fgRectLeft:" <<
+//      fgRectLeft << "; fgRectWidth:" << fgRectWidth << "; indicatorLineMiddle:" << indicatorLineMiddle <<
+//      "; indicatorLineLeft:" << indicatorLineLeft;
+
+   //
    // Make sure all coordinates are valid.
-   fgRectLeft          = qBound(0.0, fgRectLeft,          graphicalAreaWidth);
-   fgRectWidth         = qBound(0.0, fgRectWidth,         graphicalAreaWidth - fgRectLeft);
-   indicatorLineMiddle = qBound(0.0, indicatorLineMiddle, graphicalAreaWidth - (indicatorLineWidth / 2));
-   indicatorLineLeft   = qBound(0.0, indicatorLineLeft,   graphicalAreaWidth - indicatorLineWidth);
+   //
+   fgRectLeft          = std::min(fgRectLeft,          graphicalAreaWidth);
+   fgRectWidth         = std::max(0.0, std::min(fgRectWidth,         graphicalAreaWidth - fgRectLeft));
+   indicatorLineMiddle = std::max(0.0, std::min(indicatorLineMiddle, graphicalAreaWidth - (indicatorLineWidth / 2)));
+   indicatorLineLeft   = std::max(0.0, std::min(indicatorLineLeft,   graphicalAreaWidth - indicatorLineWidth));
 
    // The left-to-right position of the indicator text (also known as marker text) depends on where the slider is.
    // First we ask the painter what size rectangle it will need to display this text
    painter.setPen(indicatorTextColor);
-   painter.setFont(this->indicatorTextFont);
-   QRectF indicatorTextRect = painter.boundingRect(QRectF(),
-                                                   Qt::AlignCenter | Qt::AlignBottom,
-                                                   this->_markerTextIsValue ? this->_valText : this->_markerText);
+   painter.setFont(this->m_indicatorTextFont);
+   QRectF const indicatorTextRect =
+      painter.boundingRect(QRectF(),
+                           Qt::AlignCenter | Qt::AlignBottom,
+                           this->m_markerTextIsValue ? this->m_valText : this->m_markerText);
 
+   //
    // Then we use the size of this rectangle to try to make the middle of the text sit over the indicator marker on
    // the slider - but bounding things so that the text doesn't go off the edge of the slider.
-   double indicatorTextLeft = qBound(0.0,
-                                    indicatorLineMiddle - (indicatorTextRect.width() / 2),
-                                    graphicalAreaWidth - indicatorTextRect.width());
+   //
+   // This is a more robust way of writing
+   //
+   //    double indicatorTextLeft = qBound(0.0,
+   //                                     indicatorLineMiddle - (indicatorTextRect.width() / 2),
+   //                                     graphicalAreaWidth - indicatorTextRect.width());
+   //
+   double indicatorTextLeft = std::max(0.0, indicatorLineMiddle - (indicatorTextRect.width() / 2));
+   indicatorTextLeft = std::max(0.0, std::min(indicatorTextLeft, graphicalAreaWidth - indicatorTextRect.width()));
 
    // Now we can draw the indicator text
    painter.drawText(
       indicatorTextLeft, 0,
       indicatorTextRect.width(), indicatorTextRect.height(),
       Qt::AlignCenter | Qt::AlignBottom,
-      this->_markerTextIsValue ? this->_valText : this->_markerText
+      this->m_markerTextIsValue ? this->m_valText : this->m_markerText
    );
 
    // Next draw the value text
    // We work out its vertical position relative to the bottom of the graphical area in case (in future) we want to be
    // able to use some of the blank space above it (to the right of the indicator text).
    painter.setPen(valueTextColor);
-   painter.setFont(this->valueTextFont);
+   painter.setFont(this->m_valueTextFont);
    painter.drawText(graphicalAreaWidth, this->height() - valueTextHeight,
                     valueTextWidth, valueTextHeight,
                     Qt::AlignRight | Qt::AlignVCenter,
-                    this->_valText );
+                    this->m_valText );
 
    // All the rest of what we need to do is inside the graphical area, so move the origin to the top-left corner of it
    painter.translate(0, indicatorTextRect.height());
@@ -370,7 +405,7 @@ void RangedSlider::paintEvent([[maybe_unused]] QPaintEvent * event) {
    painter.setClipPath(clipRect);
 
    // Draw the background rectangle.
-   painter.setBrush(_bgBrush);
+   painter.setBrush(m_bgBrush);
    painter.setRenderHint(QPainter::Antialiasing);
    painter.drawRoundedRect( QRectF(0, 0, graphicalAreaWidth, graphicalAreaHeight),
                             rectangleCornerRadius,
@@ -379,8 +414,8 @@ void RangedSlider::paintEvent([[maybe_unused]] QPaintEvent * event) {
 
    // Draw the style "foreground" rectangle.
    painter.save();
-      painter.setBrush(_prefRangeBrush);
-      painter.setPen(_prefRangePen);
+      painter.setBrush(m_prefRangeBrush);
+      painter.setPen(m_prefRangePen);
       painter.setRenderHint(QPainter::Antialiasing);
       painter.drawRoundedRect( QRectF(fgRectLeft, 0, fgRectWidth, graphicalAreaHeight),
                                rectangleCornerRadius,
@@ -388,7 +423,7 @@ void RangedSlider::paintEvent([[maybe_unused]] QPaintEvent * event) {
    painter.restore();
 
    // Draw the indicator.
-   painter.setBrush(_markerBrush);
+   painter.setBrush(m_markerBrush);
    painter.drawRect( QRectF(indicatorLineLeft, 0, indicatorLineWidth, graphicalAreaHeight) );
 
    // Draw a white-to-clear gradient to suggest "glassy."
@@ -401,13 +436,13 @@ void RangedSlider::paintEvent([[maybe_unused]] QPaintEvent * event) {
 
    // Draw the ticks.
    painter.setPen(Qt::black);
-   if( _tickInterval > 0.0 )
+   if( m_tickInterval > 0.0 )
    {
       int secTick = 1;
-      for( double currentTick = _min+_tickInterval; _max - currentTick > _tickInterval-1e-6; currentTick += _tickInterval )
+      for( double currentTick = m_min+m_tickInterval; m_max - currentTick > m_tickInterval-1e-6; currentTick += m_tickInterval )
       {
-         painter.translate( graphicalAreaWidth/(_max-_min) * _tickInterval, 0);
-         if( secTick == _secondaryTicks )
+         painter.translate( graphicalAreaWidth/(m_max-m_min) * m_tickInterval, 0);
+         if( secTick == m_secondaryTicks )
          {
             painter.drawLine( QPointF(0,0.25*graphicalAreaHeight), QPointF(0,0.75*graphicalAreaHeight) );
             secTick = 1;

--- a/src/RangedSlider.h
+++ b/src/RangedSlider.h
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * RangedSlider.h is part of Brewtarget, and is copyright the following authors 2009-2020:
+ * RangedSlider.h is part of Brewtarget, and is copyright the following authors 2009-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *   • Mik Firestone <mikfire@gmail.com>
  *   • Philip Greggory Lee <rocketman768@gmail.com>
@@ -24,23 +24,22 @@
 #include <QString>
 #include <QBrush>
 #include <QPen>
+
 class QPaintEvent;
 class QMouseEvent;
 
 /*!
  * \brief Widget to display a number with an optional range on a type of read-only slider.
- *
  */
-class RangedSlider : public QWidget
-{
+class RangedSlider : public QWidget {
    Q_OBJECT
 
 public:
-   RangedSlider(QWidget* parent=0);
+   RangedSlider(QWidget * parent = nullptr);
 
-   Q_PROPERTY( double value READ value WRITE setValue )
+   Q_PROPERTY(double value READ value WRITE setValue )
 
-   double value() const { return _val; }
+   double value() const;
 
    //! \brief Set the background brush for the widget.
    void setBackgroundBrush( QBrush const& brush );
@@ -82,7 +81,7 @@ public slots:
     * \param range \c range.first and \c range.second are the min and max
     *        values for the preferred range resp.
     */
-   void setPreferredRange(QPair<double,double> range);
+   void setPreferredRange(QPair<double, double> range);
 
    /*!
     * \brief Set the range of values that the widget displays
@@ -90,14 +89,14 @@ public slots:
     * \param range \c range.first and \c range.second are the min and max
     *        values for the preferred range resp.
     */
-   void setRange(QPair<double,double> range);
+   void setRange(QPair<double, double> range);
 
    //! \brief Convenience method for setting the widget range
-   void setRange( double min, double max );
+   void setRange(double min, double max);
 
    //! \brief Convenience method for setting the preferred range
    //         Note that this is completely unrelated to "preferred size".
-   void setPreferredRange( double min, double max );
+   void setPreferredRange(double min, double max);
 
 protected:
    //! \brief Reimplemented from QWidget.
@@ -114,47 +113,39 @@ private:
    void setSizes();
    void recalculateHeightInPixels() const;
 
-   /**
-    * Minimum value the widget displays
-    */
-   double _min;
-   /**
-    * Maximum value the widget displays
-    */
-   double _max;
+   //! Minimum value the widget displays
+   double  m_min;
+   //! Maximum value the widget displays
+   double  m_max;
 
-   /**
-    * Minimum value for the "best" sub-range
-    */
-   double _prefMin;
-   /**
-    * Maximum value for the "best" sub-range
-    */
-   double _prefMax;
-   double _val;
-   QString _valText;
-   QString _markerText;
-   int _prec;
-   double _tickInterval;
-   int _secondaryTicks;
-   QString _tooltipText;
-   QBrush _bgBrush;
-   QBrush _prefRangeBrush;
-   QPen _prefRangePen;
-   QBrush _markerBrush;
-   bool _markerTextIsValue;
+   //! Minimum value for the "best" sub-range
+   double  m_prefMin;
+   //! Maximum value for the "best" sub-range
+   double  m_prefMax;
+   double  m_val;
+   QString m_valText;
+   QString m_markerText;
+   int     m_prec;
+   double  m_tickInterval;
+   int     m_secondaryTicks;
+   QString m_tooltipText;
+   QBrush  m_bgBrush;
+   QBrush  m_prefRangeBrush;
+   QPen    m_prefRangePen;
+   QBrush  m_markerBrush;
+   bool    m_markerTextIsValue;
 
    /**
     * The font used for showing the value at the right-hand side of the slider
     */
-   QFont const valueTextFont;
+   QFont const m_valueTextFont;
 
    /**
     * The font used for showing the indicator above the "needle" on the slider.  Often this is just showing the same as
     * the value - eg OG, FG, ABV - but sometimes it's something else - eg descriptive text such as "slightly hoppy" for
     * the IBU/GU reading.
     */
-   QFont const indicatorTextFont;
+   QFont const m_indicatorTextFont;
 
    /**
     * Since preferred and minimum dimensions are all based off a height we need to calculate based on the resolution of
@@ -162,7 +153,7 @@ private:
     * that height here.  However, its value is not really part of the current value/state of the object, hence mutable
     * (ie OK to change in a const function).
     */
-   mutable int heightInPixels;
+   mutable int m_heightInPixels;
 };
 
 #endif

--- a/src/RecipeFormatter.cpp
+++ b/src/RecipeFormatter.cpp
@@ -28,6 +28,7 @@
 #include <QObject>
 #include <QPrinter>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QTextBrowser>
 #include <QTextDocument>
@@ -1155,7 +1156,7 @@ QString RecipeFormatter::getBBCodeFormat() {
    }
 
    QString tmp = "";
-   QRegExp regexp("(^[^\n]*\n)(.*$)"); //Regexp to match the first line of tables
+   QRegularExpression const regexp("(^[^\n]*\n)(.*$)"); // Regexp to match the first line of tables
 
    auto style = this->pimpl->rec->style();
 

--- a/src/database/BtSqlQuery.h
+++ b/src/database/BtSqlQuery.h
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * database/BtSqlQuery.h is part of Brewtarget, and is copyright the following authors 2021:
+ * database/BtSqlQuery.h is part of Brewtarget, and is copyright the following authors 2021-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
@@ -50,8 +50,12 @@
  */
 class BtSqlQuery : public QSqlQuery {
 public:
-   // Use the same constructors as QSqlQuery
+   // Use the same constructors as QSqlQuery...
    using QSqlQuery::QSqlQuery;
+   // ...except that QSqlQuery copy constructor is deprecated (and, if you use it, you get a warning: "QSqlQuery is not
+   // meant to be copied. Use move construction instead.").  So, let's not do copy construction!
+   BtSqlQuery(BtSqlQuery const & other) = delete;
+   BtSqlQuery(QSqlQuery const & other) = delete;
 
    /**
     * \brief As \c QSqlQuery::prepare() except we don't actually call QSqlQuery::prepare() unless and until a value is
@@ -79,7 +83,8 @@ private:
 
    void reallyPrepare();
 
-
+   // This is deprecated in the base class
+   BtSqlQuery & operator=(BtSqlQuery const & other) = delete;
 };
 
 #endif

--- a/src/database/DatabaseSchemaHelper.cpp
+++ b/src/database/DatabaseSchemaHelper.cpp
@@ -102,7 +102,7 @@ namespace {
    // This is when we first defined the settings table, and defined the version as a string.
    // In the new world, this will create the settings table and define the version as an int.
    // Since we don't set the version until the very last step of the update, I think this will be fine.
-   bool migrate_to_202(Database & db, BtSqlQuery q) {
+   bool migrate_to_202(Database & db, BtSqlQuery & q) {
       bool ret = true;
 
       // Add "projected_ferm_points" to brewnote table
@@ -204,7 +204,7 @@ namespace {
       return executeSqlQueries(q, migrationQueries);
    }
 
-   bool migrate_to_5([[maybe_unused]] Database & db, BtSqlQuery q) {
+   bool migrate_to_5([[maybe_unused]] Database & db, BtSqlQuery & q) {
       QVector<QueryAndParameters> const migrationQueries{
          // Drop the previous bugged TRIGGER
          {QString("DROP TRIGGER dec_ins_num")},
@@ -221,12 +221,12 @@ namespace {
    }
 
    //
-   bool migrate_to_6([[maybe_unused]] Database & db, [[maybe_unused]] BtSqlQuery q) {
+   bool migrate_to_6([[maybe_unused]] Database & db, [[maybe_unused]] BtSqlQuery & q) {
       // I drop this table in version 8. There is no sense doing anything here, and it breaks other things.
       return true;
    }
 
-   bool migrate_to_7([[maybe_unused]] Database & db, BtSqlQuery q) {
+   bool migrate_to_7([[maybe_unused]] Database & db, BtSqlQuery & q) {
       QVector<QueryAndParameters> const migrationQueries{
          // Add "attenuation" to brewnote table
          {QString("ALTER TABLE brewnote ADD COLUMN attenuation %1").arg(db.getDbNativeTypeName<double>())} // Previously DEFAULT 0.0
@@ -234,7 +234,7 @@ namespace {
       return executeSqlQueries(q, migrationQueries);
    }
 
-   bool migrate_to_8(Database & db, BtSqlQuery q) {
+   bool migrate_to_8(Database & db, BtSqlQuery & q) {
       QString createTmpBrewnoteSql;
       QTextStream createTmpBrewnoteSqlStream(&createTmpBrewnoteSql);
       createTmpBrewnoteSqlStream <<
@@ -462,7 +462,7 @@ namespace {
 
    // To support the water chemistry, I need to add two columns to water and to
    // create the salt and salt_in_recipe tables
-   bool migrate_to_9(Database & db, BtSqlQuery q) {
+   bool migrate_to_9(Database & db, BtSqlQuery & q) {
       QString createSaltSql;
       QTextStream createSaltSqlStream(&createSaltSql);
       createSaltSqlStream <<
@@ -509,7 +509,7 @@ namespace {
       return executeSqlQueries(q, migrationQueries);
    }
 
-   bool migrate_to_10(Database & db, BtSqlQuery q) {
+   bool migrate_to_10(Database & db, BtSqlQuery & q) {
       QVector<QueryAndParameters> const migrationQueries{
          // DB-specific version of ALTER TABLE recipe ADD COLUMN ancestor_id INTEGER REFERENCES recipe(id)
          {QString(db.getSqlToAddColumnAsForeignKey()).arg("recipe",
@@ -534,7 +534,7 @@ namespace {
     *        names ending in "_pct" (for percent), "_l" (for liters), etc.  One day perhaps we'll rename all the
     *        relevant existing columns, but I think we've got enough other change in this update!
     */
-   bool migrate_to_11(Database & db, BtSqlQuery q) {
+   bool migrate_to_11(Database & db, BtSqlQuery & q) {
       //
       // Some of the bits of SQL would be too cumbersome to build up in-place inside the migrationQueries vector, so
       // we use string streams to do the string construction here.
@@ -2077,7 +2077,7 @@ namespace {
     * \brief This is not actually a schema change, but rather data fixes that were missed from migrate_to_11 - mostly
     *        things where we should have been less case-sensitive.
     */
-   bool migrate_to_12([[maybe_unused]] Database & db, BtSqlQuery q) {
+   bool migrate_to_12([[maybe_unused]] Database & db, BtSqlQuery & q) {
       QVector<QueryAndParameters> const migrationQueries{
          {QString(     "UPDATE hop SET htype = 'aroma/bittering' WHERE lower(htype) = 'both'"     )},
          {QString("     UPDATE fermentable SET ftype = 'dry extract' WHERE lower(ftype) = 'dry extract'")},
@@ -2108,7 +2108,7 @@ namespace {
     * \brief Small schema change to support measuring diameter of boil kettle for new IBU calculations.  Plus, some
     *        tidy-ups to Salt and Boil / BoilStep which we didn't get to before.
     */
-   bool migrate_to_13([[maybe_unused]] Database & db, BtSqlQuery q) {
+   bool migrate_to_13([[maybe_unused]] Database & db, BtSqlQuery & q) {
       QVector<QueryAndParameters> const migrationQueries{
          {QString("ALTER TABLE equipment  ADD COLUMN kettleInternalDiameter_cm %1").arg(db.getDbNativeTypeName<double>())},
          {QString("ALTER TABLE equipment  ADD COLUMN kettleOpeningDiameter_cm  %1").arg(db.getDbNativeTypeName<double>())},

--- a/src/database/ObjectStore.cpp
+++ b/src/database/ObjectStore.cpp
@@ -214,9 +214,12 @@ namespace {
       QString result;
       QTextStream resultAsStream{&result};
 
-      QMap<QString, QVariant> boundValueMap = sqlQuery.boundValues();
-      for (auto bv = boundValueMap.begin(); bv != boundValueMap.end(); ++bv) {
-         resultAsStream << bv.key() << ": " << bv.value().toString() << "\n";
+      // From Qt 6.6 we'll be able to write:
+      //    for (auto const & bvn : sqlQuery.boundValueNames()) {
+      //       resultAsStream << bvn << ": " << sqlQuery.boundValue(bvn).toString() << "\n";
+      //    }
+      for (auto const & bv : sqlQuery.boundValues()) {
+         resultAsStream << bv.toString() << "\n";
       }
 
       return result;
@@ -319,7 +322,7 @@ namespace {
       // Here and elsewhere, although we could just do a Q_ASSERT, we prefer (a) some extra diagnostics on debug builds
       // and (b) to bail out immediately of the DB transaction on non-debug builds.
       //
-      if (QVariant::Type::Int != primaryKey.type()) {
+      if (QMetaType::Type::Int != primaryKey.userType()) {
          qCritical() << Q_FUNC_INFO << "Unexpected contents of primaryKey QVariant: " << primaryKey.typeName();
          Q_ASSERT(false); // Stop here on debug builds
          return false;    // Continue but bail out of the current DB transaction on other builds
@@ -1561,7 +1564,7 @@ void ObjectStore::loadAll(Database * database) {
       }
       queryStringAsStream << ";";
 
-      sqlQuery = BtSqlQuery{connection};
+///      sqlQuery = BtSqlQuery{connection};
       sqlQuery.prepare(queryString);
       if (!sqlQuery.exec()) {
          qCritical() <<

--- a/src/editors/EditorBase.h
+++ b/src/editors/EditorBase.h
@@ -246,12 +246,16 @@ public:
    }
 
    //! \brief No-op version
-   void makeLiveEditItem() requires (!HasLiveEditItem<editorBaseOptions>) {
+   void setLiveEditItem() requires (!HasLiveEditItem<editorBaseOptions>) {
       return;
    }
 
-   void makeLiveEditItem() requires HasLiveEditItem<editorBaseOptions> {
-      this->m_liveEditItem = std::make_unique<NE>(*this->m_editItem);
+   void setLiveEditItem() requires HasLiveEditItem<editorBaseOptions> {
+      if (this->m_editItem) {
+         this->m_liveEditItem = std::make_unique<NE>(*this->m_editItem);
+      } else {
+         this->m_liveEditItem.reset();
+      }
       return;
    }
 
@@ -270,7 +274,7 @@ public:
          this->readFieldsFromEditItem(std::nullopt);
       }
 
-      this->makeLiveEditItem();
+      this->setLiveEditItem();
 
       // Comment below about calling this->derived().validateBeforeSave() also applies here
       this->derived().postSetEditItem();

--- a/src/editors/WaterEditor.cpp
+++ b/src/editors/WaterEditor.cpp
@@ -25,6 +25,11 @@
 #include "database/ObjectStoreWrapper.h"
 #include "model/Water.h"
 
+namespace {
+   auto const seriesNameCurrent {WaterEditor::tr("Current" )};
+   auto const seriesNameModified{WaterEditor::tr("Modified")};
+}
+
 WaterEditor::WaterEditor(QWidget *parent, QString const editorName) :
    QDialog(parent),
    EditorBase<WaterEditor, Water, WaterEditorOptions>(editorName) {
@@ -88,9 +93,13 @@ void WaterEditor::postSetEditItem() {
    if (this->m_editItem) {
       // Note that we don't need to remove the old series from any previous Water objects as the call to addSeries will
       // replace them.
-      this->waterEditRadarChart->addSeries(tr("Current"), Qt::darkGreen, *this->m_editItem);
+      this->waterEditRadarChart->addSeries(seriesNameCurrent, Qt::darkGreen, *this->m_editItem);
 
-      this->waterEditRadarChart->addSeries(tr("Modified"), Qt::green, *this->m_liveEditItem);
+      this->waterEditRadarChart->addSeries(seriesNameModified, Qt::green, *this->m_liveEditItem);
+      this->waterEditRadarChart->replot();
+   } else {
+      this->waterEditRadarChart->removeSeries(seriesNameCurrent );
+      this->waterEditRadarChart->removeSeries(seriesNameModified);
    }
    return;
 }

--- a/src/measurement/PhysicalQuantity.cpp
+++ b/src/measurement/PhysicalQuantity.cpp
@@ -225,7 +225,6 @@ std::vector<int> const & Measurement::allPossibilitiesAsInt(
    return allOfAsInt_Mass_Volume;
 }
 
-
 template<class S>
 S & operator<<(S & stream, Measurement::PhysicalQuantity const val) {
    stream <<

--- a/src/measurement/PhysicalQuantity.h
+++ b/src/measurement/PhysicalQuantity.h
@@ -297,7 +297,6 @@ namespace Measurement {
 
 }
 
-
 /**
  * \brief Convenience functions for logging
  */

--- a/src/measurement/UnitSystem.cpp
+++ b/src/measurement/UnitSystem.cpp
@@ -21,7 +21,6 @@
 
 #include <QApplication>
 #include <QDebug>
-#include <QRegExp>
 
 #include "Localization.h"
 #include "measurement/Unit.h"

--- a/src/model/NamedEntity.cpp
+++ b/src/model/NamedEntity.cpp
@@ -186,14 +186,14 @@ void NamedEntity::makeChild(NamedEntity const & copiedFrom) {
    return;
 }
 
-QRegExp const & NamedEntity::getDuplicateNameNumberMatcher() {
+QRegularExpression const & NamedEntity::getDuplicateNameNumberMatcher() {
    //
    // Note that, in the regexp, to match a bracket, we need to escape it, thus "\(" instead of "(".  However, we
    // must also escape the backslash so that the C++ compiler doesn't think we want a special character (such as
    // '\n') and barf a "unknown escape sequence" warning at us.  So "\\(" is needed in the string literal here to
    // pass "\(" to the regexp to match literal "(" (and similarly for close bracket).
    //
-   static QRegExp const duplicateNameNumberMatcher{" *\\(([0-9]+)\\)$"};
+   static QRegularExpression const duplicateNameNumberMatcher{" *\\(([0-9]+)\\)$"};
    return duplicateNameNumberMatcher;
 }
 
@@ -226,13 +226,13 @@ bool NamedEntity::operator==(NamedEntity const & other) const {
       // "Tettnang" and another called "Tettnang (1)" we wouldn't say they are different just because of the names.
       // So we want to strip off any number in brackets at the ends of the names and then compare again.
       //
-      QRegExp const & duplicateNameNumberMatcher = NamedEntity::getDuplicateNameNumberMatcher();
+      QRegularExpression const & duplicateNameNumberMatcher = NamedEntity::getDuplicateNameNumberMatcher();
       QString names[2] {this->m_name, other.m_name};
       for (auto ii = 0; ii < 2; ++ii) {
-         int positionOfMatch = duplicateNameNumberMatcher.indexIn(names[ii]);
-         if (positionOfMatch > -1) {
+         QRegularExpressionMatch match = duplicateNameNumberMatcher.match(names[ii]);
+         if (match.hasMatch()) {
             // There's some integer in brackets at the end of the name.  Chop it off.
-            names[ii].truncate(positionOfMatch);
+            names[ii].truncate(match.capturedStart(1));
          }
       }
 //      qDebug() << Q_FUNC_INFO << "Adjusted names to " << names[0] << " & " << names[1];

--- a/src/model/NamedEntity.h
+++ b/src/model/NamedEntity.h
@@ -31,6 +31,7 @@
 #include <QList>
 #include <QMetaProperty>
 #include <QObject>
+#include <QRegularExpression>
 #include <QVariant>
 
 #include "model/FolderBase.h"
@@ -255,7 +256,7 @@ public:
     * \brief Returns a regexp that will match the " (n)" (for n some positive integer) added on the end of a name to
     *        prevent name clashes.  It will also "capture" n to allow you to extract it.
     */
-   static QRegExp const & getDuplicateNameNumberMatcher();
+   static QRegularExpression const & getDuplicateNameNumberMatcher();
 
    void setName(QString const & var);
    void setDeleted(bool const var);

--- a/src/model/Recipe.h
+++ b/src/model/Recipe.h
@@ -39,7 +39,9 @@
 #include "database/ObjectStoreWrapper.h"
 #include "model/BrewNote.h"
 #include "model/FolderBase.h"
+#include "model/Instruction.h"
 #include "model/NamedEntity.h"
+#include "model/Salt.h"
 
 //======================================================================================================================
 //========================================== Start of property name constants ==========================================
@@ -115,7 +117,6 @@ AddPropertyName(yeastAdditions         )
 //=========================================== End of property name constants ===========================================
 //======================================================================================================================
 
-
 // Forward declarations
 class Boil;
 class BoilStep;
@@ -132,7 +133,6 @@ class RecipeAdditionMisc;
 class RecipeAdjustmentSalt;
 class RecipeAdditionYeast;
 class RecipeUseOfWater;
-class Salt;
 class Style;
 class Water;
 class Yeast;

--- a/src/serialization/SerializationRecord.cpp
+++ b/src/serialization/SerializationRecord.cpp
@@ -15,6 +15,7 @@
  ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌*/
 #include "serialization/SerializationRecord.h"
 
+#include <QRegularExpression>
 
 SerializationRecord::SerializationRecord() :
    m_namedParameterBundle{NamedParameterBundle::OperationMode::NotStrict},
@@ -85,13 +86,13 @@ void SerializationRecord::modifyClashingName(QString & candidateName) {
    // space(s) preceding the left bracket.  If so, we want to replace this with " (n+1)".  If not, we try " (1)".
    //
    int duplicateNumber = 1;
-   QRegExp const & nameNumberMatcher = NamedEntity::getDuplicateNameNumberMatcher();
-   int positionOfMatch = nameNumberMatcher.indexIn(candidateName);
-   if (positionOfMatch > -1) {
-      // There's already some integer in brackets at the end of the name, extract it, add one, and truncate the
-      // name.
-      duplicateNumber = nameNumberMatcher.cap(1).toInt() + 1;
-      candidateName.truncate(positionOfMatch);
+   QRegularExpression const & nameNumberMatcher = NamedEntity::getDuplicateNameNumberMatcher();
+   QRegularExpressionMatch match = nameNumberMatcher.match(candidateName);
+   QString matchedValue = match.captured(1);
+   if (matchedValue.size() > 0) {
+      // There's already some integer in brackets at the end of the name, extract it, add one, and truncate the name
+      duplicateNumber = matchedValue.toInt() + 1;
+      candidateName.truncate(match.capturedStart(1));
    }
    candidateName += QString(" (%1)").arg(duplicateNumber);
    return;

--- a/src/serialization/json/JsonSchema.cpp
+++ b/src/serialization/json/JsonSchema.cpp
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * serialization/json/JsonSchema.cpp is part of Brewtarget, and is copyright the following authors 2021-2022:
+ * serialization/json/JsonSchema.cpp is part of Brewtarget, and is copyright the following authors 2021-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
@@ -20,6 +20,7 @@
 
 #include <QDebug>
 #include <QMap>
+#include <QObject>
 #include <QString>
 
 #include <valijson/adapters/boost_json_adapter.hpp>

--- a/src/serialization/json/JsonUtils.cpp
+++ b/src/serialization/json/JsonUtils.cpp
@@ -226,7 +226,7 @@ void JsonUtils::serialize(std::ostream & stream,
                //
                if (ii->value().kind() == boost::json::kind::object &&
                    ii->value().get_object().size() == 0) {
-                  qDebug() << Q_FUNC_INFO << "Skipping output of empty object for" << ii->key();
+                  qDebug() << Q_FUNC_INFO << "Skipping output of empty object for" << QString::fromStdString(ii->key());
                   continue;
                }
 

--- a/src/serialization/json/JsonXPath.cpp
+++ b/src/serialization/json/JsonXPath.cpp
@@ -35,9 +35,14 @@ JsonXPath::JsonXPath(char const * const xPath) :
    m_pathParts{},
    m_pathNodes{} {
 
+   //
    // Because we're using std::string (because it's easier to pass in and out of Boost.JSON), we use the C++ standard
-   // regular expressions library rather than QRegExp here.  (The latter is obviously a better choice when we're
-   // manipulating QString objects.)
+   // regular expressions library rather than QRegularExpression here.  (The latter is obviously a better choice when
+   // we're manipulating QString objects.)
+   //
+   // TBD: If we wanted to improve performance we should look at
+   // https://github.com/hanickadot/compile-time-regular-expressions
+   //
 
    //
    // We could, in principle, use std::cregex_iterator on the raw char * string, but it's a bit clunky because you need

--- a/src/serialization/xml/BtDomErrorHandler.cpp
+++ b/src/serialization/xml/BtDomErrorHandler.cpp
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * serialization/xml/BtDomErrorHandler.cpp is part of Brewtarget, and is copyright the following authors 2020-2022:
+ * serialization/xml/BtDomErrorHandler.cpp is part of Brewtarget, and is copyright the following authors 2020-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
@@ -16,6 +16,7 @@
 #include "serialization/xml/BtDomErrorHandler.h"
 
 #include <QDebug>
+#include <QRegularExpression>
 #include <QString>
 
 #include <xercesc/dom/DOMLocator.hpp>
@@ -135,8 +136,9 @@ bool BtDomErrorHandler::handleError(xercesc::DOMError const & domError) {
    //
    if (nullptr != this->pimpl->errorPatternsToIgnore) {
       for (auto ii = this->pimpl->errorPatternsToIgnore->cbegin(); ii != this->pimpl->errorPatternsToIgnore->cend(); ++ii) {
-         QRegExp pattern(ii->regExMatchingErrorMessage);
-         if (pattern.indexIn(message) != -1) {
+         QRegularExpression pattern(ii->regExMatchingErrorMessage);
+         QRegularExpressionMatch match = pattern.match(message);
+         if (match.hasMatch()) {
             // We want to force the parse error onto a separate line, as it will be quite long, hence
             // ".noquote()" here.
             qWarning().noquote() <<

--- a/src/sortFilterProxyModels/SortFilterProxyModelBase.h
+++ b/src/sortFilterProxyModels/SortFilterProxyModelBase.h
@@ -1,6 +1,6 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
  * sortFilterProxyModels/SortFilterProxyModelBase.h is part of Brewtarget, and is copyright the following authors
- * 2023:
+ * 2023-2024:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewtarget is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
@@ -77,8 +77,20 @@ protected:
       if (tableModel) {
          QModelIndex index = tableModel->index(source_row, 0, source_parent);
 
-         return !m_filter || (tableModel->data(index).toString().contains(this->derived().filterRegExp()) &&
-                              tableModel->getRow(source_row)->display());
+         if (!this->m_filter) {
+            // No filter, so we accept
+            return true;
+         }
+         if (!tableModel->getRow(source_row)->display()) {
+            // Row not displayed, so reject
+            return false;
+         }
+
+         // The filterRegularExpression() member function we call here is inherited from QSortFilterProxyModel
+         QRegularExpression const filterRegExp {this->derived().filterRegularExpression()};
+         QString const dataAsString {tableModel->data(index).toString()};
+         QRegularExpressionMatch const match {filterRegExp.match(dataAsString)};
+         return match.hasMatch();
       }
 
       NeListModel* listModel = qobject_cast<NeListModel*>(this->derived().sourceModel());

--- a/src/tableModels/StepTableModelBase.h
+++ b/src/tableModels/StepTableModelBase.h
@@ -101,7 +101,7 @@ protected:
 
    //! \returns true if \c step is successfully found and removed.
    bool doRemoveStep(std::shared_ptr<StepClass> step) {
-      int ii {this->derived().rows.indexOf(step)};
+      int ii {static_cast<int>(this->derived().rows.indexOf(step))};
       if (ii >= 0) {
          qDebug() <<
             Q_FUNC_INFO << "Removing" << StepClass::staticMetaObject.className() << step->name() << "(#" <<

--- a/src/tableModels/TableModelBase.h
+++ b/src/tableModels/TableModelBase.h
@@ -737,7 +737,7 @@ protected:
          // with optional values.
          //
          // ItemDelegate::writeDataToModel should have just given us a raw string
-         Q_ASSERT(value.canConvert(QVariant::String));
+         Q_ASSERT(value.canConvert<QString>());
 
          //
          // For cases where we have an Amount and a drop-down chooser to select PhysicalQuantity (eg between Mass and

--- a/src/trees/TreeModel.cpp
+++ b/src/trees/TreeModel.cpp
@@ -27,6 +27,7 @@
 #include <QMimeData>
 #include <QModelIndex>
 #include <QObject>
+#include <QRegularExpression>
 #include <QStringBuilder>
 #include <Qt>
 #include <QVariant>
@@ -989,7 +990,7 @@ QModelIndex TreeModel::createFolderTree(QStringList dirs, TreeNode * parent, QSt
          fPath = pPath % "/" % cur;   // If it isn't we need the parent path
       }
 
-      fPath.replace(QRegExp("//"), "/");
+      fPath.replace(QRegularExpression("//"), "/");
 
       // Set the full path, which will set the name and the path
       temp->setfullPath(fPath);

--- a/src/unitTests/Testing.cpp
+++ b/src/unitTests/Testing.cpp
@@ -885,7 +885,7 @@ void Testing::testLogRotation() {
    qDebug() << Q_FUNC_INFO << "Logging::logFileSize =" << Logging::logFileSize;
    for (int i = 0; i < fileList.size(); i++) {
       QFile f(QString(fileList.at(i).canonicalFilePath()));
-      qDebug() << Q_FUNC_INFO << "File" << f << "has size" << f.size();
+      qDebug() << Q_FUNC_INFO << "File" << f.fileName() << "has size" << f.size();
       //Here we test if the file is more than 10% bigger than the specified logFileSize", if so, fail.
       QVERIFY2(f.size() <= (Logging::logFileSize * 1.1), "Wrong Sized file");
    }

--- a/src/widgets/SelectionControl.h
+++ b/src/widgets/SelectionControl.h
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * widgets/SelectionControl.h is is part of Brewtarget, and is copyright the following authors 2018-2021:
+ * widgets/SelectionControl.h is is part of Brewtarget, and is copyright the following authors 2018-2024:
  *   • Iman Ahmadvand <iman72411@gmail.com>
  *   • Matt Young <mfsy@yahoo.com>
  *
@@ -39,7 +39,7 @@ Q_SIGNALS:
    void stateChanged(int);
 
 protected:
-   void enterEvent(QEvent *) override;
+   virtual void enterEvent(QEvent *) override;
    void checkStateSet() override;
    void nextCheckState() override;
    virtual void toggle(Qt::CheckState state) = 0;

--- a/src/widgets/SmartLabel.h
+++ b/src/widgets/SmartLabel.h
@@ -183,14 +183,14 @@ public:
     * \brief We override the \c QWidget event handlers \c enterEvent and \c leaveEvent to implement mouse-over effects
     *        on the label text - specifically to give the user a visual clue that the label text is (right)-clickable
     */
-   virtual void enterEvent(QEvent* event);
-   virtual void leaveEvent(QEvent* event);
+   virtual void enterEvent(QEvent* event) override;
+   virtual void leaveEvent(QEvent* event) override;
 
    /**
     * \brief We override the \c QWidget event handler \c mouseReleaseEvent to capture left mouse clicks on us.  (Right
     *        clicks get notified to us via the \c QWidget::customContextMenuRequested signal.)
     */
-   virtual void mouseReleaseEvent(QMouseEvent * event);
+   virtual void mouseReleaseEvent(QMouseEvent * event) override;
 
 
 private:

--- a/src/widgets/UnitAndScalePopUpMenu.cpp
+++ b/src/widgets/UnitAndScalePopUpMenu.cpp
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * widgets/UnitAndScalePopUpMenu.cpp is part of Brewtarget, and is copyright the following authors 2012-2023:
+ * widgets/UnitAndScalePopUpMenu.cpp is part of Brewtarget, and is copyright the following authors 2012-2024:
  *   • Mark de Wever <koraq@xs4all.nl>
  *   • Matt Young <mfsy@yahoo.com>
  *   • Mik Firestone <mikfire@gmail.com>
@@ -17,6 +17,7 @@
  ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌*/
 #include "widgets/UnitAndScalePopUpMenu.h"
 
+#include <QActionGroup>
 #include <QApplication>
 #include <QDebug>
 

--- a/ui/waterEditor.ui
+++ b/ui/waterEditor.ui
@@ -532,42 +532,7 @@
   <tabstop>lineEdit_so4</tabstop>
   <tabstop>lineEdit_alk</tabstop>
   <tabstop>lineEdit_ph</tabstop>
-  <tabstop>plainTextEdit_notes</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>textEdit_notes</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>waterEditor</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>waterEditor</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
 </ui>


### PR DESCRIPTION
There are a bunch of things that we _have_ to do differently in Qt 6, but where we _can_ start doing in the new way in Qt 5.  The idea is to make all those changes first, so that, when we come to upgrade to Qt 6, there is less to change.

We also now have our certificate from SignPath, so we're turning on proper signing of the Windows release builds.