### PR TITLE
Make the build script work on Debian sid

### DIFF
--- a/scripts/btDependencies.py
+++ b/scripts/btDependencies.py
@@ -181,7 +181,8 @@ def installDependencies():
             'appstream', # Needed for appstreamcli -- see https://www.freedesktop.org/software/appstream/docs/re01.html
             'binutils',  # Provides objdump, readelf, elfedit
             'patchelf',  # Used to modify the ELF section of an existing binary -- eg to edit RPATH / RUNPATH
-
+            'libboost-dev',
+            'libboost-stacktrace-dev',
          ]
          for packageToInstall in installList:
             btLogger.log.debug('Installing ' + packageToInstall)

--- a/scripts/btUtils.py
+++ b/scripts/btUtils.py
@@ -140,9 +140,16 @@ def getLinuxDistroInfo():
       #
       # Now split release into major and minor
       #
-      parsedRelease = packaging.version.parse(distroInfo["release"])
-      distroInfo["major"] = parsedRelease.major
-      distroInfo["minor"] = parsedRelease.minor
+      try:
+         parsedRelease = packaging.version.parse(distroInfo["release"])
+         distroInfo["major"] = parsedRelease.major
+         distroInfo["minor"] = parsedRelease.minor
+         break
+      except Exception:
+         # On some distro (eg Debian sid), lsb_release -a returns 'Release: n/a', which makes parse() crash. Since major and
+         # minor versions are mostly used for logging, let's use dummy values if this happens
+         distroInfo["major"] = 1
+         distroInfo["minor"] = 0
 
    return distroInfo
 

--- a/scripts/btUtils.py
+++ b/scripts/btUtils.py
@@ -144,7 +144,6 @@ def getLinuxDistroInfo():
          parsedRelease = packaging.version.parse(distroInfo["release"])
          distroInfo["major"] = parsedRelease.major
          distroInfo["minor"] = parsedRelease.minor
-         break
       except Exception:
          # On some distro (eg Debian sid), lsb_release -a returns 'Release: n/a', which makes parse() crash. Since major and
          # minor versions are mostly used for logging, let's use dummy values if this happens


### PR DESCRIPTION
Hi,
When building brewtarget on my Debian sid laptop, I had to change a few things to make `bt` work:
- add missing package dependencies
- fix `getLinuxDistroInfo` because `lsb_release -a` returns 'n/a' on Debian sid, which makes parsing the version number crash. 