### PR TITLE
Update meson.build with danish languageentry

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1090,6 +1090,7 @@ translationSourceFiles = files([
    'translations/bt_ru.ts', # Russian
    'translations/bt_sr.ts', # Serbian
    'translations/bt_sv.ts', # Swedish
+   'translations/bt_da.ts', # Danish
    'translations/bt_tr.ts', # Turkish
    'translations/bt_zh.ts', # Chinese
 ])


### PR DESCRIPTION
I added a danish language file, but I was not aware that building is done with meson. So the danish language did not make it to the new version 4.0.10. I have added the needed line to meson.build.