### PR TITLE
Use Q_UNREACHABLE where appropriate

### DIFF
--- a/src/database/ObjectStore.cpp
+++ b/src/database/ObjectStore.cpp
@@ -27,6 +27,7 @@
 #include <QSqlField>
 #include <QSqlRecord>
 #include <QVector>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "database/BtSqlQuery.h"
 #include "database/Database.h"
@@ -60,8 +61,7 @@ namespace {
          // No default case needed as compiler should warn us if any options covered above
       }
       // It's a coding error if we get here!
-      Q_ASSERT(false);
-      return nullptr; // Should never get here
+      Q_UNREACHABLE();
    }
 
    /**
@@ -554,7 +554,7 @@ namespace {
          // No default case needed as compiler should warn us if any options covered above
       }
       // It's a coding error if we get here
-      Q_ASSERT(false);
+      Q_UNREACHABLE();
    }
 
    using TableColumnAndType = std::tuple<QString, QString, ObjectStore::FieldType>;
@@ -730,7 +730,7 @@ public:
             case ObjectStore::FieldType::Unit: {
                // Since Unit is stored as a pointer, it is never wrapped in std::optional, so it's a coding error if we
                // get here
-               Q_ASSERT(false);
+               Q_UNREACHABLE();
                propertyValue = QVariant();
                return;
 
@@ -738,7 +738,7 @@ public:
             // No default case needed as compiler should warn us if any options covered above
          }
          // It's a coding error if we get here!
-         Q_ASSERT(false);
+         Q_UNREACHABLE();
       }
 
       //
@@ -785,7 +785,7 @@ public:
       }
 
       // It's a coding error if we get here
-      Q_ASSERT(false);
+      Q_UNREACHABLE();
    }
 
    /**
@@ -918,7 +918,7 @@ public:
             // No default case needed as compiler should warn us if any options covered above
          }
          // It's a coding error if we get here!
-         Q_ASSERT(false);
+         Q_UNREACHABLE();
       }
 
       //
@@ -977,7 +977,7 @@ public:
       }
 
       // It's a coding error if we get here!
-      Q_ASSERT(false);
+      Q_UNREACHABLE();
    }
 
    /**
@@ -1338,13 +1338,8 @@ QString ObjectStore::getDisplayName(ObjectStore::FieldType const fieldType) {
       case ObjectStore::FieldType::Date  : return "ObjectStore::FieldType::Date"  ;
       case ObjectStore::FieldType::Enum  : return "ObjectStore::FieldType::Enum"  ;
       case ObjectStore::FieldType::Unit  : return "ObjectStore::FieldType::Unit"  ;
-      // In C++23, we'd add:
-      // default: std::unreachable();
    }
-   // In C++23, we'd add:
-   // std::unreachable()
-   // It's a coding error if we get here
-   Q_ASSERT(false);
+   Q_UNREACHABLE();
 }
 
 ObjectStore::ObjectStore(char const *             const   className,

--- a/src/measurement/ColorMethods.cpp
+++ b/src/measurement/ColorMethods.cpp
@@ -23,6 +23,7 @@
 #include <QDebug>
 #include <QString>
 #include <QObject>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "PersistentSettings.h"
 
@@ -98,7 +99,7 @@ double ColorMethods::mcuToSrm(double mcu) {
       case ColorMethods::ColorFormula::Daniel: return daniel(mcu);
       case ColorMethods::ColorFormula::Mosher: return mosher(mcu);
    }
-//      std::unreachable();
+   Q_UNREACHABLE();
 }
 
 QColor ColorMethods::srmToDisplayColor(double srm) {

--- a/src/measurement/IbuMethods.cpp
+++ b/src/measurement/IbuMethods.cpp
@@ -25,6 +25,7 @@
 #include <QDebug>
 #include <QObject>
 #include <QString>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "Algorithms.h"
 #include "measurement/Unit.h"
@@ -264,5 +265,5 @@ double IbuMethods::getIbus(IbuMethods::IbuCalculationParms const & parms) {
       case IbuMethods::IbuFormula::mIbu   : return mIbu   (parms);
 //      case IbuMethods::IbuFormula::Smph   : return smph   (parms);
    }
-//      std::unreachable();
+   Q_UNREACHABLE();
 }

--- a/src/measurement/NonPhysicalQuantity.cpp
+++ b/src/measurement/NonPhysicalQuantity.cpp
@@ -16,6 +16,7 @@
 #include "measurement/NonPhysicalQuantity.h"
 
 #include <QDebug>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 QString GetLoggableName(NonPhysicalQuantity nonPhysicalQuantity) {
    // See comment in measurement/PhysicalQuantity.cpp for why we use a switch and not an EnumStringMapping here
@@ -28,11 +29,7 @@ QString GetLoggableName(NonPhysicalQuantity nonPhysicalQuantity) {
       case NonPhysicalQuantity::OrdinalNumeral : return "OrdinalNumeral";
       case NonPhysicalQuantity::CardinalNumber : return "CardinalNumber";
       case NonPhysicalQuantity::Dimensionless  : return "Dimensionless" ;
-      // In C++23, we'd add:
-      // default: std::unreachable();
    }
-   // In C++23, we'd add:
-   // std::unreachable()
    // It's a coding error if we get here!
-   Q_ASSERT(false);
+   Q_UNREACHABLE();
 }

--- a/src/measurement/PhysicalQuantity.cpp
+++ b/src/measurement/PhysicalQuantity.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include <QDebug>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "utils/EnumStringMapping.h"
 
@@ -136,13 +137,9 @@ BtStringConst const & Measurement::getSettingsName(PhysicalQuantity const physic
       case Measurement::PhysicalQuantity::SpecificHeatCapacity: return unitSystem_specificHeatCapacity;
       case Measurement::PhysicalQuantity::HeatCapacity        : return unitSystem_heatCapacity        ;
       case Measurement::PhysicalQuantity::SpecificVolume      : return unitSystem_specificVolume      ;
-      // In C++23, we'd add:
-      // default: std::unreachable();
    }
-   // In C++23, we'd add:
-   // std::unreachable()
    // It's a coding error if we get here
-   Q_ASSERT(false);
+   Q_UNREACHABLE();
 }
 
 EnumStringMapping const Measurement::choiceOfPhysicalQuantityStringMapping {
@@ -179,10 +176,7 @@ Measurement::PhysicalQuantity Measurement::defaultPhysicalQuantity(Measurement::
          return Measurement::defaultPhysicalQuantity<Measurement::ChoiceOfPhysicalQuantity,
                                                      Measurement::ChoiceOfPhysicalQuantity::Mass_Volume_Count>();
    }
-   // Should be unreachable
-   Q_ASSERT(false);
-   // Keep the compiler happy
-   return PhysicalQuantity::Mass;
+   Q_UNREACHABLE();
 }
 
 template<Measurement::PhysicalQuantity const pq> bool isValid(Measurement::PhysicalQuantity const physicalQuantity) {
@@ -210,10 +204,7 @@ bool Measurement::isValid(Measurement::ChoiceOfPhysicalQuantity const choiceOfPh
          return Measurement::isValid<Measurement::ChoiceOfPhysicalQuantity,
                                      Measurement::ChoiceOfPhysicalQuantity::Mass_Volume_Count>(physicalQuantity);
    }
-
-   // Should be unreachable
-   Q_ASSERT(false);
-   return false;
+   Q_UNREACHABLE();
 }
 
 std::vector<Measurement::PhysicalQuantity> const & Measurement::allPossibilities(
@@ -223,10 +214,7 @@ std::vector<Measurement::PhysicalQuantity> const & Measurement::allPossibilities
       case Measurement::ChoiceOfPhysicalQuantity::Mass_Volume        : return allOf_Mass_Volume        ;
       case Measurement::ChoiceOfPhysicalQuantity::Mass_Volume_Count  : return allOf_Mass_Volume_Count  ;
    }
-   // Should be unreachable
-   Q_ASSERT(false);
-   // But we have to return something
-   return allOf_Mass_Volume;
+   Q_UNREACHABLE();
 }
 
 std::vector<int> const & Measurement::allPossibilitiesAsInt(
@@ -237,10 +225,7 @@ std::vector<int> const & Measurement::allPossibilitiesAsInt(
       case Measurement::ChoiceOfPhysicalQuantity::Mass_Volume        : return allOfAsInt_Mass_Volume        ;
       case Measurement::ChoiceOfPhysicalQuantity::Mass_Volume_Count  : return allOfAsInt_Mass_Volume_Count  ;
    }
-   // Should be unreachable
-   Q_ASSERT(false);
-   // But we have to return something
-   return allOfAsInt_Mass_Volume;
+   Q_UNREACHABLE();
 }
 
 template<class S>

--- a/src/measurement/SystemOfMeasurement.cpp
+++ b/src/measurement/SystemOfMeasurement.cpp
@@ -16,6 +16,7 @@
 #include "measurement/SystemOfMeasurement.h"
 
 #include <QDebug>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "utils/EnumStringMapping.h"
 
@@ -72,13 +73,9 @@ QString Measurement::getDisplayName(Measurement::SystemOfMeasurement const syste
       case Measurement::SystemOfMeasurement::HeatCapacityKilocalories    : return QObject::tr("Heat Capacity Kilocalories per"     );
       case Measurement::SystemOfMeasurement::HeatCapacityJoules          : return QObject::tr("Heat Capacity Joules per"           );
       case Measurement::SystemOfMeasurement::HeatCapacityBtus            : return QObject::tr("Heat Capacity Btus per"             );
-      // In C++23, we'd add:
-      // default: std::unreachable();
    }
-   // In C++23, we'd add:
-   // std::unreachable()
    // It's a coding error if we get here
-   Q_ASSERT(false);
+   Q_UNREACHABLE();
 }
 
 QString Measurement::getUniqueName(SystemOfMeasurement systemOfMeasurement) {

--- a/src/model/NamedParameterBundle.cpp
+++ b/src/model/NamedParameterBundle.cpp
@@ -24,6 +24,7 @@
 #include <QDebug>
 #include <QString>
 #include <QTextStream>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 NamedParameterBundle::NamedParameterBundle(NamedParameterBundle::OperationMode mode) :
    m_parameters{},
@@ -81,8 +82,7 @@ bool NamedParameterBundle::contains(PropertyPath const & propertyPath) const {
       }
       bundle = &bundle->m_containedBundles.at(**property);
    }
-   // This should actually be unreachable
-   return false;
+   Q_UNREACHABLE(); // We should never get here
 }
 
 template<typename P>

--- a/src/model/RecipeAdditionHop.cpp
+++ b/src/model/RecipeAdditionHop.cpp
@@ -21,6 +21,8 @@
 #include "model/Boil.h"
 #include "model/BoilStep.h"
 
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
+
 #ifdef BUILDING_WITH_CMAKE
    // Explicitly doing this include reduces potential problems with AUTOMOC when compiling with CMake
    #include "moc_RecipeAdditionHop.cpp"
@@ -136,9 +138,7 @@ RecipeAdditionHop::Use RecipeAdditionHop::use() const {
 
       // No default case as we want the compiler to warn us if we missed a case above
    }
-
-   // This should be unreachable, but putting a return statement here prevents compiler warnings
-   return RecipeAdditionHop::Use::Boil;
+   Q_UNREACHABLE(); // We should never get here
 }
 
 bool RecipeAdditionHop::isFirstWort() const {

--- a/src/model/RecipeAdditionMisc.cpp
+++ b/src/model/RecipeAdditionMisc.cpp
@@ -21,6 +21,8 @@
 #include "model/Boil.h"
 #include "model/BoilStep.h"
 
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
+
 #ifdef BUILDING_WITH_CMAKE
    // Explicitly doing this include reduces potential problems with AUTOMOC when compiling with CMake
    #include "moc_RecipeAdditionMisc.cpp"
@@ -130,9 +132,7 @@ RecipeAdditionMisc::Use  RecipeAdditionMisc::use() const {
 
       // No default case as we want the compiler to warn us if we missed a case above
    }
-
-   // This should be unreachable, but putting a return statement here prevents compiler warnings
-   return RecipeAdditionMisc::Use::Boil;
+   Q_UNREACHABLE(); // We should never get here
 }
 
 NamedEntity * RecipeAdditionMisc::ensureExists(BtStringConst const & property) {

--- a/src/model/Salt.cpp
+++ b/src/model/Salt.cpp
@@ -17,6 +17,7 @@
 #include "model/Salt.h"
 
 #include <QDebug>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "database/ObjectStoreWrapper.h"
 #include "model/InventorySalt.h"
@@ -153,7 +154,7 @@ Measurement::PhysicalQuantity Salt::suggestedMeasureFor(Salt::Type const type) {
          return Measurement::PhysicalQuantity::Volume;
       // No default case as we want the compiler to warn us if we missed one
    }
-   return Measurement::PhysicalQuantity::Mass; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 //============================================= "GETTER" MEMBER FUNCTIONS ==============================================
@@ -175,7 +176,7 @@ bool Salt::typeIsAcid(Salt::Type const type) {
          return true;
       // No default case as we want the compiler to warn us if we missed one
    }
-   return false; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 bool Salt::isAcid() const {
@@ -201,8 +202,7 @@ void Salt::setType(Salt::Type type) {
             case Salt::Type::LacticAcid    : newPercentAcid = 88.0; break;
             case Salt::Type::H3PO4         : newPercentAcid = 10.0; break;
             case Salt::Type::AcidulatedMalt: newPercentAcid =  2.0; break;
-            // The next line should be unreachable!
-            default                        : Q_ASSERT(false); break;
+            default                        : Q_UNREACHABLE(); break;
          }
       }
    }
@@ -283,7 +283,7 @@ double Salt::massConcPpm_Ca_perGramPerLiter() const {
       case Salt::Type::AcidulatedMalt: return 0.0;
       // No default case as we want the compiler to warn us if we missed one
    }
-   return 0.0; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 double Salt::massConcPpm_Cl_perGramPerLiter() const {
@@ -298,7 +298,7 @@ double Salt::massConcPpm_Cl_perGramPerLiter() const {
       case Salt::Type::H3PO4         : return 0.0;
       case Salt::Type::AcidulatedMalt: return 0.0;
    }
-   return 0.0; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 double Salt::massConcPpm_CO3_perGramPerLiter() const {
@@ -314,7 +314,7 @@ double Salt::massConcPpm_CO3_perGramPerLiter() const {
       case Salt::Type::AcidulatedMalt: return 0.0;
       // No default case as we want the compiler to warn us if we missed one
    }
-   return 0.0; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 double Salt::massConcPpm_HCO3_perGramPerLiter() const {
@@ -330,7 +330,7 @@ double Salt::massConcPpm_HCO3_perGramPerLiter() const {
       case Salt::Type::AcidulatedMalt: return 0.0;
       // No default case as we want the compiler to warn us if we missed one
    }
-   return 0.0; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 double Salt::massConcPpm_Mg_perGramPerLiter() const {
@@ -346,7 +346,7 @@ double Salt::massConcPpm_Mg_perGramPerLiter() const {
       case Salt::Type::AcidulatedMalt: return 0.0;
       // No default case as we want the compiler to warn us if we missed one
    }
-   return 0.0; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 double Salt::massConcPpm_Na_perGramPerLiter() const {
@@ -362,7 +362,7 @@ double Salt::massConcPpm_Na_perGramPerLiter() const {
       case Salt::Type::AcidulatedMalt: return 0.0;
       // No default case as we want the compiler to warn us if we missed one
    }
-   return 0.0; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 double Salt::massConcPpm_SO4_perGramPerLiter() const {
@@ -378,7 +378,7 @@ double Salt::massConcPpm_SO4_perGramPerLiter() const {
       case Salt::Type::AcidulatedMalt: return 0.0;
       // No default case as we want the compiler to warn us if we missed one
    }
-   return 0.0; // Should be unreachable, but GCC gives a warning if we don't have this
+   Q_UNREACHABLE();
 }
 
 // This class supports NamedEntity::numRecipesUsedIn

--- a/src/model/Water.cpp
+++ b/src/model/Water.cpp
@@ -23,6 +23,8 @@
 #include "model/Recipe.h"
 #include "utils/AutoCompare.h"
 
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
+
 #ifdef BUILDING_WITH_CMAKE
    // Explicitly doing this include reduces potential problems with AUTOMOC when compiling with CMake
    #include "moc_Water.cpp"
@@ -364,9 +366,7 @@ double Water::ppm(Water::Ion const ion) const {
       case Water::Ion::SO4:  return this->m_sulfate_ppm;
       // No default case as we want the compiler to warn us if we missed one of the enum values above
    }
-
-   // Should be unreachable
-   return 0.0;
+   Q_UNREACHABLE(); // We should never get here
 }
 
 // This class supports NamedEntity::numRecipesUsedIn

--- a/src/serialization/json/JsonRecord.cpp
+++ b/src/serialization/json/JsonRecord.cpp
@@ -22,6 +22,7 @@
 #include <QDate>
 #include <QDebug>
 #include <QMetaType>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "serialization/json/JsonCoding.h"
 #include "serialization/json/JsonRecordDefinition.h"
@@ -525,7 +526,7 @@ SerializationRecordDefinition const & JsonRecord::recordDefinition() const {
                   // This should be unreachable as we dealt with these cases separately above, but having case
                   // statements for them eliminates a compiler warning whilst still retaining the useful warning if we
                   // have ever omitted processing for another field type.
-                  Q_ASSERT(false);
+                  Q_UNREACHABLE();
                   break;
 
                case JsonRecordDefinition::FieldType::MeasurementWithUnits:
@@ -831,7 +832,7 @@ void JsonRecord::insertValue(JsonRecordDefinition::FieldDefinition const & field
          // This should be unreachable as JsonRecord::toJson dealt with these cases separately before calling this
          // function, but having an case statement for it eliminates a compiler warning whilst still retaining the
          // useful warning if we have ever omitted processing for another field type.
-         Q_ASSERT(false);
+         Q_UNREACHABLE();
          break;
 
       case JsonRecordDefinition::FieldType::MeasurementWithUnits:

--- a/src/trees/RecipeTreeModel.cpp
+++ b/src/trees/RecipeTreeModel.cpp
@@ -308,7 +308,7 @@ void RecipeTreeModel::revertRecipeToPreviousVersion(QModelIndex index) {
 // This is detaching a Recipe from its previous versions
 void RecipeTreeModel::orphanRecipe(QModelIndex index) {
    TreeNode* node = this->treeNode(index);
-   TreeNode* parentNode = node->rawParent();
+   //TreeNode* parentNode = node->rawParent();
    QModelIndex pIndex = this->parent(index);
 
    // It's a coding error if the index supplied doesn't point to a Recipe node...

--- a/src/trees/TreeModelBase.h
+++ b/src/trees/TreeModelBase.h
@@ -34,6 +34,7 @@
 #include <QString>
 #include <QStringBuilder> // Needed for efficient QString concatenation operator (%)
 #include <QVariant>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "database/ObjectStoreWrapper.h"
 #include "trees/TreeNode.h"
@@ -875,7 +876,7 @@ public:
          return this->insertChild(static_cast<TreeFolderNode<NE> &>(*parentNode), parentIndex, row, element);
       }
 
-//      std::unreachable();
+      Q_UNREACHABLE(); // We should never get here
    }
 
    template<std::derived_from<TreeNode> TreeNodeType>

--- a/src/trees/TreeNode.cpp
+++ b/src/trees/TreeNode.cpp
@@ -27,6 +27,7 @@
 #include <Qt>
 #include <QVariant>
 #include <QVector>
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
 
 #include "Html.h"
 #include "Localization.h"
@@ -285,7 +286,7 @@ template<> bool TreeItemNode<Recipe>::columnIsLessThan(TreeItemNode<Recipe> cons
          return lhs.ancestors().length() < rhs.ancestors().length();
    }
 
-//   std::unreachable();
+   Q_UNREACHABLE();
    return lhs.name() < rhs.name();
 }
 
@@ -298,7 +299,7 @@ template<> bool TreeItemNode<BrewNote>::columnIsLessThan(TreeItemNode<BrewNote> 
          return lhs.brewDate() < rhs.brewDate();
    }
 
-//   std::unreachable();
+   Q_UNREACHABLE();
    return lhs.name() < rhs.name();
 }
 
@@ -315,7 +316,7 @@ template<> bool TreeItemNode<Equipment>::columnIsLessThan(TreeItemNode<Equipment
                 rhs.boilTime_min().value_or(Equipment::default_boilTime_mins);
    }
 
-//   std::unreachable();
+   Q_UNREACHABLE();
    return lhs.name() < rhs.name();
 }
 
@@ -328,7 +329,7 @@ template<> bool TreeItemNode<Mash>::columnIsLessThan(TreeItemNode<Mash> const & 
       case TreeItemNode<Mash>::ColumnIndex::TotalWater: return lhs.totalMashWater_l() < rhs.totalMashWater_l();
       case TreeItemNode<Mash>::ColumnIndex::TotalTime : return lhs.totalTime_mins()   < rhs.totalTime_mins();
    }
-//   std::unreachable();
+   Q_UNREACHABLE();
    return lhs.name() < rhs.name();
 }
 

--- a/src/trees/TreeNodeBase.h
+++ b/src/trees/TreeNodeBase.h
@@ -21,6 +21,8 @@
 #include "trees/TreeNodeTraits.h"
 #include "utils/CuriouslyRecurringTemplateBase.h"
 
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
+
 /**
  * \class TreeNodeBase Curiously Recurring Template Base for NewTreeNode subclasses
  *
@@ -464,7 +466,7 @@ public:
          case TreeNodeTraits<Folder, NE>::ColumnIndex::Path     : return lhs.path    () < rhs.path    ();
          case TreeNodeTraits<Folder, NE>::ColumnIndex::FullPath : return lhs.fullPath() < rhs.fullPath();
       }
-//      std::unreachable();
+      Q_UNREACHABLE(); // We should never get here
    }
 
    // Have to override the version in \c TreeNodeBase as that will give Folder::staticMetaObject.className() rather

--- a/src/trees/TreeNodeTraits.h
+++ b/src/trees/TreeNodeTraits.h
@@ -34,6 +34,8 @@
 #include "model/Water.h"
 #include "model/Yeast.h"
 
+#include <qglobal.h> // For Q_ASSERT and Q_UNREACHABLE
+
 namespace {
    /**
     * \brief When we have an optional property, we can't just hand a std::optional type back to Qt, so we handle both
@@ -114,8 +116,7 @@ template <class NE> struct TreeNodeTraits<Folder, NE> {
          case ColumnIndex::FullPath:
             return QVariant(folder.fullPath());
       }
-      // Once we stop supporting Ubuntu 22.04, we'll be on new enough compiler versions to use:
-      //      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -138,7 +139,7 @@ template<> struct TreeNodeTraits<BrewNote, Recipe> {
          case ColumnIndex::BrewDate:
             return QVariant(brewNote.brewDate_short());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -169,7 +170,7 @@ template<> struct TreeNodeTraits<Recipe, Recipe> {
          case ColumnIndex::Style:
             return recipe.style() ? QVariant(recipe.style()->name()) : QVariant();
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -198,7 +199,7 @@ template<> struct TreeNodeTraits<Equipment, Equipment> {
          case ColumnIndex::BoilTime:
             return QVariant::fromValue(equipment.boilTime_min());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -228,7 +229,7 @@ template<> struct TreeNodeTraits<Fermentable, Fermentable> {
             return QVariant(Measurement::displayAmount(Measurement::Amount{fermentable.color_srm(),
                                                                            Measurement::Units::srm}, 0));
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 
 };
@@ -260,7 +261,7 @@ template<> struct TreeNodeTraits<Hop, Hop> {
          case ColumnIndex::Origin:
             return QVariant(hop.origin());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -290,7 +291,7 @@ template<> struct TreeNodeTraits<MashStep, Mash> {
 //         case ColumnIndex::InfusionTemp: return QVariant(mashStep.infuseTemp_c ());
 //         case ColumnIndex::TargetTemp  : return QVariant(mashStep.startTemp_c  ());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -319,7 +320,7 @@ template<> struct TreeNodeTraits<Mash, Mash> {
          case ColumnIndex::TotalTime:
             return MashStep::tr("%1 mins").arg(mash.totalTime_mins());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -359,7 +360,7 @@ template<> struct TreeNodeTraits<BoilStep, Boil> {
 //         case ColumnIndex::EndGravity  : return QVariant::fromValue(boilStep.  endGravity_sg());
 //         case ColumnIndex::ChillingType: return QVariant::fromValue(BoilStep::chillingTypeDisplayNames[boilStep.chillingType   ()]);
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -394,7 +395,7 @@ template<> struct TreeNodeTraits<Boil, Boil> {
          case ColumnIndex::LengthOfBoilProper:
             return QVariant::fromValue(boil.boilTime_mins());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -422,7 +423,7 @@ template<> struct TreeNodeTraits<FermentationStep, Fermentation> {
 //         case ColumnIndex::StartTemp    : return QVariant(fermentationStep.startTemp_c         ());
 //         case ColumnIndex::EndTemp      : return QVariant(fermentationStep.endTemp_c     ());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -447,7 +448,7 @@ template<> struct TreeNodeTraits<Fermentation, Fermentation> {
          case ColumnIndex::Description:
             return QVariant::fromValue(fermentation.description());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -472,7 +473,7 @@ template<> struct TreeNodeTraits<Misc, Misc> {
          case ColumnIndex::Type:
             return QVariant(Misc::typeDisplayNames[misc.type()]);
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -508,7 +509,7 @@ template<> struct TreeNodeTraits<Yeast, Yeast> {
          case ColumnIndex::Form:
             return QVariant(Yeast::formDisplayNames[yeast.form()]);
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -539,7 +540,7 @@ template<> struct TreeNodeTraits<Salt, Salt> {
          case ColumnIndex::PercentAcid:
             return qVariantFromOptional(salt.percentAcid());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -573,7 +574,7 @@ template<> struct TreeNodeTraits<Style, Style> {
          case ColumnIndex::StyleGuide:
             return QVariant(style.styleGuide());
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 
@@ -616,7 +617,7 @@ template<> struct TreeNodeTraits<Water, Water> {
          case ColumnIndex::pH:
             return water.ph() ? QVariant(*water.ph()) : QVariant();
       }
-//      std::unreachable();
+      Q_UNREACHABLE();
    }
 };
 


### PR DESCRIPTION
There were a few places in the code where the intention was to use `std::unreachable()`. Those places were commented out due to some older compiler not supporting this feature. This commit changed those to Q_UNREACHABLE macro which is equivalent to it.