### PR TITLE
Fix order inversion of hop additions in recipe instructions

### DIFF
--- a/src/model/Recipe.cpp
+++ b/src/model/Recipe.cpp
@@ -370,6 +370,113 @@ public:
       return;
    }
 
+   template<typename AdditionType, RecipeAddition::Stage stage>
+   void instructionsForRecipeAddition(AdditionType const & addition, QVector<PreInstruction> & preInstructions) const {
+      if (addition->stage() == stage) {
+         std::optional<int> const step = addition->step();
+         std::optional<double> stepLength_mins = std::nullopt;
+         if (step) {
+            // stepTime_mins() will return either double or std::optional<double> depending on whether it's a required
+            // field for that step type (eg yes for Mash, no for Boil).
+            //
+            // TBD: We could probably do some sort of templating here to avoid this clunky if/else
+            if constexpr (RecipeAddition::Stage::Mash == stage) {
+               if (auto const mash = this->m_self.mash();
+                   mash && *step <= static_cast<int>(mash->numSteps())) {
+                  stepLength_mins = mash->stepAt(*step)->stepTime_mins();
+               }
+            } else if constexpr (RecipeAddition::Stage::Boil == stage) {
+               if (auto const boil = this->m_self.boil();
+                   boil && *step <= static_cast<int>(boil->numSteps())) {
+                  stepLength_mins = boil->stepAt(*step)->stepTime_mins();
+               }
+            } else if constexpr (RecipeAddition::Stage::Fermentation == stage) {
+               if (auto const fermentation = this->m_self.fermentation();
+                   fermentation && *step <= static_cast<int>(fermentation->numSteps())) {
+                  stepLength_mins = fermentation->stepAt(*step)->stepTime_mins();
+               }
+            } else if constexpr (RecipeAddition::Stage::Packaging == stage) {
+               // We don't yet fully support packaging
+               stepLength_mins = std::nullopt;
+            }
+         }
+         double const additionDuration_mins{
+            // If we have a duration, this will take precedence over the calculated one
+            addition->duration_mins().value_or(
+               // If addAtTime_mins is not set, we assume addition happens at the start of the stage
+               this->stageLength_mins<stage>() - addition->addAfterStart_mins(stepLength_mins).value_or(0.0)
+            )
+         };
+         //
+         // When the duration is 0 -- either because we're adding something at the end of the stage or because we
+         // don't have a length for the stage, we want to show "at end of [stage name]" rather than "for 0 minutes",
+         // hence the extra layer of indirection below in string construction.
+         //
+         // We take advantage of compile-time string literal concatenation to make things a bit more readable in the
+         // source code.
+         //
+         // TODO: This next block is common with instructionsForMiscAdditions, so we should factor it out into a
+         //       separate function.
+         //
+         QString str;
+         switch (stage) {
+            case RecipeAddition::Stage::Mash:
+               str = tr("Put %1 %2 into mash" "%3.");
+               break;
+            case RecipeAddition::Stage::Boil:
+               if constexpr (std::same_as<AdditionType, RecipeAdditionHop>) {
+                  if (addition->isFirstWort()) {
+                     str = tr("Put %1 %2 into first wort" "%3.");
+                  } else if (addition->isAroma()) {
+                     str = tr("Steep %1 %2 in wort" "%3.");
+                  } else {
+                     str = tr("Put %1 %2 into boil" "%3.");
+                  }
+               } else {
+                  str = tr("Put %1 %2 into boil" "%3.");
+               }
+               break;
+            case RecipeAddition::Stage::Fermentation:
+               if constexpr (std::same_as<AdditionType, RecipeAdditionHop>) {
+                  str = tr("Put %1 %2 into fermenter" "%3.");
+               } else {
+                  if (step == 1) {
+                     str = tr("Put %1 %2 into primary" "%3.");
+                  } else {
+                     str = tr("Put %1 %2 into secondary" "%3.");
+                  }
+               }
+               break;
+            case RecipeAddition::Stage::Packaging:
+               str = tr("Use %1 %2 at bottling" "%3.");
+               break;
+            // NB: No default case as we want compiler to warn us if we missed a value above
+         }
+         QString const durationString{
+            qFuzzyIsNull(additionDuration_mins) ?
+               tr(" at end of %1").arg(RecipeAddition::stageDisplayNames[stage]) :
+               tr(" for %1").arg(
+                  Measurement::displayAmount(Measurement::Amount{additionDuration_mins,
+                                                                 Measurement::Units::minutes}, 0)
+               )
+         };
+
+         str = str.arg(Measurement::displayAmount(addition->amount(), 1))
+                  .arg(addition->ingredientRaw()->name())
+                  .arg(durationString);
+
+         preInstructions.push_back(
+            PreInstruction(addition->stage(),
+                           addition->step(),
+                           additionDuration_mins,
+                           // localisedName() gives tr("Hop"), tr("Misc"), etc
+                           tr("%1 addition").arg(addition->ingredientRaw()->localisedName()),
+                           str)
+         );
+      }
+      return;
+   }
+
    /**
     * @brief Generate the (pre-)instructions for Hop additions for the given Recipe stage.
     *
@@ -379,76 +486,15 @@ public:
    void instructionsForHopAdditions(QVector<PreInstruction> & preInstructions) const {
       //
       // Recipe additions have two time fields: addAtTime_mins and duration_mins.  The latter is often unset, signifying
-      // that the addition remains for the duration (eg until the end of the boil).  For recipe instructions, it is
-      // mostly standard to express the addition point as "time before the end of the boil" etc -- eg Hop X added Y
-      // minutes before the end of the boil.  We express this as "Add Hop X for Y minutes".
+      // that the addition remains for the duration (eg until the end of the boil).  Per the comments in
+      // \c RecipeAddition.h, for additions to the boil, addAtTime_mins is measured backwards from the end of the
+      // boil -- ie "time before the end of the boil" etc.  We express this in the instructions as "Add Hop X for Y
+      // minutes".
       //
 
       // TBD: What about hopAddition->addAtTime_mins()?
       for (auto const & hopAddition : m_self.hopAdditions()) {
-         if (hopAddition->stage() == stage) {
-            double const additionDuration_mins{
-               // If we have a duration, this will take precedence over the calculated one
-               hopAddition->duration_mins().value_or(
-                  // If addAtTime_mins is not set, we assume addition happens at the start of the stage
-                  this->stageLength_mins<stage>() - hopAddition->addAtTime_mins().value_or(0.0)
-               )
-            };
-            //
-            // When the duration is 0 -- either because we're adding something at the end of the stage or because we
-            // don't have a length for the stage, we want to show "at end of [stage name]" rather than "for 0 minutes",
-            // hence the extra layer of indirection below in string construction.
-            //
-            // We take advantage of compile-time string literal concatenation to make things a bit more readable in the
-            // source code.
-            //
-            // TODO: This next block is common with instructionsForMiscAdditions, so we should factor it out into a
-            //       separate function.
-            //
-            QString str;
-            switch (stage) {
-               case RecipeAddition::Stage::Mash:
-                  str = tr("Put %1 %2 into mash" "%3.");
-                  break;
-               case RecipeAddition::Stage::Boil:
-                  if (hopAddition->isFirstWort()) {
-                     str = tr("Put %1 %2 into first wort" "%3.");
-                  } else if (hopAddition->isAroma()) {
-                     str = tr("Steep %1 %2 in wort" "%3.");
-                  } else {
-                     str = tr("Put %1 %2 into boil" "%3.");
-                  }
-                  break;
-               case RecipeAddition::Stage::Fermentation:
-                  str = tr("Put %1 %2 into fermenter" "%3.");
-                  break;
-               case RecipeAddition::Stage::Packaging:
-                  // We don't really support this yet, but best to say something if we read in a recipe that has this
-                  str = tr("Put %1 %2 into packaging" "%3.");
-                  break;
-               // NB: No default case as we want compiler to warn us if we missed a value above
-            }
-            QString const durationString{
-               qFuzzyIsNull(additionDuration_mins) ?
-                  tr(" at end of %1").arg(RecipeAddition::stageDisplayNames[stage]) :
-                  tr(" for %1").arg(
-                     Measurement::displayAmount(Measurement::Amount{additionDuration_mins,
-                                                                    Measurement::Units::minutes}, 0)
-                  )
-            };
-
-            str = str.arg(Measurement::displayAmount(hopAddition->amount(), 1))
-                     .arg(hopAddition->hop()->name())
-                     .arg(durationString);
-
-            preInstructions.push_back(
-               PreInstruction(hopAddition->stage(),
-                              hopAddition->step(),
-                              additionDuration_mins,
-                              tr("Hop addition"),
-                              str)
-            );
-         }
+         this->instructionsForRecipeAddition<decltype(hopAddition), stage>(hopAddition, preInstructions);
       }
       return;
    }
@@ -461,64 +507,10 @@ public:
     *
     * @param preInstructions OUT
     */
