### PR TITLE
Fixes for two crashes

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -20,7 +20,11 @@ Bug fixes and minor enhancements.
 * None
 
 ### Bug Fixes
-* None
+* Combo boxes not displaying properly on Windows [894](https://github.com/Brewtarget/brewtarget/issues/894)
+* Icons Misisng [895](https://github.com/Brewtarget/brewtarget/issues/895)
+* Brewtarget 4.0.7 Qt6 issue on Ubuntu (libQt6Multimedia.so.6 missing) [861](https://github.com/Brewtarget/brewtarget/issues/861)
+* Opening user recipe causes crash [897](https://github.com/Brewtarget/brewtarget/issues/897)
+* Copy recipe crash [899](https://github.com/Brewtarget/brewtarget/issues/899)
 
 ### Release Timestamp
 Sun, 24 Nov 2024 04:00:12 +0100

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1904,7 +1904,7 @@ void MainWindow::showChanges(QMetaProperty* prop) {
    // TODO: One day we'll want to do some work to properly handle no-boil recipes....
    std::optional<double> const boilSize = this->pimpl->m_recipeObs->boil() ? this->pimpl->m_recipeObs->boil()->preBoilSize_l() : std::nullopt;
    this->lineEdit_boilSize  ->setQuantity(boilSize);
-   this->lineEdit_boilTime  ->setQuantity(this->pimpl->m_recipeObs->boil()->boilTime_mins());
+   this->lineEdit_boilTime  ->setQuantity(this->pimpl->m_recipeObs->boil() ? this->pimpl->m_recipeObs->boil()->boilTime_mins() : 0.0);
    this->lineEdit_boilSg    ->setQuantity(this->pimpl->m_recipeObs->boilGrav());
    this->lineEdit_name      ->setCursorPosition(0);
    this->lineEdit_batchSize ->setCursorPosition(0);
@@ -2407,6 +2407,8 @@ void MainWindow::addStepToStepOwner(std::shared_ptr<MashStep> mashStep) {
    return;
 }
 void MainWindow::addStepToStepOwner(std::shared_ptr<BoilStep> boilStep) {
+   // It's a coding error if we're trying to add a BoilStep when there is no Boil
+   Q_ASSERT(this->pimpl->m_recipeObs->boil());
    this->addStepToStepOwner(this->pimpl->m_recipeObs->boil(), boilStep);
    return;
 }

--- a/src/model/Boil.cpp
+++ b/src/model/Boil.cpp
@@ -78,7 +78,7 @@ Boil::Boil(QString name) :
 Boil::Boil(NamedParameterBundle const & namedParameterBundle) :
    NamedEntity     {namedParameterBundle},
    FolderBase<Boil>{namedParameterBundle},
-   StepOwnerBase<Boil, BoilStep>{},
+   StepOwnerBase<Boil, BoilStep>{namedParameterBundle},
    SET_REGULAR_FROM_NPB (m_description  , namedParameterBundle, PropertyNames::Boil::description  ),
    SET_REGULAR_FROM_NPB (m_notes        , namedParameterBundle, PropertyNames::Boil::notes        ),
    SET_REGULAR_FROM_NPB (m_preBoilSize_l, namedParameterBundle, PropertyNames::Boil::preBoilSize_l) {
@@ -154,6 +154,7 @@ void Boil::setBoilTime_mins(double const val) {
 }
 
 void Boil::acceptStepChange(QMetaProperty prop, QVariant val) {
+   // TBD I don't think anything listens for changes to boilTime_mins
    this->doAcceptStepChange(this->sender(), prop, val, {&PropertyNames::Boil::boilTime_mins});
    return;
 }

--- a/src/model/OwnedSet.h
+++ b/src/model/OwnedSet.h
@@ -143,6 +143,7 @@ public:
     */
    OwnedSet(Owner & owner, [[maybe_unused]] OwnedSet const & other) requires (!IsCopyable<ownedSetOptions>) :
       m_owner{owner} {
+      qDebug() << Q_FUNC_INFO << "Copy is no-op";
       return;
    }
 
@@ -162,6 +163,7 @@ public:
 
          // However, if we insert the new Item in the object store, that will give it its own ID
          ObjectStoreWrapper::insert(itemToAdd);
+         qDebug() << Q_FUNC_INFO << "Copied" << *item << "to" << *itemToAdd;
 
          // Store the ID of the copy Item
          // If and when we get our ID then we can give it to our Items

--- a/src/model/Recipe.cpp
+++ b/src/model/Recipe.cpp
@@ -356,6 +356,8 @@ public:
    /**
     * \brief Getting a recipe's \c Boil, \c Fermentation, etc is pretty much the same logic, so we template it
     *
+    * \param ourId The primary key of the \c Boil, \c Fermentation, etc.
+    *
     *        In BeerJSON, each of mash, boil and fermentation is optional.  I guess no fermentation is for recipes for
     *        making hop water etc.  Equally, there are people making beer without boiling -- eg see
     *        https://byo.com/article/raw-ale/.  In both cases, our current support for "no boil" and/or "no ferment" is
@@ -1095,10 +1097,10 @@ public:
       double nonFermentableSugars_kg   = sugars.nonFermentableSugars_kg;  // Mass of sugar that is not fermentable (also counted in sugar_kg_ignoreEfficiency)
 
       // Uncomment for diagnosing problems with calculations
-      qDebug() <<
-         Q_FUNC_INFO << "Recipe #" << this->m_self.key() << "(" << this->m_self.name() << ") "
-         "sugar_kg: " << sugar_kg << ", sugar_kg_ignoreEfficiency: " << sugar_kg_ignoreEfficiency <<
-         ", nonFermentableSugars_kg:" << nonFermentableSugars_kg;
+//      qDebug() <<
+//         Q_FUNC_INFO << "Recipe #" << this->m_self.key() << "(" << this->m_self.name() << ") "
+//         "sugar_kg: " << sugar_kg << ", sugar_kg_ignoreEfficiency: " << sugar_kg_ignoreEfficiency <<
+//         ", nonFermentableSugars_kg:" << nonFermentableSugars_kg;
 
       // We might lose some sugar in the form of Trub/Chiller loss and lauter deadspace.
       auto equipment = this->m_self.equipment();
@@ -1172,10 +1174,10 @@ public:
       }
 
       // Uncomment for diagnosing problems with calculations
-      qDebug() <<
-         Q_FUNC_INFO << "Recipe #" << this->m_self.key() << "(" << this->m_self.name() << ") "
-         "attenuation_pct:" << attenuation_pct << ", m_og_fermentable:" << m_og_fermentable << ", m_fg_fermentable: " <<
-         m_fg_fermentable;
+//      qDebug() <<
+//         Q_FUNC_INFO << "Recipe #" << this->m_self.key() << "(" << this->m_self.name() << ") "
+//         "attenuation_pct:" << attenuation_pct << ", m_og_fermentable:" << m_og_fermentable << ", m_fg_fermentable: " <<
+//         m_fg_fermentable;
 
       if (!qFuzzyCompare(this->m_self.m_og, calculatedOg)) {
          qDebug() <<
@@ -1764,6 +1766,8 @@ Recipe::Recipe(Recipe const & other) :
 Recipe::~Recipe() = default;
 
 void Recipe::setKey(int key) {
+   this->NamedEntity::setKey(key);
+
    qDebug() << Q_FUNC_INFO << "Promulgating key for Recipe #" << key;
 
    //
@@ -2598,7 +2602,9 @@ double Recipe::ibuFromHopAddition(RecipeAdditionHop const & hopAddition) {
       Q_FUNC_INFO
    );
 
-   // It's a coding error to ask one recipe about another's hop additions!
+   // It's a coding error to ask one recipe about another's hop additions!  Uncomment the log statement here if the
+   // assert is firing.
+//   qDebug() << Q_FUNC_INFO << *this << " / " << hopAddition << "; hopAddition.recipeId():" << hopAddition.recipeId();
    Q_ASSERT(hopAddition.recipeId() == this->key());
 
    double AArating = hopAddition.hop()->alpha_pct() / 100.0;


### PR DESCRIPTION
Fixes for:
* Opening user recipe causes crash [897](https://github.com/Brewtarget/brewtarget/issues/897)
* Copy recipe crash [899](https://github.com/Brewtarget/brewtarget/issues/899)
