### PR TITLE
Fix missing signal for new recipe addition

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -23,9 +23,11 @@ Bug fixes and minor enhancements.
 * Crash on Windows when opening Print and Print Preview dialog [873](https://github.com/Brewtarget/brewtarget/issues/873)
 * Crash when you click Yes or No in the pop-up about downloading the latest version [878](https://github.com/Brewtarget/brewtarget/issues/878)
 * Drop down menu for Style and Equipment are so narrow, cannot see contents [879](https://github.com/Brewtarget/brewtarget/issues/879)
+* OG doesn't immediately change when adding malt to a recipe [880](https://github.com/Brewtarget/brewtarget/issues/880)
+* IBU doesn't update when adding hops [881](https://github.com/Brewtarget/brewtarget/issues/881)
 
 ### Release Timestamp
-Sun, 17 Nov 2024 04:00:11 +0100
+Tue, 19 Nov 2024 04:00:11 +0100
 
 ## v4.0.10
 Bug fixes and minor enhancements.

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -20,6 +20,7 @@
 
 #include <sstream>      // For std::ostringstream
 
+//#include <stacktrace>
 #include <boost/stacktrace.hpp>
 
 #include <QApplication>
@@ -527,11 +528,17 @@ QString Logging::getStackTrace() {
    //
    // TBD: Once all our compilers have full C++23 support, we should look at switching to <stacktrace> in the standard
    //      library.
+   //      As at 2024-11-19, according to https://en.cppreference.com/w/cpp/compiler_support, Clang and Apple Clang do
+   //      not have support for <stacktrace> (and GCC needs to be version 14 to have support enabled by default.
    //
    std::ostringstream stacktrace;
    stacktrace << boost::stacktrace::stacktrace();
    QString returnValue;
    QTextStream returnValueAsStream(&returnValue);
+   // What we'd like to be able to write:
+//   returnValueAsStream << "\nStacktrace:\n" << QString::fromStdString( std::to_string(std::stacktrace::current()));
+   // What we use in the meantime:
    returnValueAsStream << "\nStacktrace:\n" << QString::fromStdString(stacktrace.str());
+
    return returnValue;
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1895,14 +1895,15 @@ void MainWindow::showChanges(QMetaProperty* prop) {
    if (prop) {
       propName = prop->name();
    }
+   qDebug() << Q_FUNC_INFO << "propName:" << propName;
 
    // May St. Stevens preserve me
-   this->lineEdit_name      ->setText  (this->pimpl->m_recipeObs->name          ());
+   this->lineEdit_name      ->setText    (this->pimpl->m_recipeObs->name          ());
    this->lineEdit_batchSize ->setQuantity(this->pimpl->m_recipeObs->batchSize_l   ());
+   this->lineEdit_efficiency->setQuantity(this->pimpl->m_recipeObs->efficiency_pct());
    // TODO: One day we'll want to do some work to properly handle no-boil recipes....
    std::optional<double> const boilSize = this->pimpl->m_recipeObs->boil() ? this->pimpl->m_recipeObs->boil()->preBoilSize_l() : std::nullopt;
    this->lineEdit_boilSize  ->setQuantity(boilSize);
-   this->lineEdit_efficiency->setQuantity(this->pimpl->m_recipeObs->efficiency_pct());
    this->lineEdit_boilTime  ->setQuantity(this->pimpl->m_recipeObs->boil()->boilTime_mins());
    this->lineEdit_boilSg    ->setQuantity(this->pimpl->m_recipeObs->boilGrav());
    this->lineEdit_name      ->setCursorPosition(0);

--- a/src/measurement/IbuMethods.h
+++ b/src/measurement/IbuMethods.h
@@ -91,8 +91,8 @@ namespace IbuMethods {
     *        say that Tinseth himself confirmed "Post boil volume is correct" because "We are concerned with the mg/L
     *        and any portions of a liter lost post boil doesn’t affect the calculation".
     * \param wortGravity_sg in specific gravity at around 60F I guess.
-    * \param boilTime_minutes - minutes that the hops are in the boil: usually measured from the point at which hops are
-    *                           added until flameout
+    * \param timeInBoil_minutes - minutes that the hops are in the boil: usually measured from the point at which hops
+    *                             are added until flameout
     *
     * \param coolTime_minutes - (Only used in mIbu)  Time after flameout, without forced cooling.  Note per
     *        https://alchemyoverlord.wordpress.com/2015/05/12/a-modified-ibu-measurement-especially-for-late-hopping/
@@ -110,7 +110,7 @@ namespace IbuMethods {
       double hops_grams;
       double postBoilVolume_liters;
       double wortGravity_sg;
-      double boilTime_minutes;
+      double timeInBoil_minutes;
       std::optional<double> coolTime_minutes          = std::nullopt;
       std::optional<double> kettleInternalDiameter_cm = std::nullopt;
       std::optional<double> kettleOpeningDiameter_cm  = std::nullopt;

--- a/src/model/NamedEntity.cpp
+++ b/src/model/NamedEntity.cpp
@@ -460,13 +460,14 @@ void NamedEntity::prepareForPropertyChange(BtStringConst const & propertyName) {
 }
 
 void NamedEntity::propagatePropertyChange(BtStringConst const & propertyName, bool notify) const {
+   //
+   // Normally leave this log statement commented out as otherwise it can generate a lot of lines in the log files
+   //
+//   qDebug() <<
+//      Q_FUNC_INFO << "Property name" << *propertyName << "change on" << this->metaObject()->className() <<
+//      ": m_propagationAndSignalsEnabled " << (this->m_propagationAndSignalsEnabled ? "set" : "unset") << ", notify" <<
+//      (notify ? "on" : "off");
    if (!this->m_propagationAndSignalsEnabled) {
-      //
-      // Normally leave this log statement commented out as otherwise it can generate a lot of lines in the log files
-      //
-//      qDebug() <<
-//         Q_FUNC_INFO << "Not propagating" << *propertyName << "change on" << this->metaObject()->className() <<
-//         "as m_propagationAndSignalsEnabled unset";
       return;
    }
 
@@ -491,6 +492,8 @@ void NamedEntity::notifyPropertyChange(BtStringConst const & propertyName) const
    Q_ASSERT(idx >= 0);
    QMetaProperty metaProperty = this->metaObject()->property(idx);
    QVariant value = metaProperty.read(this);
+   // Normally leave this log statement commented out as otherwise it can generate a lot of lines in the log files
+//   qDebug() << Q_FUNC_INFO << this->metaObject()->className() << ":" << propertyName << "=" << value;
    emit this->changed(metaProperty, value);
 
    return;

--- a/src/model/OwnedSet.h
+++ b/src/model/OwnedSet.h
@@ -81,6 +81,8 @@ template <OwnedSetOptions os> concept CONCEPT_FIX_UP IsCopyable   = is_Copyable 
  *        For an "unordered" set, we do not have a strict ordering of the owned items (eg two hop additions could happen
  *        at the same time).
  *
+ *        When the set changes, we emit the \c NamedEntity::changed signal on the \c owner object.
+ *
  * \param Owner class needs to inherit from \c NamedEntity
  * \param Item class also needs to inherit from \c NamedEntity, plus implement: \c ownerId, \c setOwnerId
  *        For an enumerated set, \c Item also needs to implement \c seqNum, \c setSeqNum
@@ -195,7 +197,7 @@ public:
     *             be.
     */
    void acceptItemChange(Item const & item, [[maybe_unused]] QMetaProperty prop, [[maybe_unused]] QVariant val) {
-      // If one of our steps changed, our pseudo properties may also change, so we need to emit some signals
+      // If one of our items changed, our pseudo properties may also change, so we need to emit some signals
       if (item.ownerId() == this->m_owner.key()) {
          emit this->m_owner.changed(this->m_owner.metaProperty(*propertyName), QVariant());
       }
@@ -415,7 +417,10 @@ private:
          this->m_itemIds.append(item->key());
       }
 
-      // Now we changed the size of the set, have the owner tell people about it
+      // Now we added an item to the set, we need to listen for changes to it
+      this->connectItemChangedSignal(item);
+
+      // And, now we changed the size of the set, we have the owner tell people about it
       this->emitSetChanged();
 
       return item;

--- a/src/undoRedo/UndoableAddOrRemove.h
+++ b/src/undoRedo/UndoableAddOrRemove.h
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * undoRedo/UndoableAddOrRemove.h is part of Brewtarget, and is copyright the following authors 2020-2022:
+ * undoRedo/UndoableAddOrRemove.h is part of Brewtarget, and is copyright the following authors 2020-2024:
  *   • Mattias Måhl <mattias@kejsarsten.com>
  *   • Matt Young <mfsy@yahoo.com>
  *
@@ -27,6 +27,7 @@
 #include <QUndoCommand>
 
 #include "database/ObjectStoreWrapper.h"
+#include "Logging.h"
 
 class MainWindow;
 
@@ -148,6 +149,8 @@ private:
             Q_FUNC_INFO << (this->everDone ? "Redo" : "Do" ) << this->text() << "for " <<
             this->whatToAddOrRemove->metaObject()->className() << "#" << this->whatToAddOrRemove->key() << "(" <<
             this->whatToAddOrRemove->name() << ")";
+         // Normally leave the next line commented out as it generates a lot of logging
+//         qDebug().noquote() << Q_FUNC_INFO << Logging::getStackTrace();
 
          this->whatToAddOrRemove = (this->updatee.*(this->doer))(this->whatToAddOrRemove);
          qDebug() <<

--- a/translations/bt_ca.ts
+++ b/translations/bt_ca.ts
@@ -8484,7 +8484,7 @@ El volum final al primari és de %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_cs.ts
+++ b/translations/bt_cs.ts
@@ -8336,7 +8336,7 @@ Celkový objem pro hlavní kvašení je %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_da.ts
+++ b/translations/bt_da.ts
@@ -373,6 +373,14 @@
         <source>Brewday</source>
         <translation>Brygdag</translation>
     </message>
+    <message>
+        <source>Overwrite Existing Instructions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generating instructions will overwrite the existing ones.  This is not undoable.  Do you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BrewDayWidget</name>
@@ -1924,7 +1932,7 @@ Logfil indeholder måske flere detaljer.</translation>
     </message>
     <message>
         <source>Add %1 step to recipe</source>
-        <translation>Føj %1 trin til opskrift</translation>
+        <translation type="vanished">Føj %1 trin til opskrift</translation>
     </message>
     <message>
         <source>Remove %1</source>
@@ -2447,6 +2455,13 @@ Hvis du har brug for hjælp, bedes du åbne en sag (issue) på %1</translation>
     </message>
 </context>
 <context>
+    <name>NE</name>
+    <message>
+        <source>Change %1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>NamedEntity</name>
     <message>
         <source>Named Entity</source>
@@ -2715,6 +2730,35 @@ Hvis du har brug for hjælp, bedes du åbne en sag (issue) på %1</translation>
     <message>
         <source>Could not open the file %1 for writing! please try again with a new filename or diretory</source>
         <translation>Kunne ikke skrive til filen %1! Prøv igen med nyt filnavn eller mappe</translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <source>%1 is already running!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Another instance of %1 is already running.
+
+Running two copies of the program at once may lead to data loss.
+
+Press OK to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Application terminates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.
+Error message:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The application encountered a fatal error.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3449,6 +3493,57 @@ Logfil indeholder evt. flere detaljer.</translation>
         <source>Tertiary Fermentation Step for %1</source>
         <translation>Tredje gæringstrin i %1</translation>
     </message>
+    <message>
+        <source>%1 Catalog / Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Recipe</source>
+        <translation type="unfinished">Føj til opskrift</translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Add selected %1 to recipe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create new %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Nej</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RaIngrd</name>
+    <message>
+        <source>Add %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Recipe</name>
@@ -3474,7 +3569,7 @@ Logfil indeholder evt. flere detaljer.</translation>
     </message>
     <message>
         <source>%1 water to %2, </source>
-        <translation>%1 vand til %2</translation>
+        <translation type="vanished">%1 vand til %2</translation>
     </message>
     <message>
         <source>for upcoming infusions.</source>
@@ -3669,7 +3764,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>%1 water to %2 </source>
-        <translation>%1 vand til %2 </translation>
+        <translation type="vanished">%1 vand til %2 </translation>
     </message>
     <message>
         <source>Put %1 %2 into packaging for %3.</source>
@@ -4037,6 +4132,10 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Attenuation</source>
         <translation>Forgæring</translation>
+    </message>
+    <message>
+        <source>Times Cultured</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4616,6 +4715,13 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Step</source>
         <translation>Trin</translation>
+    </message>
+</context>
+<context>
+    <name>StepClass</name>
+    <message>
+        <source>Add %1 step to recipe</source>
+        <translation type="unfinished">Føj %1 trin til opskrift</translation>
     </message>
 </context>
 <context>
@@ -5447,7 +5553,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>New hop</source>
-        <translation>Ny humle</translation>
+        <translation type="vanished">Ny humle</translation>
     </message>
     <message>
         <source>Save and close</source>
@@ -5456,6 +5562,22 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Discard and close</source>
         <translation>Annuller og luk</translation>
+    </message>
+    <message>
+        <source>New boil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">Gem</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
     </message>
 </context>
 <context>
@@ -5763,6 +5885,17 @@ The final volume in the primary is %1.</source>
     </message>
 </context>
 <context>
+    <name>editorClass</name>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Nej</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>equipmentEditor</name>
     <message>
         <source>Losses</source>
@@ -6007,6 +6140,26 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Discard and close</source>
         <translation>Annuller og luk</translation>
+    </message>
+    <message>
+        <source>Internal Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Opening Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">Gem</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
     </message>
 </context>
 <context>
@@ -6283,6 +6436,18 @@ The final volume in the primary is %1.</source>
         <source>Grain Group</source>
         <translation>Maltgruppe</translation>
     </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">Gem</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
+    </message>
 </context>
 <context>
     <name>fermentationEditor</name>
@@ -6308,7 +6473,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>New hop</source>
-        <translation>Ny humle</translation>
+        <translation type="vanished">Ny humle</translation>
     </message>
     <message>
         <source>Save and close</source>
@@ -6317,6 +6482,22 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Discard and close</source>
         <translation>Annuller og luk</translation>
+    </message>
+    <message>
+        <source>New fermentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">Gem</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
     </message>
 </context>
 <context>
@@ -6684,28 +6865,40 @@ The final volume in the primary is %1.</source>
         <source>Discard and close</source>
         <translation>Annuller og luk</translation>
     </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">Gem</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
+    </message>
 </context>
 <context>
     <name>instructionWidget</name>
     <message>
         <source>Form</source>
-        <translation>Type</translation>
+        <translation type="vanished">Type</translation>
     </message>
     <message>
         <source>Show a timer</source>
-        <translation>Vis en timer</translation>
+        <translation type="vanished">Vis en timer</translation>
     </message>
     <message>
         <source>Show timer</source>
-        <translation>Vis timer</translation>
+        <translation type="vanished">Vis timer</translation>
     </message>
     <message>
         <source>Mark this step completed</source>
-        <translation>Marker dette trin som afsluttet</translation>
+        <translation type="vanished">Marker dette trin som afsluttet</translation>
     </message>
     <message>
         <source>Step completed</source>
-        <translation>Trin afsluttet</translation>
+        <translation type="vanished">Trin afsluttet</translation>
     </message>
 </context>
 <context>
@@ -7112,7 +7305,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>(See Boil tab below)</source>
-        <translation>(se faneblad Kogning herunder)</translation>
+        <translation type="vanished">(se faneblad Kogning herunder)</translation>
     </message>
     <message>
         <source>&amp;Efficiency (%)</source>
@@ -7289,6 +7482,10 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Brew It!</source>
         <translation>Bryg den!</translation>
+    </message>
+    <message>
+        <source>See Boil tab below</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7647,7 +7844,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>New misc</source>
-        <translation>Ny diverse ingrediens</translation>
+        <translation type="vanished">Ny diverse ingrediens</translation>
     </message>
     <message>
         <source>Save and close</source>
@@ -7656,6 +7853,18 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Discard and close</source>
         <translation>Annuller og luk</translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">Gem</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
     </message>
 </context>
 <context>
@@ -8546,7 +8755,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Gem</translation>
+        <translation>Gem</translation>
     </message>
     <message>
         <source>Main</source>
@@ -8591,6 +8800,14 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Discard and close</source>
         <translation>Annuller og luk</translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
     </message>
 </context>
 <context>
@@ -8766,7 +8983,7 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>New hop</source>
-        <translation>Ny humle</translation>
+        <translation type="vanished">Ny humle</translation>
     </message>
     <message>
         <source>Save and close</source>
@@ -8775,6 +8992,22 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Discard and close</source>
         <translation>Annuller og luk</translation>
+    </message>
+    <message>
+        <source>New water</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">Gem</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
     </message>
 </context>
 <context>
@@ -8829,11 +9062,11 @@ The final volume in the primary is %1.</source>
     </message>
     <message>
         <source>Times Recultured</source>
-        <translation>Antal gange genhøstet</translation>
+        <translation type="vanished">Antal gange genhøstet</translation>
     </message>
     <message>
         <source>Times this yeast has been recultured</source>
-        <translation>Antal gange denne gær er blevet genhøstet</translation>
+        <translation type="vanished">Antal gange denne gær er blevet genhøstet</translation>
     </message>
     <message>
         <source>Max Recultures</source>
@@ -8974,6 +9207,18 @@ The final volume in the primary is %1.</source>
     <message>
         <source>Discard and close</source>
         <translation>Annuller og luk</translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">Gem</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
     </message>
 </context>
 </TS>

--- a/translations/bt_de.ts
+++ b/translations/bt_de.ts
@@ -8381,7 +8381,7 @@ Das endgültige Volumen in der Hauptgärung beträgt %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_el.ts
+++ b/translations/bt_el.ts
@@ -8370,7 +8370,7 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_en.ts
+++ b/translations/bt_en.ts
@@ -6511,11 +6511,11 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>Boil Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Boil Time</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_es.ts
+++ b/translations/bt_es.ts
@@ -8436,7 +8436,7 @@ El volumen final en el primario es %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_et.ts
+++ b/translations/bt_et.ts
@@ -6619,7 +6619,7 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_eu.ts
+++ b/translations/bt_eu.ts
@@ -6631,7 +6631,7 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_fr.ts
+++ b/translations/bt_fr.ts
@@ -8502,7 +8502,7 @@ Le volume final dans la cuve de fermentation est de %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_gl.ts
+++ b/translations/bt_gl.ts
@@ -6988,7 +6988,7 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_hu.ts
+++ b/translations/bt_hu.ts
@@ -8400,7 +8400,7 @@ Végleges mennyiség az elsődleges erjesztőben: %1</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_it.ts
+++ b/translations/bt_it.ts
@@ -8473,7 +8473,7 @@ Il Volume finale del primo è %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_lv.ts
+++ b/translations/bt_lv.ts
@@ -6818,11 +6818,11 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>Boil Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Boil Time</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_nb.ts
+++ b/translations/bt_nb.ts
@@ -8381,7 +8381,7 @@ Sluttvolumet i primærgjæringskaret er %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_nl.ts
+++ b/translations/bt_nl.ts
@@ -8430,7 +8430,7 @@ Het uiteindelijke volume in de hoofdvergisting is %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_pl.ts
+++ b/translations/bt_pl.ts
@@ -8286,7 +8286,7 @@ Końcowa pojemność w fermentorze wyniesie %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_pt.ts
+++ b/translations/bt_pt.ts
@@ -8408,7 +8408,7 @@ O volume final do fermentador primário é %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_ru.ts
+++ b/translations/bt_ru.ts
@@ -8436,7 +8436,7 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_sr.ts
+++ b/translations/bt_sr.ts
@@ -7756,7 +7756,7 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_sv.ts
+++ b/translations/bt_sv.ts
@@ -8465,7 +8465,7 @@ Primärens slutgiltiga volym är %1.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_tr.ts
+++ b/translations/bt_tr.ts
@@ -8295,7 +8295,7 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bt_zh.ts
+++ b/translations/bt_zh.ts
@@ -8198,7 +8198,7 @@ The final volume in the primary is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(See Boil tab below)</source>
+        <source>See Boil tab below</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This fixes https://github.com/Brewtarget/brewtarget/issues/881 and https://github.com/Brewtarget/brewtarget/issues/880.  The actual fix is just the extra call to `this->connectItemChangedSignal(item)` in `src/model/OwnedSet.h` but I also added some extra debugging statements along the way and corrected a misleadingly-named variable.