### PR TITLE
Fix Windows build unintentionally opening a console window

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -13,9 +13,6 @@ happens, so I'm now setting it to a slightly arbitrary time early in the morning
 * TODO: Additional methods for calculating IBU
 * We'll list other new features here...
 
-### Bug Fixes
-* Windows version opens a console in addition to the main window [976](https://github.com/Brewtarget/brewtarget/issues/976)
-
 ## v4.1.2
 Bug fixes and minor enhancements.
 
@@ -24,6 +21,7 @@ Bug fixes and minor enhancements.
 
 ### Bug Fixes
 * Crash when deleting a water profile [974](https://github.com/Brewtarget/brewtarget/issues/974)
+* Windows version opens a console in addition to the main window [976](https://github.com/Brewtarget/brewtarget/issues/976)
 
 ### Release Timestamp
 Mon, 2 Jun 2025 04:01:02 +0100

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -13,6 +13,9 @@ happens, so I'm now setting it to a slightly arbitrary time early in the morning
 * TODO: Additional methods for calculating IBU
 * We'll list other new features here...
 
+### Bug Fixes
+* Windows version opens a console in addition to the main window [976](https://github.com/Brewtarget/brewtarget/issues/976)
+
 ## v4.1.2
 Bug fixes and minor enhancements.
 

--- a/meson.build
+++ b/meson.build
@@ -1720,7 +1720,7 @@ mainExecutable = executable(mainExecutableTargetName,
                             link_with : commonCodeStaticLib,
                             kwargs : platformSpecificArgs,
                             install : true,
-                            gui_app : true)
+                            win_subsystem : 'windows')
 
 testRunner = executable(testRunnerTargetName,
                         unitTestMainSourceFile,

--- a/meson.build
+++ b/meson.build
@@ -1719,7 +1719,8 @@ mainExecutable = executable(mainExecutableTargetName,
                             dependencies : mainExeDependencies,
                             link_with : commonCodeStaticLib,
                             kwargs : platformSpecificArgs,
-                            install : true)
+                            install : true,
+                            gui_app : true)
 
 testRunner = executable(testRunnerTargetName,
                         unitTestMainSourceFile,


### PR DESCRIPTION
From Meson docs:

https://mesonbuild.com/Reference-manual_functions.html#executable_win_subsystem

The default value for `win_subsystem` is `'console'`, which resulted in the unintended behavior of a console window being opened in addition to the main Brewtarget GUI.  Setting `win_subsystem: windows` resolves #976.