### PR TITLE
Fix for not detecting current unit system settings when doing contextless unit conversions

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -22,6 +22,7 @@ Bug fixes and minor enhancements.
 ### Bug Fixes
 * Inconsistent ABV calculation [918](https://github.com/Brewtarget/brewtarget/issues/918)
 * US / Imperial quart ("qt") conversion is treated as pints instead [923](https://github.com/Brewtarget/brewtarget/issues/923)
+* "Converter Tool" does not respect Units settings for US vs Imperial [924](https://github.com/Brewtarget/brewtarget/issues/924)
 
 ### Release Timestamp
 Sat, 4 Jan 2025 04:00:16 +0100

--- a/src/measurement/Unit.h
+++ b/src/measurement/Unit.h
@@ -1,5 +1,5 @@
 /*╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
- * measurement/Unit.h is part of Brewtarget, and is copyright the following authors 2009-2023:
+ * measurement/Unit.h is part of Brewtarget, and is copyright the following authors 2009-2025:
  *   • Jeff Bailey <skydvr38@verizon.net>
  *   • Mark de Wever <koraq@xs4all.nl>
  *   • Matt Young <mfsy@yahoo.com>
@@ -128,6 +128,12 @@ namespace Measurement {
        * \brief The unit name will be the singular of the commonly used abbreviation.
        */
       QString const name;
+
+      /**
+       * \brief Returns details that can be output by \c operator<< (see below).  We can't implement this in the header
+       *        as it would require circular dependencies with \c UnitSystem.
+       */
+      QString getOutputForStream() const;
 
       /**
        * \brief Returns the canonical units we use for \c PhysicalQuantity this \c Unit relates to.  These are the units
@@ -432,7 +438,7 @@ namespace Measurement {
  */
 template<class S>
 S & operator<<(S & stream, Measurement::Unit const & unit) {
-   stream << unit.name << " (" << unit.getPhysicalQuantity() << ")";
+   stream << unit.getOutputForStream();
    return stream;
 }
 template<class S>


### PR DESCRIPTION
See https://github.com/Brewtarget/brewtarget/issues/924.