-   template<RecipeAddition::Stage stage, int step = 0>
+   template<RecipeAddition::Stage stage>
    void instructionsForMiscAdditions(QVector<PreInstruction> & preInstructions) const {
       for (auto const & miscAddition : m_self.miscAdditions()) {
-         //
-         // See comments above in instructionsForHopAdditions() about duration.
-         //
-         // TBD: We should probably pull this logic out into a common function.
-         //
-         if (miscAddition->stage() == stage) {
-            QString str;
-            double const additionDuration_mins{
-               // If we have a duration, this will take precedence over the calculated one
-               miscAddition->duration_mins().value_or(
-                  // If addAtTime_mins is not set, we assume addition happens at the start of the stage
-                  this->stageLength_mins<stage>() - miscAddition->addAtTime_mins().value_or(0.0)
-               )
-            };
-            switch (stage) {
-               case RecipeAddition::Stage::Mash:
-                  str = tr("Put %1 %2 into mash" "%3.");
-                  break;
-               case RecipeAddition::Stage::Boil:
-                  str = tr("Put %1 %2 into boil" "%3.");
-                  break;
-               case RecipeAddition::Stage::Fermentation:
-                  if (step == 1) {
-                     str = tr("Put %1 %2 into primary" "%3.");
-                  } else {
-                     str = tr("Put %1 %2 into secondary" "%3.");
-                  }
-                  break;
-               case RecipeAddition::Stage::Packaging:
-                  str = tr("Use %1 %2 at bottling" "%3.");
-                  break;
-               // No default case as we want the compiler to warn us if we missed a case above
-            }
-            QString const durationString{
-               qFuzzyIsNull(additionDuration_mins) ?
-                  tr(" at end of %1").arg(RecipeAddition::stageDisplayNames[stage]) :
-                  tr(" for %1").arg(
-                     Measurement::displayAmount(Measurement::Amount{additionDuration_mins,
-                                                                    Measurement::Units::minutes},
-                                                0)
-                  )
-            };
-
-            str = str.arg(Measurement::displayAmount(miscAddition->amount(), 1))
-                     .arg(miscAddition->misc()->name())
-                     .arg(durationString);
-
-            preInstructions.push_back(
-               PreInstruction(miscAddition->stage(),
-                              miscAddition->step(),
-                              additionDuration_mins,
-                              tr("Misc addition"),
-                              str)
-            );
-         }
+         this->instructionsForRecipeAddition<decltype(miscAddition), stage>(miscAddition, preInstructions);
       }
       return;
    }
