### PR TITLE
Update recipeExtrasWidget.ui

### DIFF
--- a/ui/recipeExtrasWidget.ui
+++ b/ui/recipeExtrasWidget.ui
@@ -171,7 +171,7 @@
          <item row="5" column="1">
           <widget class="BtOptionalDateEdit" name="dateEdit_date">
            <property name="displayFormat">
-            <string>dd MMM yyyy</string>
+            <string>dd MM yyyy</string>
            </property>
            <property name="calendarPopup">
             <bool>true</bool>


### PR DESCRIPTION
Corrected error in date-format from dd MMM yyyy to dd MM yyyy.
The error resulted in month-number shown as 00 on the Extra tab in the recipe window. A little detail, and ideally changes in Options for date format should also be shown here. But that's a very little issue.