@@ -2089,8 +2081,8 @@ void Recipe::generateInstructions() {
 
       /*** End primary yeast ***/
 
-      /*** Primary misc ***/
-      this->pimpl->instructionsForMiscAdditions<RecipeAddition::Stage::Fermentation, 1>(preInstructions);
+      /*** Primary & Secondary misc ***/
+      this->pimpl->instructionsForMiscAdditions<RecipeAddition::Stage::Fermentation>(preInstructions);
 
       preInstructions.push_back(
          PreInstruction(RecipeAddition::Stage::Fermentation,
@@ -2112,8 +2104,8 @@ void Recipe::generateInstructions() {
          );
       }
 
-      /*** Secondary misc ***/
-      this->pimpl->instructionsForMiscAdditions<RecipeAddition::Stage::Fermentation, 2>(preInstructions);
+///      /*** Secondary misc ***/
+///      this->pimpl->instructionsForMiscAdditions<RecipeAddition::Stage::Fermentation, 2>(preInstructions);
 
       /*** Dry hopping ***/
       this->pimpl->instructionsForHopAdditions<RecipeAddition::Stage::Fermentation>(preInstructions);

--- a/src/model/RecipeAddition.cpp
+++ b/src/model/RecipeAddition.cpp
@@ -178,7 +178,37 @@ void RecipeAddition::setAddAtGravity_sg(std::optional<double> const val) { SET_A
 void RecipeAddition::setAddAtAcidity_pH(std::optional<double> const val) { SET_AND_NOTIFY(PropertyNames::RecipeAddition::addAtAcidity_pH, this->m_addAtAcidity_pH, val); return; }
 void RecipeAddition::setDuration_mins  (std::optional<double> const val) { SET_AND_NOTIFY(PropertyNames::RecipeAddition::duration_mins  , this->m_duration_mins  , val); return; }
 
-
 QString RecipeAddition::extraLogInfo() const {
    return QString("Stage: %1").arg(RecipeAddition::stageStringMapping[this->m_stage]);
+}
+
+std::optional<double> RecipeAddition::addAfterStart_mins(std::optional<double> stepLength_mins) const {
+   //
+   // Boil is the stage we measure from the end
+   //
+   if (RecipeAddition::Stage::Boil == this->m_stage) {
+      if (stepLength_mins.has_value() && this->m_addAtTime_mins.has_value()) {
+         return *stepLength_mins - *this->m_addAtTime_mins;
+      }
+      return std::nullopt;
+   }
+
+   //
+   // Other stages we measure from the start
+   //
+   return this->m_addAtTime_mins;
+}
+
+std::optional<double> RecipeAddition::addBeforeEnd_mins(std::optional<double> stepLength_mins) const {
+   //
+   // This is essentially the reverse of \c RecipeAddition::addAfterStart_mins
+   //
+   if (RecipeAddition::Stage::Boil != this->m_stage) {
+      if (stepLength_mins.has_value() && this->m_addAtTime_mins.has_value()) {
+         return *stepLength_mins - *this->m_addAtTime_mins;
+      }
+      return std::nullopt;
+   }
+
+   return this->m_addAtTime_mins;
 }

--- a/src/model/RecipeAddition.h
+++ b/src/model/RecipeAddition.h
@@ -101,7 +101,8 @@ public:
    static QString localisedName_duration_mins  ();
 
    /**
-    * Note that we rely on these values being in "chronological" order for \c lessThanByTime
+    * Note that we rely on these values being in "chronological" order for \c lessThanByTime and for sorting of
+    * \c PreInstruction
     */
    enum class Stage {Mash        ,
                      Boil        ,
@@ -166,10 +167,31 @@ public:
    Q_PROPERTY(std::optional<int> step READ step WRITE setStep)
 
    /**
-    * \brief If set, tells us how long after the start of the step (or stage if step is not set) to make the addition.
+    * \brief This corresponds to the BeerJSON TimingType::time field, which is described in the documentation as "What
+    *        time during a process step is added, eg a value of 2 days for a dry hop addition would be added 2 days into
+    *        the fermentation step."
     *
-    *        For boil additions, we typically show the reverse of this number in the UI -- ie
-    *        "boilLength_min - addAfter_min"
+    *        HOWEVER, there is more to it than this.  In pretty much any beer recipe, the timing of hop additions to the
+    *        boil is given in minutes before the end of the boil, not minutes after the start.  Moreover, measuring from
+    *        the start and from the end are not interchangeable.  Eg if we have a recipe with a 75-minute boil and a hop
+    *        addition 60 minutes before the end of the boil, changing the length of the boil to 90 minutes should not
+    *        affect the length of time the hops are in the boil.
+    *
+    *        If you look at the example/test BeerJSON files at https://github.com/beerjson/beerjson/tree/master/tests,
+    *        it is clear that, in almost all cases:
+    *           - for additions to the boil, this is really time before the end of the boil
+    *           - for additions to the fermentation, this is time after the start of the fermentation
+    *           - where the time is not specified, we may take it as meaning the addition happens at the start of the
+    *             step.
+    *        We assume that it is _only_ additions during the boil where time is counted backwards -- ie that it is
+    *        counted forwards for Mash, Fermentation and Packaging (though I can't personally think of a time when I
+    *        needed to add something to the Mash other than at the start).
+    *
+    *        (If we were designing a new system from scratch, we might make this a signed field and have positive values
+    *        represent "time after start of the step" and negative ones represent "time before end of step", with
+    *        \c std::nullopt meaning "at the start of the step" and 0.0 meaning "at the end".  But I'm not sure the
+    *        world is ready for yet another beer recipe serialisation format.)
+    *
     */
    Q_PROPERTY(std::optional<double> addAtTime_mins   READ addAtTime_mins   WRITE setAddAtTime_mins)
 
@@ -218,6 +240,16 @@ public:
    void setDuration_mins  (std::optional<double> const val);
 
    virtual QString extraLogInfo() const override;
+
+   /**
+    * \brief Converts \c addAtTime_mins to something that's always measured from the start of the step
+    */
+   std::optional<double> addAfterStart_mins(std::optional<double> stepLength_mins) const;
+
+   /**
+    * \brief Converts \c addAtTime_mins to something that's always measured from the end of the step
+    */
+   std::optional<double> addBeforeEnd_mins(std::optional<double> stepLength_mins) const;
 
 protected:
    virtual bool compareWith(NamedEntity const & other, QList<BtStringConst const *> * propertiesThatDiffer) const override;


### PR DESCRIPTION
Addresses remaining part of https://github.com/Brewtarget/brewtarget/issues/1082